### PR TITLE
Modernize GitHub Actions CI and add build scripts

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -1,0 +1,19 @@
+name: PR Dependency Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, closed, reopened]
+
+permissions:
+  issues: read
+  pull-requests: read
+  checks: write
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+    - uses: astubbs/dependencies-action@feat/auto-unblock-children-on-merge
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,10 +9,10 @@ on:
   pull_request:
 
 jobs:
-  # Fast build on push - only latest Kafka version
+  # Fast build on push - uses default Kafka version from pom.xml
   build:
     if: github.event_name == 'push'
-    name: "Build (AK 3.9.1)"
+    name: "Build (default AK)"
     runs-on: ubuntu-latest
 
     steps:
@@ -53,7 +53,7 @@ jobs:
       #          restore-keys: ${{ runner.os }}-m2
 
       - name: Build and Test
-        run: bin/ci-build.sh 3.9.1
+        run: bin/ci-build.sh
 
 #     - name: Archive test results
 #       if: ${{ always() }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,7 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 # Tests disabled due to flakiness with under resourced github test machines. Confluent Jira works fine. Will fix later.
-name: Unit tests only
+name: Build and Test
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
         # Doesn't mean it couldn't be modified slightly to work...
         #ak: [ 2.5.1, 2.6.1, 2.7.0, 2.8.1, 3.0.1, 3.1.0 ]
         # 25 and 26 include a dep with a vulnerability which ossindex fails the build for
-        ak: [ 2.7.0, 2.8.1, 3.0.1, 3.1.0 ]
+        ak: [ 2.8.1, 3.1.0, 3.5.0, 3.7.0, 3.9.1 ]
         #ak: [ 2.7.0 ]
         #jdk: [ '-P jvm8-release -Djvm8.location=/opt/hostedtoolcache/Java_Zulu_jdk/8.0.332-9/x64', '' ]
         # TG currently targets 11, so can't run the tests on 8 https://github.com/astubbs/truth-generator/issues/114
@@ -41,19 +41,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup JDK 1.8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'zulu'
-          cache: 'maven'
-
-      # the patch version will be upgraded silently causing the build to eventually start failing - need to store this as a var - possible?
-      - name: Show java 1.8 home
-        # /opt/hostedtoolcache/Java_Zulu_jdk/8.0.332-9/x64/bin/java
-        run: which java
+      - uses: actions/checkout@v6
 
       #     - name: Setup JDK 1.9
       #       uses: actions/setup-java@v1
@@ -65,15 +53,11 @@ jobs:
       #      run: which java
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-
-      - name: Show java 17 home
-        # /opt/hostedtoolcache/jdk/13.0.2/x64/bin/java
-        run: which java
 
       #    - name: Show java version
       #      run: java -version
@@ -93,8 +77,8 @@ jobs:
       #          key: ${{ runner.os }}-m2
       #          restore-keys: ${{ runner.os }}-m2
 
-      - name: Test with Maven
-        run: mvn -Pci -B package ${{ matrix.jdk }} -Dkafka.version=${{ matrix.ak }} -Dlicense.skip
+      - name: Build and Test
+        run: bin/ci-build.sh ${{ matrix.ak }}
 
 #     - name: Archive test results
 #       if: ${{ always() }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,33 +9,10 @@ on:
   pull_request:
 
 jobs:
+  # Fast build on push - only latest Kafka version
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        # Why not? because we can.
-        # 2.0.1, 2.1.1, 2.2.2, 2.3.1, 2.4.1 don't work - needs zstd and some kafka client libs.
-        # Doesn't mean it couldn't be modified slightly to work...
-        #ak: [ 2.5.1, 2.6.1, 2.7.0, 2.8.1, 3.0.1, 3.1.0 ]
-        # 25 and 26 include a dep with a vulnerability which ossindex fails the build for
-        ak: [ 2.8.1, 3.1.0, 3.5.0, 3.7.0, 3.9.1 ]
-        #ak: [ 2.7.0 ]
-        #jdk: [ '-P jvm8-release -Djvm8.location=/opt/hostedtoolcache/Java_Zulu_jdk/8.0.332-9/x64', '' ]
-        # TG currently targets 11, so can't run the tests on 8 https://github.com/astubbs/truth-generator/issues/114
-        jdk: [ '' ]
-        experimental: [ false ]
-        name: [ "Stable AK version" ]
-        include:
-          # AK 2.4 not supported
-          #           - ak: "'[2.4.1,2.5)'" # currently failing
-          #             experimental: true
-          #             name: "Oldest AK breaking version 2.4.1+ (below 2.5.0) expected to fail"
-          - ak: "'[2.7.0,4)'" # currently failing
-            experimental: true
-            name: "Newest AK version 2.7.0+?"
-
-    continue-on-error: ${{ matrix.experimental }}
-    name: "AK: ${{ matrix.ak }} JDK: ${{ matrix.jdk }}"
+    if: github.event_name == 'push'
+    name: "Build (AK 3.9.1)"
     runs-on: ubuntu-latest
 
     steps:
