### PR TITLE
ci: tag-on-merge release pipeline via maven-release-plugin

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,73 @@
+# One-click release preparation.
+#
+# Runs `mvn release:prepare`, which rewrites the poms and makes the two release commits
+# (it does NOT build or push - see the maven-release-plugin config in the root pom), then
+# pushes the branch and opens a PR. Review + merge that PR (merge-commit or rebase, NOT
+# squash); publish.yml then tags + publishes the release commit on merge.
+#
+# Note: the release PR is opened with GITHUB_TOKEN, so its "Build and Test" checks may not
+# auto-run (GitHub does not trigger workflows from token-created PRs). The code is unchanged
+# version-only bumps, and merging still runs Build and Test on master (which gates publish).
+# Provide a PAT as `token:` below if you want checks to run on the release PR itself.
+
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version, e.g. 0.6.0.0'
+        required: true
+      developmentVersion:
+        description: 'Next development version, e.g. 0.6.0.1-SNAPSHOT'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Run release:prepare on a release branch
+        run: |
+          BRANCH="release/${{ inputs.releaseVersion }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          # preparationGoals=validate + pushChanges=false come from the pom; this only
+          # rewrites poms and makes the two commits. No build, no push, no tag pushed.
+          ./mvnw --batch-mode release:prepare \
+            -DreleaseVersion=${{ inputs.releaseVersion }} \
+            -DdevelopmentVersion=${{ inputs.developmentVersion }} \
+            -Dlicense.skip -Darguments="-Dlicense.skip"
+          git push origin "$BRANCH"
+
+      - name: Open the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base master \
+            --head "release/${{ inputs.releaseVersion }}" \
+            --title "release: ${{ inputs.releaseVersion }}" \
+            --body "Automated release preparation for **${{ inputs.releaseVersion }}** via \`maven-release-plugin\`.
+
+          Contains the two version commits: \`release ${{ inputs.releaseVersion }}\` and \`prepare for next development iteration ${{ inputs.developmentVersion }}\`.
+
+          > **Merge with a merge-commit or rebase - NOT squash.** Squash collapses the release commit and the release won't publish (\`publish.yml\` has a guard that will fail the build if this happens).
+
+          On merge, \`publish.yml\` finds the \`[maven-release-plugin] prepare release\` commit, deploys it to Maven Central, tags \`v${{ inputs.releaseVersion }}\`, and cuts a GitHub release. master returns to \`${{ inputs.developmentVersion }}\`."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,46 +1,47 @@
-# Publishes to Maven Central on every push to master.
+# Publishes to Maven Central after "Build and Test" passes on master.
 #
-# The pom.xml version is the source of truth:
-#   - Versions ending in -SNAPSHOT  -> publish snapshot
-#   - Versions without -SNAPSHOT    -> publish release + create git tag + GitHub release
-#
-# To cut a release: open a PR that strips -SNAPSHOT, merge it. CI will publish.
-# Then open another PR bumping to the next -SNAPSHOT.
+# Release model (version-in-committed-code, PR-based, tag on merge):
+#   - master is ALWAYS a -SNAPSHOT.
+#   - A release is cut by merging a "Prepare Release" PR (see prepare-release.yml),
+#     which lands two commits from maven-release-plugin:
+#       [maven-release-plugin] prepare release vX                (pom = X)
+#       [maven-release-plugin] prepare for next development ...   (pom = X+1-SNAPSHOT)
+#   - This job finds the "prepare release vX" commit whose tag doesn't exist yet,
+#     checks it out, deploys it as the release, then tags + GitHub-releases that SHA.
+#   - No release commit present -> deploys a snapshot from the master tip.
+#   Works with merge-commit OR rebase-and-merge (both preserve the release commit).
+#   Squashing collapses it away and is caught by the "Squash guard" step.
 #
 # Required GitHub secrets:
-#   MAVEN_CENTRAL_USERNAME   - Sonatype Central Portal token username
-#   MAVEN_CENTRAL_PASSWORD   - Sonatype Central Portal token password
-#   MAVEN_GPG_PRIVATE_KEY    - Armored GPG private key (gpg --export-secret-keys --armor KEYID)
-#   MAVEN_GPG_PASSPHRASE     - Passphrase for the GPG key
+#   MAVEN_CENTRAL_USERNAME, MAVEN_CENTRAL_PASSWORD, MAVEN_GPG_PRIVATE_KEY, MAVEN_GPG_PASSPHRASE
 
 name: Publish to Maven Central
 
 on:
-  # Only publish after CI passes - workflow_run triggers when "Build and Test" completes
   workflow_run:
     workflows: ["Build and Test"]
     branches: [ master ]
     types: [completed]
-  workflow_dispatch:  # allow manual re-runs
+  workflow_dispatch:
 
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false  # never cancel a publish mid-flight
 
 permissions:
-  contents: write  # needed to create tags and releases
+  contents: write  # tags + releases
 
 jobs:
   publish:
     name: Publish
-    # Skip if CI failed (workflow_run fires on both success and failure)
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0  # need full history for tag creation
+          ref: master
+          fetch-depth: 0  # full history + tags to find the release commit
 
       - name: Setup JDK 17
         uses: actions/setup-java@v5
@@ -48,34 +49,54 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-          # Configure Maven settings.xml with Sonatype credentials and GPG
           server-id: central
           server-username: MAVEN_CENTRAL_USERNAME
           server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Read project version
-        id: version
+      - name: Detect release commit
+        id: detect
         run: |
-          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          if [[ "$VERSION" == *-SNAPSHOT ]]; then
-            echo "is_snapshot=true" >> "$GITHUB_OUTPUT"
-            echo "Detected SNAPSHOT version: $VERSION"
+          # Find the most recent "[maven-release-plugin] prepare release <label>" commit
+          # whose tag <label> does not already exist. That is the SHA to release.
+          sha=""; label=""
+          while read -r c subject; do
+            case "$subject" in
+              "[maven-release-plugin] prepare release "*)
+                l="${subject##*prepare release }"
+                if ! git rev-parse "refs/tags/${l}" >/dev/null 2>&1; then
+                  sha="$c"; label="$l"; break
+                fi
+                ;;
+            esac
+          done < <(git log -30 --format='%H %s')
+
+          if [ -n "$sha" ]; then
+            echo "mode=release" >> "$GITHUB_OUTPUT"
+            echo "sha=$sha"     >> "$GITHUB_OUTPUT"
+            echo "tag=$label"   >> "$GITHUB_OUTPUT"
+            echo "Release commit $sha -> tag $label"
           else
-            echo "is_snapshot=false" >> "$GITHUB_OUTPUT"
-            echo "Detected RELEASE version: $VERSION"
+            echo "mode=snapshot" >> "$GITHUB_OUTPUT"
+            echo "No un-tagged release commit found; publishing a snapshot from the master tip."
           fi
 
-      - name: Check tag does not exist (releases only)
-        if: steps.version.outputs.is_snapshot == 'false'
+      - name: Squash guard
+        if: steps.detect.outputs.mode == 'snapshot'
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists - aborting to prevent re-release"
+          # A squashed release PR loses the "prepare release" commit but its intent survives
+          # in the squash commit subject (default = the PR title, "release: X"). Fail loudly
+          # rather than silently no-op the release.
+          if git log -5 --format='%s' | grep -qE '^release: ' \
+             && ! git log -5 --format='%s' | grep -q '\[maven-release-plugin\] prepare release'; then
+            echo "::error::A release PR looks SQUASHED - the '[maven-release-plugin] prepare release' commit is missing, so no release can be cut. Re-merge the release PR with a merge-commit or rebase (never squash)."
             exit 1
           fi
+
+      - name: Checkout release SHA
+        if: steps.detect.outputs.mode == 'release'
+        run: git checkout --detach ${{ steps.detect.outputs.sha }}
 
       - name: Deploy to Maven Central
         env:
@@ -83,37 +104,21 @@ jobs:
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |
-          # Unified publish path: central-publishing-maven-plugin handles both
-          # snapshots and releases. For snapshots it PUTs directly to the Central
-          # Portal snapshot endpoint; for releases it bundles, validates, and
-          # auto-publishes via the Portal API. Requires SNAPSHOT publishing to be
-          # enabled on the namespace in central.sonatype.com/publishing/namespaces.
-          #
-          # -pl exclusion: examples are sample code, not library artifacts; skip them
-          # from the deploy reactor.
-          ./mvnw --batch-mode \
-            -Pmaven-central \
-            -Pci \
+          # central-publishing-maven-plugin handles both snapshot and release endpoints.
+          # Examples are sample code, not library artifacts - excluded from the deploy.
+          ./mvnw --batch-mode -Pmaven-central -Pci \
             -pl '!:parallel-consumer-examples,!:parallel-consumer-example-core,!:parallel-consumer-example-metrics,!:parallel-consumer-example-streams,!:parallel-consumer-example-vertx,!:parallel-consumer-example-reactor' \
-            clean deploy \
-            -DskipTests \
-            -Dlicense.skip
+            clean deploy -DskipTests -Dlicense.skip
 
-      - name: Create git tag (releases only)
-        if: steps.version.outputs.is_snapshot == 'false'
-        run: |
-          TAG="v${{ steps.version.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-
-      - name: Create GitHub release (releases only)
-        if: steps.version.outputs.is_snapshot == 'false'
+      - name: Tag + GitHub release
+        if: steps.detect.outputs.mode == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes
+          TAG="${{ steps.detect.outputs.tag }}"
+          SHA="${{ steps.detect.outputs.sha }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG" "$SHA"
+          git push origin "$TAG"
+          gh release create "$TAG" --title "$TAG" --target "$SHA" --generate-notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,12 +84,14 @@ bin/performance-test.sh
 
 ## Releasing
 
-The pom.xml version drives publishing — there is no `maven-release-plugin` dance.
+Version-in-committed-code, PR-based, tag-on-merge. `master` is **always** a `-SNAPSHOT`; the release version is baked into a commit by `maven-release-plugin`, and the release is published from that commit when its PR merges.
 
 **Cut a release:**
-1. Open a PR removing `-SNAPSHOT` from `<version>` in the parent pom (e.g. `0.6.0.0-SNAPSHOT` → `0.6.0.0`)
-2. Merge it to master → CI publishes to Maven Central, tags `v0.6.0.0`, creates a GitHub release
-3. Open another PR bumping to the next snapshot (e.g. `0.6.0.1-SNAPSHOT`) and merge
+1. Run the **Prepare Release** workflow (Actions → *Prepare Release* → *Run workflow*) with the release version (e.g. `0.6.0.0`) and next dev version (e.g. `0.6.0.1-SNAPSHOT`). It runs `mvn release:prepare` (rewrites the poms, makes the two release commits — **no build**) and opens a `release: <version>` PR.
+2. Review and **merge that PR with a merge-commit or rebase — NOT squash** (squash drops the release commit; `publish.yml` fails loudly if it happens).
+3. On merge, `publish.yml` finds the `[maven-release-plugin] prepare release` commit, deploys **that SHA** to Maven Central, tags `v<version>`, and cuts a GitHub release. `master` is already back on the next `-SNAPSHOT`.
+
+Snapshots publish automatically on every push to `master`. Workflows: `prepare-release.yml` (prepare), `publish.yml` (deploy).
 
 **Required GitHub repo secrets** for `publish.yml`:
 - `MAVEN_CENTRAL_USERNAME` — Sonatype Central Portal token username

--- a/README.adoc
+++ b/README.adoc
@@ -1365,18 +1365,13 @@ All `ci-*` scripts use the `-Pci` Maven profile which enables license checking a
 
 === Releasing
 
-The `pom.xml` version is the source of truth for publishing — there is no `maven-release-plugin` step.
-
-On every push to `master`, `.github/workflows/publish.yml` deploys to Maven Central:
-
-* If the version ends in `-SNAPSHOT` → publishes a snapshot
-* If the version does not end in `-SNAPSHOT` → publishes a full release, creates a `v<version>` git tag, and creates a GitHub release
+Releases use `maven-release-plugin` to bake the release version into a commit, then publish that commit when its PR merges. `master` is always a `-SNAPSHOT`; snapshots publish automatically on every push to `master`.
 
 To cut a release:
 
-. Open a PR removing `-SNAPSHOT` from `<version>` in the parent `pom.xml` (e.g. `0.6.0.0-SNAPSHOT` → `0.6.0.0`)
-. Merge it to master → CI publishes the release
-. Open another PR bumping to the next snapshot (e.g. `0.6.0.1-SNAPSHOT`) and merge
+. Run the *Prepare Release* workflow (Actions tab), supplying the release version (e.g. `0.6.0.0`) and the next development version (e.g. `0.6.0.1-SNAPSHOT`). It runs `release:prepare` (poms only, no build) and opens a `release: <version>` PR containing the two version commits.
+. Review and merge that PR with a *merge-commit or rebase — not squash* (squash drops the release commit; the publish job guards against it).
+. On merge, `.github/workflows/publish.yml` finds the `[maven-release-plugin] prepare release` commit, deploys it to Maven Central, tags `v<version>`, and creates a GitHub release. `master` returns to the next `-SNAPSHOT` automatically.
 
 Required GitHub repository secrets:
 

--- a/pom.xml
+++ b/pom.xml
@@ -594,7 +594,16 @@
                 <version>3.0.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <!-- release:prepare only rewrites the poms and makes the two release
+                         commits ("prepare release X" + "prepare for next development
+                         iteration"). It does NOT build (preparationGoals=validate) and does
+                         NOT push (pushChanges=false) - the prepare-release workflow pushes the
+                         branch (commits only, no tag) into a PR, and publish.yml detects the
+                         "[maven-release-plugin] prepare release" commit once it lands on master
+                         and tags + publishes that exact SHA. See .github/workflows/. -->
+                    <preparationGoals>validate</preparationGoals>
+                    <pushChanges>false</pushChanges>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -1116,18 +1116,13 @@ All `ci-*` scripts use the `-Pci` Maven profile which enables license checking a
 
 === Releasing
 
-The `pom.xml` version is the source of truth for publishing — there is no `maven-release-plugin` step.
-
-On every push to `master`, `.github/workflows/publish.yml` deploys to Maven Central:
-
-* If the version ends in `-SNAPSHOT` → publishes a snapshot
-* If the version does not end in `-SNAPSHOT` → publishes a full release, creates a `v<version>` git tag, and creates a GitHub release
+Releases use `maven-release-plugin` to bake the release version into a commit, then publish that commit when its PR merges. `master` is always a `-SNAPSHOT`; snapshots publish automatically on every push to `master`.
 
 To cut a release:
 
-. Open a PR removing `-SNAPSHOT` from `<version>` in the parent `pom.xml` (e.g. `0.6.0.0-SNAPSHOT` → `0.6.0.0`)
-. Merge it to master → CI publishes the release
-. Open another PR bumping to the next snapshot (e.g. `0.6.0.1-SNAPSHOT`) and merge
+. Run the *Prepare Release* workflow (Actions tab), supplying the release version (e.g. `0.6.0.0`) and the next development version (e.g. `0.6.0.1-SNAPSHOT`). It runs `release:prepare` (poms only, no build) and opens a `release: <version>` PR containing the two version commits.
+. Review and merge that PR with a *merge-commit or rebase — not squash* (squash drops the release commit; the publish job guards against it).
+. On merge, `.github/workflows/publish.yml` finds the `[maven-release-plugin] prepare release` commit, deploys it to Maven Central, tags `v<version>`, and creates a GitHub release. `master` returns to the next `-SNAPSHOT` automatically.
 
 Required GitHub repository secrets:
 


### PR DESCRIPTION
Replaces the manual "strip `-SNAPSHOT` → merge → bump `-SNAPSHOT`" release dance with a **version-in-committed-code, PR-based, tag-on-merge** golden path. `master` is always a `-SNAPSHOT`.

## The flow (one PR, no extra bits)

1. **Actions → Prepare Release → Run**, giving the release version (`0.6.0.0`) + next dev version (`0.6.0.1-SNAPSHOT`). It runs `mvn release:prepare` (**poms only, no build**) and opens a `release: <version>` PR with the two version commits.
2. Review + **merge (merge-commit or rebase, not squash)**.
3. On merge, `publish.yml` finds the `[maven-release-plugin] prepare release` commit, deploys **that exact SHA**, tags `v<version>`, cuts a GitHub release. `master` is already back on the next `-SNAPSHOT`.

## How it publishes the non-tip commit

After merge, master's tip is the *next-dev* (snapshot) commit, so CI can't just build the tip. Instead `publish.yml` scans recent commits for the `[maven-release-plugin] prepare release <label>` subject whose tag doesn't exist yet, checks out **that** SHA, and releases it. This is why it works with **merge-commit or rebase-and-merge** (both preserve the commit) but not **squash** (collapses it) - and there's a **squash guard** that fails loudly rather than silently no-op'ing a squashed release.

## Changes
- `pom.xml`: reconfigure existing `maven-release-plugin` (`tagNameFormat=v@{project.version}`, `preparationGoals=validate`, `pushChanges=false`).
- `.github/workflows/prepare-release.yml` (new): `workflow_dispatch` → `release:prepare` + open PR.
- `.github/workflows/publish.yml`: detect-release-commit-or-snapshot + tag/publish that SHA.
- `AGENTS.md` + README: rewritten Releasing docs.

## Known limitations (flagged, not blockers)
- **Merge release PRs with merge-commit or rebase, never squash** (guard catches it, but it's the one rule).
- The release PR is opened with `GITHUB_TOKEN`, so its own "Build and Test" checks may not auto-run (GitHub doesn't trigger workflows from token-created PRs). The commits are version-only bumps, and merging still runs Build and Test on master (which gates publish). Swap in a PAT for `token:` if you want checks on the release PR itself.
- These workflows need a **live shake-out** on first use (CI can't be fully exercised without running) - I'd validate on a throwaway/patch release before trusting it for a headline one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
