### PR TITLE
ci(dependabot): group non-major maven bumps + declare hand-managed ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,12 @@ updates:
       # Managed by hand in the curated versions-maven-plugin sweep instead.
       # See parallel-consumer-example-metrics/pom.xml.
       - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
+      # Frozen workaround pin, NOT a dep to track upward: byte-buddy is held at
+      # mockito's version because wiremock-jre8 2.35.2 drags in an ancient byte-buddy
+      # that breaks mockito (MockitoInitializationException). A bump buys nothing and
+      # risks re-breaking it. Remove this pin entirely when wiremock moves to 3.x
+      # (which drops the stale transitive) - do not bump it in the meantime.
+      - dependency-name: "net.bytebuddy:*"
       # micrometer 1.13+ renamed the Prometheus registry package -> breaks CoreApp.
       # Allow patches within the pinned line; block minor/major until CoreApp migrates.
       - dependency-name: "io.micrometer:*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,51 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    # Collapse routine non-major bumps into ONE reviewable PR per run instead of
+    # a swarm of one-PR-per-dependency. This is the "big dep upgrade PR" we thought
+    # we already had - we never actually configured grouping, so every dep came in
+    # separately (that's how jackson-databind arrived as its own PR #76).
+    open-pull-requests-limit: 10
+    groups:
+      maven-non-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    # Deps we manage by hand or that are deferred majors. Declaring the ignores HERE
+    # (version-controlled + self-documenting) is better than `@dependabot ignore` PR
+    # comments, whose ignore conditions live invisibly in Dependabot's state and give
+    # future maintainers no clue why a dependency silently stopped updating.
+    # Full rationale for each: docs/inflight.md "Deferred dependency upgrades".
+    ignore:
+      # Module-local, test-scoped pin coupled to WireMock's Jackson. Bumping it
+      # globally forces WireMock onto an incompatible Jackson and breaks VertxTest.
+      # Managed by hand in the curated versions-maven-plugin sweep instead.
+      # See parallel-consumer-example-metrics/pom.xml.
+      - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
+      # micrometer 1.13+ renamed the Prometheus registry package -> breaks CoreApp.
+      # Allow patches within the pinned line; block minor/major until CoreApp migrates.
+      - dependency-name: "io.micrometer:*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      # Deferred majors - each needs a deliberate migration, not a Dependabot PR.
+      - dependency-name: "org.apache.kafka:*"          # Kafka 4 (needs Java 11 baseline)
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.junit.jupiter:*"         # JUnit 6 (needs Java 17 + ArchUnit engine)
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.junit.platform:*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.testcontainers:*"        # Testcontainers 2.x
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "io.vertx:*"                  # Vert.x 5
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "io.smallrye.reactive:mutiny" # Mutiny 3
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "com.github.tomakehurst:wiremock-jre8" # WireMock 3 (artifact renamed)
+        update-types: ["version-update:semver-major"]
 # Don't use any github-actions anymore
 #  - package-ecosystem: "github-actions"
 #    directory: "/"

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -150,6 +150,17 @@ and Confluent `-ce`/`-ccs` Kafka builds — without the `-ce` filter, kafka "lat
   to compile against 1.17. Both are pinned with in-pom comments. **To upgrade:** migrate the `CoreApp`
   imports + registry construction, then bump the whole micrometer family together (keep the two aligned).
 
+**jackson-databind — hand-managed, module-local test pin (Dependabot told to ignore):**
+- **jackson-databind** held at `2.17.2` in `parallel-consumer-example-metrics` (test scope) — parses the
+  Prometheus metadata JSON in that module's integration test. Kept as a module-local, explicitly-versioned
+  test dep **on purpose**: pinning it globally via root `dependencyManagement` forces WireMock
+  (`parallel-consumer-vertx`, `wiremock-jre8`) onto an incompatible Jackson and breaks `VertxTest` (HTTP
+  500), so it stays scoped to this one module. Dependabot proposed `2.17.2 → 2.18.9` (PR #76); we told it
+  `@dependabot ignore this dependency` because these bumps belong in the curated `versions-maven-plugin`
+  sweep with an `example-metrics` integration-test run, not standalone PRs. **To upgrade:** bump the pin in
+  the next sweep and confirm the example-metrics integration test is green (the module-local scope means it
+  cannot affect `VertxTest`). Test-scoped, so it never reaches the published artifact classpath.
+
 **Build plugins — only pre-releases available, held by the risk policy:**
 - Maven-4-era plugins offered only as betas/milestones: `maven-clean/deploy/install/jar/resources/source/
   compiler` `4.0.0-beta-*`; `maven-surefire`/`maven-failsafe` `3.6.0-M1`; `maven-site-plugin` `4.0.0-M16`


### PR DESCRIPTION
## Why

The Dependabot config had **no grouping at all**, so every dependency opened its own PR - a known gap, made concrete when `jackson-databind` arrived as a standalone PR (#76) instead of riding along with our curated `versions-maven-plugin` dependency sweep (#73). This PR closes that gap declaratively.

## What

- **Group non-major bumps.** New `maven-non-major` group collapses routine minor/patch updates into a single reviewable PR per run instead of a swarm of one-per-dependency PRs. The curated sweep stays the real driver; the grouped PR is just a low-noise "what's newly available" heads-up.
- **Declare hand-managed ignores in version control.** `ignore:` rules for deps we manage by hand or that are deferred majors: `jackson-databind`, the micrometer family, and the deferred majors (kafka / junit / testcontainers / vertx / mutiny / wiremock). This is strictly better than `@dependabot ignore` PR comments, whose ignore conditions live invisibly in Dependabot's server-side state with no in-repo explanation for future maintainers.
- **Track the jackson hold.** `docs/inflight.md` now records why `jackson-databind` is pinned at `2.17.2`: a module-local, `test`-scoped pin coupled to WireMock's Jackson (pinning it globally breaks `VertxTest` with HTTP 500). Bump it in the next sweep with an `example-metrics` integration-test check.

## Notes

- Config only takes effect once merged to the **default branch** (Dependabot reads config from `master`).
- Ignore semantics: security updates are unaffected by these version-update ignores; the majors are ignored only at `semver-major`, so security/patch fixes still flow.
- `#76` itself is already handled via the exact `@dependabot ignore com.fasterxml.jackson.core:jackson-databind` command (Dependabot acknowledged); this PR makes that decision declarative and durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
