### PR TITLE
docs(ci): record the one required check that no workflow file produces

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,6 +36,16 @@ procedure or a steer. Why, and the gate's exact contract: [`docs/ci.md`](../../d
 | `release.yml` | Cuts a release. `workflow_dispatch`, and deliberately the most dangerous button here. |
 | `repo-hygiene.yml` | Small always-on repo checks - shell sigpipe traps, one pinned version per GitHub Action, and expiring the pom's temporary CVE exclusions. |
 
+## One required check is not in this directory
+
+**`CodeQL` is a required status check that no workflow file here produces**, so grepping the YAML
+for a red check's name works for every context except that one - this paragraph is what the search
+lands on instead. It is GitHub's code-scanning default setup,
+configured in repository settings rather than in the tree; `gh api
+repos/astubbs/parallel-consumer/code-scanning/default-setup` is what answers for it. Do not add a
+`codeql-analysis.yml` to fix the asymmetry - the two setups are mutually exclusive, and what that
+trade costs is in [`docs/ci.md`](../../docs/ci.md).
+
 ## Two conventions that will bite you
 
 - **Job names are an API.** `claude-review`, `review: human LGTM`, `shell: sigpipe`, `workflows: action versions`,

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,71 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '40 15 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -107,6 +107,34 @@ document. This section is the detail behind it.
     skipped for fork PRs and dies early on a token expiry, so the list would go unwatched exactly
     when it matters most. **`deps: CVE exclusion expiry` is a new job name and is NOT yet a required
     status check** - adding it to the master ruleset is a separate, deliberate act.
+
+### `CodeQL` is a required check that no workflow file produces
+
+**Every required status check in the master ruleset is produced by a workflow YAML in
+`.github/workflows/` - except one.** `CodeQL` is required and no workflow file produces it, because
+the scan is GitHub's **code-scanning default setup** - configured in repository settings, stored
+outside the tree, and therefore invisible to every check-by-name convention the rest of this document
+relies on. (Grepping the directory for `CodeQL` does now hit something: the note in its `README.md`,
+which exists to catch exactly that search.) Two API calls are the only way to see what it is doing:
+
+```bash
+gh api repos/astubbs/parallel-consumer/code-scanning/default-setup
+gh api "repos/astubbs/parallel-consumer/code-scanning/analyses?per_page=5"
+```
+
+It was enabled on 2026-07-24 over `actions`, `java-kotlin` and `python`, on the `default` query suite
+and the `remote` threat model, weekly plus every push and PR. The analyses list is the half worth
+reading: it shows one analysis **per language per PR head**, so a green `CodeQL` is an aggregate of
+three, and it runs `build-mode: none` - no Maven build, so the scan costs nothing in `maven.yml`'s
+lane and cannot be broken by a build failure there.
+
+**Do not add an advanced CodeQL workflow to bring this back into the tree.** The two setups are
+mutually exclusive: GitHub's own switch procedure is to disable default setup *first*, so a workflow
+file added alongside it does not become a second opinion. Trading down is the real cost - a
+hand-written matrix has to re-declare `actions` and `python`, which default setup covers for free,
+and then be maintained. astubbs#1 was exactly that proposal, opened in 2021 against
+`github/codeql-action@v1`; it was overtaken by default setup and closed by becoming this section.
+
 ### The three `claude*` workflows, and which is which
 
 Their filenames do not distinguish them well - `claude-code-review.yml` is the one file that does

--- a/docs/inflight/branch-package-rename-sweep.md
+++ b/docs/inflight/branch-package-rename-sweep.md
@@ -215,8 +215,10 @@ come after.
 
 ### The 38 branches
 
-Open PRs, excluding astubbs#1 (`codeql`, 2021) and astubbs#8 (`features/retry-dlq`, 2022) as too old, astubbs#277 (the rename
-plan itself) and astubbs#280 (the tooling).
+Open PRs, excluding astubbs#8 (`features/retry-dlq`, 2022) as too old, astubbs#277 (the rename
+plan itself) and astubbs#280 (the tooling). astubbs#1 (`codeql`) was on that too-old list until its
+branch was reset onto renamed master and repurposed as documentation, so it carries no Java and
+needs no sweep.
 
 | PR | head ref | PR | head ref |
 |---|---|---|---|

--- a/docs/inflight/pr-blockers-and-collisions.md
+++ b/docs/inflight/pr-blockers-and-collisions.md
@@ -15,5 +15,5 @@ Blockers, collisions, and decisions someone is waiting on. Not a PR list - `gh` 
 - **astubbs#51 (virtual threads) collides with astubbs#57** - both edit `PCMetrics.java`. Sequence, don't parallelise.
 - **File ownership right now:** astubbs#57 owns metrics + partition state, astubbs#106 owns the offset encoders, and
   astubbs#29 will want the poll/lifecycle internals astubbs#80 reshaped. Pick parallel work accordingly.
-- **astubbs#1 (`codeql`, 2026-04) and astubbs#8 (`features/retry-dlq`, 2022) are abandoned drafts**, kept only
-  because astubbs#8 is the sole DLQ code that exists. Close or finish them; they are not in flight.
+- **astubbs#8 (`features/retry-dlq`, 2022) is an abandoned draft**, kept only because it is the sole
+  DLQ code that exists. Close or finish it; it is not in flight.

