### PR TITLE
build: change Maven groupId to bz.stub.parallelconsumer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Project context for AI coding agents (Claude Code, Copilot, Cursor, etc.).
 
 Parallel Consumer is a Java library that enables concurrent message processing from Apache Kafka with a single consumer, avoiding the need to increase partition counts. It maintains ordering guarantees (by partition or key) while processing messages in parallel.
 
-This is a community-maintained fork of `confluentinc/parallel-consumer` (the upstream is no longer actively maintained), published to Maven Central as `io.github.astubbs.parallelconsumer`.
+This is a community-maintained fork of `confluentinc/parallel-consumer` (the upstream is no longer actively maintained), published to Maven Central as `bz.stub.parallelconsumer`.
 
 ## Build Requirements
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,8 @@ A high level summary of noteworthy changes in each version.
 
 NOTE:: Dependency version bumps are not listed here.
 
+NOTE:: *Reference convention (this is a fork).* Links and bare `#NN` / commit hashes refer to this fork, https://github.com/astubbs/parallel-consumer[astubbs/parallel-consumer]. Upstream references are written explicitly as `upstream #NN` and link to https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer]. Entries below `0.6.0.0` predate the fork and their `#NN` refer to upstream.
+
 // git log --pretty="* %s" 0.3.0.2..HEAD
 
 // only show TOC if this is the root document (not in the README)
@@ -18,18 +20,18 @@ endif::[]
 
 === Breaking
 
-* Maven coordinates rebranded from `io.confluent.parallelconsumer` to `io.github.astubbs.parallelconsumer`. Update your dependency declarations.
+* Maven coordinates rebranded from `io.confluent.parallelconsumer` to `bz.stub.parallelconsumer` (https://github.com/astubbs/parallel-consumer/pull/55[#55]). Update your dependency declarations.
 
 === Fixes
 
-* fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered
-* fix: test pollution from leaked threads and Awaitility global state across test classes
+* fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered (https://github.com/astubbs/parallel-consumer/commit/afde8c5e[afde8c5e]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/326[#326])
+* fix: test pollution from leaked threads and Awaitility global state across test classes (https://github.com/astubbs/parallel-consumer/commit/9e133ce0[9e133ce0])
 
 === Improvements
 
-* ci: modernized GitHub Actions CI with parallel test suites (unit, integration, performance), SpotBugs, duplicate detection, mutation testing (PIT), and dependency vulnerability scanning
-* ci: added publish workflow for automated Maven Central deployment
-* docs: updated README and added upstream PR analysis report
+* ci: modernized GitHub Actions CI with parallel test suites (unit, integration, performance), SpotBugs, duplicate detection, mutation testing (PIT), and dependency vulnerability scanning (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873])
+* ci: added publish workflow for automated Maven Central deployment (https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9])
+* docs: updated README and added upstream PR analysis report (https://github.com/astubbs/parallel-consumer/commit/dc346dad[dc346dad])
 
 == 0.5.3.4
 

--- a/README.adoc
+++ b/README.adoc
@@ -44,7 +44,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-image:https://maven-badges.herokuapp.com/maven-central/io.github.astubbs.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/io.github.astubbs.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
+image:https://maven-badges.herokuapp.com/maven-central/bz.stub.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
 
 image:https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml/badge.svg?branch=master[link=https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml,Build and Test]
 
@@ -53,7 +53,7 @@ image:https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml/b
 
 Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with *key concurrency* and *extendable non-blocking IO* processing.
 
-IMPORTANT: This is a community-maintained fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer], published under different Maven coordinates (`io.github.astubbs.parallelconsumer`). The original upstream project is no longer actively maintained.
+IMPORTANT: This is a community-maintained fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer], published under different Maven coordinates (`bz.stub.parallelconsumer`). The original upstream project is no longer actively maintained.
 
 Confluent's https://www.confluent.io/confluent-accelerators/#parallel-consumer[product page for the original project is here].
 
@@ -409,18 +409,18 @@ This library is copyright Confluent, Inc. and contributors, and licensed under t
 
 This project is available in Maven Central, https://repo1.maven.org/maven2/io/github/astubbs/parallelconsumer/[repo1].
 
-Latest version can be seen https://search.maven.org/artifact/io.github.astubbs.parallelconsumer/parallel-consumer-core[here].
+Latest version can be seen https://search.maven.org/artifact/bz.stub.parallelconsumer/parallel-consumer-core[here].
 
 Where `${project.version}` is the version to be used:
 
-* group ID: `io.github.astubbs.parallelconsumer`
+* group ID: `bz.stub.parallelconsumer`
 * artifact ID: `parallel-consumer-core`
