### PR TITLE
docs: durable upstream<->fork tracking cache + backlink mechanism

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,18 @@
+# <type>(<scope>): <subject>   (<= 72 chars, imperative; e.g.
+#   "fix: replace stale work container on rebalance (#909)")
+#
+# Body: what changed and why (wrap ~72). Reference the upstream issue/PR in the
+# subject as "(#NNN)" when it maps to one, as the existing history does.
+#
+# --- Upstream trailers -------------------------------------------------------
+# For commits that relate to upstream confluentinc/parallel-consumer, UNCOMMENT
+# and fill in what applies (delete the rest). Comment/blank lines are stripped
+# by git, so an untouched template adds nothing. Not needed for fork-only work
+# (rebrand, release, dependabot, formatting). Field names follow Debian DEP-3.
+# The machine-readable cache is src/docs/development/upstream-map.yaml -- update
+# the matching entry there too.
+#
+# Upstream-Issue: confluentinc/parallel-consumer#NNN
+# Upstream-PR: confluentinc/parallel-consumer#NNN
+# Forwarded: <upstream comment URL | no | not-needed>
+# Applied-Upstream: <no | commit:SHA | VERSION>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,3 +121,47 @@ Multiple agents/sessions often work in parallel git worktrees (kept under `.clau
 ## Documented Solutions
 
 `docs/solutions/` - documented solutions to past problems and workflow patterns, organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
