### PR TITLE
docs: worktree-ownership convention + worktree-status helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .DS_Store
 CLAUDE.md
 
+# Local per-worktree ownership markers (see AGENTS.md "Worktree ownership")
+.worktree-owner
+
 # Compiled class file
 *.class
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,15 @@ Snapshots publish automatically on every push to `master`. Workflows: `prepare-r
 - `MAVEN_GPG_PRIVATE_KEY` — Armored GPG private key for signing artifacts
 - `MAVEN_GPG_PASSPHRASE` — Passphrase for the GPG key
 
+## Worktree ownership
+
+Multiple agents/sessions often work in parallel git worktrees (kept under `.claude/worktrees/`). Neither git nor the Claude UI records **which agent is using which worktree**, so this repo uses a convention:
+
+- **`.worktree-owner` marker** — each worktree holds a `.worktree-owner` file at its root describing `owner`, `status`, `branch`, `pr`, and a brief `work:` line. It is **local-only** (git-ignored via `.gitignore`, so it is never committed). When you claim, hand off, or finish a worktree, write/update this file.
+- **`bin/worktree-status.sh`** — prints every worktree with its marker fields plus live process holders (via `lsof`), giving the "who's on what" view the UI lacks. Run it before starting parallel work: `bash bin/worktree-status.sh`.
+- **Before deleting a worktree**, verify it is safe: no live `lsof` holder, no uncommitted changes, and its branch content is merged or preserved. A marker `status: merged — SAFE TO DELETE` records that verification. For stronger protection, `git worktree lock --reason "..."` makes git refuse removal.
+- The higher-level map of what each branch/worktree is for lives in `docs/inflight.md`.
+
 ## Documented Solutions
 
 `docs/solutions/` - documented solutions to past problems and workflow patterns, organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.

--- a/bin/worktree-status.sh
+++ b/bin/worktree-status.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# worktree-status — show who/what owns each git worktree.
+# Reads the local-only `.worktree-owner` marker in each worktree and cross-checks
+# live process holders via lsof. The marker convention answers the question the
+# Claude UI can't: which agent/session is working in which worktree.
+# See AGENTS.md "Worktree ownership".
+#
+# Usage: bash bin/worktree-status.sh
+set -euo pipefail
+export PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
+
+cd "$(git rev-parse --show-toplevel)"
+
+git worktree list --porcelain | awk '
+  /^worktree /{path=$2}
+  /^branch /{sub("refs/heads/","",$2); print path"\t"$2}
+  /^detached/{print path"\tdetached"}
+' | while IFS=$'\t' read -r path branch; do
+  name=$(basename "$path")
+  marker="$path/.worktree-owner"
+  if [ -f "$marker" ]; then
+    owner=$(grep -E '^owner:'  "$marker" | head -1 | cut -d: -f2- | sed 's/^ *//')
+    st=$(grep -E '^status:' "$marker" | head -1 | cut -d: -f2- | sed 's/^ *//')
+    work=$(grep -E '^work:'   "$marker" | head -1 | cut -d: -f2- | sed 's/^ *//')
+  else
+    owner="<no marker>"; st="<unmarked>"; work=""
+  fi
+  holder=$(lsof +D "$path" 2>/dev/null | awk 'NR>1{print $1}' | sort -u | paste -sd, - || true)
+  printf '\n\033[1m%s\033[0m  [%s]\n' "$name" "$branch"
+  printf '  owner:  %s\n' "$owner"
+  printf '  status: %s\n' "$st"
+  [ -n "$work" ] && printf '  work:   %s\n' "$work"
+  printf '  live:   %s\n' "${holder:-idle}"
+done


### PR DESCRIPTION
## Summary

Adds a convention so parallel agents/sessions can tell **who is working in which git worktree** — something neither git nor the Claude UI surfaces.

- **`.worktree-owner` marker** — a local-only file at each worktree root recording `owner`, `status`, `branch`, `pr`, and a brief `work:` line. Git-ignored (added to `.gitignore`), so it's coordination state, never repo content.
- **`bin/worktree-status.sh`** — prints every worktree with its marker fields plus live process holders (`lsof`) — the "who's on what" view the UI lacks. Run before starting parallel work or before deleting a worktree.
- **AGENTS.md "Worktree ownership"** — documents the convention, the pre-delete safety checks (no live `lsof` holder / merged / optional `git worktree lock`), and points at `docs/inflight.md` for the branch→work map.

## Why

While juggling several in-flight worktrees, we nearly removed one that a GUI (and separately, another agent's shell) was actively holding. This makes ownership explicit and gives a one-command safety check.

## Notes

- The markers themselves are intentionally uncommitted; only the convention, ignore rule, and helper are.
- `bin/worktree-status.sh`'s `lsof` on the main checkout is naturally noisy (it recurses into nested `.claude/worktrees/*`); per-worktree output is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
