### PR TITLE
docs: prepare for 0.6.0.0 release (changelog + README)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,20 +18,21 @@ endif::[]
 
 == 0.6.0.0
 
+First release of the community fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer] (upstream is no longer actively maintained). Drop-in compatible with upstream 0.5.x — the only required change is the Maven groupId (see Breaking below). Includes upstream fixes and features merged after upstream's last release (0.5.3.3) that were never published there.
+
 === Breaking
 
-* Maven coordinates rebranded from `io.confluent.parallelconsumer` to `bz.stub.parallelconsumer` (https://github.com/astubbs/parallel-consumer/pull/55[#55]). Update your dependency declarations.
+* Maven coordinates rebranded from `io.confluent.parallelconsumer` to `bz.stub.parallelconsumer` (https://github.com/astubbs/parallel-consumer/pull/55[#55]). Update your dependency declarations; the library API is otherwise unchanged from upstream.
+
+=== Improvements
+
+* feature: new `parallel-consumer-mutiny` module — SmallRye Mutiny (Quarkus) integration (upstream https://github.com/confluentinc/parallel-consumer/pull/891[#891]).
+* Commit-failure error logging now includes the offsets being committed, to aid diagnosis of failed commits (upstream https://github.com/confluentinc/parallel-consumer/pull/850[#850]).
+* Modernized CI (parallel unit/integration/performance suites, SpotBugs, PIT mutation testing, dependency scanning) and automated Maven Central publishing (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873], https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9]).
 
 === Fixes
 
 * fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered (https://github.com/astubbs/parallel-consumer/commit/afde8c5e[afde8c5e]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/326[#326])
-* fix: test pollution from leaked threads and Awaitility global state across test classes (https://github.com/astubbs/parallel-consumer/commit/9e133ce0[9e133ce0])
-
-=== Improvements
-
-* ci: modernized GitHub Actions CI with parallel test suites (unit, integration, performance), SpotBugs, duplicate detection, mutation testing (PIT), and dependency vulnerability scanning (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873])
-* ci: added publish workflow for automated Maven Central deployment (https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9])
-* docs: updated README and added upstream PR analysis report (https://github.com/astubbs/parallel-consumer/commit/dc346dad[dc346dad])
 
 == 0.5.3.4
 

--- a/README.adoc
+++ b/README.adoc
@@ -53,9 +53,21 @@ image:https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml/b
 
 Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with *key concurrency* and *extendable non-blocking IO* processing.
 
-IMPORTANT: This is a community-maintained fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer], published under different Maven coordinates (`bz.stub.parallelconsumer`). The original upstream project is no longer actively maintained.
+[IMPORTANT]
+====
+This is a community-maintained fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer], published under new Maven coordinates. The original upstream project is no longer actively maintained.
 
-Confluent's https://www.confluent.io/confluent-accelerators/#parallel-consumer[product page for the original project is here].
+It is a *drop-in replacement*: the Java API and package (`io.confluent.parallelconsumer`) are unchanged from upstream 0.5.x -- only the Maven `groupId` differs.
+
+[source,xml]
+----
+<dependency>
+    <groupId>bz.stub.parallelconsumer</groupId>
+    <artifactId>parallel-consumer-core</artifactId>
+    <version>0.6.0.0</version>
+</dependency>
+----
+====
 
 TIP: If you like this project, please ⭐ Star it in GitHub to show your appreciation, help us gauge popularity of the project and allocate resources.
 
@@ -1582,20 +1594,21 @@ endif::[]
 
 == 0.6.0.0
 
+First release of the community fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer] (upstream is no longer actively maintained). Drop-in compatible with upstream 0.5.x — the only required change is the Maven groupId (see Breaking below). Includes upstream fixes and features merged after upstream's last release (0.5.3.3) that were never published there.
+
 === Breaking
 
