### PR TITLE
docs(release): fix 0.6.0.0 changelog + use it as the GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,27 @@ jobs:
         if: ${{ !inputs.dryRun }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "v${{ inputs.releaseVersion }}" --title "v${{ inputs.releaseVersion }}" --generate-notes
+        run: |
+          # Use our curated CHANGELOG.adoc section as the release notes (not --generate-notes). This step
+          # runs at tag vX (the deploy step already checked it out), so CHANGELOG.adoc is present. Extract
+          # the "== <releaseVersion>" AsciiDoc section, convert it to Markdown (GitHub renders Markdown:
+          # "=== Heading" -> "### Heading", AsciiDoc "https://url[text]" -> "[text](https://url)"), and pass
+          # it via --notes-file. Fall back to --generate-notes if the section is missing/empty so a release
+          # never fails for lack of notes.
+          notes="$(mktemp)"
+          awk -v h="== ${{ inputs.releaseVersion }}" '
+            $0 == h {grab=1; next}
+            /^== / && grab {exit}
+            grab && /^\/\// {next}
+            grab {print}
+          ' CHANGELOG.adoc \
+            | sed -E 's/^=== /### /; s#(https?://[^[]+)\[([^]]+)\]#[\2](\1)#g' > "$notes"
+          if [ -s "$notes" ]; then
+            gh release create "v${{ inputs.releaseVersion }}" --title "v${{ inputs.releaseVersion }}" --notes-file "$notes"
+          else
+            echo "::warning::No CHANGELOG section for ${{ inputs.releaseVersion }}; using auto-generated notes."
+            gh release create "v${{ inputs.releaseVersion }}" --title "v${{ inputs.releaseVersion }}" --generate-notes
+          fi
 
       - name: Clean release plugin state
         if: always()

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ First release of the community fork of https://github.com/confluentinc/parallel-
 
 === Improvements
 
+* The project is renamed to *Kafka Parallel Consumer* (README and branding). Java package names (`io.confluent.parallelconsumer.*`) are unchanged, so imports are unaffected — only the Maven groupId changed (see Breaking).
 * feature: new `parallel-consumer-mutiny` module — SmallRye Mutiny (Quarkus) integration (upstream https://github.com/confluentinc/parallel-consumer/pull/891[#891]).
 * Commit-failure error logging now includes the offsets being committed, to aid diagnosis of failed commits (upstream https://github.com/confluentinc/parallel-consumer/pull/850[#850]).
 * Modernized CI (parallel unit/integration/performance suites, SpotBugs, PIT mutation testing, dependency scanning) and automated Maven Central publishing (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873], https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9]).
@@ -33,12 +34,10 @@ First release of the community fork of https://github.com/confluentinc/parallel-
 === Fixes
 
 * fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered (https://github.com/astubbs/parallel-consumer/commit/afde8c5e[afde8c5e]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/326[#326])
+* fix: `OffsetMapCodecManager` is kept instantiated so PC metrics are no longer recreated on every commit (upstream https://github.com/confluentinc/parallel-consumer/pull/892[#892]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/859[#859]).
 
-== 0.5.3.4
-
-=== Fixes
-
-* fix: keep instantiated OffsetMapCodecManager so that metrics will not be recreated every commit (#859)
+// There is no 0.5.3.4 release. The #892 metrics fix once tracked under a "0.5.3.4" heading here was
+// never published upstream as 0.5.3.4; it ships in this fork's 0.6.0.0 (folded into the Fixes above).
 
 == 0.5.3.3
 

--- a/README.adoc
+++ b/README.adoc
@@ -1597,6 +1597,7 @@ First release of the community fork of https://github.com/confluentinc/parallel-
 
 === Improvements
 
+* The project is renamed to *Kafka Parallel Consumer* (README and branding). Java package names (`io.confluent.parallelconsumer.*`) are unchanged, so imports are unaffected — only the Maven groupId changed (see Breaking).
 * feature: new `parallel-consumer-mutiny` module — SmallRye Mutiny (Quarkus) integration (upstream https://github.com/confluentinc/parallel-consumer/pull/891[#891]).
 * Commit-failure error logging now includes the offsets being committed, to aid diagnosis of failed commits (upstream https://github.com/confluentinc/parallel-consumer/pull/850[#850]).
 * Modernized CI (parallel unit/integration/performance suites, SpotBugs, PIT mutation testing, dependency scanning) and automated Maven Central publishing (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873], https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9]).
@@ -1604,12 +1605,10 @@ First release of the community fork of https://github.com/confluentinc/parallel-
 === Fixes
 
 * fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered (https://github.com/astubbs/parallel-consumer/commit/afde8c5e[afde8c5e]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/326[#326])
+* fix: `OffsetMapCodecManager` is kept instantiated so PC metrics are no longer recreated on every commit (upstream https://github.com/confluentinc/parallel-consumer/pull/892[#892]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/859[#859]).
 
-== 0.5.3.4
-
-=== Fixes
-
-* fix: keep instantiated OffsetMapCodecManager so that metrics will not be recreated every commit (#859)
+// There is no 0.5.3.4 release. The #892 metrics fix once tracked under a "0.5.3.4" heading here was
+// never published upstream as 0.5.3.4; it ships in this fork's 0.6.0.0 (folded into the Fixes above).
 
 == 0.5.3.3
 


### PR DESCRIPTION
## Why

Prep for the `0.6.0.0` release. Reconciling `CHANGELOG.adoc` against the 37 commits since upstream `0.5.3.3` surfaced two release-notes problems.

## Changes

**1. Changelog accuracy**
- The PCMetrics fix (upstream #892 / #859 - "keep `OffsetMapCodecManager` instantiated so metrics aren't recreated every commit") was filed under a phantom **`0.5.3.4`** heading. But `0.5.3.4` was never tagged - we go `0.5.3.3` → `0.6.0.0` - so that user-visible fix actually ships **in 0.6.0.0**. Folded it into the `0.6.0.0` Fixes; replaced the heading with an explanatory `//` comment.
- Added a `0.6.0.0` Improvements line for the project rename to **Kafka Parallel Consumer** (branding only; Java package names unchanged, imports unaffected).
- Regenerated `README.adoc` (it `include::`s `CHANGELOG.adoc` via the template - per the "README is generated" rule).

**2. Release notes now come from the changelog**
`release.yml`'s GitHub-release step used `--generate-notes` (GitHub's auto PR list), not our curated changelog. It now extracts the `== <version>` changelog section, converts AsciiDoc → Markdown (`===` → `###`, `url[text]` → `[text](url)`), strips `//` comments, and passes `--notes-file` - with a `--generate-notes` fallback if the section is missing/empty. Version-generic, so it works for future releases too.

## Validation

Ran the exact `awk | sed` extraction locally against the edited changelog: produces clean Markdown (converted links, `###` sub-headings, stops before `0.5.3.3`, no phantom section, no raw `//` lines). README diff mirrors the changelog changes.

Everything else in the 37 commits is already covered by the `0.6.0.0` section or correctly excluded (dependency bumps per the file's policy; CI/docs/test-infra as internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6Biwo4QXfD9CFrZnCq1zw