-* version: image:https://maven-badges.herokuapp.com/maven-central/io.github.astubbs.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/io.github.astubbs.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
+* version: image:https://maven-badges.herokuapp.com/maven-central/bz.stub.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
 
 .Core Module Dependency
 [source,xml,indent=0]
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -428,7 +428,7 @@ Where `${project.version}` is the version to be used:
 .Reactor Module Dependency
 [source,xml,indent=0]
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-reactor</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -436,7 +436,7 @@ Where `${project.version}` is the version to be used:
 .Vert.x Module Dependency
 [source,xml,indent=0]
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-vertx</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -1571,6 +1571,8 @@ A high level summary of noteworthy changes in each version.
 
 NOTE:: Dependency version bumps are not listed here.
 
+NOTE:: *Reference convention (this is a fork).* Links and bare `#NN` / commit hashes refer to this fork, https://github.com/astubbs/parallel-consumer[astubbs/parallel-consumer]. Upstream references are written explicitly as `upstream #NN` and link to https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer]. Entries below `0.6.0.0` predate the fork and their `#NN` refer to upstream.
+
 // git log --pretty="* %s" 0.3.0.2..HEAD
 
 // only show TOC if this is the root document (not in the README)
@@ -1582,18 +1584,18 @@ endif::[]
 
 === Breaking
 
-* Maven coordinates rebranded from `io.confluent.parallelconsumer` to `io.github.astubbs.parallelconsumer`. Update your dependency declarations.
+* Maven coordinates rebranded from `io.confluent.parallelconsumer` to `bz.stub.parallelconsumer` (https://github.com/astubbs/parallel-consumer/pull/55[#55]). Update your dependency declarations.
 
 === Fixes
 
-* fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered
-* fix: test pollution from leaked threads and Awaitility global state across test classes
+* fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered (https://github.com/astubbs/parallel-consumer/commit/afde8c5e[afde8c5e]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/326[#326])
+* fix: test pollution from leaked threads and Awaitility global state across test classes (https://github.com/astubbs/parallel-consumer/commit/9e133ce0[9e133ce0])
 
 === Improvements
 
-* ci: modernized GitHub Actions CI with parallel test suites (unit, integration, performance), SpotBugs, duplicate detection, mutation testing (PIT), and dependency vulnerability scanning
-* ci: added publish workflow for automated Maven Central deployment
-* docs: updated README and added upstream PR analysis report
+* ci: modernized GitHub Actions CI with parallel test suites (unit, integration, performance), SpotBugs, duplicate detection, mutation testing (PIT), and dependency vulnerability scanning (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873])
+* ci: added publish workflow for automated Maven Central deployment (https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9])
+* docs: updated README and added upstream PR analysis report (https://github.com/astubbs/parallel-consumer/commit/dc346dad[dc346dad])
 
 == 0.5.3.4
 

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -6,7 +6,7 @@
 
 ## 0.6.0 — first fork release (off `master`)
 
-The fork's debut is the **rebrand already on `master`** (`io.github.astubbs.parallelconsumer`, Java 8,
+The fork's debut is the **rebrand already on `master`** (`bz.stub.parallelconsumer`, Java 8,
 Jabel intact). It builds green and **already snapshot-published** (5 successful publish runs on
 2026-04-22; the Central snapshot has likely aged out of the ~90-day retention since). No Java-baseline
 change. Release = strip `-SNAPSHOT` → `0.6.0.0` and merge to `master`. Release blockers are tracked by

--- a/docs/solutions/workflow-issues/copyright-header-rules-for-fork-2026-04-21.md
+++ b/docs/solutions/workflow-issues/copyright-header-rules-for-fork-2026-04-21.md
@@ -25,7 +25,7 @@ tags:
 
 ## Context
 
-The `astubbs/parallel-consumer` repository is an Apache 2.0 fork of `confluentinc/parallel-consumer`, rebranded under `io.github.astubbs.parallelconsumer` Maven coordinates. During the `dev/rebrand-fork` branch review, three copyright header problems surfaced:
+The `astubbs/parallel-consumer` repository is an Apache 2.0 fork of `confluentinc/parallel-consumer`, rebranded under `bz.stub.parallelconsumer` Maven coordinates. During the `dev/rebrand-fork` branch review, three copyright header problems surfaced:
 
 1. **License plugin auto-bumps years**: The `license-maven-plugin` (Mycila) auto-bumps copyright year ranges when run without `-Dlicense.skip`. A routine pom.xml property addition caused `parallel-consumer-mutiny/pom.xml` to silently gain a year bump from `2020-2025` to `2020-2026` as an unintended side effect.
 

--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -6,7 +6,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <artifactId>parallel-consumer-parent</artifactId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>

--- a/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
@@ -19,13 +19,13 @@
     <dependencies>
         <!-- tag::exampleDep[] -->
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- end::exampleDep[] -->
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
@@ -19,7 +19,7 @@
     <dependencies>
         <!-- tag::exampleDep[] -->
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -30,7 +30,7 @@
         </dependency>
         <!-- end::exampleDep[] -->
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
@@ -19,20 +19,20 @@
     <dependencies>
         <!-- tag::exampleDep[] -->
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-reactor</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- end::exampleDep[] -->
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-reactor</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -41,7 +41,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <artifactId>parallel-consumer-examples</artifactId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
@@ -19,20 +19,20 @@
     <dependencies>
         <!-- tag::exampleDep[] -->
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-vertx</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!-- end::exampleDep[] -->
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-vertx</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/parallel-consumer-examples/pom.xml
+++ b/parallel-consumer-examples/pom.xml
@@ -9,7 +9,7 @@
 
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
 

--- a/parallel-consumer-mutiny/pom.xml
+++ b/parallel-consumer-mutiny/pom.xml
@@ -7,7 +7,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -22,12 +22,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/parallel-consumer-reactor/pom.xml
+++ b/parallel-consumer-reactor/pom.xml
@@ -7,7 +7,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>parallel-consumer-parent</artifactId>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -17,12 +17,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -6,7 +6,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>io.github.astubbs.parallelconsumer</groupId>
+        <groupId>bz.stub.parallelconsumer</groupId>
         <artifactId>parallel-consumer-parent</artifactId>
         <version>0.6.0.0-SNAPSHOT</version>
     </parent>
@@ -22,12 +22,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.astubbs.parallelconsumer</groupId>
+            <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.astubbs.parallelconsumer</groupId>
+    <groupId>bz.stub.parallelconsumer</groupId>
     <artifactId>parallel-consumer-parent</artifactId>
     <name>Kafka Parallel Consumer</name>
     <version>0.6.0.0-SNAPSHOT</version>
@@ -211,7 +211,7 @@
                                             <onlyWhenRelease>false</onlyWhenRelease>
                                             <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
                                             <excludes>
-                                                <exclude>io.github.astubbs.parallelconsumer:</exclude>
+                                                <exclude>bz.stub.parallelconsumer:</exclude>
                                             </excludes>
                                         </requireReleaseDeps>
                                     </rules>

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -44,7 +44,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-image:https://maven-badges.herokuapp.com/maven-central/io.github.astubbs.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/io.github.astubbs.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
+image:https://maven-badges.herokuapp.com/maven-central/bz.stub.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
 
 image:https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml/badge.svg?branch=master[link=https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml,Build and Test]
 
@@ -53,7 +53,7 @@ image:https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml/b
 
 Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with *key concurrency* and *extendable non-blocking IO* processing.
 
-IMPORTANT: This is a community-maintained fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer], published under different Maven coordinates (`io.github.astubbs.parallelconsumer`). The original upstream project is no longer actively maintained.
+IMPORTANT: This is a community-maintained fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer], published under different Maven coordinates (`bz.stub.parallelconsumer`). The original upstream project is no longer actively maintained.
 
 Confluent's https://www.confluent.io/confluent-accelerators/#parallel-consumer[product page for the original project is here].
 