-* Maven coordinates rebranded from `io.confluent.parallelconsumer` to `bz.stub.parallelconsumer` (https://github.com/astubbs/parallel-consumer/pull/55[#55]). Update your dependency declarations.
+* Maven coordinates rebranded from `io.confluent.parallelconsumer` to `bz.stub.parallelconsumer` (https://github.com/astubbs/parallel-consumer/pull/55[#55]). Update your dependency declarations; the library API is otherwise unchanged from upstream.
+
+=== Improvements
+
+* feature: new `parallel-consumer-mutiny` module — SmallRye Mutiny (Quarkus) integration (upstream https://github.com/confluentinc/parallel-consumer/pull/891[#891]).
+* Commit-failure error logging now includes the offsets being committed, to aid diagnosis of failed commits (upstream https://github.com/confluentinc/parallel-consumer/pull/850[#850]).
+* Modernized CI (parallel unit/integration/performance suites, SpotBugs, PIT mutation testing, dependency scanning) and automated Maven Central publishing (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873], https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9]).
 
 === Fixes
 
 * fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered (https://github.com/astubbs/parallel-consumer/commit/afde8c5e[afde8c5e]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/326[#326])
-* fix: test pollution from leaked threads and Awaitility global state across test classes (https://github.com/astubbs/parallel-consumer/commit/9e133ce0[9e133ce0])
-
-=== Improvements
-
-* ci: modernized GitHub Actions CI with parallel test suites (unit, integration, performance), SpotBugs, duplicate detection, mutation testing (PIT), and dependency vulnerability scanning (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873])
-* ci: added publish workflow for automated Maven Central deployment (https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9])
-* docs: updated README and added upstream PR analysis report (https://github.com/astubbs/parallel-consumer/commit/dc346dad[dc346dad])
 
 == 0.5.3.4
 

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -106,3 +106,32 @@ the sequenced items after #57 lands. (Backlog source: `src/docs/development/upst
 - **Issue #40** — dedup `MockConsumer*` test classes (test-only; duplication bot keeps flagging these).
 - **#915 batch construction strategy** (cherry-pick upstream, closes 4-yr issue #266) — medium effort.
 - **DLQ** (#310 / revive #366) — most-demanded missing feature; large, idea-bank spec not a live branch.
+
+## CI reliability / gate issues (follow-up work)
+
+Surfaced while diagnosing PR #56 (docs-only) showing 4 red checks. **None were caused by the docs** —
+all are pre-existing job/gate problems. Only three checks actually gate merge (ruleset on `master`):
+**Unit Tests, Integration Tests, Performance Tests**. Everything else is advisory. Track and fix:
+
+- **`Integration Tests` is flaky (required → blocks merges).** Fails intermittently on TestContainers
+  Kafka broker startup: `BrokerIntegrationTest.ensureTopic` → `TimeoutException` (e.g. 1 error / 104 in
+  PR #56, `TransactionMarkersTest.setup`). Because it's a *required* check, each flake blocks an
+  otherwise-green PR. **Fix:** harden broker/topic setup (longer/again-with-backoff waits) and/or add
+  Surefire/Failsafe `rerunFailingTestsCount` for setup-timeout errors. Highest priority — it's the only
+  flaky *required* gate.
+- **`Duplicate Code (jscpd)` absolute cap is below baseline → fails on EVERY PR.** jscpd cap is 4% but
+  the codebase baseline is already 4.22% (85 clones), so the absolute-limit rule red-flags all PRs even
+  when "max increase vs base" is +0.00% (as in #56). PMD CPD is fine (3.60% < 5%). **Fix:** raise
+  `INPUT_JSCPD_MAX_PCT` above baseline (e.g. 5%, matching PMD) and rely on the max-increase-vs-base gate,
+  which is the real safety net. Not a merge blocker (advisory), but noisy on every PR.
+- **`Kafka Compat (experimental 4.x)` is known-broken until the Kafka 4 migration.** Compile failure
+  under kafka-clients 4.x (`MockProducer<>` type inference in `AbstractParallelEoSStreamProcessorTestBase`,
+  and the removed-API set in 0.7.x "Unit 3" above). **Fix:** mark the job `continue-on-error` /
+  non-blocking until 0.7.x lands so it stops red-flagging unrelated PRs. Advisory, not a blocker.
+- **`Mutation Testing (PIT)` cascades from any flaky test.** PIT requires a fully green suite, so a
+  single flaky/timeout test aborts the whole run ("1 test did not pass without mutation"). **Fix:**
+  depends on the Integration flake fix; consider not gating PIT on the integration suite. Advisory.
+- **Path-filter inconsistency.** `Build and Test` (and `SpotBugs Baseline`) are *skipped* on docs-only
+  PRs, but Integration / PIT / Kafka-Compat are *not* filtered the same way, so they run and fail on
+  changes that touch no code. **Fix:** align the `paths`/`paths-ignore` filters across these jobs so a
+  docs-only change runs a consistent (or fully skipped) set.

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -2,7 +2,7 @@
 
 > Shared, cross-branch working notes (not an issue tracker), kept on `master` so any branch or session
 > can see them. Records work that is parked, in progress on other branches, or otherwise not obvious
-> from `git log`. Keep it current when context-switching. Last updated: 2026-07-24.
+> from `git log`. Keep it current when context-switching. Last updated: 2026-07-28.
 
 ## 0.6.0 — first fork release (off `master`)
 
@@ -51,11 +51,14 @@ the PR #53 branch):
 
 ## In-flight on other branches / worktrees
 
-- **`bugs/859-pcmetrics-leak-v2`** (worktree `.claude/worktrees/dev-cc`) — 5 commits ahead of master,
-  clean tree. Fixes PCMetrics memory leak (#859): duplicate Micrometer meter re-registration on
-  partition assignment/revocation. Touches `PCMetrics.java`, `PartitionStateManager.java`; has
-  regression tests (`PCMetricsTest859.java`) + a P1-review-hardening pass. **Ready/near-ready for PR.**
-  Stacks on cherry-picks #893 (offset accuracy on assignment) and #905 (max-queued-records-per-shard metric).
+- **`fix/859-metrics-leak-plus-cherrypicks`** (**PR #57, open**; worktree `.claude/worktrees/dev-cc`) —
+  5 commits ahead of master, rebased clean, targets `master`. Fixes PCMetrics memory leak (#859):
+  duplicate Micrometer meter re-registration on partition assignment/revocation. Owns `PCMetrics.java`,
+  `PCMetricsDef.java`, `PartitionState.java`, `PartitionStateManager.java`, `ShardManager.java`;
+  regression test `PCMetricsTest859.java` + a P1-review-hardening pass. **Now bundles** cherry-picks
+  #893 (offset accuracy on assignment) and #905 (max-queued-records-per-shard metric) into the one PR
+  rather than a stack. Supersedes the old 3-deep cherry-pick stack (closed **#42** → open-then-closed
+  **#43** → closed **#45**); the old `bugs/859-pcmetrics-leak-v2` branch still exists on origin.
 - **`bugs/857-paused-consumption-multi-consumers-bug`** — silent-stall-after-rebalance. **Root cause
   found + fixed:** `synchronized(commitCommand)` deadlock between poll thread (`onPartitionsRevoked`)
   and control thread (`commitOffsetsThatAreReady`), replaced with `ReentrantLock.tryLock()`. Chaos test
@@ -63,7 +66,10 @@ the PR #53 branch):
   5 fixes, "ready for PR." (Memory note is old — re-verify before relying on it.) Relates to upstream
   PR #548 (same deadlock) and issues #326/#541/#546. User weighing a larger single-thread refactor
   (merge poll + control threads) to kill this bug class.
-- **`bugs/912-vertx-stream-memory-leak`** — clear JStream deque on close (#912).
+- **`bugs/912-vertx-stream-memory-leak`** — clear JStream deque on close (#912). Fix + regression test
+  (`JStreamMemoryLeakTest912`) committed and pushed to origin; **no PR yet.** Touches only the vertx
+  module (`JStream*Processor.java`) — isolated from core. Production memory leak (issue #912, Jan 2026).
+  **Ready to resume:** rebase onto master → open PR.
 - **`fix/909-stale-container-replacement`** — regression test for stale container at same offset.
 - **`astubbs/orca`** (worktree `/Users/astubbs/orca/workspaces/parallel-consumer/orca`) — 9 ahead / 9
   behind master, diverged, clean. CI/tooling: Claude Code Review + PR Assistant workflows, PR-dependency
@@ -72,3 +78,31 @@ the PR #53 branch):
   `cherry-pick/893-offset-reset`, `cherry-pick/905-max-shard-metric`, `refactor/test-hardening`.
 - **Stale/backup:** `backup/*` (pre-rebase snapshots), `dev-cc` & `master-confluent` (pinned at
   pre-rebrand `7f290122`), `dev/self-hosted-runner`, 4× `dependabot/maven/*`.
+
+## Parallel-safe work while PR #57 is in flight
+
+PR #57 owns the metrics/state core: `metrics/PCMetrics.java`, `metrics/PCMetricsDef.java`,
+`state/PartitionState.java`, `state/PartitionStateManager.java`, `state/ShardManager.java`. The verdicts
+below are purely about **file collision with #57** — pick parallel-safe work to avoid rebase churn; run
+the sequenced items after #57 lands. (Backlog source: `src/docs/development/upstream-pr-analysis.adoc`.)
+
+**Collides with #57 → sequence after it merges (do NOT run in parallel):**
+- **#857** deadlock fix (`bugs/857-...`) — touches `PartitionState`/`PartitionStateManager`. Fixed &
+  "ready for PR" but shares files. Pair with #909 as one post-#57 rebalance-correctness stream.
+- **#909** stale-container replacement (`fix/909-stale-container-replacement`) — touches `ShardManager`.
+- **#51** virtual threads (`features/enable-virtual-threads`) — also edits `PCMetrics.java`.
+
+**Parallel-safe (no overlap with #57), ranked by readiness:**
+- **#912 vertx memory leak** — *ready*, branch done & pushed, just needs rebase + PR (see above). Best
+  immediate parallel pick.
+- **0.6.0.0 release** (`release/0.6.0.0`, PR #56, worktree `.claude/worktrees/pc-release`) — pom/docs
+  only. Already running in parallel.
+- **Logging-verbosity cleanup** — batch issues #629/#631/#640 into one PR (`ConsumerOffsetCommitter`,
+  `RemovedPartitionState`, `AbstractParallelEoSStreamProcessor`). Low-effort, high-ROI.
+- **Security dep bumps** — #851 (postgres), #913 (assertj); pom-only. Logback already in flight on
+  `ci/tag-triggered-release` (bumped 1.5.19→1.6.0).
+- **Contributor-friction build fixes** — #162 (mvn compile without test-jar), #861 (`ManagedTruth` not
+  found), #906 (pom version mismatch). Small, unblocks external contributors.
+- **Issue #40** — dedup `MockConsumer*` test classes (test-only; duplication bot keeps flagging these).
+- **#915 batch construction strategy** (cherry-pick upstream, closes 4-yr issue #266) — medium effort.
+- **DLQ** (#310 / revive #366) — most-demanded missing feature; large, idea-bank spec not a live branch.

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -53,9 +53,21 @@ image:https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml/b
 
 Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with *key concurrency* and *extendable non-blocking IO* processing.
 
-IMPORTANT: This is a community-maintained fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer], published under different Maven coordinates (`bz.stub.parallelconsumer`). The original upstream project is no longer actively maintained.
+[IMPORTANT]
+====
+This is a community-maintained fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer], published under new Maven coordinates. The original upstream project is no longer actively maintained.
 
-Confluent's https://www.confluent.io/confluent-accelerators/#parallel-consumer[product page for the original project is here].
+It is a *drop-in replacement*: the Java API and package (`io.confluent.parallelconsumer`) are unchanged from upstream 0.5.x -- only the Maven `groupId` differs.
+
+[source,xml]
+----
+<dependency>
+    <groupId>bz.stub.parallelconsumer</groupId>
+    <artifactId>parallel-consumer-core</artifactId>
+    <version>0.6.0.0</version>
+</dependency>
+----
+====
 
 TIP: If you like this project, please ⭐ Star it in GitHub to show your appreciation, help us gauge popularity of the project and allocate resources.
 


### PR DESCRIPTION
Release groundwork for the fork's first release, `0.6.0.0` - **docs only, no version-number changes** (the poms stay on `0.6.0.0-SNAPSHOT`).

## Changes
- **CHANGELOG** - finalize the `0.6.0.0` section:
  - first-release intro + **"drop-in compatible with upstream 0.5.x - only the groupId changes"** note
  - surface two user-facing changes that were missing: the new **`parallel-consumer-mutiny`** module (upstream #891) and **commit-failure offset logging** (upstream #850)
  - trim internal test/CI/docs noise per changelog policy
- **README** - add the top-of-page **Maven coordinates block** (copy-paste dependency snippet) and **remove the dead Confluent product-page link**.

## Not in this PR
The version bump (`-SNAPSHOT` → `0.6.0.0`) and the actual publish are handled by the new tag-on-merge release pipeline (#58) via the **Prepare Release** workflow. This PR just lands the release docs on `master` first.

Depends on #58 for the release mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
