### PR TITLE
fix(publish): skip deploying example modules and empty test-jars

### DIFF
--- a/parallel-consumer-examples/pom.xml
+++ b/parallel-consumer-examples/pom.xml
@@ -25,4 +25,23 @@
         <module>parallel-consumer-example-reactor</module>
     </modules>
 
+    <!-- Examples are sample code, not library artifacts. Don't publish them to Maven Central. -->
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+        <gpg.skip>true</gpg.skip>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -844,6 +844,12 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <!-- Don't produce a test-jar when there are no test classes
+                                 (e.g. the parent pom module or examples). Otherwise an empty
+                                 test-jar gets generated, signed, and uploaded to Maven Central. -->
+                            <skipIfEmpty>true</skipIfEmpty>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary

The first CI publish attempt on master failed at `parallel-consumer-example-reactor` with a 403 from Sonatype trying to upload `parallel-consumer-reactor:jar.asc:tests`. Nothing was actually published to Maven Central (snapshot URLs still return 404).

This PR fixes two issues:

1. **Skip deploying the 5 example modules.** They're sample code, not consumable library artifacts. They also trigger a cross-module upload conflict with the `central-publishing-maven-plugin` where each example's deploy step re-attempts uploading the `.asc` signature of its tests-classifier dependency (which was already uploaded by the library module's own deploy step earlier in the build).

2. **Skip empty test-jars.** The root parent pom (`packaging=pom`, no source) was producing an empty `parallel-consumer-parent-X-tests.jar` + `.asc` because `maven-jar-plugin`'s `test-jar` execution was inherited by all modules. Added `skipIfEmpty=true` so modules with no test classes don't produce empty test-jars.

## Background

Upstream (confluentinc/parallel-consumer) publishes all example modules to Maven Central successfully with the same config. The difference: upstream historically published **snapshots via legacy OSSRH** (direct HTTP PUT), not via the `central-publishing-maven-plugin`'s snapshot path. They no longer actively publish snapshots. Our fork is the first use of the plugin's snapshot path with this module layout.

## Test plan

- [ ] Merge; push-to-master triggers publish workflow
- [ ] Build and Test passes
- [ ] Publish workflow succeeds this time (previously failed at example-reactor)
- [ ] Library modules appear on `central.sonatype.com/repository/maven-snapshots/io/github/astubbs/parallelconsumer/`
- [ ] Example modules do NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)