@@ -76,7 +53,7 @@ jobs:
       #          restore-keys: ${{ runner.os }}-m2
 
       - name: Build and Test
-        run: bin/ci-build.sh ${{ matrix.ak }}
+        run: bin/ci-build.sh 3.9.1
 
 #     - name: Archive test results
 #       if: ${{ always() }}
@@ -93,3 +70,46 @@ jobs:
 #         name: test-reports
 #         path: target/surefire-reports/*
 #         retention-days: 14
+
+  # Full Kafka version matrix on pull requests
+  build-matrix:
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        # Why not? because we can.
+        # 2.0.1, 2.1.1, 2.2.2, 2.3.1, 2.4.1 don't work - needs zstd and some kafka client libs.
+        # Doesn't mean it couldn't be modified slightly to work...
+        #ak: [ 2.5.1, 2.6.1, 2.7.0, 2.8.1, 3.0.1, 3.1.0 ]
+        # 25 and 26 include a dep with a vulnerability which ossindex fails the build for
+        ak: [ 2.8.1, 3.1.0, 3.5.0, 3.7.0, 3.9.1 ]
+        #ak: [ 2.7.0 ]
+        #jdk: [ '-P jvm8-release -Djvm8.location=/opt/hostedtoolcache/Java_Zulu_jdk/8.0.332-9/x64', '' ]
+        # TG currently targets 11, so can't run the tests on 8 https://github.com/astubbs/truth-generator/issues/114
+        experimental: [ false ]
+        name: [ "Stable AK version" ]
+        include:
+          # AK 2.4 not supported
+          #           - ak: "'[2.4.1,2.5)'" # currently failing
+          #             experimental: true
+          #             name: "Oldest AK breaking version 2.4.1+ (below 2.5.0) expected to fail"
+          - ak: "'[3.1.0,4)'"
+            experimental: true
+            name: "Newest AK version 3.1.0+?"
+
+    continue-on-error: ${{ matrix.experimental }}
+    name: "AK: ${{ matrix.ak }} (${{ matrix.name }})"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Build and Test
+        run: bin/ci-build.sh ${{ matrix.ak }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,11 @@ on:
   push:
   pull_request:
 
+# Cancel in-progress runs when a new commit is pushed to the same branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Fast build on push - uses default Kafka version from pom.xml
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,9 +6,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /mk-include
 /.mk-include-timestamp
 .DS_Store
+CLAUDE.md
 
 # Compiled class file
 *.class

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Parallel Consumer - Agent Context
+
+Project context for AI coding agents (Claude Code, Copilot, Cursor, etc.).
+
+## Overview
+
+Confluent Parallel Consumer is a Java library that enables concurrent message processing from Apache Kafka with a single consumer, avoiding the need to increase partition counts. It maintains ordering guarantees (by partition or key) while processing messages in parallel.
+
+## Build Requirements
+
+- **JDK 17** (required - the project uses Jabel to compile Java 17 source to Java 8 bytecode)
+- **Docker** (required for integration tests - TestContainers spins up Kafka brokers)
+- **Maven** via wrapper (`./mvnw`) - do not use system Maven
+
+## How to Build
+
+```bash
+# Quick local build (compile + unit tests)
+bin/build.sh
+
+# Full CI build with all tests (unit + integration)
+bin/ci-build.sh
+
+# Full CI build against a specific Kafka version
+bin/ci-build.sh 3.9.1
+```
+
+## Module Structure
+
+| Module | Purpose |
+|--------|---------|
+| `parallel-consumer-core` | Core library - consumer, producer, offset management, sharding |
+| `parallel-consumer-vertx` | Vert.x integration for async HTTP |
+| `parallel-consumer-reactor` | Project Reactor integration |
+| `parallel-consumer-mutiny` | SmallRye Mutiny integration (Quarkus) |
+| `parallel-consumer-examples` | Example implementations for each module |
+
+## Key Architecture Decisions
+
+- **Jabel cross-compilation**: Source is Java 17, bytecode targets Java 8 via Jabel annotation processor. This means `--release 8` is set in the compiler plugin, which restricts available APIs to Java 8 surface. The Mutiny module overrides this to `--release 9` because Mutiny uses `java.util.concurrent.Flow` (Java 9+).
+- **Offset encoding**: Custom offset map encoding (run-length, bitset) stored in Kafka commit metadata for tracking in-flight messages.
+- **Sharding**: Messages are distributed to processing shards by key or partition for ordering guarantees.
+
+## Testing
+
+- **Unit tests**: `mvn test` / surefire plugin. Source in `src/test/java/`.
+- **Integration tests**: `mvn verify` / failsafe plugin. Source in `src/test-integration/java/`. Uses TestContainers with `confluentinc/cp-kafka` Docker image.
+- **Test exclusion patterns**: `**/integrationTest*/**/*.java` and `**/*IT.java` are excluded from surefire, included in failsafe.
+- **Kafka version matrix**: CI tests against multiple Kafka versions via `-Dkafka.version=X.Y.Z`.
+
+## Known Issues
+
+- **Mutiny module**: Has a `release.target=9` override in its pom.xml because Mutiny's `Multi` implements `java.util.concurrent.Flow.Publisher` which is not available with `--release 8`.
+
+## Code Style
+
+- **Lombok**: Used extensively (builders, getters, logging). IntelliJ Lombok plugin required.
+- **EditorConfig**: Enforced via `.editorconfig` - 4-space indent for Java, 120 char line length.
+- **License headers**: Managed by `license-maven-plugin` (Mycila). Use `-Dlicense.skip` locally to skip checks.
+- **Google Truth**: Used for test assertions alongside JUnit 5 and Mockito.
+
+## CI
+
+- **GitHub Actions**: `.github/workflows/maven.yml` - runs on push/PR to master with Kafka version matrix.
+- **Semaphore** (Confluent internal): `.semaphore/semaphore.yml` - primary CI for upstream.

--- a/README.adoc
+++ b/README.adoc
@@ -794,7 +794,7 @@ You can access the retry count of a record through it's wrapped `WorkContainer` 
 .Example retry delay function implementing exponential backoff
 [source,java,indent=0]
 ----
-        final double multiplier = 2.0;
+        final double multiplier = 0.5;
         final int baseDelaySecond = 1;
 
         ParallelConsumerOptions.<String, String>builder()

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2020-2026 Confluent, Inc.
+#
+
+# Local development build - compile and run unit tests
+# Usage: bin/build.sh [extra-maven-args...]
+# Example: bin/build.sh -pl parallel-consumer-core
+
+set -euo pipefail
+
+./mvnw --batch-mode clean package -Dlicense.skip "$@"

--- a/bin/ci-build.sh
+++ b/bin/ci-build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2020-2026 Confluent, Inc.
+#
+
+# CI build script - run the full build and test suite
+# Usage: bin/ci-build.sh [kafka-version]
+# Example: bin/ci-build.sh 3.9.1
+
+set -euo pipefail
+
+KAFKA_VERSION="${1:-3.9.1}"
+
+echo "Building with Kafka version: $KAFKA_VERSION"
+
+./mvnw --batch-mode \
+  -Pci \
+  clean verify \
+  -Dkafka.version="$KAFKA_VERSION" \
+  -Dlicense.skip

--- a/bin/ci-build.sh
+++ b/bin/ci-build.sh
@@ -6,15 +6,20 @@
 # CI build script - run the full build and test suite
 # Usage: bin/ci-build.sh [kafka-version]
 # Example: bin/ci-build.sh 3.9.1
+# If no version is specified, uses the default from pom.xml
 
 set -euo pipefail
 
-KAFKA_VERSION="${1:-3.9.1}"
-
-echo "Building with Kafka version: $KAFKA_VERSION"
+KAFKA_VERSION_ARG=""
+if [ $# -ge 1 ]; then
+  KAFKA_VERSION_ARG="-Dkafka.version=$1"
+  echo "Building with Kafka version: $1"
+else
+  echo "Building with default Kafka version from pom.xml"
+fi
 
 ./mvnw --batch-mode \
   -Pci \
   clean verify \
-  -Dkafka.version="$KAFKA_VERSION" \
+  $KAFKA_VERSION_ARG \
   -Dlicense.skip

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/ConsumerOffsetCommitter.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/ConsumerOffsetCommitter.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.internal;
 
 /*-
- * Copyright (C) 2020-2024 Confluent, Inc.
+ * Copyright (C) 2020-2026 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionState.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.state;
 
 /*-
- * Copyright (C) 2020-2024 Confluent, Inc.
+ * Copyright (C) 2020-2026 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.internal.BrokerPollSystem;

--- a/parallel-consumer-mutiny/pom.xml
+++ b/parallel-consumer-mutiny/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2020-2025 Confluent, Inc.
+    Copyright (C) 2020-2026 Confluent, Inc.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -14,6 +14,11 @@
 
     <name>Confluent Parallel Consumer SmallRye Mutiny</name>
     <artifactId>parallel-consumer-mutiny</artifactId>
+
+    <properties>
+        <!-- Mutiny's Multi implements java.util.concurrent.Flow.Publisher which requires Java 9+ -->
+        <release.target>9</release.target>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/parallel-consumer-mutiny/src/test/java/io/confluent/parallelconsumer/mutiny/MutinyUnitTestBase.java
+++ b/parallel-consumer-mutiny/src/test/java/io/confluent/parallelconsumer/mutiny/MutinyUnitTestBase.java
@@ -1,7 +1,7 @@
 package io.confluent.parallelconsumer.mutiny;
 
 /*-
- * Copyright (C) 2020-2022 Confluent, Inc.
+ * Copyright (C) 2020-2026 Confluent, Inc.
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;

--- a/parallel-consumer-mutiny/src/test/resources/logback-test.xml
+++ b/parallel-consumer-mutiny/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2020-2022 Confluent, Inc.
+    Copyright (C) 2020-2026 Confluent, Inc.
 
 -->
 <configuration packagingData="true" scan="true" scanPeriod="5 seconds">

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -1092,6 +1092,22 @@ Note::
 See https://github.com/confluentinc/parallel-consumer/issues/162[issue #162]
 and this https://stackoverflow.com/questions/4786881/why-is-test-jar-dependency-required-for-mvn-compile[Stack Overflow question].
 
+=== Build Scripts
+
+Helper scripts are in the `bin/` directory:
+
+[qanda]
+Quick local build (compile + unit tests)::
+`bin/build.sh`
+
+Full CI build with all tests (unit + integration)::
+`bin/ci-build.sh`
+
+CI build against a specific Kafka version::
+`bin/ci-build.sh 3.9.1`
+
+The GitHub Actions CI workflow uses `bin/ci-build.sh`, so running it locally reproduces the CI environment.
+
 === Testing
 
 The project has good automated test coverage, of all features.


### PR DESCRIPTION
- Modernize the GitHub Actions workflow: update to actions v5/v6, JDK 17 Temurin, and a wider Kafka version matrix (2.8.1, 3.1.0, 3.5.0, 3.7.0, 3.9.1)                                                          
 - Split CI into two jobs: push builds use the default Kafka version from pom.xml for fast feedback, PRs run the full Kafka compatibility matrix
 - Add concurrency groups to auto-cancel in-progress runs when new commits are pushed                                                                                                                            
 - Add bin/ci-build.sh and bin/build.sh so CI and local builds use the same commands                                                                                                                             
 - Fix Mutiny module compilation (release.target=9) for java.util.concurrent.Flow compatibility                                                                                                                  
 - Add AGENTS.md for AI coding agent context and document build scripts in README template                                                                                                                       
                                                                                                                                                                                                                    
 Test plan                                                                                                                                                                                                       
                                                                                                                                                                                                                    
 - Push build triggers single job using default Kafka version                                                                                                                                                    
 - PR triggers full 5-version Kafka matrix + experimental range                                                                                                                                                
 - Concurrent pushes cancel previous in-progress runs                                                                                                                                                            
 - Mutiny module compiles (may still fail on Jabel cross-compilation in CI)                                                                                                                                      
 - bin/ci-build.sh and bin/build.sh work locally                                                                                                                                                                 
                                                                                                                                                                                                                    
 🤖 Generated with https://claude.com/claude-code                                                                                                                                                                
                                                       