### PR TITLE
ci: add PR dependency check workflow

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -1,0 +1,19 @@
+name: PR Dependency Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, closed, reopened]
+
+permissions:
+  issues: read
+  pull-requests: read
+  checks: write
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+    - uses: astubbs/dependencies-action@feat/auto-unblock-children-on-merge
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that enforces PR merge ordering using [astubbs/dependencies-action](https://github.com/astubbs/dependencies-action).

- Child PRs with `depends on #N` in their description are blocked until parent PR #N merges
- When a parent PR merges, child PRs are automatically re-evaluated (no manual re-run needed)

This needs to be merged first before adding `depends on` references to our stacked PRs (#29, #30, future #912 PR).

## Test plan

- [x] Merge this PR
- [ ] Add `depends on #29` to PR #30's description
- [ ] Verify PR #30 shows a failing dependency check
- [ ] Merge PR #29
- [ ] Verify PR #30's check automatically re-runs and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)