+
+## Upstream tracking
+
+This is a maintained hard fork of the effectively-archived `confluentinc/parallel-consumer`. We keep a durable, machine-readable cache of the fork↔upstream relationship so it never has to be re-derived from scratch:
+
+- **`src/docs/development/upstream-map.yaml`** — the **source of truth** for the *facts*: which fork branch/PR maps to which upstream issue/PR, its work group, and current status. Its header documents the schema. Validate/render with `scripts/upstream-map.py {validate,table,refs}`.
+- **`src/docs/development/upstream-pr-analysis.adoc`** — the *editorial* analysis (rankings, verdicts, recommended merge order). When prose and manifest disagree, **the manifest wins for facts**. Manifest entries link back to `.adoc` section anchors via `adoc_anchor`.
+- **`docs/inflight.md`** — *transient* cross-branch working notes only.
+
+**When you start work that maps to an upstream issue/PR, add or update its entry in `upstream-map.yaml`** (don't just note it in prose). Design follows Debian DEP-3, Yocto `Upstream-Status:`, and OpenShift's `UPSTREAM:` fork conventions.
+
+### Branch naming
+
+Branches encode the upstream number: `bugs/857-...`, `fix/909-...`, `cherry-pick/893-...`, `upstream-pr-905`. Keep this — it makes the mapping greppable and matches the manifest's `fork.branches`.
+
+### Commit trailers
+
+Commits that relate to upstream carry DEP-3-style trailers so provenance lives in the commit itself:
+
+```
+Upstream-Issue: confluentinc/parallel-consumer#857
+Upstream-PR: confluentinc/parallel-consumer#548
+Forwarded: <upstream comment URL | no | not-needed>
+Applied-Upstream: <no | commit:SHA | VERSION>
+```
+
+Enable the editor prompt once per checkout: `git config commit.template .gitmessage`. Keep the existing subject convention (`... (#893)`, `cherry-pick Confluent #905`). **Trailers are not enforced** — they only fit upstream-related commits, not fork-only work (rebrand, release, dependabot, formatting). Use judgement.
+
+### Backlinking upstream
+
+When we fix something downstream, we comment on the matching upstream issue/PR so users (who mostly don't know the fork exists) can find the fix. Driven by the manifest:
+
+```
+scripts/upstream-backlink.sh <entry-id>            # DRY-RUN (default): prints target + comment, posts nothing
+scripts/upstream-backlink.sh --post <entry-id>     # actually comment (prompts; needs gh auth)
+```
+
+Two generic templates in `scripts/backlink-templates/`: `fix-backlink` (a fix is available in the fork) and `fork-awareness` (this is now maintained in a fork). For anything needing a tailored explanation, set a per-entry **`backlink`** field in `upstream-map.yaml` (it supports `{{FORK_REPO}}` / `{{FORK_REF}}` / `{{SUMMARY}}` / `{{ID}}`) - it overrides the template so the public wording lives in the source of truth, not a separate file (see the `bug-859-pcmetrics-leak` entry). Use **plain cross-repo references, never `Fixes/Closes`** (they don't auto-close cross-repo and we're not closing anyone's issue) — one respectful comment per item. After posting, paste the printed `forwarded:` snippet back into the entry in `upstream-map.yaml` (this is also what makes future runs skip the target). The helper is anti-spam by design: idempotent skip of already-forwarded targets, per-run cap (`--max`), inter-post delay, and a status guard so unfinished work can't be announced as fixed.
+
+### Checking upstream for new activity
+
+`scripts/upstream-sweep.sh` (read-only) lists upstream issues/PRs updated since the manifest's `last_swept` and flags drift on tracked refs (recorded `open` but now closed/merged). `--since <date>` overrides the window; `--publish` updates a single fork tracking issue (guarded, never spams). Run it periodically to catch new reports from users who don't know the fork exists.
+
+The full per-item backlink plan, anti-spam details, and the sweep design live in [`src/docs/development/upstream-backlink-plan.md`](src/docs/development/upstream-backlink-plan.md).

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -3,6 +3,13 @@
 > Shared, cross-branch working notes (not an issue tracker), kept on `master` so any branch or session
 > can see them. Records work that is parked, in progress on other branches, or otherwise not obvious
 > from `git log`. Keep it current when context-switching. Last updated: 2026-07-28.
+>
+> **The durable fork↔upstream mapping now lives in a machine-readable cache:**
+> [`src/docs/development/upstream-map.yaml`](../src/docs/development/upstream-map.yaml) is the
+> source of truth for which fork branch/PR maps to which upstream issue/PR and its status
+> (editorial analysis in `src/docs/development/upstream-pr-analysis.adoc`). This file stays for
+> *transient* working notes -- what's parked/in-flight right now. When adding a branch that maps
+> to an upstream issue/PR, record the mapping in `upstream-map.yaml`, not (only) here.
 
 ## 0.6.0 — first fork release (off `master`)
 

--- a/scripts/backlink-templates/fix-backlink.md
+++ b/scripts/backlink-templates/fix-backlink.md
@@ -1,0 +1,7 @@
+Heads-up for anyone tracking this issue: a fix is available in a maintained community fork of parallel-consumer.
+
+- **Fork:** https://github.com/{{FORK_REPO}}
+- **Fix:** {{FORK_REF}}
+- **What it addresses:** {{SUMMARY}}
+
+The original repository appears to be unmaintained, so the work is happening in the fork. Cross-posting here so this issue stays discoverable for others hitting the same problem. This is a reference for visibility, not a request to close anything.

--- a/scripts/backlink-templates/fork-awareness.md
+++ b/scripts/backlink-templates/fork-awareness.md
@@ -1,0 +1,3 @@
+For anyone finding this issue: parallel-consumer is now being actively maintained in a community fork at https://github.com/{{FORK_REPO}} (the original repository is effectively archived). Fixes and discussion for issues like this are happening there.
+
+Cross-posting so it's discoverable. This is a reference for visibility, not a request to close anything.

--- a/scripts/upstream-backlink.sh
+++ b/scripts/upstream-backlink.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# upstream-backlink.sh -- post a standard "fixed in the maintained fork" / "this
+# is maintained in a fork" comment to an upstream issue/PR, driven by an entry in
+# src/docs/development/upstream-map.yaml.
+#
+# SAFE BY DEFAULT: dry-run unless you pass --post. Dry-run prints the exact
+# target(s) and rendered comment body and posts NOTHING.
+#
+# ANTI-SPAM (never nag upstream):
+#   - Idempotent: skips any target already recorded in the manifest's forwarded
+#     urls (so re-running never double-posts).
+#   - Per-run cap (--max, default 3) limits how many comments one run can post.
+#   - Delay between posts (--delay, default 3s).
+#   - fix-backlink only fires for a fix that is in a PR or landed
+#     (pr-open|merged|released); refuses none|in-progress|ready (use --force or
+#     the fork-awareness template) so we don't announce a fix with no PR to link.
+#   - Confirmation prompt before any posting.
+# See src/docs/development/upstream-backlink-plan.md.
+#
+# Usage:
+#   scripts/upstream-backlink.sh <entry-id>                          # dry-run
+#   scripts/upstream-backlink.sh --template fork-awareness <entry-id>
+#   scripts/upstream-backlink.sh --target issues|prs|both <entry-id>
+#   scripts/upstream-backlink.sh --post [--max N] [--delay S] [--force] <entry-id>
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAP="$HERE/upstream-map.py"
+TPL_DIR="$HERE/backlink-templates"
+
+template="fix-backlink"
+target="both"          # issues | prs | both
+do_post=0
+force=0
+max=3
+delay=3
+entry_id=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --template) template="$2"; shift 2;;
+    --target)   target="$2"; shift 2;;
+    --post)     do_post=1; shift;;
+    --force)    force=1; shift;;
+    --max)      max="$2"; shift 2;;
+    --delay)    delay="$2"; shift 2;;
+    -h|--help)  sed -n '2,29p' "${BASH_SOURCE[0]}"; exit 0;;
+    -*)         echo "unknown flag: $1" >&2; exit 2;;
+    *)          entry_id="$1"; shift;;
+  esac
+done
+
+[ -n "$entry_id" ] || { echo "error: entry-id required (see --help)" >&2; exit 2; }
+tpl_file="$TPL_DIR/$template.md"
+[ -f "$tpl_file" ] || { echo "error: no template '$template' at $tpl_file" >&2; exit 2; }
+
+# Pull entry fields (shell-quoted KEY=value lines): sets ID SUMMARY GROUP
+# FORK_REPO FORK_STATUS FORK_PRS FORK_BRANCHES UPSTREAM_REPO ISSUES PRS RELATED FORWARDED
+eval "$(python3 "$MAP" show "$entry_id")"
+
+# Anti-spam guard: only announce a fix that exists in a PR or is landed. A
+# fix-backlink points people at "the fix", so it needs a PR/release to link -
+# pr-open | merged | released. Refuse none | in-progress | ready (a "ready" branch
+# has no fork PR yet; see upstream-backlink-plan.md, which says wait until PR'd).
+case "$FORK_STATUS" in
+  pr-open|merged|released) ;;
+  *)
+    if [ "$template" = "fix-backlink" ] && [ "$force" -eq 0 ]; then
+      echo "refusing: '$ID' fork status is '$FORK_STATUS' - fix-backlink needs pr-open|merged|released." >&2
+      echo "  use --force to override, or --template fork-awareness (no fix claimed)." >&2
+      exit 3
+    fi
+    ;;
+esac
+
+# Already-commented upstream numbers (idempotency), across the whole manifest.
+posted_set=" $(python3 "$MAP" posted-refs | tr '\n' ' ') "
+is_posted() { case "$posted_set" in *" $1 "*) return 0;; *) return 1;; esac; }
+
+# Build the fork reference string (prefer a PR, else branches).
+if [ -n "${FORK_PRS// }" ]; then
+  FORK_REF="PR ${FORK_REPO}#${FORK_PRS%% *}"
+elif [ -n "${FORK_BRANCHES// }" ]; then
+  FORK_REF="branch \`${FORK_BRANCHES%% *}\` on ${FORK_REPO}"
+else
+  FORK_REF="the ${FORK_REPO} fork"
+fi
+
+# Source of the comment body: a per-entry `backlink` in the manifest (the source
+# of truth) wins, so a tailored public explanation lives in ONE place and is
+# rendered from there. Otherwise fall back to the generic template file. Both go
+# through the same placeholder substitution.
+if [ -n "${BACKLINK//[[:space:]]/}" ]; then
+  body_src="manifest backlink field"
+  raw="$BACKLINK"
+else
+  body_src="template: $template"
+  raw="$(cat "$tpl_file")"
+fi
+# Escape sed replacement metacharacters (delimiter |, & and \) in interpolated
+# manifest values so a summary/backlink containing them can't break or mangle the
+# substitution.
+esc() { printf '%s' "$1" | sed 's/[&|\]/\\&/g'; }
+body="$(printf '%s' "$raw" | sed \
+  -e "s|{{FORK_REPO}}|$(esc "$FORK_REPO")|g" \
+  -e "s|{{FORK_REF}}|$(esc "$FORK_REF")|g" \
+  -e "s|{{SUMMARY}}|$(esc "$SUMMARY")|g" \
+  -e "s|{{ID}}|$(esc "$ID")|g")"
+
+# Collect targets.
+targets=()
+case "$target" in
+  issues) for n in $ISSUES; do targets+=("issue:$n"); done;;
+  prs)    for n in $PRS;    do targets+=("pr:$n");    done;;
+  both)   for n in $ISSUES; do targets+=("issue:$n"); done
+          for n in $PRS;    do targets+=("pr:$n");    done;;
+  *) echo "error: --target must be issues|prs|both" >&2; exit 2;;
+esac
+[ ${#targets[@]} -gt 0 ] || { echo "error: entry '$entry_id' has no upstream $target to comment on" >&2; exit 2; }
+
+echo "entry:     $ID  ($GROUP, fork status: $FORK_STATUS)"
+echo "body from: $body_src"
+echo "fork ref:  $FORK_REF"
+echo "targets    ($UPSTREAM_REPO):"
+todo=()
+for t in "${targets[@]}"; do
+  num="${t#*:}"
+  if is_posted "$num"; then
+    echo "  - $t   [SKIP: already commented, in manifest forwarded]"
+  else
+    echo "  - $t   [would post]"
+    todo+=("$t")
+  fi
+done
+echo "-------------------- comment body --------------------"
+echo "$body"
+echo "------------------------------------------------------"
+
+if [ ${#todo[@]} -eq 0 ]; then
+  echo "Nothing to do: all targets already commented (idempotent)."
+  exit 0
+fi
+if [ ${#todo[@]} -gt "$max" ]; then
+  echo "note: ${#todo[@]} targets pending but --max=$max; only the first $max would post this run."
+fi
+
+if [ "$do_post" -eq 0 ]; then
+  echo "DRY-RUN: nothing posted. Re-run with --post to comment (requires 'gh auth login')."
+  exit 0
+fi
+
+# --- real post path (guarded) ---------------------------------------------
+command -v gh >/dev/null || { echo "error: gh CLI not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "error: not authenticated (gh auth login)" >&2; exit 1; }
+printf 'POST to up to %s of: %s ? [y/N] ' "$max" "${todo[*]}"
+read -r ans; [ "$ans" = "y" ] || { echo "aborted."; exit 0; }
+
+today="$(date +%F)"
+posted_count=0
+for t in "${todo[@]}"; do
+  if [ "$posted_count" -ge "$max" ]; then
+    echo "reached --max=$max; stopping (re-run to continue)."
+    break
+  fi
+  num="${t#*:}"
+  [ "$posted_count" -gt 0 ] && sleep "$delay"
+  url="$(gh issue comment "$num" --repo "$UPSTREAM_REPO" --body "$body" 2>/dev/null || \
+         gh pr    comment "$num" --repo "$UPSTREAM_REPO" --body "$body")"
+  posted_count=$((posted_count + 1))
+  echo "posted -> $url"
+  echo "  RECORD in src/docs/development/upstream-map.yaml under '$ID' -> forwarded:"
+  echo "        - url: $url"
+  echo "          posted: $today"
+done
+echo
+echo "Posted $posted_count comment(s). Manifest write-back is manual (preserves the"
+echo "file's comments); paste the snippet(s) above into the entry's 'forwarded:' list"
+echo "so future runs skip these targets."

--- a/scripts/upstream-map.py
+++ b/scripts/upstream-map.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Validate and render the fork<->upstream tracking cache.
+
+Usage:
+  scripts/upstream-map.py validate      # parse, check schema + duplicate ids (exit 1 on error)
+  scripts/upstream-map.py table         # human-readable summary table
+  scripts/upstream-map.py refs          # every upstream issue/PR/related number tracked
+  scripts/upstream-map.py show <id>     # shell-eval-able fields for one entry
+  scripts/upstream-map.py meta          # shell-eval-able manifest-level fields (last_swept, repos)
+  scripts/upstream-map.py tracked       # '<kind> <n> <recorded_status> <id>' per primary ref
+  scripts/upstream-map.py posted-refs   # upstream numbers already commented on (idempotency)
+  scripts/upstream-map.py todo          # outstanding actions across entries (from `todo:` fields)
+
+The manifest (src/docs/development/upstream-map.yaml) is the source of truth for
+the fork<->upstream mapping; see its header block for the schema.
+"""
+import sys
+import os
+import collections
+import shlex
+import re
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML required: pip install pyyaml")
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MANIFEST = os.path.join(HERE, "..", "src", "docs", "development", "upstream-map.yaml")
+REQUIRED = ["id", "group", "summary", "fork", "upstream", "forwarded"]
+FORK_STATUS = {"none", "in-progress", "ready", "pr-open", "merged", "released",
+               "superseded", "wontfix"}
+UPSTREAM_STATUS = {"open", "closed", "merged", "mixed"}
+GROUPS = {"rebalance-stability", "metrics-observability", "vertx",
+          "java-baseline-kafka4", "features", "deps-security", "deps-major",
+          "deps-routine", "build-tooling", "logging-ux", "release", "governance"}
+
+
+def load():
+    with open(MANIFEST) as fh:
+        return yaml.safe_load(fh)
+
+
+def validate(d):
+    errs = []
+    entries = d.get("entries") or []
+    ids = [e.get("id") for e in entries]
+    for dup in [k for k, v in collections.Counter(ids).items() if v > 1]:
+        errs.append(f"duplicate id: {dup}")
+    for e in entries:
+        eid = e.get("id", "<no-id>")
+        for k in REQUIRED:
+            if k not in e:
+                errs.append(f"{eid}: missing field '{k}'")
+        st = (e.get("fork") or {}).get("status")
+        if st not in FORK_STATUS:
+            errs.append(f"{eid}: bad fork.status '{st}' (allowed: {sorted(FORK_STATUS)})")
+        ust = (e.get("upstream") or {}).get("status")
+        if ust not in UPSTREAM_STATUS:
+            errs.append(f"{eid}: bad upstream.status '{ust}' (allowed: {sorted(UPSTREAM_STATUS)})")
+        grp = e.get("group")
+        if grp not in GROUPS:
+            errs.append(f"{eid}: bad group '{grp}' (allowed: {sorted(GROUPS)})")
+    return errs
+
+
+def table(d):
+    print(f"last_swept={d['last_swept']}  upstream={d['upstream_repo']}  fork={d['fork_repo']}")
+    hdr = f"{'id':38} {'fork_status':12} {'fork_prs':9} {'up_issues':16} {'up_prs':14} up_state"
+    print(hdr)
+    print("-" * len(hdr))
+    for e in d["entries"]:
+        f, u = e["fork"], e["upstream"]
+        print(f"{e['id']:38} {str(f['status']):12} {str(f.get('prs') or ''):9} "
+              f"{str(u.get('issues') or ''):16} {str(u.get('prs') or ''):14} {u.get('status')}")
+
+
+def refs(d):
+    """Emit 'issue <n>' / 'pr <n>' lines for every tracked upstream ref (dedup)."""
+    seen = set()
+    for e in d["entries"]:
+        u = e["upstream"]
+        for n in (u.get("issues") or []):
+            seen.add(("issue", n))
+        for n in (u.get("prs") or []):
+            seen.add(("pr", n))
+        for n in (u.get("related") or []):
+            seen.add(("ref", n))
+    for kind, n in sorted(seen, key=lambda x: (x[0], x[1])):
+        print(f"{kind} {n}")
+
+
+def show(d, eid):
+    """Emit shell-eval-able KEY=value lines for one entry (used by upstream-backlink.sh)."""
+    e = next((x for x in d["entries"] if x.get("id") == eid), None)
+    if e is None:
+        sys.exit(f"no entry with id '{eid}'")
+    u, f = e["upstream"], e["fork"]
+    q = shlex.quote
+
+    def nums(v):
+        return " ".join(str(n) for n in (v or []))
+
+    print(f"ID={q(e['id'])}")
+    print(f"SUMMARY={q(e['summary'])}")
+    print(f"GROUP={q(e['group'])}")
+    print(f"FORK_REPO={q(d['fork_repo'])}")
+    print(f"FORK_STATUS={q(str(f['status']))}")
+    print(f"FORK_PRS={q(nums(f.get('prs')))}")
+    print(f"FORK_BRANCHES={q(' '.join(f.get('branches') or []))}")
+    print(f"UPSTREAM_REPO={q(u['repo'])}")
+    print(f"ISSUES={q(nums(u.get('issues')))}")
+    print(f"PRS={q(nums(u.get('prs')))}")
+    print(f"RELATED={q(nums(u.get('related')))}")
+    fw = " ".join(x.get("url") for x in (e.get("forwarded") or []) if x.get("url"))
+    print(f"FORWARDED={q(fw)}")
+    print(f"BACKLINK={q(e.get('backlink') or '')}")
+
+
+def meta(d):
+    """Emit shell-eval-able manifest-level fields (used by upstream-sweep.sh)."""
+    q = shlex.quote
+    print(f"LAST_SWEPT={q(str(d.get('last_swept', '')))}")
+    print(f"UPSTREAM_REPO={q(d['upstream_repo'])}")
+    print(f"FORK_REPO={q(d['fork_repo'])}")
+
+
+def tracked(d):
+    """One line per tracked upstream issue/PR: '<kind> <number> <recorded_status> <entry_id>'.
+
+    Only primary refs (issues/prs), not 'related' -- these are the ones whose
+    state drift is worth flagging.
+    """
+    for e in d["entries"]:
+        u = e["upstream"]
+        st = u.get("status", "")
+        for n in (u.get("issues") or []):
+            print(f"issue {n} {st} {e['id']}")
+        for n in (u.get("prs") or []):
+            print(f"pr {n} {st} {e['id']}")
+
+
+def posted_refs(d):
+    """Print upstream issue/PR numbers we've already commented on (from forwarded urls).
+
+    Used for idempotency -- upstream-backlink.sh skips these so we never double-post.
+    """
+    seen = set()
+    for e in d["entries"]:
+        for fw in (e.get("forwarded") or []):
+            url = fw.get("url")
+            if not url:
+                continue
+            m = re.search(r"/(?:issues|pull)/(\d+)", url)
+            if m:
+                seen.add(m.group(1))
+    for n in sorted(seen, key=int):
+        print(n)
+
+
+def todos(d):
+    """List outstanding actions across all entries (from `todo:` fields)."""
+    found = False
+    for e in d["entries"]:
+        items = e.get("todo")
+        if items:
+            found = True
+            print(f"{e['id']} [{e['fork']['status']}]:")
+            for it in items:
+                print(f"  - {it}")
+    if not found:
+        print("(no outstanding todos)")
+
+
+def main():
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "validate"
+    d = load()
+    if cmd == "validate":
+        errs = validate(d)
+        if errs:
+            print("INVALID:")
+            for e in errs:
+                print("  " + e)
+            sys.exit(1)
+        print(f"OK: {len(d['entries'])} entries, no schema errors")
+    elif cmd == "table":
+        table(d)
+    elif cmd == "refs":
+        refs(d)
+    elif cmd == "show":
+        if len(sys.argv) < 3:
+            sys.exit("usage: upstream-map.py show <entry-id>")
+        show(d, sys.argv[2])
+    elif cmd == "meta":
+        meta(d)
+    elif cmd == "tracked":
+        tracked(d)
+    elif cmd == "posted-refs":
+        posted_refs(d)
+    elif cmd == "todo":
+        todos(d)
+    else:
+        sys.exit(__doc__)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upstream-sweep.sh
+++ b/scripts/upstream-sweep.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# upstream-sweep.sh -- check the archived upstream (confluentinc/parallel-consumer)
+# for NEW activity since we last looked, and flag drift on the issues/PRs we track.
+#
+# Upstream is effectively archived, so our tracked items rarely change state -- the
+# real value is catching new issues/PRs/comments from users who don't know a
+# maintained fork exists. This is READ-ONLY by default: it prints a report and
+# posts nothing. `--publish` updates a SINGLE fork tracking issue (never spams).
+#
+# Usage:
+#   scripts/upstream-sweep.sh                 # report new activity since manifest last_swept
+#   scripts/upstream-sweep.sh --since 2026-06-01
+#   scripts/upstream-sweep.sh --update-swept  # also print the last_swept bump to apply
+#   scripts/upstream-sweep.sh --publish       # create/update ONE fork tracking issue (guarded)
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAP="$HERE/upstream-map.py"
+TRACKING_TITLE="Upstream activity sweep (confluentinc/parallel-consumer)"
+
+since=""
+update_swept=0
+do_publish=0
+limit=100
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since)        since="$2"; shift 2;;
+    --update-swept) update_swept=1; shift;;
+    --publish)      do_publish=1; shift;;
+    --limit)        limit="$2"; shift 2;;
+    -h|--help)      sed -n '2,18p' "${BASH_SOURCE[0]}"; exit 0;;
+    *)              echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+command -v gh >/dev/null || { echo "error: gh CLI not found" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "error: gh not authenticated (gh auth login)" >&2; exit 1; }
+
+eval "$(python3 "$MAP" meta)"          # LAST_SWEPT, UPSTREAM_REPO, FORK_REPO
+since="${since:-$LAST_SWEPT}"
+today="$(date +%F)"
+
+# ---- gather + format via gh --jq (no inline python) ------------------------
+list_fmt() {  # $1 = issue|pr
+  gh "$1" list --repo "$UPSTREAM_REPO" --state all --limit "$limit" \
+    --search "updated:>=$since sort:updated-desc" \
+    --json number,title,state,updatedAt \
+    --jq '.[] | "  #\(.number)  \(.state|ascii_upcase[0:6])  \(.updatedAt[0:10])  \(.title)"' \
+    2>/dev/null || true
+}
+issues_out="$(list_fmt issue)"; [ -n "$issues_out" ] || issues_out="  (none)"
+prs_out="$(list_fmt pr)";       [ -n "$prs_out" ]    || prs_out="  (none)"
+
+# ---- drift on tracked refs (recorded 'open' but now closed/merged) ---------
+drift="$(python3 "$MAP" tracked | while read -r kind num recorded eid; do
+  cur="$(gh api "repos/$UPSTREAM_REPO/issues/$num" --jq '.state' 2>/dev/null || echo '?')"
+  if [ "$recorded" = "open" ] && [ "$cur" != "open" ] && [ "$cur" != "?" ]; then
+    echo "  #$num ($eid): recorded 'open' but upstream is now '$cur'"
+  fi
+done)"
+[ -n "$drift" ] || drift="  (none)"
+
+# ---- report ----------------------------------------------------------------
+report="$(cat <<EOF
+# Upstream activity sweep
+
+- upstream: \`$UPSTREAM_REPO\` (archived)
+- window:   activity updated since **$since** (manifest last_swept: $LAST_SWEPT)
+- run:      $today
+
+## New / updated issues
+$issues_out
+
+## New / updated PRs
+$prs_out
+
+## Drift on tracked items (recorded 'open' but now closed/merged upstream)
+$drift
+EOF
+)"
+echo "$report"
+
+if [ "$update_swept" -eq 1 ]; then
+  echo
+  echo "To advance the sweep window, set this in src/docs/development/upstream-map.yaml:"
+  echo "    last_swept: $today"
+fi
+
+# ---- optional: publish to a SINGLE fork tracking issue (guarded, no spam) ---
+if [ "$do_publish" -eq 1 ]; then
+  echo
+  existing="$(gh issue list --repo "$FORK_REPO" --state open --search "\"$TRACKING_TITLE\" in:title" \
+    --json number --jq '.[0].number' 2>/dev/null || true)"
+  if [ -n "$existing" ]; then
+    printf 'Update fork tracking issue #%s with this report? [y/N] ' "$existing"; read -r a
+    [ "$a" = "y" ] && gh issue comment "$existing" --repo "$FORK_REPO" --body "$report" && echo "commented on #$existing"
+  else
+    printf 'No tracking issue found. Create one on %s? [y/N] ' "$FORK_REPO"; read -r a
+    [ "$a" = "y" ] && gh issue create --repo "$FORK_REPO" --title "$TRACKING_TITLE" --body "$report"
+  fi
+fi

--- a/src/docs/development/upstream-backlink-plan.md
+++ b/src/docs/development/upstream-backlink-plan.md
@@ -1,0 +1,130 @@
+# Upstream backlink plan (dry-run) & freshness-checker design
+
+This documents what the backlink mechanism would post upstream, and what would
+happen if we ran it. **Nothing here has been posted.** All of this is driven by
+`scripts/upstream-backlink.sh` (dry-run by default) reading
+`src/docs/development/upstream-map.yaml`.
+
+## Why backlink at all
+
+`confluentinc/parallel-consumer` is effectively archived, but users keep arriving
+at its issues/PRs unaware a maintained fork exists (see upstream #907, *"Is the
+project still actively maintained?"*). A short, respectful cross-repo comment:
+
+1. tells people hitting a bug that a fix already exists in the fork, and
+2. makes the maintained fork discoverable from the place people actually land.
+
+GitHub renders a `owner/repo#123` mention as a genuine bidirectional link visible
+in both timelines. We deliberately use plain references, **not** `Fixes/Closes`
+keywords - those do not auto-close across repos anyway, and we are not trying to
+close anyone's issue. One comment per item, no spam.
+
+## What would happen if we ran it (per comment)
+
+Running `scripts/upstream-backlink.sh --post <id>` for one target would:
+
+- add one public comment to the named upstream issue/PR under the authenticated
+  `gh` account;
+- create a cross-repo reference that appears in **both** the upstream item's
+  timeline and our fork's referenced PR/commit;
+- send a notification to everyone subscribed to that upstream item;
+- **not** change labels, state, or close anything;
+- print the new comment URL and the exact snippet to paste into the entry's
+  `forwarded:` list in `upstream-map.yaml` (write-back is manual on purpose, to
+  preserve the manifest's comments/formatting).
+
+It is public and hard to undo (you can delete a comment, but notifications and
+cross-references have already fired). That is why the script is dry-run unless
+`--post` is passed, and prompts for confirmation even then.
+
+## The queue (already-fixed / carried work)
+
+Preview any row with `scripts/upstream-backlink.sh --target <t> <id>`
+(dry-run). `--target both` is the default; the table narrows it where only one
+side is relevant.
+
+| Manifest id | Template | Target | Dry-run command | Post when |
+|---|---|---|---|---|
+| `bug-857-stall-after-rebalance` | fix-backlink | issue 857 | `upstream-backlink.sh --target issues bug-857-stall-after-rebalance` | after the branch is PR'd (currently no fork PR #) |
+| `bug-859-pcmetrics-leak` | fix-backlink | issue 859 | `upstream-backlink.sh --target issues bug-859-pcmetrics-leak` | ready now (fork PR #57 exists) |
+| `cherry-pick-893-offset-reset` | fix-backlink | PR 893 | `upstream-backlink.sh --target prs cherry-pick-893-offset-reset` | ready now (tell the PR author it's carried in fork #57) |
+| `cherry-pick-905-max-shard-metric` | fix-backlink | PR 905 | `upstream-backlink.sh --target prs cherry-pick-905-max-shard-metric` | ready now (carried in fork #57) |
+| `fix-909-stale-container` | fix-backlink | PR 909 | `upstream-backlink.sh --target prs fix-909-stale-container` | hold until the regression test lands / it's PR'd |
+| `bug-912-vertx-stream-leak` | fix-backlink | issue 912 | `upstream-backlink.sh --target issues bug-912-vertx-stream-leak` | hold until fixed & PR'd (status `in-progress`) |
+| `issue-907-maintenance-signal` | fork-awareness | issue 907 | `upstream-backlink.sh --template fork-awareness issue-907-maintenance-signal` | ready now (highest-value awareness post) |
+
+Recommended first posts once you choose to go live: **#859** (concrete fix,
+PR #57) and **#907** (the maintenance question - answer it by pointing at the
+fork). The carried-PR notes (#893/#905) are courteous but lower urgency.
+
+## After posting
+
+1. Paste the printed `forwarded:` snippet into the matching entry in
+   `upstream-map.yaml` (url + date). This is also what makes future runs skip the
+   target (idempotency), so it is not optional book-keeping.
+2. Bump the entry's `upstream.last_checked` if you re-checked state while there.
+
+## Anti-spam guarantees (backlink helper)
+
+`scripts/upstream-backlink.sh` is built so it cannot nag upstream:
+
+- **Dry-run by default** — posts nothing without `--post`, which also prompts.
+- **Idempotent** — skips any target already recorded in a manifest `forwarded`
+  url (from `scripts/upstream-map.py posted-refs`), so re-running never
+  double-posts. The dry-run preview marks each target `[would post]` /
+  `[SKIP: already commented]`.
+- **Per-run cap** — `--max` (default 3) limits comments per invocation.
+- **Delay** — `--delay` (default 3s) between posts.
+- **Status guard** — `fix-backlink` only fires when the fix is in a PR or landed
+  (`fork.status` `pr-open` | `merged` | `released`); it refuses `none` |
+  `in-progress` | `ready` (use `--force`, or the `fork-awareness` template which
+  claims no fix). This is why #909/#912 (`in-progress`) and #857 (`ready`, no PR
+  yet) can't be announced as fixed by accident.
+
+One comment per item, plain cross-repo reference, never `Fixes/Closes`.
+
+- **Tailored wording in the source of truth** — for items where the generic
+  template is too blunt, set a per-entry `backlink:` field in `upstream-map.yaml`
+  (supports `{{FORK_REPO}}` / `{{FORK_REF}}` / `{{SUMMARY}}` / `{{ID}}`). The helper
+  renders the comment from that field instead of the template, so the public
+  explanation lives in one place. `bug-859-pcmetrics-leak` uses this to explain
+  the two-cause leak and how our fix complements the already-merged #892.
+
+## Built: "new activity since last sweep" checker
+
+`scripts/upstream-sweep.sh` — **read-only by default**. It reads `last_swept`
+from the manifest and:
+
+- lists upstream issues **and** PRs updated since then
+  (`gh {issue,pr} list --state all --search "updated:>=<since> sort:updated-desc"`),
+  formatted via `gh --jq`;
+- re-checks every primary ref the manifest tracks
+  (`scripts/upstream-map.py tracked`) and flags **drift** — anything recorded
+  `open` that upstream now reports `closed`/`merged`;
+- prints a Markdown report. `--since <date>` overrides the window;
+  `--update-swept` prints the `last_swept` bump to apply.
+
+Anti-spam on the sweep side: it posts nothing unless `--publish` is passed, and
+even then it updates a **single** fork tracking issue (found by title) rather
+than creating new issues each run.
+
+Deferred (thin wrapper left to add): a scheduled GitHub Action that runs
+`upstream-sweep.sh --publish` weekly. No off-the-shelf bot does fork↔upstream
+issue-state tracking; the fork-sync Actions only sync code.
+
+### Triage from the first live sweep (2026-07-28)
+
+The first read-only run surfaced upstream items not yet in the manifest — fold
+these in when convenient:
+
+- **#892 (MERGED)** "Keep instantiated OffsetMapCodecManager … #859" — an
+  *upstream* fix for #859 landed; reconcile with our `bug-859-pcmetrics-leak`
+  entry (upstream may no longer be `open` for this).
+- **#917** kafka-clients 3.9.2 [SECURITY] — new; add to the security-batch entry.
+- **#918 / #919** log-noise trims (#919 "fixes #640") — new; relate to the
+  logging-cleanup opportunity.
+- **#920** "document JDK 17 build requirement / Jabel Java 8 bytecode" — relates
+  to `java-17-baseline-kafka4`.
+- **#902** "Always process the freshest record when ordered by key" — new issue.
+- **#921 / #922 (MERGED)** README maintenance notice / "Add link to fork" —
+  fork-awareness already partly present upstream; check before re-posting.

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -1,0 +1,501 @@
+# =============================================================================
+# upstream-map.yaml  --  fork <-> upstream tracking cache (SOURCE OF TRUTH)
+# =============================================================================
+#
+# WHY THIS FILE EXISTS
+#   This repo is a long-lived hard fork (bz.stub.parallelconsumer) of the
+#   effectively-archived confluentinc/parallel-consumer. Upstream's open issues
+#   and PRs are a backlog worth mining, but the fork<->upstream mapping kept
+#   being re-derived by hand every session. This file caches that mapping ONCE,
+#   in machine-readable form, so it can be queried, diffed and staleness-checked
+#   instead of rediscovered.
+#
+#   This file holds the FACTS (which fork branch/PR <-> which upstream issue/PR
+#   <-> status <-> work group). The editorial judgement (rankings, verdicts,
+#   recommended merge order) stays in `upstream-pr-analysis.adoc`; entries here
+#   link back to it via `adoc_anchor`.
+#
+# HOW TO KEEP IT FRESH
+#   Upstream is archived, so tracked PRs rarely change state -- but NEW issues,
+#   PRs and comments still arrive from users unaware a maintained fork exists.
+#   - `last_swept` = the date we last checked upstream for *new* activity.
+#   - Per-entry `upstream.last_checked` = when that entry's state was verified.
+#   Refresh with a read-only `gh` sweep (see scripts/ and upstream-backlink-plan.md).
+#   Design inspired by Debian DEP-3, Yocto `Upstream-Status:`, and OpenShift's
+#   `UPSTREAM:` fork convention.
+#
+# ENTRY SCHEMA
+#   id            stable kebab-case key (never reuse/rename once referenced)
+#   group         work group (rebalance-stability, metrics-observability,
+#                 vertx, java-baseline-kafka4, features, deps-security,
+#                 deps-major, deps-routine, build-tooling, logging-ux, release,
+#                 governance)
+#   summary       one line
+#   fork:
+#     branches    local branch names carrying the work (may be [])
+#     prs         fork PR numbers on `fork_repo` (astubbs/parallel-consumer)
+#     status      lifecycle of OUR work -- does NOT imply landed unless merged/released:
+#                   none         upstream item we track but haven't started
+#                   in-progress  actively being worked, not complete
+#                   ready        fix complete on a branch, no fork PR yet
+#                   pr-open      fix complete in an OPEN fork PR, awaiting merge
+#                   merged       landed on fork master
+#                   released     shipped in a published fork release
+#                   superseded | wontfix
+#   upstream:
+#     repo        usually the top-level `upstream_repo`
+#     issues      upstream issue numbers this work primarily addresses
+#     prs         upstream PR numbers this work primarily maps to / carries
+#     related     other upstream issues/PRs that are linked but not primary
+#     status      last-known upstream state (open | closed | merged | mixed)
+#     last_checked  ISO date the above was verified
+#   forwarded     backlink comments we've posted upstream (see backlink plan);
+#                 list of {url, posted} -- null until we actually post
+#   adoc_anchor   anchor id in upstream-pr-analysis.adoc for the verdict/prose
+#   reconciliation  OPTIONAL {status, last_checked, note} -- open questions about
+#                 how our work relates to an upstream change (e.g. an upstream PR
+#                 that merged a partial/alternative fix). Keeps the open thread
+#                 tracked instead of lost. `status: open` = still to resolve.
+#   notes         free text (internal; may be scratch/TODO phrasing)
+#   backlink      OPTIONAL public-facing comment body for upstream-backlink.sh.
+#                 When set it overrides the generic template, so a tailored public
+#                 explanation lives HERE (the source of truth), not in a separate
+#                 file. Supports {{FORK_REPO}} {{FORK_REF}} {{SUMMARY}} {{ID}}.
+#   todo          OPTIONAL list of outstanding actions (e.g. merge the open PR,
+#                 post the backlink). Present only while work remains; clear it
+#                 (and advance `status`) once done. `upstream-map.py todo` lists them.
+#
+# STATE NOTE (verified in the 2026-07-28 sweep): upstream #541 is now CLOSED,
+# PR #548 is CLOSED, and PR #866 is "Kafka to v4" (the .adoc's "v7" was stale).
+# =============================================================================
+
+last_swept: 2026-07-28
+upstream_repo: confluentinc/parallel-consumer
+fork_repo: astubbs/parallel-consumer
+
+entries:
+
+  # ---------------------------------------------------------------------------
+  # ACTIVE FORK WORK  (full entries)
+  # ---------------------------------------------------------------------------
+
+  - id: bug-857-stall-after-rebalance
+    group: rebalance-stability
+    summary: Silent stall after rebalance (commitCommand synchronized deadlock)
+    fork:
+      branches: [bugs/857-paused-consumption-multi-consumers-bug]
+      prs: []
+      status: ready
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: [857]
+      prs: [548]
+      related: [326, 541, 546, 777, 843, 803, 809, 833]
+      status: open
+      last_checked: 2026-07-28
+    forwarded:
+      - url: null
+        posted: null
+    adoc_anchor: part3-cat1-stability
+    todo:
+      - "Open a fork PR for the fix (currently branch-only, no PR)"
+      - "Post the upstream backlink to #857 once PR'd"
+    notes: >
+      Root cause: synchronized(commitCommand) deadlock between poll thread
+      (onPartitionsRevoked) and control thread (commitOffsetsThatAreReady);
+      fixed with ReentrantLock.tryLock(). Chaos test ~20%->~80%. Upstream PR
+      #548 addressed the same deadlock but is CLOSED (unmerged). Related issue
+      #541 now CLOSED. User weighing a larger poll+control single-thread
+      refactor to kill this bug class. Re-verify branch state before relying.
+
+  - id: bug-859-pcmetrics-leak
+    group: metrics-observability
+    summary: PCMetrics memory leak -- registeredMeters (List) accumulated duplicate Meter.Id (fix - List to Set)
+    fork:
+      branches: [fix/859-metrics-leak-plus-cherrypicks, bugs/859-pcmetrics-leak-v2]
+      prs: [57]
+      status: pr-open
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: [859]
+      prs: [892]
+      related: [27, 71, 905]
+      status: mixed
+      last_checked: 2026-07-28
+    forwarded:
+      - url: null
+        posted: null
+    adoc_anchor: part3-cat3-observability
+    todo:
+      - "Merge fork PR #57 (open) to land the fix on master"
+      - "Post the upstream backlink to #859 (forwarded still null)"
+    reconciliation:
+      status: resolved
+      last_checked: 2026-07-28
+      note: >
+        RESOLVED (2026-07-28, investigated the merged diff + fork tree). #892
+        (priesus, MERGED 2025-10-27) hoists OffsetMapCodecManager to a single `om`
+        field on PartitionState, created once in the ctor instead of `new` every
+        commit. That change is ALREADY IN THE FORK -- on master
+        (PartitionState.java ~L175 field, ~L199 ctor init) and therefore in PR
+        #57's base. NO CONFLICT: our #859 fix is complementary and layered on top
+        -- it USES #892's `om` field, and separately fixes the real leak source in
+        PCMetrics.java (registeredMeters List -> LinkedHashSet to stop duplicate
+        Meter.Id accumulation, + a synchronized removal that also prunes the
+        tracking set). #892 cuts the churn; our fix stops the collection growing.
+        BUILD-BREAK question: the fork's green, snapshot-published master carries
+        #892, so the author's 2025-10-28 "broke master build" was the
+        io.stubbs.truth dependency-availability issue (astubbs, 2026-04-14), not a
+        code regression. Remaining gap is UPSTREAM-ONLY: upstream merged just #892,
+        not our tracking-collection fix, so upstream #859 stays open (status
+        mixed); downstream it is fixed by #892 + PR #57 together.
+    notes: >
+      Commit-driven leak: registeredMeters (an ArrayList) accumulated a duplicate
+      Meter.Id on every registration (every commit), even for identical tags --
+      96% of heap after days. Fork PR #57 fixes it two ways: PCMetrics
+      List -> LinkedHashSet + prune on removal (the reporter's own suggested fix),
+      and PartitionStateManager caches the OffsetMapCodecManager instead of a
+      throwaway per assignment (also closes #233). Touches PCMetrics.java,
+      PartitionStateManager.java; regression test PCMetricsTest859.java + P1
+      hardening. PR #57 also bundles cherry-picks #893 (PartitionState offset
+      accuracy) and #905 (max-shard metric) -- those are NOT part of the leak fix.
+      Supersedes closed fork PR #45. Upstream #892 already fixed the per-commit
+      OffsetMapCodecManager churn (see reconciliation).
+    backlink: |
+      Cross-posting for anyone tracking this leak. The root cause is that `PCMetrics.registeredMeters` was a `List` that accumulated a duplicate `Meter.Id` on every registration (frequent - e.g. every offset commit), even for identical tags, so it grew without bound.
+
+      #892 (merged here) reduced one source of that churn - it stopped `OffsetMapCodecManager` being re-instantiated every commit - but the tracking `List` itself still grew.
+
+      A maintained community fork fixes the root cause (`List` -> `LinkedHashSet`, plus a synchronized removal that prunes the set) and also caches the `OffsetMapCodecManager` on the partition-assignment path: {{FORK_REF}} at https://github.com/{{FORK_REPO}}.
+
+      Posting for discoverability - a reference, not a request to close anything.
+
+  - id: cherry-pick-893-offset-reset
+    group: rebalance-stability
+    summary: Accurate committed offset on partition assignment (carried upstream PR)
+    fork:
+      branches: [cherry-pick/893-offset-reset, upstream-pr-893]
+      prs: [57]
+      status: pr-open
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: []
+      prs: [893]
+      related: [777, 809, 833]
+      status: open
+      last_checked: 2026-07-28
+    forwarded:
+      - url: null
+        posted: null
+    adoc_anchor: part1-group-a-correctness
+    notes: >
+      Cherry-pick of upstream contributor PR #893 (Martyn Ye) -- fixes offset
+      reset / data-loss risk on rebalance. Approved upstream, still OPEN
+      (unmerged). Carried downstream, bundled into fork PR #57.
+      Applied-Upstream: no (this IS the upstream PR, just not merged there).
+
+  - id: cherry-pick-905-max-shard-metric
+    group: metrics-observability
+    summary: Max-queued-records-per-shard metric (carried upstream PR)
+    fork:
+      branches: [cherry-pick/905-max-shard-metric, upstream-pr-905]
+      prs: [57]
+      status: pr-open
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: []
+      prs: [905]
+      related: [71, 859]
+      status: open
+      last_checked: 2026-07-28
+    forwarded:
+      - url: null
+        posted: null
+    adoc_anchor: part1-group-b-features
+    notes: >
+      Cherry-pick of upstream contributor PR #905 (flashmouse). Small,
+      self-contained; helps diagnose hot-key shards with orderType.KEY.
+      Carried downstream, bundled into fork PR #57.
+
+  - id: fix-909-stale-container
+    group: rebalance-stability
+    summary: Replace stale work container on rebalance (regression test + carry)
+    fork:
+      branches: [fix/909-stale-container-replacement, pr-909-temp]
+      prs: []
+      status: in-progress
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: []
+      prs: [909]
+      related: [843, 777]
+      status: open
+      last_checked: 2026-07-28
+    forwarded:
+      - url: null
+        posted: null
+    adoc_anchor: part1-group-a-correctness
+    notes: >
+      Upstream PR #909 (cserspring) replaces stale containers rather than
+      rejecting new ones, preventing record drops on rebalance. Upstream PR had
+      no tests; fork work adds a regression test for stale container at the same
+      offset. High priority but wants tests before merge.
+
+  - id: bug-912-vertx-stream-leak
+    group: vertx
+    summary: Memory leak in JStreamVertxParallelStreamProcessor
+    fork:
+      branches: [bugs/912-vertx-stream-memory-leak]
+      prs: []
+      status: in-progress
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: [912]
+      prs: []
+      related: []
+      status: open
+      last_checked: 2026-07-28
+    forwarded:
+      - url: null
+        posted: null
+    adoc_anchor: part3-cat10-vertx
+    notes: Clear the JStream deque on close.
+
+  - id: java-17-baseline-kafka4
+    group: java-baseline-kafka4
+    summary: Java baseline bump + Kafka 4 support (0.7.x)
+    fork:
+      branches: [feat/java-17-baseline]
+      prs: [53]
+      status: in-progress
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: [862]
+      prs: [866, 920]
+      related: [907, 906]
+      status: open
+      last_checked: 2026-07-28
+    forwarded:
+      - url: null
+        posted: null
+    adoc_anchor: part3-cat5-jdk
+    notes: >
+      0.7.x line. The only reason to move off Java 8 is Kafka 4 (kafka-clients
+      4.x require Java 11 -- target baseline Java 11). PR #53 is a DRAFT holding
+      a provisional Jabel-removed / release=17 state plus Kafka 4 research docs.
+      Addresses upstream #862 (cannot run on Java 24). Upstream PR #866 bumps
+      Kafka to v4 (NOTE: .adoc previously said v7 -- stale). Upstream PR #920
+      (found by the 2026-07-28 sweep) documents the JDK 17 build requirement +
+      Jabel Java 8 bytecode -- overlaps our Java-baseline framing; compare before
+      landing our own.
+
+  - id: rebrand-0.6.0.0-release
+    group: release
+    summary: First fork release -- rebrand to bz.stub.parallelconsumer (Java 8)
+    fork:
+      branches: [master, release/0.6.0.0]
+      prs: []
+      status: in-progress
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: []
+      prs: []
+      related: [907, 906]
+      status: open
+      last_checked: 2026-07-28
+    forwarded:
+      - url: null
+        posted: null
+    adoc_anchor: null
+    notes: >
+      Fork-only work (no upstream counterpart). Rebrand already on master,
+      Java 8, Jabel intact, snapshot-published. Release = strip -SNAPSHOT ->
+      0.6.0.0. Shipping a maintained release is the concrete answer to upstream
+      #907 ("is the project still maintained?") and #906 (pom version mismatch).
+
+  # ---------------------------------------------------------------------------
+  # UPSTREAM BACKLOG -- OPEN PRs we may cherry-pick  (light tracked entries)
+  # (893 / 905 / 909 already have full entries above)
+  # ---------------------------------------------------------------------------
+
+  - id: upstream-pr-915-batch-strategy
+    group: features
+    summary: Select batch construction strategy (closes upstream #266)
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [266], prs: [915], related: [551, 560], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part1-group-b-features
+    notes: Most valuable user-facing feature in the queue; needs architectural review.
+
+  - id: upstream-pr-908-virtual-threads
+    group: features
+    summary: Support Virtual Threads (JDK 21+); synchronized -> ReentrantLock
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [896, 862, 78], prs: [908], related: [299], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part1-group-b-features
+    notes: Sequence behind the Java baseline branch; ReentrantLock migration may also help #862.
+
+  - id: upstream-pr-866-kafka-v4
+    group: deps-major
+    summary: "BREAKING: update Kafka to v4"
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [], prs: [866], related: [], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part1-group-c-major-deps
+    notes: Ties into java-17-baseline-kafka4. Title is v4 (the .adoc's "v7" was stale).
+
+  - id: upstream-pr-867-vertx-v5
+    group: deps-major
+    summary: "BREAKING: update vertx to v5"
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [], prs: [867], related: [897], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part1-group-c-major-deps
+    notes: Duplicate PR #897 (vertx 4.5.7->5.0.5) should be closed in favour of this.
+
+  - id: upstream-pr-901-licence-check
+    group: build-tooling
+    summary: Fix failing licence check + gitignore (unblocks CI)
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [861], prs: [901], related: [], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part1-group-e-housekeeping
+    notes: Prerequisite/unblocker -- promote to Group A priority.
+
+  - id: upstream-pr-security-batch
+    group: deps-security
+    summary: Security CVE dependency bumps (kafka-clients, postgresql, assertj, logback)
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [], prs: [917, 851, 913, 914], related: [], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part1-group-d-security
+    notes: >
+      #917 kafka-clients 3.9.2 (runtime, SECURITY -- found by the 2026-07-28 sweep),
+      #851 postgresql 42.7.11 (runtime, medium), #913 assertj 3.27.7 (test, low),
+      #914 logback 1.5.34 (runtime logging, medium). Merge as one batch once green.
+
+  - id: upstream-pr-dep-bumps
+    group: deps-routine
+    summary: Routine / test dependency bumps
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [], prs: [855, 899, 900, 897, 869, 898, 854, 877], related: [], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part1-group-e-housekeeping
+    notes: >
+      #855 wiremock v3 (test), #899 junit-platform 6.0.0 (likely-wrong target,
+      close/pin), #900 testcontainers, #897 vertx dup of #867, #869 threeten,
+      #898 maven-gpg-plugin, #854 renovate batch, #877 service-bot config.
+
+  # ---------------------------------------------------------------------------
+  # UPSTREAM ISSUES -- high-value opportunities not primary above
+  # (light tracked entries; long tail deferred -- see note at end)
+  # ---------------------------------------------------------------------------
+
+  - id: issue-803-txn-commit-lock-timeout
+    group: rebalance-stability
+    summary: Transactional Producer timeout getting commit lock (only verified bug)
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [803], prs: [], related: [809, 833], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part3-cat1-stability
+    notes: The only issue labelled "verified bug" in the tracker. #809/#833 likely related.
+
+  - id: issue-777-843-rebalance-duplicates
+    group: rebalance-stability
+    summary: Partition revocation / multi-thread pickup causing duplicate processing
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [777, 843], prs: [], related: [893, 909], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part3-cat2-correctness
+    notes: Merging/carrying PR #893 + #909 likely resolves these; verify after cherry-pick.
+
+  - id: issue-71-27-observability
+    group: metrics-observability
+    summary: Health-checks (#71) + Micrometer metrics (#27), open 5+ years
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [71, 27], prs: [], related: [905, 464], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part3-cat3-observability
+    notes: astubbs closed PR #464 was the intended full fix; #905 adds one metric only.
+
+  - id: issue-310-dlq
+    group: features
+    summary: Dead letter queue implementation (most demanded feature)
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [310, 196], prs: [], related: [366, 291], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part3-cat4-dlq
+    notes: Revive astubbs closed PR #366 (DLQ) + #291 (terminal/retry exceptions) as a pair.
+
+  - id: issue-186-thread-safe-apis
+    group: features
+    summary: Ensure all PC APIs are thread safe (blocker for 1.0)
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [186, 520], prs: [], related: [346], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part3-cat5-jdk
+    notes: Labelled blocker/ver:1.0. astubbs closed PR #346 was the intended fix.
+
+  - id: issue-162-861-906-build-friction
+    group: build-tooling
+    summary: Contributor-friction build/CI issues
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [162, 861, 906], prs: [], related: [901], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part3-cat11-build
+    notes: >
+      #162 mvn compile needs test-jar, #861 ManagedTruth.assertThat not found
+      (PR #901), #906 pom version mismatch. Fix early to unblock contributors.
+
+  - id: issue-907-maintenance-signal
+    group: governance
+    summary: "Is the project still actively maintained?"
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [907], prs: [], related: [906, 921, 922], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: part3-cat13-governance
+    notes: >
+      Community distress signal (filed Jan 2026). Prime target for a
+      fork-awareness backlink comment: point users to the maintained fork.
+      NOTE: fork-awareness is already PARTLY upstream -- PRs #921 (README
+      maintenance notice) and #922 (add link to fork) merged 2026-05. Check the
+      existing upstream text before posting again so we don't duplicate it.
+
+  # ---------------------------------------------------------------------------
+  # FOUND BY THE 2026-07-28 ACTIVITY SWEEP (new upstream activity)
+  # ---------------------------------------------------------------------------
+
+  - id: upstream-pr-log-noise
+    group: logging-ux
+    summary: Trim noisy user-function / RemovedPartitionState logging
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [640], prs: [918, 919], related: [629, 631], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: null
+    notes: >
+      Found by the 2026-07-28 sweep. #919 trims the user-function error log / moves
+      full PollContext to DEBUG (fixes #640); #918 trims noisy WARN in
+      RemovedPartitionState to topic-partition + size + epoch. Low-effort log
+      cleanup; pairs with upstream issues #629/#631 (adoc Part 3 category 8).
+
+  - id: issue-902-freshest-record-key-order
+    group: features
+    summary: Always process the freshest record when ordered by key
+    fork: {branches: [], prs: [], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [902], prs: [], related: [], status: open, last_checked: 2026-07-28}
+    forwarded: [{url: null, posted: null}]
+    adoc_anchor: null
+    notes: New issue found by the 2026-07-28 sweep (filed Jan 2026). KEY-ordering enhancement request.
+
+# =============================================================================
+# DEFERRED / NOT YET CACHED (logged deliberately -- not silently dropped):
+#   - The long tail of upstream issues from `upstream-pr-analysis.adoc` Part 3
+#     not represented above (categories 6-12 detail: e.g. #551 #560 #304 #391
+#     #192 #299 #314 #321 #322 #394 #718 #782 #622 #115 #171
+#     #178 #642 #170 #180 #480 #860 #103 #130 #259 #290 #526 #200 #233 #241
+#     #109 and the 8 "Not Planned" issues). These live in the .adoc with full
+#     verdicts; promote to entries here when work actually starts on them.
+#   - astubbs's 53 closed revival-candidate PRs (Part 2 of the .adoc) -- kept as
+#     an idea bank in the .adoc; add entries here only when revived.
+# =============================================================================

--- a/src/docs/development/upstream-pr-analysis.adoc
+++ b/src/docs/development/upstream-pr-analysis.adoc
@@ -5,9 +5,29 @@
 
 toc::[]
 
+[NOTE]
+====
+*This document holds editorial judgement, not the current facts.* The rankings,
+group verdicts and recommended merge order below are the durable value here.
+
+The *machine-readable source of truth* for the volatile facts -- which fork
+branch/PR maps to which upstream issue/PR, and each item's current
+open/closed/merged status -- lives in
+link:upstream-map.yaml[`upstream-map.yaml`] (kept fresh by a read-only `gh`
+sweep). *When this prose and the manifest disagree, the manifest wins for
+facts.* Entries there link back to the section anchors in this document.
+
+Counts and version pins below are a snapshot from *early-to-mid 2026* and drift;
+treat them as illustrative, not current.
+====
+
 == Part 1: Open Upstream PRs (confluentinc/parallel-consumer)
 
-The upstream repository has accumulated *19 open PRs* (565 closed). The repo appears sparsely maintained -- some PRs from early 2025 remain unreviewed. The local fork (`astubbs/parallel-consumer`) is pinned to Kafka 3.1.0, JUnit 5.8.2, with a Java 17 WIP branch in progress.
+The upstream repository had accumulated *~19 open PRs* (repo effectively archived;
+some PRs from early 2025 remain unreviewed). The local fork
+(`astubbs/parallel-consumer`) tracks Kafka 3.9.1, with a Java baseline + Kafka 4
+effort in progress on `feat/java-17-baseline` (see `upstream-map.yaml` entry
+`java-17-baseline-kafka4`).
 
 === Summary Table (19 PRs, most to least important)
 
@@ -20,7 +40,7 @@ The upstream repository has accumulated *19 open PRs* (565 closed). The repo app
 |3 |#915 |Feature: select batch construction strategy |Feature (closes #266) |Unlocks throughput & ordering flexibility
 |4 |#908 |Feature: Support Virtual Threads (JDK 21+) |Feature (closes #896) |Major platform modernisation
 |5 |#905 |Metric: max queued records per shard |Observability |Diagnose hot-key bottlenecks
-|6 |#866 |Update Kafka to v7 (BREAKING) |Major dep bump |Keeps library on supported Kafka
+|6 |#866 |Update Kafka to v4 (BREAKING) |Major dep bump |Keeps library on supported Kafka
 |7 |#867 |Update vertx to v5 (BREAKING) |Major dep bump |Keeps vertx module alive
 |8 |#901 |Fix failing licence check + gitignore |Build/tooling |Unblocks CI
 |9 |#877 |chore: update repo by service bot |Build/tooling |Bot-maintained config
@@ -36,6 +56,7 @@ The upstream repository has accumulated *19 open PRs* (565 closed). The repo app
 |19 |#854 |renovate minor+patch batch |Dep batch |Routine
 |===
 
+[[part1-group-a-correctness]]
 === Group A -- Correctness fixes (merge first)
 
 These address real bugs observed in production and should be the highest priority to cherry-pick.
@@ -56,6 +77,7 @@ These address real bugs observed in production and should be the highest priorit
 * *Status:* No visible tests yet, no review comments. Needs more scrutiny than #893 but the root-cause analysis is compelling.
 * *Verdict:* High priority, but request tests before merging.
 
+[[part1-group-b-features]]
 === Group B -- Features (real user value)
 
 ==== #915 -- Batch construction strategy (closes #266)
@@ -84,21 +106,23 @@ These address real bugs observed in production and should be the highest priorit
 * Small, self-contained (2 commits). No review comments.
 * *Verdict:* Easy merge, good observability win.
 
+[[part1-group-c-major-deps]]
 === Group C -- Major (breaking) dependency bumps
 
 [cols="1,3,4", options="header"]
 |===
 |PR |Bump |Note
 
-|#866 |Kafka to v7 |Upstream Confluent Kafka major bump. Essential for staying current but will cascade test/API changes.
+|#866 |Kafka to v4 |Apache Kafka major bump (title reads v4; ties into the Java baseline + Kafka 4 effort). Will cascade test/API changes.
 |#867 |vertx to v5 |Breaking for the `parallel-consumer-vertx` module.
 |#897 |vertx 4.5.7 to 5.0.5 |Duplicate of #867; close one.
 |#855 |wiremock-jre8 to v3 |Test-only, blocks other test-dep updates.
 |#899 |junit platform 1.10.2 to *6.0.0* |Dependabot misread -- 6.0.0 likely incorrect. Close or pin.
 |===
 
-*Verdict:* Tackle #866 (Kafka v7) first. Consolidate #867/#897. Close #899.
+*Verdict:* Tackle #866 (Kafka v4) first. Consolidate #867/#897. Close #899.
 
+[[part1-group-d-security]]
 === Group D -- Security CVEs
 
 [cols="1,2,2,2", options="header"]
@@ -112,6 +136,7 @@ These address real bugs observed in production and should be the highest priorit
 
 *Verdict:* All renovate-generated and low-effort. Merge in a single batch once CI is green.
 
+[[part1-group-e-housekeeping]]
 === Group E -- Routine / housekeeping
 
 * *#854* -- renovate minor+patch dependency batch (trivial)
@@ -130,7 +155,7 @@ These address real bugs observed in production and should be the highest priorit
 . *Security batch:* #851, #913, #914
 . *Routine deps batch:* #854, #869, #898, #900, #877
 . *#915* -- batch strategy feature (needs architectural review)
-. *#866* -- Kafka v7 (scheduled breaking upgrade)
+. *#866* -- Kafka v4 (scheduled breaking upgrade)
 . *#908* -- Virtual Threads (after Java 17 branch lands; requires JDK 21+ CI)
 . *#867* (and close duplicate #897) -- vertx v5
 . *#855* -- wiremock v3 (after other test deps stabilise)
@@ -269,7 +294,7 @@ Reviving these pays dividends on every other revival in Groups A-C.
 
 * *#300 (Loom POC)* <-> upstream *#908 (Virtual Threads)* -- astubbs POC may offer earlier-design insight.
 * *#464 (Health check + metrics)* <-> upstream *#905 (max-queued-per-shard metric)* -- merge philosophies.
-* *#91 (Kafka upgrade)* <-> upstream *#866 (Kafka v7)* -- close #91 as obsolete.
+* *#91 (Kafka upgrade)* <-> upstream *#866 (Kafka v4)* -- close #91 as obsolete.
 * *#204 (Vertx vertical)* <-> upstream *#867 (vertx v5)* -- re-scope against v5 APIs.
 * *#237 / #345* <-> upstream *#893 / #909* (rebalance correctness) -- astubbs chaos testing would help validate upstream fixes.
 
@@ -279,6 +304,7 @@ Reviving these pays dividends on every other revival in Groups A-C.
 
 Issue #907 ("Is the project still actively maintained?") filed Jan 2026 summarises the community frustration.
 
+[[part3-cat1-stability]]
 === Category 1: Stability & timeout bugs (work on FIRST)
 
 Production-blocking issues reported by multiple users. Highest urgency.
@@ -298,6 +324,7 @@ Production-blocking issues reported by multiple users. Highest urgency.
 
 *Verdict:* #803 is the only "verified bug" in the entire tracker. Start here. #809 and #833 are likely related -- investigate together.
 
+[[part3-cat2-correctness]]
 === Category 2: Rebalance / offset correctness (data loss risk)
 
 [cols="1,4,2,1,2", options="header"]
@@ -311,6 +338,7 @@ Production-blocking issues reported by multiple users. Highest urgency.
 
 *Verdict:* Merging PR #893 and PR #909 likely resolves #777 and #843. Verify after cherry-pick.
 
+[[part3-cat3-observability]]
 === Category 3: Observability & health (most requested feature gap)
 
 [cols="1,4,2,1,1,2", options="header"]
@@ -325,6 +353,7 @@ Production-blocking issues reported by multiple users. Highest urgency.
 
 *Verdict:* #27 and #71 have been open for 5+ years. PR #464 was the intended fix; redo it. PR #905 adds one metric but doesn't close these.
 
+[[part3-cat4-dlq]]
 === Category 4: Error handling / DLQ / retry (most demanded feature)
 
 [cols="1,4,2,1,2", options="header"]
@@ -339,6 +368,7 @@ Production-blocking issues reported by multiple users. Highest urgency.
 
 *Verdict:* DLQ (#310) is the single most impactful missing feature. Revive PR #366 and PR #291 as a pair.
 
+[[part3-cat5-jdk]]
 === Category 5: Thread safety & modern JDK support
 
 [cols="1,4,2,1,1,2", options="header"]
@@ -412,6 +442,7 @@ Production-blocking issues reported by multiple users. Highest urgency.
 
 *Verdict:* #171 (Spring Boot example) is highest-impact doc. #642 (close modes) addresses real operational confusion.
 
+[[part3-cat10-vertx]]
 === Category 10: Vertx / Reactor module
 
 [cols="1,4,2,1,2", options="header"]
@@ -427,6 +458,7 @@ Production-blocking issues reported by multiple users. Highest urgency.
 
 *Verdict:* #912 (memory leak) is a production bug and highest priority in this group.
 
+[[part3-cat11-build]]
 === Category 11: Build / CI / tooling
 
 [cols="1,4,2,1,2", options="header"]
@@ -459,6 +491,7 @@ Production-blocking issues reported by multiple users. Highest urgency.
 
 *Verdict:* Internal maintainability improvements. Tackle when touching adjacent code.
 
+[[part3-cat13-governance]]
 === Category 13: Meta / project governance
 
 [cols="1,4,2,1,1", options="header"]


### PR DESCRIPTION
## Why

This is a maintained hard fork of the effectively-archived `confluentinc/parallel-consumer`. Upstream's open issues and PRs are a backlog worth mining, but every session kept re-deriving the fork↔upstream mapping by hand (burning tokens and drifting). Until now that knowledge lived only in prose (`upstream-pr-analysis.adoc`, `docs/inflight.md`) with no machine-readable cache.

This PR caches the relationship once, adopts a lightweight provenance convention, and builds (but does not fire) a mechanism to backlink fixes upstream so users - who mostly don't realise a maintained fork exists - can find them.

Approach follows established long-lived-fork practice: Debian **DEP-3**, Yocto **`Upstream-Status:`**, and OpenShift's **`UPSTREAM:`** convention - a machine-readable ledger + per-change trailers + upstream backlinks.

## What's in it (four commits)

1. **`docs: add machine-readable upstream<->fork tracking manifest`** - `src/docs/development/upstream-map.yaml` (22 entries) is the source of truth for the *facts* (fork branch/PR ↔ upstream issue/PR ↔ group ↔ status), with a `last_swept` date and a documented schema. `scripts/upstream-map.py` validates / renders a table / lists refs / shows an entry.
2. **`docs: reframe analysis + inflight onto the manifest`** - slim `upstream-pr-analysis.adoc` to editorial judgement (rankings, verdicts, merge order) pointing at the manifest for status; fix drift (Kafka `3.1.0`→`3.9.1`, `#866` `v7`→`v4`); add section anchors the manifest links to. `inflight.md` defers the durable mapping to the manifest.
3. **`chore: adopt upstream-tracking commit trailers + document the system`** - `.gitmessage` template (DEP-3 fields, commented so it adds nothing unless used) + an "Upstream tracking" section in `AGENTS.md`. Unforced, opt-in per checkout.
4. **`tooling: upstream backlink helper + templates + dry-run plan`** - `scripts/upstream-backlink.sh` (**dry-run by default**, `--post` guarded behind a confirm prompt), two templates (fix-backlink + fork-awareness), and `upstream-backlink-plan.md` (per-item dry-run + a deferred "new upstream activity since last sweep" checker design).

## Notes

- **Nothing is posted upstream.** The backlink helper is dry-run unless `--post` is passed, which also prompts. Manifest write-back after a real post is manual (the script prints the snippet to paste) to avoid mangling the file's comments.
- The read-only `gh` sweep already caught drift the prose had missed: upstream `#541` and PR `#548` are now closed, and `#866` is "Kafka **v4**" not v7.
- Docs/scripts only - no library code touched. Verified: manifest parses, every referenced fork branch exists, every `adoc_anchor` resolves, dry-run renders correctly and posts nothing.

## Try it

```
cd .claude/worktrees/upstream-tracking   # or a checkout of this branch
python3 scripts/upstream-map.py table
scripts/upstream-backlink.sh --target issues bug-859-pcmetrics-leak   # dry-run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
