### PR TITLE
docs(changelog): record the dependency refresh + require future changelog entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,16 @@ bin/performance-test.sh
 - **`.github/workflows/publish.yml`** — Publishes to Maven Central on every push to `master`. The pom.xml version is the source of truth: `-SNAPSHOT` versions deploy as snapshots, non-snapshot versions deploy as full releases (and create a git tag + GitHub release).
 - **`.semaphore/`** — Legacy Confluent internal CI/release pipelines, retained but inactive on the fork.
 
+## Changelog
+
+`CHANGELOG.adoc` (repo root) is the source of truth for release notes; `README.adoc` regenerates from it at build/release time (never hand-edit `README.adoc` - see Code Style / the generated-README rule). **When you make a user- or operator-visible change, add a `CHANGELOG.adoc` entry in the same PR**, under `== Unreleased` (create that heading if it's missing, above the latest version), in the right subsection: `=== Breaking`, `=== Improvements`, `=== Fixes`, `=== Dependencies`, or `=== Build & CI`.
+
+- **Do add:** behavioural/API changes, new features or modules, user-affecting bug fixes, and *notable or coordinated* dependency refreshes or any change to a user-facing runtime dependency (especially the Kafka client) - for a library these affect the transitive dependencies and compatibility that consumers inherit.
+- **Don't add:** routine/automated single dependency bumps (Dependabot), internal refactors, test-only changes, CI/tooling, docs, or formatting - those are visible in git history and just add noise.
+- **Reference convention:** a bare `#NN` refers to this fork; write `upstream #NN` for upstream references, and link the PR/issue.
+
+Keep it a changelog people actually read, not a commit log: merge related entries, drop vanity items, and write for a future reader scanning for what changed.
+
 ## Releasing
 
 **Tag-as-truth, dispatch-triggered.** `master` is **always** a `-SNAPSHOT`. A dispatch runs

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,7 +5,7 @@
 
 A high level summary of noteworthy changes in each version.
 
-NOTE:: Dependency version bumps are not listed here.
+NOTE:: Routine/automated dependency bumps (e.g. Dependabot) are not listed here. Notable or coordinated dependency refreshes - and any change to a user-facing runtime dependency such as the Kafka client - are summarised under the relevant version, since for a library these affect the transitive dependencies and compatibility that consumers inherit.
 
 NOTE:: *Reference convention (this is a fork).* Links and bare `#NN` / commit hashes refer to this fork, https://github.com/astubbs/parallel-consumer[astubbs/parallel-consumer]. Upstream references are written explicitly as `upstream #NN` and link to https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer]. Entries below `0.6.0.0` predate the fork and their `#NN` refer to upstream.
 
@@ -17,6 +17,11 @@ toc::[]
 endif::[]
 
 == Unreleased
+
+=== Dependencies
+
+* Dependencies and build plugins refreshed to their latest non-major versions ahead of the release (https://github.com/astubbs/parallel-consumer/pull/73[#73]): JUnit 5.10.2 → 5.14.4, Mockito 5.12.0 → 5.23.0, Testcontainers 1.19.8 → 1.21.4, AssertJ 3.24.2 → 3.27.7, SLF4J 2.0.13 → 2.0.18, Project Reactor 3.6.2 → 3.8.6, SmallRye Mutiny 2.9.4 → 2.9.5, Vert.x 4.5.7 → 4.5.31, Lombok 1.18.28 → 1.18.46, plus Guava, commons-lang3, Logback and the PostgreSQL driver.
+* The Kafka client stays on **3.9.1** — Kafka 4.x (and the other majors JUnit 6, Testcontainers 2, Vert.x 5, Mutiny 3, WireMock 3) were deliberately deferred to keep this a low-risk patch release. See link:docs/inflight.md[docs/inflight.md].
 
 === Build & CI
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,17 +16,6 @@ ifndef::github_name[]
 toc::[]
 endif::[]
 
-== Unreleased
-
-=== Dependencies
-
-* Dependencies and build plugins refreshed to their latest non-major versions ahead of the release (https://github.com/astubbs/parallel-consumer/pull/73[#73]): JUnit 5.10.2 → 5.14.4, Mockito 5.12.0 → 5.23.0, Testcontainers 1.19.8 → 1.21.4, AssertJ 3.24.2 → 3.27.7, SLF4J 2.0.13 → 2.0.18, Project Reactor 3.6.2 → 3.8.6, SmallRye Mutiny 2.9.4 → 2.9.5, Vert.x 4.5.7 → 4.5.31, Lombok 1.18.28 → 1.18.46, plus Guava, commons-lang3, Logback and the PostgreSQL driver.
-* The Kafka client stays on **3.9.1** — Kafka 4.x (and the other majors JUnit 6, Testcontainers 2, Vert.x 5, Mutiny 3, WireMock 3) were deliberately deferred to keep this a low-risk patch release. See link:docs/inflight.md[docs/inflight.md].
-
-=== Build & CI
-
-* New `Self-Hosted Tests` workflow runs the integration and performance suites on a self-hosted runner (a Proxmox Linux VM or a Mac), parallelised on real hardware where the `ci` profile runs them sequentially for GitHub's 2-core hosted runners. Integration runs in forked per-broker mode (`-DforkCount=4 -DreuseForks=true`, each JVM fork gets its own broker); performance uses in-JVM thread parallelism (`-Dparallel-tests=true`). Manual/scheduled only, never on PRs; the GitHub-hosted PR gate is unchanged. See link:docs/SELF_HOSTED_RUNNER.md[docs/SELF_HOSTED_RUNNER.md]. Replaces the earlier Windows-only performance workflow.
-
 == 0.6.0.0
 
 First release of the community fork of https://github.com/confluentinc/parallel-consumer[confluentinc/parallel-consumer] (upstream is no longer actively maintained). Drop-in compatible with upstream 0.5.x — the only required change is the Maven groupId (see Breaking below). Includes upstream fixes and features merged after upstream's last release (0.5.3.3) that were never published there.
@@ -46,6 +35,15 @@ First release of the community fork of https://github.com/confluentinc/parallel-
 
 * fix: null epoch race condition in EpochAndRecordsMap - poll() returning records before onPartitionsAssigned() no longer causes NPE; records are safely skipped and re-delivered (https://github.com/astubbs/parallel-consumer/commit/afde8c5e[afde8c5e]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/326[#326])
 * fix: `OffsetMapCodecManager` is kept instantiated so PC metrics are no longer recreated on every commit (upstream https://github.com/confluentinc/parallel-consumer/pull/892[#892]; relates to upstream https://github.com/confluentinc/parallel-consumer/issues/859[#859]).
+
+=== Dependencies
+
+* Dependencies and build plugins refreshed to their latest non-major versions (https://github.com/astubbs/parallel-consumer/pull/73[#73]): JUnit 5.10.2 → 5.14.4, Mockito 5.12.0 → 5.23.0, Testcontainers 1.19.8 → 1.21.4, AssertJ 3.24.2 → 3.27.7, SLF4J 2.0.13 → 2.0.18, Project Reactor 3.6.2 → 3.8.6, SmallRye Mutiny 2.9.4 → 2.9.5, Vert.x 4.5.7 → 4.5.31, Lombok 1.18.28 → 1.18.46, plus Guava, commons-lang3, Logback and the PostgreSQL driver.
+* The Kafka client stays on **3.9.1** — Kafka 4.x (and the other majors JUnit 6, Testcontainers 2, Vert.x 5, Mutiny 3, WireMock 3) were deliberately deferred to keep the release low-risk. See link:docs/inflight.md[docs/inflight.md].
+
+=== Build & CI
+
+* New `Self-Hosted Tests` workflow runs the integration and performance suites on a self-hosted runner (a Proxmox Linux VM or a Mac), parallelised on real hardware where the `ci` profile runs them sequentially for GitHub's 2-core hosted runners. Integration runs in forked per-broker mode (`-DforkCount=4 -DreuseForks=true`, each JVM fork gets its own broker); performance uses in-JVM thread parallelism (`-Dparallel-tests=true`). Manual/scheduled only, never on PRs; the GitHub-hosted PR gate is unchanged. See link:docs/SELF_HOSTED_RUNNER.md[docs/SELF_HOSTED_RUNNER.md]. Replaces the earlier Windows-only performance workflow.
 
 // There is no 0.5.3.4 release. The #892 metrics fix once tracked under a "0.5.3.4" heading here was
 // never published upstream as 0.5.3.4; it ships in this fork's 0.6.0.0 (folded into the Fixes above).


### PR DESCRIPTION
Follow-up to #73 (the non-major dependency refresh, already merged). Adds the changelog entry for it and closes the process gap that let it slip.

## What & why
- **Refines the changelog convention.** `CHANGELOG.adoc` carried a 2022 upstream-era note "Dependency version bumps are not listed here." That fits routine Dependabot churn, but for a **library** the runtime dependency versions (above all the Kafka client) affect the transitives and compatibility consumers inherit - so they belong in release notes. The note now says: skip routine/automated bumps, but summarise **notable/coordinated** refreshes and user-facing runtime deps. (Older release sections already have `=== Dependencies` subsections, so this matches existing precedent.)
- **Records the #73 refresh under `0.6.0.0`** - a `=== Dependencies` entry (itemized notable bumps; Kafka client held at 3.9.1, all majors deferred). Also moved the `Self-Hosted Tests` (#68) entry there. Both landed on master before 0.6.0.0 was cut and ship in it, so they were moved out of `Unreleased` (now empty, removed) into the `0.6.0.0` release notes - otherwise the released artifact would contain changes its notes don't mention.
- **AGENTS.md: new `Changelog` section** so future agents/contributors add entries - what to add (behavioural/API changes, features, user-affecting fixes, notable dep refreshes + Kafka-client changes) vs skip (routine bumps, refactors, tests, CI, docs), plus the README-is-generated and `#NN` reference conventions.

## Changelog audit
Reviewed all 41 commits since the last release tag (`0.5.3.3`). **No other significant user-visible changes are missing** - the `0.6.0.0` section already covers the rebrand (Breaking), Mutiny module (#891), commit-failure offset logging (#850), the null-epoch race fix (#326), and the OffsetMapCodecManager/metrics fix (#892/#859). Everything else is internal (CI/tests/docs/release-mechanics) or routine single dep bumps, correctly omitted.

Docs-only; `README.adoc` regenerates from `CHANGELOG.adoc` at build/release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvzjf3ismokntun3GHZzue
