### PR TITLE
ci: re-enable parallel test execution (experiment)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,17 @@
             <id>ci</id>
             <properties>
                 <license.mode>check</license.mode>
-                <parallel-tests>false</parallel-tests>
+                <!-- EXPERIMENT (ci/reenable-parallel-tests): parallel test execution was
+                     disabled in CI on suspicion it caused flaky tests. Re-enabling to
+                     measure current speed and reliability on GitHub-hosted runners.
+                     The tests are I/O-bound (Kafka via TestContainers) and JUnit is
+                     configured to run them concurrently (dynamic factor 20) - see
+                     parallel-consumer-core/src/test/resources/junit-platform.properties.
+                     Watch the surefire "Flaky Tests" summary in the CI logs: the
+                     integration suite reruns failures (rerunFailingTestsCount=2), so a
+                     flake reports as a Flaky Test rather than failing the build. Revert
+                     this to false if flakiness returns. -->
+                <parallel-tests>true</parallel-tests>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
## What

Flips `parallel-tests` back to `true` in the `ci` Maven profile (`pom.xml`), re-enabling JUnit's concurrent test execution in CI. One-line change + a comment.

## Why

The `ci` profile disabled parallel tests on the suspicion they caused **flaky tests**. This is an **experiment** to see, on current code and dependencies, whether that's still true - and what the speedup is.

The suites are I/O-bound (Kafka via TestContainers) and JUnit is already configured to run them concurrently (dynamic factor 20, see `parallel-consumer-core/src/test/resources/junit-platform.properties`). Off-CI (local dev) they already run parallel; only the `ci` profile forced them sequential.

## What to watch in this PR's checks

- **Speed:** compare the `Unit Tests` / `Integration Tests` / `Performance Tests` job durations here vs. a recent master run. Target was ~30%.
- **Reliability:** the integration suite reruns failures (`rerunFailingTestsCount=2`), so a flake shows as a **"Flaky Tests"** entry in the surefire summary rather than red. Green-with-flakes = mildly flaky; consistently green across a couple of re-runs = safe to keep.

## Outcome

- Fast **and** clean -> keep it (parallel CI for every PR, not just the self-hosted runner).
- Flakiness returns -> revert; the self-hosted runner path can still opt into parallelism on beefier hardware.

Not for immediate merge - it exists to generate the CI signal.