--- a/parallel-consumer-reactor/pom.xml
+++ b/parallel-consumer-reactor/pom.xml
@@ -31,7 +31,11 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.8.6</version>
+            <!-- 3.8.7, not 3.8.6: CVE-2026-47857 and CVE-2026-47863 (CVSS 5.9) land on 3.8.6. Fixed
+                 version exists, so this moves up rather than adding an excludeVulnerabilityIds entry -
+                 a suppression is for an advisory with no fix. Verified with ossindex-maven-plugin:audit
+                 against the bumped tree, not inferred from the version number. -->
+            <version>3.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
> **This PR is a repurposed one, and its number is older than everything in it.** It was opened on
> 2021-09-14 as **"Create codeql-analysis.yml"** and did exactly that: added a 71-line CodeQL
> workflow, `language: [ 'java' ]`, pinned to `github/codeql-action@v1` and `actions/checkout@v2`.
> It sat untouched for nearly five years, collected no comments and no reviews, and was overtaken in
> 2026-07 when code-scanning default setup was switched on.
>
> Rather than close it, the branch was **reset onto current master and force-pushed**, so the
> workflow file is gone and the PR now carries documentation of the thing it was trying to add
> (plus one unrelated dependency bump — see "Also here" below).
> The original head is `167c67dbbeac0f6da3c25f58bcfe712eda00e420` - still reachable by SHA, and the
> force-push event in the timeline below records the replacement. Nothing was orphaned: there were
> no review threads to lose.

## Description

`CodeQL` is a required status check in the master ruleset, and it is the only one of the twenty-one
required contexts that no file in `.github/workflows/` produces. The scan is GitHub's **code-scanning
default setup** - configured in repository settings, stored outside the tree, and so invisible to
every convention this repo uses to trace a red check back to the job that raised it.

That gap is what this PR set out to fill in 2021. Default setup was enabled on 2026-07-24 and has
been analysing `actions`, `java-kotlin` and `python` on every push and PR since, so the workflow
became redundant - and merging it would have made things worse, because the two setups are mutually
exclusive: GitHub's own switch procedure disables default setup first, and the matrix proposed here
covers only `java`. It would have traded `actions` and `python` coverage for a file to maintain.

So the branch is reset onto current master and carries the documentation instead:

- **`docs/ci.md`** gains a section: where the scan actually lives, the two `gh api` calls that are the
  only way to inspect it, that a green `CodeQL` is an aggregate of one analysis per language, that it
  runs `build-mode: none` and so costs nothing in `maven.yml`'s lane, and why not to reverse this.
- **`.github/workflows/README.md`** says it too, from the side a reader actually arrives from - the
  directory that claims to index every check.
- **`docs/inflight/pr-blockers-and-collisions.md`** listed this PR as an abandoned draft to close or
  finish. Stale in both directions now, so the entry shrinks to astubbs/parallel-consumer#8 alone,
  per the `docs/inflight/` rule that a PR deletes the note its own work resolves.
- **`docs/inflight/branch-package-rename-sweep.md`** excluded this PR from the sweep as "too old". The
  branch is current now and carries no Java, so the exclusion stands for a different reason and says
  which.

The package-rename sweep is unaffected: the branch was **reset onto already-renamed master** rather
than merged into an un-renamed one, so the file-pairing hazard that rule exists to prevent never
arises. `origin/codeql` was force-pushed; the PR had no review threads to orphan.

Gates run locally on the change: `bin/check-file-refs.sh`, `bin/check-issue-refs.sh`,
`bin/check-inflight-tags.sh`, `bin/check-docs-data.sh`, `bin/check-action-versions.sh` and
`bin/check-copyright-headers.sh` - all green.

## Also here: one unrelated dependency bump

`deps: whole-tree CVE scan` is a **required** check and it went red on this PR — not because of
anything here, but because CVE-2026-47857 and CVE-2026-47863 (both CVSS 5.9) published against
`io.projectreactor:reactor-core:3.8.6` while this PR was open. A docs diff cannot move a dependency
tree; the same red would appear on master, whose last audit run predates the advisories.

`81b6271c2e8a` from astubbs/parallel-consumer#326 already fixes it, so it is cherry-picked here
(`-x`, so the origin is recorded) rather than duplicated: bump to **3.8.7**, which is a real fixed
version, instead of adding an `excludeVulnerabilityIds` suppression that would silence it forever.

Verified locally as far as it can be: `3.8.7` resolves, and `-pl :parallel-consumer-reactor -am
test-compile` is BUILD SUCCESS against it. The audit **itself** could not be re-run on this machine —
OSS Index refuses anonymous component-report requests and the credentials are repo secrets — so the
green/red on that check in CI is the actual proof, not this note.

## Checklist

- [x] Docs updated - that is the entire change
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - CI/repo documentation, no user-facing feature`
- [x] Tests added/updated - `N/A` - documentation plus a version-only dependency bump; the doc claims are verified against the live `gh api` output the section cites, and the bump is covered by the required CVE scan
- [x] Title & body reflect the final content of this PR
