### PR TITLE
feat: add max-queued-records-per-shard metric (cherry-pick Confluent #905)

### DIFF
--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/metrics/PCMetricsDef.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/metrics/PCMetricsDef.java
@@ -38,6 +38,7 @@ public enum PCMetricsDef {
 
     INCOMPLETE_OFFSETS_TOTAL("incomplete.offsets.total", "Total number of incomplete offsets", PCMetricsSubsystem.SHARD_MANAGER, GAUGE),
     SHARDS_SIZE("shards.size", "Number of records queued for processing across all shards", PCMetricsSubsystem.SHARD_MANAGER, GAUGE),
+    SHARDS_MAX_SIZE("shards.max.size", "The number of queued records in the shards with the most queued records", PCMetricsSubsystem.SHARD_MANAGER, GAUGE),
 
 
     //TODO: Not implemented yet - add to Metrics.adoc when implemented

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/ShardManager.java
@@ -83,6 +83,7 @@ public class ShardManager<K, V> {
     private Optional<ShardKey> iterationResumePoint = Optional.empty();
 
     private Gauge shardsSizeGauge;
+    private Gauge shardsMaxSizeGauge;
     private Gauge numberOfShardsGauge;
 
     private final PCMetrics pcMetrics;
@@ -302,7 +303,10 @@ public class ShardManager<K, V> {
         shardsSizeGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.SHARDS_SIZE,
                 this, shardManager -> shardManager.processingShards.values().stream()
                         .mapToInt(processingShard -> processingShard.getEntries().size()).sum());
+        shardsMaxSizeGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.SHARDS_MAX_SIZE,
+                this, shardManager -> shardManager.processingShards.values().stream()
+                        .mapToInt(processingShard -> processingShard.getEntries().size()).max().orElse(0));
         numberOfShardsGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.NUMBER_OF_SHARDS,
-                this, shardManager -> shardManager.processingShards.keySet().size());
+                this, shardManager -> shardManager.processingShards.size());
     }
 }


### PR DESCRIPTION
## Summary

Cherry-pick of [confluentinc/parallel-consumer#905](https://github.com/confluentinc/parallel-consumer/pull/905) by flashmouse.

- Adds `SHARDS_MAX_SIZE` gauge: reports the record count in the most-loaded shard
- Useful with `KEY` ordering to detect hot-key bottlenecks at a glance
- Also simplifies `.keySet().size()` to `.size()` on the shards map

2 files changed, 6 insertions, 1 deletion. Self-contained observability win.

Partial progress toward upstream issues #27 (Micrometer metrics) and #71 (health checks).

depends on #42

## Test plan

- [ ] Existing unit tests pass
- [ ] PCMetricsTest verifies metric registration (may want to add assertion for the new gauge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)