@@ -407,13 +407,13 @@ This library is copyright Confluent, Inc. and contributors, and licensed under t
 
 This project is available in Maven Central, https://repo1.maven.org/maven2/io/github/astubbs/parallelconsumer/[repo1].
 
-Latest version can be seen https://search.maven.org/artifact/io.github.astubbs.parallelconsumer/parallel-consumer-core[here].
+Latest version can be seen https://search.maven.org/artifact/bz.stub.parallelconsumer/parallel-consumer-core[here].
 
 Where `${project.version}` is the version to be used:
 
-* group ID: `io.github.astubbs.parallelconsumer`
+* group ID: `bz.stub.parallelconsumer`
 * artifact ID: `parallel-consumer-core`
-* version: image:https://maven-badges.herokuapp.com/maven-central/io.github.astubbs.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/io.github.astubbs.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
+* version: image:https://maven-badges.herokuapp.com/maven-central/bz.stub.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
 
 .Core Module Dependency
 [source,xml,indent=0]


### PR DESCRIPTION
Two pieces of pre-first-release hygiene.

## 1. Maven groupId → `bz.stub.parallelconsumer`

Moves the fork's coordinates from `io.github.astubbs.parallelconsumer` to **`bz.stub.parallelconsumer`** - reverse-DNS of the maintainer's own domain (`stub.bz`).

- **Why now:** coordinates are permanent once a stable release publishes; before `0.6.0.0` is the only cheap time.
- **Scope:** coordinates only. Java package (`io.confluent.parallelconsumer`) unchanged. All module poms + README/AGENTS/CHANGELOG snippets.
- **Verified:** `stub.bz` namespace verified on Maven Central; full reactor `mvn install` green under the new coordinate.
- **On merge:** publishes `bz.stub.parallelconsumer:*:0.6.0.0-SNAPSHOT` - first end-to-end proof of the new coordinate.

## 2. CHANGELOG traceability + fork/upstream convention

- Adds a convention note: bare `#NN` / commit hashes = this fork; `upstream #NN` = `confluentinc/parallel-consumer` (disambiguates fork vs upstream issue numbers).
- Links every `0.6.0.0` entry to its PR/commit. Both fork fixes are one-offs (SHA-linked); the null-epoch fix notes `relates to upstream #326` (not "fixes" - #326 is labelled not-a-bug and is a different symptom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
