### PR TITLE
build(deps): refresh dependencies + build plugins to latest non-major

### DIFF
--- a/bin/deps-version-rules.xml
+++ b/bin/deps-version-rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Risk-averse patch-release ruleset for versions-maven-plugin.
+     ignoreVersion type="regex" is FULL-MATCH (Pattern.matches), so each regex
+     must match the entire version string. We exclude:
+       - pre-releases: alpha / beta / milestone (-Mn) / RC / CR / snapshot / preview / EA
+       - Confluent Kafka builds (-ce / -ccs) so kafka stays on the Apache line
+     Major bumps are excluded separately via -DallowMajorUpdates=false. -->
+<ruleset comparisonMethod="maven"
+         xmlns="http://www.mojohaus.org/versions-maven-plugin/rule/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.mojohaus.org/versions-maven-plugin/rule/2.0.0 https://www.mojohaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+    <ignoreVersions>
+        <ignoreVersion type="regex">(?i).*alpha.*</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*beta.*</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*milestone.*</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*-m\d+</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*-rc\d*.*</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*-cr\d*.*</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*snapshot.*</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*preview.*</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*-ea\d*.*</ignoreVersion>
+        <ignoreVersion type="regex">.*-ce</ignoreVersion>
+        <ignoreVersion type="regex">.*-ccs</ignoreVersion>
+    </ignoreVersions>
+</ruleset>

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -155,6 +155,30 @@ and Confluent `-ce`/`-ccs` Kafka builds — without the `-ce` filter, kafka "lat
   compiler` `4.0.0-beta-*`; `maven-surefire`/`maven-failsafe` `3.6.0-M1`; `maven-site-plugin` `4.0.0-M16`
   (left at `4.0.0-M15`). Revisit once these reach GA.
 
+### SpotBugs 4.10 surfaced 11 pre-existing concurrency findings (follow-up, not this PR)
+
+The `spotbugs 4.8.6 → 4.10.3` bump in this PR expanded the multithreading (`AT_*`) detectors, so the
+`SpotBugs` PR job reports **11 "new" bugs**. They are **not introduced here** — this PR changes no
+`src/main/**/*.java`; the CI baseline was just generated with the *old* 4.8.6, so 4.10.3's new detectors
+fire on **existing** code. All are in `parallel-consumer-core`, all real-looking thread-visibility/atomicity
+observations worth a proper look as their own task (several sit in the poll/control-thread coordination
+that the **#857** single-thread refactor is already reworking — fixing piecemeal now may conflict/be moot):
+
+- **`AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE`** (8) — non-atomic read-modify-write (e.g. `count++`) on a
+  shared field:
+  - `AbstractParallelEoSStreamProcessor.numberOfAssignedPartitions` (lines 420, 448, 463)
+  - `ConsumerManager` counters `noWakeups` (143, 226), `erroneousWakups` (201, 233), `correctPollWakeups` (111)
+- **`AT_STALE_THREAD_WRITE_OF_PRIMITIVE`** (3) — primitive written in one thread may not be visible to another
+  (missing `volatile`/sync):
+  - `AbstractParallelEoSStreamProcessor.lastWorkRequestWasFulfilled` (979)
+  - `ConsumerManager.commitRequested` (287)
+  - `RetryQueue.closed` (287)
+
+**Action:** don't block this deps PR. After merge, master's push build regenerates the SpotBugs baseline
+with 4.10.3, so these drop out of "new". Track the actual fixes (make the counters `AtomicInteger`/`Atomic
+Long`, mark the flags `volatile`, or fold into the #857 threading rework) as a follow-up. Note `ConsumerManager
+.erroneousWakups` is also a pre-existing typo ("Wakups") worth fixing while there.
+
 ## CI reliability / gate issues (follow-up work)
 
 Surfaced while diagnosing PR #56 (docs-only) showing 4 red checks. **None were caused by the docs** —

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -128,13 +128,20 @@ and Confluent `-ce`/`-ccs` Kafka builds — without the `-ce` filter, kafka "lat
 - **kafka-clients / kafka-streams / kafka-streams-test-utils** `3.9.1 → 4.3.1` — Apache Kafka 4;
   requires the Java 11 baseline. Already tracked above under **0.7.x — Java baseline + Kafka 4** (Unit 2).
 - **junit-jupiter** `5.14.4 → 6.1.2` + **junit-platform** `1.14.4 → 6.1.2` — JUnit 6 requires Java 17;
-  blocked by the same Java-baseline move. Do it with the Kafka 4 / Java-baseline work.
+  blocked by the same Java-baseline move. Do it with the Kafka 4 / Java-baseline work. **Second blocker:**
+  `archunit-junit5` will not run on JUnit 6 and there is no `archunit-junit6` engine yet (TNG/ArchUnit
+  [#1556](https://github.com/TNG/ArchUnit/issues/1556)) — the ArchUnit tests must be migrated/re-wired
+  before the JUnit 6 bump can land.
 - **org.testcontainers:testcontainers** `1.21.4 → 2.0.5` — Testcontainers 2.x (core artifact only; the
   `kafka`/`postgresql`/`junit-jupiter` TC modules already moved to 1.21.4 in this pass).
 - **io.vertx** vertx-junit5 / vertx-web-client `4.5.31 → 5.1.5` — Vert.x 5.
 - **io.smallrye.reactive:mutiny** `2.9.5 → 3.3.0` — Mutiny 3.
 - **com.github.tomakehurst:wiremock-jre8** `2.35.2 → 3.0.1` — WireMock 3 (artifact renamed to
-  `org.wiremock:wiremock`; test-only).
+  `org.wiremock:wiremock`; test-only). **Side effect while it stays on 2.x:** wiremock-jre8 2.35.2 drags
+  in an ancient `net.bytebuddy:byte-buddy 1.12.18` that wins the version conflict and lacks the `JAVA_V21`
+  field mockito 5.23 needs (`MockitoInitializationException` → every Mockito unit test errors). Worked
+  around by pinning `byte-buddy`/`byte-buddy-agent` to `1.17.7` (mockito's version) in
+  `dependencyManagement` (`byte-buddy.version` property). **Remove that pin when wiremock moves to 3.x.**
 
 **Micrometer family — source-incompatible, held back even though it's NOT a major:**
 - **micrometer-core** (`1.13.0`) + **micrometer-registry-prometheus** (`1.12.2`) → latest `1.17.x`.

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -114,6 +114,40 @@ the sequenced items after #57 lands. (Backlog source: `src/docs/development/upst
 - **#915 batch construction strategy** (cherry-pick upstream, closes 4-yr issue #266) — medium effort.
 - **DLQ** (#310 / revive #366) — most-demanded missing feature; large, idea-bank spec not a live branch.
 
+## Deferred dependency upgrades (branch `deps/cap-non-major-upgrades`, 2026-07-29)
+
+Ahead of the 0.6.0.0 patch release we bumped **every dependency + build plugin to its newest
+*non-major* version** and deliberately capped anything whose only newer release is a major (fork /
+patch-release risk aversion). Enforced with `versions-maven-plugin` `-DallowMajorUpdates=false` plus a
+ruleset (`bin/deps-version-rules.xml`) that also ignores pre-releases (alpha/beta/`-Mn`/RC/snapshot)
+and Confluent `-ce`/`-ccs` Kafka builds — without the `-ce` filter, kafka "latest" mis-resolves to
+`8.3.0-ce` (a Confluent build), not Apache. Build is green (`mvn -Dlicense.skip -DskipTests verify`, all
+11 modules). **The following were intentionally NOT taken and still need updating later:**
+
+**Majors — need a deliberate migration (not for a patch release):**
+- **kafka-clients / kafka-streams / kafka-streams-test-utils** `3.9.1 → 4.3.1` — Apache Kafka 4;
+  requires the Java 11 baseline. Already tracked above under **0.7.x — Java baseline + Kafka 4** (Unit 2).
+- **junit-jupiter** `5.14.4 → 6.1.2` + **junit-platform** `1.14.4 → 6.1.2` — JUnit 6 requires Java 17;
+  blocked by the same Java-baseline move. Do it with the Kafka 4 / Java-baseline work.
+- **org.testcontainers:testcontainers** `1.21.4 → 2.0.5` — Testcontainers 2.x (core artifact only; the
+  `kafka`/`postgresql`/`junit-jupiter` TC modules already moved to 1.21.4 in this pass).
+- **io.vertx** vertx-junit5 / vertx-web-client `4.5.31 → 5.1.5` — Vert.x 5.
+- **io.smallrye.reactive:mutiny** `2.9.5 → 3.3.0` — Mutiny 3.
+- **com.github.tomakehurst:wiremock-jre8** `2.35.2 → 3.0.1` — WireMock 3 (artifact renamed to
+  `org.wiremock:wiremock`; test-only).
+
+**Micrometer family — source-incompatible, held back even though it's NOT a major:**
+- **micrometer-core** (`1.13.0`) + **micrometer-registry-prometheus** (`1.12.2`) → latest `1.17.x`.
+  Micrometer 1.13 renamed the Prometheus registry package `io.micrometer.prometheus` →
+  `io.micrometer.prometheusmetrics` (and reworked the artifact), so `example-metrics/CoreApp.java` fails
+  to compile against 1.17. Both are pinned with in-pom comments. **To upgrade:** migrate the `CoreApp`
+  imports + registry construction, then bump the whole micrometer family together (keep the two aligned).
+
+**Build plugins — only pre-releases available, held by the risk policy:**
+- Maven-4-era plugins offered only as betas/milestones: `maven-clean/deploy/install/jar/resources/source/
+  compiler` `4.0.0-beta-*`; `maven-surefire`/`maven-failsafe` `3.6.0-M1`; `maven-site-plugin` `4.0.0-M16`
+  (left at `4.0.0-M15`). Revisit once these reach GA.
+
 ## CI reliability / gate issues (follow-up work)
 
 Surfaced while diagnosing PR #56 (docs-only) showing 4 red checks. **None were caused by the docs** —

--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -26,13 +26,13 @@
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.5.5-4</version>
+            <version>1.5.7-12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.10.5</version>
+            <version>1.1.10.8</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.12</version>
+            <version>42.7.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.threeten</groupId>
             <artifactId>threeten-extra</artifactId>
-            <version>1.7.2</version>
+            <version>1.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>uk.co.jemos.podam</groupId>
             <artifactId>podam</artifactId>
-            <version>8.0.1.RELEASE</version>
+            <version>8.0.2.RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -26,6 +26,10 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+            <!-- Pinned to 1.12.x: micrometer 1.13+ renamed the registry package
+                 io.micrometer.prometheus -> io.micrometer.prometheusmetrics, which breaks
+                 CoreApp.java. Bump together with micrometer-core when migrating that import.
+                 See docs/inflight.md "Deferred dependency upgrades". -->
             <version>1.12.2</version>
         </dependency>
         <!-- end::exampleDep[] -->

--- a/parallel-consumer-mutiny/pom.xml
+++ b/parallel-consumer-mutiny/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
-            <version>2.9.4</version>
+            <version>2.9.5</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/parallel-consumer-reactor/pom.xml
+++ b/parallel-consumer-reactor/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.6.2</version>
+            <version>3.8.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -17,7 +17,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <vertx.version>4.5.7</vertx.version>
+        <vertx.version>4.5.31</vertx.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -89,17 +89,17 @@
 
         <!-- version numbers -->
         <!-- plugins -->
-        <mycila.version>5.0.0</mycila.version>
-        <lombok.version>1.18.28</lombok.version>
+        <mycila.version>5.1.1</mycila.version>
+        <lombok.version>1.18.46</lombok.version>
         <auto-service.version>1.1.1</auto-service.version>
-        <surefire.version>3.2.5</surefire.version>
-        <spotbugs.version>4.8.6</spotbugs.version>
-        <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
-        <pitest.version>1.17.4</pitest.version>
-        <pitest-junit5.version>1.2.2</pitest-junit5.version>
+        <surefire.version>3.5.6</surefire.version>
+        <spotbugs.version>4.10.3</spotbugs.version>
+        <spotbugs-maven-plugin.version>4.10.3.0</spotbugs-maven-plugin.version>
+        <pitest.version>1.25.8</pitest.version>
+        <pitest-junit5.version>1.2.3</pitest-junit5.version>
 
         <!-- core -->
-        <slf4j.version>2.0.13</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <kafka.version>3.9.1</kafka.version>
         <version.unij>0.1.3</version.unij>
 
@@ -107,15 +107,18 @@
         <parallel-tests>true</parallel-tests>
 
         <!-- tests deps-->
-        <junit.version>5.10.2</junit.version>
-        <junit.platform.version>1.10.2</junit.platform.version>
-        <testcontainers.version>1.19.8</testcontainers.version>
-        <truth.version>1.3.0</truth.version>
-        <flogger.version>0.8</flogger.version>
-        <mockito.version>5.12.0</mockito.version>
+        <junit.version>5.14.4</junit.version>
+        <junit.platform.version>1.14.4</junit.platform.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
+        <truth.version>1.4.5</truth.version>
+        <flogger.version>0.9</flogger.version>
+        <mockito.version>5.23.0</mockito.version>
         <truth-generator-maven-plugin.version>0.1.1</truth-generator-maven-plugin.version>
         <jabel.version>1.0.0</jabel.version>
-        <logback.version>1.6.0</logback.version>
+        <logback.version>1.6.1</logback.version>
+        <!-- Held at 1.13.0: keep the micrometer family version-aligned with
+             micrometer-registry-prometheus (pinned to 1.12.x in example-metrics until the
+             prometheus package rename is migrated). See docs/inflight.md. -->
         <micrometer-core.version>1.13.0</micrometer-core.version>
     </properties>
 
@@ -236,7 +239,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -257,7 +260,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.10.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
@@ -335,7 +338,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -384,7 +387,7 @@
         <dependency>
             <groupId>one.util</groupId>
             <artifactId>streamex</artifactId>
-            <version>0.8.2</version>
+            <version>0.9.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -430,7 +433,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.truth</groupId>
@@ -453,12 +456,12 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.2.0-jre</version>
+                <version>33.6.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>me.tongfei</groupId>
                 <artifactId>progressbar</artifactId>
-                <version>0.10.1</version>
+                <version>0.10.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -527,7 +530,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-help-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.2</version>
                 <executions>
                     <execution>
                         <id>show-profiles</id>
@@ -591,7 +594,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.3.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -676,7 +679,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.12.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <annotationProcessorPaths>
                         <path>
@@ -752,7 +755,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.11</version>
+                <version>0.8.15</version>
                 <executions>
                     <execution>
                         <goals>
@@ -813,7 +816,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -856,7 +859,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -874,7 +877,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.6.1</version>
                 <executions>
                     <!-- integration test sources -->
                     <execution>
@@ -937,7 +940,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.12.0</version>
                 <configuration>
                     <sourcepath>${delombok.output}</sourcepath>
                     <sourcepath>${delombok.output}</sourcepath>
@@ -966,7 +969,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -979,7 +982,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -993,7 +996,7 @@
                 <!-- for use in idea -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.16.2</version>
+                <version>2.21.0</version>
             </plugin>
         </plugins>
 
@@ -1018,7 +1021,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1028,12 +1031,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.11.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
         <truth.version>1.4.5</truth.version>
         <flogger.version>0.9</flogger.version>
         <mockito.version>5.23.0</mockito.version>
+        <!-- Aligns byte-buddy with what mockito 5.23 requires (it ships 1.17.7). The ancient
+             wiremock-jre8 2.35.2 otherwise drags in byte-buddy 1.12.18, which wins the conflict
+             and lacks the JAVA_V21 field mockito 5.23 needs -> MockitoInitializationException.
+             Remove this pin once wiremock 3.x (a deferred major) drops the stale transitive.
+             Test/provided scope only - not in the shipped artifact. See docs/inflight.md. -->
+        <byte-buddy.version>1.17.7</byte-buddy.version>
         <truth-generator-maven-plugin.version>0.1.1</truth-generator-maven-plugin.version>
         <jabel.version>1.0.0</jabel.version>
         <logback.version>1.6.1</logback.version>
@@ -394,6 +400,18 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Pin byte-buddy so mockito 5.23 gets the version it needs (see byte-buddy.version
+                 property); overrides the stale 1.12.18 pulled transitively by wiremock-jre8. -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-core</artifactId>
@@ -997,6 +1015,14 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>2.21.0</version>
+                <configuration>
+                    <!-- Risk-averse upgrade policy: ignore pre-releases (alpha/beta/-Mn/RC) and
+                         Confluent -ce/-ccs kafka builds. Combine with -DallowMajorUpdates=false to
+                         cap to newest non-major. Applies to display-*-updates / update-* goals. -->
+                    <!-- multiModuleProjectDirectory = reactor root (bin/ only exists there);
+                         ${project.basedir} would be wrong for child modules. -->
+                    <rulesUri>file://${maven.multiModuleProjectDirectory}/bin/deps-version-rules.xml</rulesUri>
+                </configuration>
             </plugin>
         </plugins>
 


### PR DESCRIPTION
Ahead of the **0.6.0.0** patch release, this bumps **every dependency and build plugin to its newest non-major version** and deliberately **caps every major** - risk-averse for a fork patch release. Majors are reported, not taken.

## How the cap is enforced
`versions-maven-plugin` with `-DallowMajorUpdates=false`, plus a committed ruleset (`bin/deps-version-rules.xml`) that also excludes:
- **pre-releases** - alpha / beta / `-Mn` milestone / RC / snapshot (caught `slf4j 2.1.0-alpha1`, `assertj 4.0.0-M1`, the Maven-4 `4.0.0-beta` plugin line)
- **Confluent `-ce`/`-ccs` Kafka builds** - without this, kafka's "latest" mis-resolves to `8.3.0-ce` (a Confluent build) instead of Apache

## Applied (non-major)
**Dependencies:** junit 5.10.2→5.14.4, junit-platform 1.10.2→1.14.4, mockito 5.12.0→5.23.0, truth 1.3.0→1.4.5, assertj 3.24.2→**3.27.7** (not 4.0.0-M1), testcontainers 1.19.8→1.21.4, slf4j 2.0.13→**2.0.18** (not 2.1.0-alpha1), reactor 3.6.2→3.8.6, mutiny 2.9.4→2.9.5, vertx 4.5.7→4.5.31, lombok 1.18.28→1.18.46, guava 33.2.0→33.6.0, commons-lang3 3.18.0→3.20.0, logback 1.6.0→1.6.1, postgres 42.7.12→42.7.13, plus zstd/snappy/threeten/podam/streamex/flogger/progressbar. Kafka stays at 3.9.1 (already latest 3.x).

**Build plugins:** compiler 3.12.1→3.15.0, surefire/failsafe 3.2.5→3.5.6, spotbugs 4.8.6→4.10.3, pitest 1.17.4→1.25.8, jacoco 0.8.11→0.8.15, enforcer/jar/javadoc/source/dependency/help/build-helper/install/resources/versions-plugin, and the **release-path plugins** release 3.0.1→3.3.1, gpg 3.1.0→3.2.8, central-publishing 0.10.0→0.11.0.

## Deferred (recorded in `docs/inflight.md`)
- **Majors:** kafka 4.3.1, junit 6.1.2, testcontainers-core 2.0.5, vertx 5.1.5, mutiny 3.3.0, wiremock 3.0.1 (Kafka/JUnit/Vert.x are tied to the Java-baseline move already tracked in the 0.7.x section).
- **Micrometer family** (`micrometer-core` 1.13.0 + `micrometer-registry-prometheus` 1.12.2): **verify caught a real break** - Micrometer 1.13 renamed the Prometheus registry package `io.micrometer.prometheus` → `io.micrometer.prometheusmetrics`, so 1.17 fails to compile `example-metrics/CoreApp.java`. Both reverted (family kept aligned) and pinned with in-pom comments; the migration is a follow-up.
- **Maven-4 plugins** available only as `4.0.0-beta`/`3.6.0-M1` (clean/deploy/install/jar/resources/source/compiler, surefire/failsafe, site-plugin M16) - held until GA.

## Two things worth a look
1. **Release-path plugin bumps** (release, gpg, central-publishing) go live in the very release being prepped. In scope here, but easy to revert to a follow-up if you'd rather not touch the publish path on this patch.
2. **Tests were not run** here - verification was `mvn -Dlicense.skip -DskipTests verify` (all 11 modules compile + SpotBugs pass). CI runs the full suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvzjf3ismokntun3GHZzue
