### PR TITLE
ci: re-pin File Similarity action to merged master (fixes spurious failures)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astubbs/duplicate-code-detection-tool@4e302e720f86c4e95f709196bae21333a9696937 # feat/base-vs-pr-comparison
+      - uses: astubbs/duplicate-code-detection-tool@74adf74b65b6a288b21ba957d7d7bef43831ee65 # master: base-vs-PR comparison + ce-review fixes
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           directories: 'parallel-consumer-core/src,parallel-consumer-vertx/src,parallel-consumer-reactor/src,parallel-consumer-mutiny/src'


### PR DESCRIPTION
## Why

The **File Similarity Check** has been failing on PRs that change no source code (e.g. dependabot PR #78). Root cause was a bug in the custom fork of the similarity tool this workflow pins - its base-vs-PR comparison misread the base scan's exit code as a failure, discarded the base data, and gated the PR on absolute pre-existing similarity.

That fork's fixes (plus a full multi-persona code review) are now merged to its `master`. This bumps the pin from the old feature-branch SHA to the merged commit.

## What

`.github/workflows/maven.yml`:
```
- astubbs/duplicate-code-detection-tool@4e302e7…  # feat/base-vs-pr-comparison
+ astubbs/duplicate-code-detection-tool@74adf74…  # master: base-vs-PR comparison + ce-review fixes
```

Upstream fixes now picked up:
- Base scan exit-code fix + delta-driven verdict (the actual spurious-failure fix)
- Fail on newly-introduced duplication (not just increases)
- ce-review hardening: exception-safe stdout, CI log matches verdict, corrupt-base-JSON degrades instead of crashing, `eval`-injection removed, symmetric-pair dedup, float-boundary rounding
- A hermetic unit-test suite + a CI workflow in the tool repo

Also swaps a fragile feature-branch-SHA pin for a stable merged-master commit.

## Effect

The File Similarity Check should now pass on PRs that introduce no new duplication, while still flagging genuinely new/increased duplication. Verify on this PR's own File Similarity run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)