### PR TITLE
ci: provenance-aware copyright header check - and stop the license plugin mislabeling fork files

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,42 @@
+# Copyright header conformance - fast, GitHub-hosted, gate-friendly.
+#
+# Enforces the fork's two-header policy (AGENTS.md "Copyright rules for this fork"):
+# upstream-derived files keep the Confluent header; fork-original files (added after
+# the pinned fork point) must carry the fork header and must not claim Confluent
+# copyright. The mycila license plugin cannot express this (single header template,
+# git-based year auto-bumping), so it is skipped by default in the root pom and this
+# scanner is the enforcement instead.
+#
+# fetch-depth: 0 because the scanner classifies provenance via the fork-point commit,
+# which a shallow clone does not contain.
+
+name: Copyright Headers
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: copyright-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: "Copyright header check"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout (full history - scanner needs the fork-point commit)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Self-test the scanner (fixture repos)
+        run: bash bin/test-check-copyright-headers.sh
+
+      - name: Check copyright headers
+        run: bash bin/check-copyright-headers.sh

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -12,8 +12,11 @@
 
 name: Copyright Headers
 
+# push is scoped to master (matching maven.yml) so PR-branch commits run once via the
+# pull_request event instead of twice.
 on:
   push:
+    branches: [ master ]
   pull_request:
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,15 @@ bin/performance-test.sh
   - The `NOTICE` file at repo root contains the legal attribution structure for the fork
   - New files written entirely for the fork use `Copyright (C) <year> Antony Stubbs and contributors` -
     never the Confluent header
-  - Files renamed/moved from upstream keep their Confluent header - register such paths in the
-    `UPSTREAM_DERIVED_EXCEPTIONS` list inside `bin/check-copyright-headers.sh`
+  - Upstream-derived files MODIFIED on the fork retain the Confluent notice and ADD
+    `Modifications Copyright (C) <year> Antony Stubbs and contributors` beneath it (Apache 2.0
+    4(b) retain-notices + 4(c) change-notice - the convention used by e.g. Amazon Corretto and
+    MariaDB for derived files). The scanner detects modification against the fork point
+    automatically, so forgetting the line fails CI
+  - Files renamed or extracted from upstream keep the Confluent header - register renames in
+    `RENAMED_FROM_UPSTREAM` (`newpath|oldpath` lines) and extractions in `EXTRACTED_FROM_UPSTREAM`
+    inside `bin/check-copyright-headers.sh`. Renames with content changes, and all extractions,
+    also require the modifications line
 - **Google Truth**: Used for test assertions alongside JUnit 5 and Mockito.
 
 ## CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,13 +96,20 @@ bin/performance-test.sh
 
 - **Lombok**: Used extensively (builders, getters, logging). IntelliJ Lombok plugin required.
 - **EditorConfig**: Enforced via `.editorconfig` - 4-space indent for Java, 120 char line length.
-- **License headers**: Managed by `license-maven-plugin` (Mycila). Use `-Dlicense.skip` locally to skip checks.
+- **License headers**: Enforced by `bin/check-copyright-headers.sh` (runs in CI via the
+  `Copyright Headers` workflow; run it locally before pushing header-related changes). The mycila
+  `license-maven-plugin` is skipped by default in the root pom - it knows only the Confluent header
+  template, so its `format` goal used to stamp the wrong attribution onto fork-original files and its
+  git-year resolver auto-bumped years and broke in worktrees. `-Dlicense.skip` on the command line is
+  no longer needed (harmless if still passed).
 - **Copyright rules for this fork**:
   - Do not change copyright headers on existing files unless the file has substantive code changes in the same commit
   - Do not bump copyright years as an incidental or standalone change
   - The `NOTICE` file at repo root contains the legal attribution structure for the fork
-  - New files written entirely for the fork should not claim Confluent copyright
-  - Always pass `-Dlicense.skip` to Maven to prevent the license plugin from auto-bumping years
+  - New files written entirely for the fork use `Copyright (C) <year> Antony Stubbs and contributors` -
+    never the Confluent header
+  - Files renamed/moved from upstream keep their Confluent header - register such paths in the
+    `UPSTREAM_DERIVED_EXCEPTIONS` list inside `bin/check-copyright-headers.sh`
 - **Google Truth**: Used for test assertions alongside JUnit 5 and Mockito.
 
 ## CI

--- a/bin/check-copyright-headers.sh
+++ b/bin/check-copyright-headers.sh
@@ -3,14 +3,20 @@
 # Copyright header conformance check for the fork.
 #
 # Policy (AGENTS.md, "Copyright rules for this fork"):
-#   - Files present at the fork point (upstream-derived) keep the Confluent header.
-#   - Files added since the fork point (fork-original) must use the fork header:
-#       Copyright (C) <years> Antony Stubbs and contributors
+#   - Upstream-derived files UNMODIFIED since the fork point keep the Confluent header as-is.
+#   - Upstream-derived files MODIFIED since the fork point (including fork-side renames with
+#     changes, and extractions of upstream code) must ALSO carry the modifications line:
+#       Modifications Copyright (C) <year> Antony Stubbs and contributors
+#     (Apache 2.0 s4(b) retain-notices + s4(c) prominent-change-notice, the convention used by
+#     e.g. Amazon Corretto and MariaDB for derived files.)
+#   - Fork-original files (added after the fork point) must use the fork header:
+#       Copyright (C) <year> Antony Stubbs and contributors
 #     and must NOT claim Confluent copyright.
 #
 # Provenance is derived from the pinned fork-point tree below, so the check is fully
 # local and deterministic - no network, no upstream remote needed. It requires the
 # fork-point commit to be present in history (CI: actions/checkout fetch-depth: 0).
+# "Modified" is judged against the WORKING TREE, so local uncommitted edits count.
 #
 # Years are deliberately NOT policed: never bump copyright years as an incidental
 # change (see AGENTS.md). This scanner replaces the mycila license-maven-plugin's
@@ -23,7 +29,8 @@
 #
 # Test-harness overrides (used by bin/test-check-copyright-headers.sh; not needed
 # for normal use): COPYRIGHT_CHECK_FORK_POINT pins a different fork-point commit,
-# COPYRIGHT_CHECK_EXTRA_EXCEPTIONS appends newline-separated exception paths.
+# COPYRIGHT_CHECK_EXTRA_RENAMES appends 'newpath|oldpath' lines,
+# COPYRIGHT_CHECK_EXTRA_EXTRACTIONS appends extraction paths.
 
 set -eu
 
@@ -32,19 +39,26 @@ cd "$(git rev-parse --show-toplevel)"
 # merge-base of the fork's master and confluentinc/parallel-consumer master:
 # "Migrate to V3 based sonatype secret (#916)", 2026-03-24.
 FORK_POINT="${COPYRIGHT_CHECK_FORK_POINT:-7f2901226bccac68a2a71f0d9da343887b1abb46}"
+FORK_HOLDER="Antony Stubbs and contributors"
+HEADER_WINDOW=8 # lines from the top of the file searched for copyright notices
 
-# Fork-side RENAMES/moves/extractions of upstream files keep the Confluent header
-# even though their path is not in the fork-point tree. One path per line.
-# - The three example ITs were relocated into integrationTests/ subpackages in fface195.
-# - ManagedPCInstance (chaos-suite branch stack, not yet on master) is an EXTRACTION of
-#   upstream-derived IT code, so it keeps the Confluent header by design (see PR #83).
-#   Listing it before it exists on master is harmless - only tracked files are checked.
-UPSTREAM_DERIVED_EXCEPTIONS="
-parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/CoreAppMetricsIntegrationTest.java
-parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/PrometheusContainer.java
-parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/integrationTests/StreamsAppTest.java
+# Fork-side RENAMES of upstream files: 'newpath|oldpath-at-fork-point'. They keep the
+# Confluent header; if their content has diverged from the fork-point blob they must
+# also carry the modifications line. (These three were relocated in fface195.)
+RENAMED_FROM_UPSTREAM="
+parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/CoreAppMetricsIntegrationTest.java|parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/CoreAppMetricsIntegrationTest.java
+parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/PrometheusContainer.java|parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/PrometheusContainer.java
+parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/integrationTests/StreamsAppTest.java|parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/StreamsAppTest.java
+${COPYRIGHT_CHECK_EXTRA_RENAMES:-}
+"
+
+# EXTRACTIONS of upstream-derived code into new files (no single origin path): always
+# Confluent + modifications line. ManagedPCInstance lives on the chaos-suite branch
+# stack, not yet on master - listing it early is harmless (only tracked files are
+# checked) and stops the check ambushing the stack at merge (see PR #83).
+EXTRACTED_FROM_UPSTREAM="
 parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/ManagedPCInstance.java
-${COPYRIGHT_CHECK_EXTRA_EXCEPTIONS:-}
+${COPYRIGHT_CHECK_EXTRA_EXTRACTIONS:-}
 "
 
 if ! git cat-file -e "${FORK_POINT}^{commit}" 2>/dev/null; then
@@ -54,31 +68,59 @@ if ! git cat-file -e "${FORK_POINT}^{commit}" 2>/dev/null; then
 fi
 
 upstream_files=$(git ls-tree -r --name-only "$FORK_POINT")
+# vs the working tree, so uncommitted local edits are judged too
+modified_since_fork=$(git diff --name-only "$FORK_POINT" -- '*.java')
 
 fails=0
 checked=0
+
+require_confluent() { # <file> <header>
+    if ! printf '%s' "$2" | grep -q "Copyright (C)"; then
+        echo "FAIL (upstream-derived file has no copyright header): $1"
+        return 1
+    elif ! printf '%s' "$2" | grep -q "Confluent"; then
+        echo "FAIL (upstream-derived file lost its Confluent header): $1"
+        return 1
+    fi
+}
+
+require_modifications_line() { # <file> <header> <reason>
+    if ! printf '%s' "$2" | grep -q "$FORK_HOLDER"; then
+        echo "FAIL ($3 but missing 'Modifications Copyright ... ${FORK_HOLDER}' line): $1"
+        return 1
+    fi
+}
+
 while IFS= read -r f; do
     [ -f "$f" ] || continue
     checked=$((checked + 1))
-    header=$(head -5 "$f")
+    header=$(head -"$HEADER_WINDOW" "$f")
 
-    if printf '%s\n' "$upstream_files" | grep -qxF "$f" \
-        || printf '%s' "$UPSTREAM_DERIVED_EXCEPTIONS" | grep -qxF "$f"; then
-        # upstream-derived: must keep Confluent attribution
-        if ! printf '%s' "$header" | grep -q "Copyright (C)"; then
-            echo "FAIL (upstream-derived file has no copyright header): $f"
-            fails=$((fails + 1))
-        elif ! printf '%s' "$header" | grep -q "Confluent"; then
-            echo "FAIL (upstream-derived file lost its Confluent header): $f"
-            fails=$((fails + 1))
+    rename_entry=$(printf '%s\n' "$RENAMED_FROM_UPSTREAM" | grep -F "${f}|" || true)
+    if [ -n "$rename_entry" ]; then
+        old_path=${rename_entry#*|}
+        require_confluent "$f" "$header" || { fails=$((fails + 1)); continue; }
+        if ! git cat-file blob "${FORK_POINT}:${old_path}" 2>/dev/null | cmp -s - "$f"; then
+            require_modifications_line "$f" "$header" \
+                "renamed upstream file modified since the fork point" || fails=$((fails + 1))
+        fi
+    elif printf '%s\n' "$EXTRACTED_FROM_UPSTREAM" | grep -qxF "$f"; then
+        require_confluent "$f" "$header" || { fails=$((fails + 1)); continue; }
+        require_modifications_line "$f" "$header" \
+            "extraction of upstream-derived code" || fails=$((fails + 1))
+    elif printf '%s\n' "$upstream_files" | grep -qxF "$f"; then
+        require_confluent "$f" "$header" || { fails=$((fails + 1)); continue; }
+        if printf '%s\n' "$modified_since_fork" | grep -qxF "$f"; then
+            require_modifications_line "$f" "$header" \
+                "upstream-derived file modified since the fork point" || fails=$((fails + 1))
         fi
     else
         # fork-original: fork header required, Confluent claim forbidden
         if printf '%s' "$header" | grep -q "Confluent"; then
             echo "FAIL (fork-original file claims Confluent copyright): $f"
             fails=$((fails + 1))
-        elif ! printf '%s' "$header" | grep -q "Antony Stubbs and contributors"; then
-            echo "FAIL (fork-original file missing 'Antony Stubbs and contributors' header): $f"
+        elif ! printf '%s' "$header" | grep -q "$FORK_HOLDER"; then
+            echo "FAIL (fork-original file missing '${FORK_HOLDER}' header): $f"
             fails=$((fails + 1))
         fi
     fi

--- a/bin/check-copyright-headers.sh
+++ b/bin/check-copyright-headers.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Copyright header conformance check for the fork.
+#
+# Policy (AGENTS.md, "Copyright rules for this fork"):
+#   - Files present at the fork point (upstream-derived) keep the Confluent header.
+#   - Files added since the fork point (fork-original) must use the fork header:
+#       Copyright (C) <years> Antony Stubbs and contributors
+#     and must NOT claim Confluent copyright.
+#
+# Provenance is derived from the pinned fork-point tree below, so the check is fully
+# local and deterministic - no network, no upstream remote needed. It requires the
+# fork-point commit to be present in history (CI: actions/checkout fetch-depth: 0).
+#
+# Years are deliberately NOT policed: never bump copyright years as an incidental
+# change (see AGENTS.md). This scanner replaces the mycila license-maven-plugin's
+# check/format for headers - that plugin knows only ONE header template, so running
+# its format goal is exactly what used to stamp Confluent headers onto fork files
+# (it is now skipped by default via <license.skip> in the root pom).
+#
+# Usage: bin/check-copyright-headers.sh
+# Exit codes: 0 = conformant, 1 = violations found, 2 = cannot run (shallow clone).
+#
+# Test-harness overrides (used by bin/test-check-copyright-headers.sh; not needed
+# for normal use): COPYRIGHT_CHECK_FORK_POINT pins a different fork-point commit,
+# COPYRIGHT_CHECK_EXTRA_EXCEPTIONS appends newline-separated exception paths.
+
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+
+# merge-base of the fork's master and confluentinc/parallel-consumer master:
+# "Migrate to V3 based sonatype secret (#916)", 2026-03-24.
+FORK_POINT="${COPYRIGHT_CHECK_FORK_POINT:-7f2901226bccac68a2a71f0d9da343887b1abb46}"
+
+# Fork-side RENAMES/moves/extractions of upstream files keep the Confluent header
+# even though their path is not in the fork-point tree. One path per line.
+# - The three example ITs were relocated into integrationTests/ subpackages in fface195.
+# - ManagedPCInstance (chaos-suite branch stack, not yet on master) is an EXTRACTION of
+#   upstream-derived IT code, so it keeps the Confluent header by design (see PR #83).
+#   Listing it before it exists on master is harmless - only tracked files are checked.
+UPSTREAM_DERIVED_EXCEPTIONS="
+parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/CoreAppMetricsIntegrationTest.java
+parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/PrometheusContainer.java
+parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/integrationTests/StreamsAppTest.java
+parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/ManagedPCInstance.java
+${COPYRIGHT_CHECK_EXTRA_EXCEPTIONS:-}
+"
+
+if ! git cat-file -e "${FORK_POINT}^{commit}" 2>/dev/null; then
+    echo "ERROR: fork-point commit ${FORK_POINT} not found in history." >&2
+    echo "       Fetch full history first (CI: actions/checkout with fetch-depth: 0)." >&2
+    exit 2
+fi
+
+upstream_files=$(git ls-tree -r --name-only "$FORK_POINT")
+
+fails=0
+checked=0
+while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    checked=$((checked + 1))
+    header=$(head -5 "$f")
+
+    if printf '%s\n' "$upstream_files" | grep -qxF "$f" \
+        || printf '%s' "$UPSTREAM_DERIVED_EXCEPTIONS" | grep -qxF "$f"; then
+        # upstream-derived: must keep Confluent attribution
+        if ! printf '%s' "$header" | grep -q "Copyright (C)"; then
+            echo "FAIL (upstream-derived file has no copyright header): $f"
+            fails=$((fails + 1))
+        elif ! printf '%s' "$header" | grep -q "Confluent"; then
+            echo "FAIL (upstream-derived file lost its Confluent header): $f"
+            fails=$((fails + 1))
+        fi
+    else
+        # fork-original: fork header required, Confluent claim forbidden
+        if printf '%s' "$header" | grep -q "Confluent"; then
+            echo "FAIL (fork-original file claims Confluent copyright): $f"
+            fails=$((fails + 1))
+        elif ! printf '%s' "$header" | grep -q "Antony Stubbs and contributors"; then
+            echo "FAIL (fork-original file missing 'Antony Stubbs and contributors' header): $f"
+            fails=$((fails + 1))
+        fi
+    fi
+done <<EOF
+$(git ls-files '*.java')
+EOF
+
+echo "Checked ${checked} java files against fork point ${FORK_POINT} - ${fails} violation(s)."
+[ "$fails" -eq 0 ]

--- a/bin/test-check-copyright-headers.sh
+++ b/bin/test-check-copyright-headers.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Self-test for bin/check-copyright-headers.sh.
+#
+# Builds throwaway git repos that simulate the fork's provenance model (an "upstream"
+# commit pinned as the fork point, then fork-original files layered on top) and asserts
+# the scanner's verdict for every rule:
+#   1. upstream-derived file keeping its Confluent header        -> pass
+#   2. upstream-derived file that LOST its header                -> FAIL
+#   3. fork-original file with the fork header                   -> pass
+#   4. fork-original file claiming Confluent copyright           -> FAIL
+#   5. fork-original file with no recognised header              -> FAIL
+#   6. renamed upstream file registered as an exception          -> pass
+#   7. clean repo                                                -> exit 0
+#   8. fork-point commit missing from history (shallow clone)    -> exit 2
+#
+# Run: bin/test-check-copyright-headers.sh   (CI runs it before the real scan)
+
+set -eu
+
+SCANNER="$(cd "$(dirname "$0")" && pwd)/check-copyright-headers.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+failures=0
+
+assert() { # <description> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "ok:   $1"
+    else
+        echo "FAIL: $1 (expected '$2', got '$3')"
+        failures=$((failures + 1))
+    fi
+}
+
+assert_contains() { # <description> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "ok:   $1" ;;
+        *) echo "FAIL: $1 (output missing '$2')"; failures=$((failures + 1)) ;;
+    esac
+}
+
+new_repo() { # <dir>
+    git init -q "$1"
+    git -C "$1" config user.email test@example.invalid
+    git -C "$1" config user.name "scanner-test"
+}
+
+confluent_file() { # <path>
+    printf '/*-\n * Copyright (C) 2020-2022 Confluent, Inc.\n */\nclass X {}\n' > "$1"
+}
+
+fork_file() { # <path>
+    printf '/*-\n * Copyright (C) 2026 Antony Stubbs and contributors\n */\nclass X {}\n' > "$1"
+}
+
+headerless_file() { # <path>
+    printf 'class X {}\n' > "$1"
+}
+
+# --- Fixture A: one repo exercising rules 1-6 ------------------------------------
+repoA="$WORK/a"
+new_repo "$repoA"
+confluent_file "$repoA/Upstream.java"           # rule 1: stays good
+confluent_file "$repoA/LosesHeader.java"        # rule 2: header removed post-fork
+git -C "$repoA" add -A && git -C "$repoA" commit -qm upstream
+fork_point_a=$(git -C "$repoA" rev-parse HEAD)
+
+headerless_file "$repoA/LosesHeader.java"       # rule 2 violation
+fork_file "$repoA/ForkGood.java"                # rule 3
+confluent_file "$repoA/ForkClaimsConfluent.java" # rule 4 violation
+headerless_file "$repoA/ForkNoHeader.java"      # rule 5 violation
+confluent_file "$repoA/RenamedUpstream.java"    # rule 6: exception keeps Confluent
+git -C "$repoA" add -A && git -C "$repoA" commit -qm fork
+
+out=$( (cd "$repoA" && COPYRIGHT_CHECK_FORK_POINT="$fork_point_a" \
+        COPYRIGHT_CHECK_EXTRA_EXCEPTIONS="RenamedUpstream.java" \
+        bash "$SCANNER") 2>&1 ) && rc=0 || rc=$?
+assert        "violating repo exits 1"                       1 "$rc"
+assert_contains "detects upstream file losing its header"    "upstream-derived file has no copyright header): LosesHeader.java" "$out"
+assert_contains "detects fork file claiming Confluent"       "fork-original file claims Confluent copyright): ForkClaimsConfluent.java" "$out"
+assert_contains "detects fork file with no header"           "missing 'Antony Stubbs and contributors' header): ForkNoHeader.java" "$out"
+assert_contains "reports exactly 3 violations"               "3 violation(s)" "$out"
+case "$out" in
+    *"ForkGood.java"*|*"Upstream.java"*|*"RenamedUpstream.java"*)
+        echo "FAIL: conformant files were flagged"; failures=$((failures + 1)) ;;
+    *) echo "ok:   conformant, upstream, and exception files not flagged" ;;
+esac
+
+# --- Fixture B: clean repo (rule 7) -----------------------------------------------
+repoB="$WORK/b"
+new_repo "$repoB"
+confluent_file "$repoB/Upstream.java"
+git -C "$repoB" add -A && git -C "$repoB" commit -qm upstream
+fork_point_b=$(git -C "$repoB" rev-parse HEAD)
+fork_file "$repoB/ForkGood.java"
+git -C "$repoB" add -A && git -C "$repoB" commit -qm fork
+
+out=$( (cd "$repoB" && COPYRIGHT_CHECK_FORK_POINT="$fork_point_b" bash "$SCANNER") 2>&1 ) && rc=0 || rc=$?
+assert "clean repo exits 0" 0 "$rc"
+assert_contains "clean repo reports zero violations" "0 violation(s)" "$out"
+
+# --- Fixture C: fork point not in history (rule 8) ---------------------------------
+out=$( (cd "$repoB" && COPYRIGHT_CHECK_FORK_POINT=0000000000000000000000000000000000000000 \
+        bash "$SCANNER") 2>&1 ) && rc=0 || rc=$?
+assert          "missing fork point exits 2"            2 "$rc"
+assert_contains "missing fork point explains the fix"   "fetch-depth: 0" "$out"
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "All scanner self-tests passed."
+else
+    echo "$failures scanner self-test(s) FAILED."
+    exit 1
+fi

--- a/bin/test-check-copyright-headers.sh
+++ b/bin/test-check-copyright-headers.sh
@@ -3,16 +3,20 @@
 # Self-test for bin/check-copyright-headers.sh.
 #
 # Builds throwaway git repos that simulate the fork's provenance model (an "upstream"
-# commit pinned as the fork point, then fork-original files layered on top) and asserts
+# commit pinned as the fork point, then fork-original work layered on top) and asserts
 # the scanner's verdict for every rule:
-#   1. upstream-derived file keeping its Confluent header        -> pass
-#   2. upstream-derived file that LOST its header                -> FAIL
-#   3. fork-original file with the fork header                   -> pass
-#   4. fork-original file claiming Confluent copyright           -> FAIL
-#   5. fork-original file with no recognised header              -> FAIL
-#   6. renamed upstream file registered as an exception          -> pass
-#   7. clean repo                                                -> exit 0
-#   8. fork-point commit missing from history (shallow clone)    -> exit 2
+#    1. upstream-derived file, unmodified, Confluent header        -> pass
+#    2. upstream-derived file that LOST its header                 -> FAIL
+#    3. upstream-derived file MODIFIED, no modifications line      -> FAIL
+#    4. upstream-derived file MODIFIED, dual header                -> pass
+#    5. renamed upstream file, content unchanged, Confluent-only   -> pass
+#    6. renamed upstream file, content changed, no mods line       -> FAIL
+#    7. extraction of upstream code, no mods line                  -> FAIL
+#    8. fork-original file with the fork header                    -> pass
+#    9. fork-original file claiming Confluent copyright            -> FAIL
+#   10. fork-original file with no recognised header               -> FAIL
+#   11. clean repo                                                 -> exit 0
+#   12. fork-point commit missing from history (shallow clone)     -> exit 2
 #
 # Run: bin/test-check-copyright-headers.sh   (CI runs it before the real scan)
 
@@ -46,8 +50,12 @@ new_repo() { # <dir>
     git -C "$1" config user.name "scanner-test"
 }
 
-confluent_file() { # <path>
-    printf '/*-\n * Copyright (C) 2020-2022 Confluent, Inc.\n */\nclass X {}\n' > "$1"
+confluent_file() { # <path> [body]
+    printf '/*-\n * Copyright (C) 2020-2022 Confluent, Inc.\n */\nclass X { %s }\n' "${2:-}" > "$1"
+}
+
+dual_file() { # <path> [body]
+    printf '/*-\n * Copyright (C) 2020-2022 Confluent, Inc.\n * Modifications Copyright (C) 2026 Antony Stubbs and contributors\n */\nclass X { %s }\n' "${2:-}" > "$1"
 }
 
 fork_file() { # <path>
@@ -58,41 +66,59 @@ headerless_file() { # <path>
     printf 'class X {}\n' > "$1"
 }
 
-# --- Fixture A: one repo exercising rules 1-6 ------------------------------------
+# --- Fixture A: one repo exercising rules 1-10 ------------------------------------
 repoA="$WORK/a"
 new_repo "$repoA"
-confluent_file "$repoA/Upstream.java"           # rule 1: stays good
-confluent_file "$repoA/LosesHeader.java"        # rule 2: header removed post-fork
+confluent_file "$repoA/Upstream.java"                       # 1: stays untouched
+confluent_file "$repoA/LosesHeader.java"                    # 2: header removed post-fork
+confluent_file "$repoA/ModifiedNoLine.java"                 # 3: modified post-fork, line forgotten
+confluent_file "$repoA/ModifiedDual.java"                   # 4: modified post-fork, line added
+confluent_file "$repoA/RenamedSameOld.java"                 # 5: renamed verbatim post-fork
+confluent_file "$repoA/RenamedChangedOld.java"              # 6: renamed WITH changes post-fork
 git -C "$repoA" add -A && git -C "$repoA" commit -qm upstream
 fork_point_a=$(git -C "$repoA" rev-parse HEAD)
 
-headerless_file "$repoA/LosesHeader.java"       # rule 2 violation
-fork_file "$repoA/ForkGood.java"                # rule 3
-confluent_file "$repoA/ForkClaimsConfluent.java" # rule 4 violation
-headerless_file "$repoA/ForkNoHeader.java"      # rule 5 violation
-confluent_file "$repoA/RenamedUpstream.java"    # rule 6: exception keeps Confluent
+headerless_file "$repoA/LosesHeader.java"                   # rule 2 violation
+confluent_file "$repoA/ModifiedNoLine.java" "int changed;"  # rule 3 violation
+dual_file "$repoA/ModifiedDual.java" "int changed;"         # rule 4 conformant
+git -C "$repoA" mv RenamedSameOld.java RenamedSame.java     # rule 5 conformant (verbatim)
+git -C "$repoA" mv RenamedChangedOld.java RenamedChanged.java
+confluent_file "$repoA/RenamedChanged.java" "int changed;"  # rule 6 violation
+confluent_file "$repoA/Extraction.java" "int extracted;"    # rule 7 violation
+fork_file "$repoA/ForkGood.java"                            # rule 8 conformant
+confluent_file "$repoA/ForkClaimsConfluent.java"            # rule 9 violation
+headerless_file "$repoA/ForkNoHeader.java"                  # rule 10 violation
 git -C "$repoA" add -A && git -C "$repoA" commit -qm fork
 
+renames="RenamedSame.java|RenamedSameOld.java
+RenamedChanged.java|RenamedChangedOld.java"
+
 out=$( (cd "$repoA" && COPYRIGHT_CHECK_FORK_POINT="$fork_point_a" \
-        COPYRIGHT_CHECK_EXTRA_EXCEPTIONS="RenamedUpstream.java" \
+        COPYRIGHT_CHECK_EXTRA_RENAMES="$renames" \
+        COPYRIGHT_CHECK_EXTRA_EXTRACTIONS="Extraction.java" \
         bash "$SCANNER") 2>&1 ) && rc=0 || rc=$?
-assert        "violating repo exits 1"                       1 "$rc"
-assert_contains "detects upstream file losing its header"    "upstream-derived file has no copyright header): LosesHeader.java" "$out"
-assert_contains "detects fork file claiming Confluent"       "fork-original file claims Confluent copyright): ForkClaimsConfluent.java" "$out"
-assert_contains "detects fork file with no header"           "missing 'Antony Stubbs and contributors' header): ForkNoHeader.java" "$out"
-assert_contains "reports exactly 3 violations"               "3 violation(s)" "$out"
+assert          "violating repo exits 1"                        1 "$rc"
+assert_contains "detects upstream file losing its header"       "upstream-derived file has no copyright header): LosesHeader.java" "$out"
+assert_contains "detects modified upstream file w/o mods line"  "upstream-derived file modified since the fork point but missing 'Modifications Copyright ... Antony Stubbs and contributors' line): ModifiedNoLine.java" "$out"
+assert_contains "detects changed rename w/o mods line"          "renamed upstream file modified since the fork point but missing 'Modifications Copyright ... Antony Stubbs and contributors' line): RenamedChanged.java" "$out"
+assert_contains "detects extraction w/o mods line"              "extraction of upstream-derived code but missing 'Modifications Copyright ... Antony Stubbs and contributors' line): Extraction.java" "$out"
+assert_contains "detects fork file claiming Confluent"          "fork-original file claims Confluent copyright): ForkClaimsConfluent.java" "$out"
+assert_contains "detects fork file with no header"              "missing 'Antony Stubbs and contributors' header): ForkNoHeader.java" "$out"
+assert_contains "reports exactly 6 violations"                  "6 violation(s)" "$out"
 case "$out" in
-    *"ForkGood.java"*|*"Upstream.java"*|*"RenamedUpstream.java"*)
+    *"ForkGood.java"*|*"Upstream.java"*|*"ModifiedDual.java"*|*"RenamedSame.java"*)
         echo "FAIL: conformant files were flagged"; failures=$((failures + 1)) ;;
-    *) echo "ok:   conformant, upstream, and exception files not flagged" ;;
+    *) echo "ok:   conformant files (untouched, dual-header, verbatim rename, fork) not flagged" ;;
 esac
 
-# --- Fixture B: clean repo (rule 7) -----------------------------------------------
+# --- Fixture B: clean repo (rule 11) -----------------------------------------------
 repoB="$WORK/b"
 new_repo "$repoB"
 confluent_file "$repoB/Upstream.java"
+confluent_file "$repoB/Modified.java"
 git -C "$repoB" add -A && git -C "$repoB" commit -qm upstream
 fork_point_b=$(git -C "$repoB" rev-parse HEAD)
+dual_file "$repoB/Modified.java" "int changed;"
 fork_file "$repoB/ForkGood.java"
 git -C "$repoB" add -A && git -C "$repoB" commit -qm fork
 
@@ -100,7 +126,7 @@ out=$( (cd "$repoB" && COPYRIGHT_CHECK_FORK_POINT="$fork_point_b" bash "$SCANNER
 assert "clean repo exits 0" 0 "$rc"
 assert_contains "clean repo reports zero violations" "0 violation(s)" "$out"
 
-# --- Fixture C: fork point not in history (rule 8) ---------------------------------
+# --- Fixture C: fork point not in history (rule 12) ---------------------------------
 out=$( (cd "$repoB" && COPYRIGHT_CHECK_FORK_POINT=0000000000000000000000000000000000000000 \
         bash "$SCANNER") 2>&1 ) && rc=0 || rc=$?
 assert          "missing fork point exits 2"            2 "$rc"

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -443,3 +443,23 @@ all are pre-existing job/gate problems. Only three checks actually gate merge (r
   PRs, but Integration / PIT / Kafka-Compat are *not* filtered the same way, so they run and fail on
   changes that touch no code. **Fix:** align the `paths`/`paths-ignore` filters across these jobs so a
   docs-only change runs a consistent (or fully skipped) set.
+
+## Copyright headers - enforcement + fork convention (2026-07-31, PR #90)
+
+- **Root cause of the mislabeled-header class, fixed:** the mycila license plugin defaulted to
+  `format` mode with its single Confluent header template, so any bare `mvn` build stamped the wrong
+  attribution onto fork-original files (this is how the chaos-suite files got Confluent headers), and
+  its git-year resolver auto-bumped years and broke in worktrees. Now skipped by default
+  (`<license.skip>true</license.skip>`); `-Dlicense.skip` on command lines is obsolete-but-harmless.
+- **Enforcement:** `bin/check-copyright-headers.sh` + the `Copyright Headers` workflow (self-tested,
+  13 fixture assertions, runs on every PR + master push). Provenance from the pinned fork point
+  (7f290122): fork-original files need the fork header; upstream-derived files keep Confluent's; and
+  **modified-since-fork derived files (incl. changed renames + extractions) must ADD
+  `Modifications Copyright (C) <year> Antony Stubbs and contributors`** - the Apache 2.0
+  4(b)/4(c) dual-notice convention (Corretto/MariaDB style). Nothing is planned to go upstream, so
+  no header is held back for upstream-PR diff cleanliness.
+- **Sweep DONE on master (PR #90):** 45 modified-derived files got the modifications line.
+- **Remaining, chaos stack:** `ManagedPCInstance` is registered as an upstream EXTRACTION so the
+  scanner requires Confluent + modifications line - PR #83 currently has it Confluent-only, so the
+  chaos stack needs that one-line addition (plus its already-committed fork-header fixes) once #90
+  merges and the check starts running on those PRs.

--- a/docs/inflight.md
+++ b/docs/inflight.md
@@ -4,6 +4,11 @@
 > can see them. Records work that is parked, in progress on other branches, or otherwise not obvious
 > from `git log`. Keep it current when context-switching. Last updated: 2026-07-28.
 >
+> **Scope rule: this file records ONLY inflight work, or context required for something inflight.**
+> No completed-work narratives, root-cause write-ups, or policy documentation - those belong in
+> AGENTS.md (policy), PR descriptions/commit messages (history), or `docs/solutions/` (lessons).
+> When work finishes, delete or shrink its entry rather than converting it into a record.
+>
 > **The durable fork↔upstream mapping now lives in a machine-readable cache:**
 > [`src/docs/development/upstream-map.yaml`](../src/docs/development/upstream-map.yaml) is the
 > source of truth for which fork branch/PR maps to which upstream issue/PR and its status
@@ -444,22 +449,10 @@ all are pre-existing job/gate problems. Only three checks actually gate merge (r
   changes that touch no code. **Fix:** align the `paths`/`paths-ignore` filters across these jobs so a
   docs-only change runs a consistent (or fully skipped) set.
 
-## Copyright headers - enforcement + fork convention (2026-07-31, PR #90)
+## Copyright headers - open follow-up (2026-07-31)
 
-- **Root cause of the mislabeled-header class, fixed:** the mycila license plugin defaulted to
-  `format` mode with its single Confluent header template, so any bare `mvn` build stamped the wrong
-  attribution onto fork-original files (this is how the chaos-suite files got Confluent headers), and
-  its git-year resolver auto-bumped years and broke in worktrees. Now skipped by default
-  (`<license.skip>true</license.skip>`); `-Dlicense.skip` on command lines is obsolete-but-harmless.
-- **Enforcement:** `bin/check-copyright-headers.sh` + the `Copyright Headers` workflow (self-tested,
-  13 fixture assertions, runs on every PR + master push). Provenance from the pinned fork point
-  (7f290122): fork-original files need the fork header; upstream-derived files keep Confluent's; and
-  **modified-since-fork derived files (incl. changed renames + extractions) must ADD
-  `Modifications Copyright (C) <year> Antony Stubbs and contributors`** - the Apache 2.0
-  4(b)/4(c) dual-notice convention (Corretto/MariaDB style). Nothing is planned to go upstream, so
-  no header is held back for upstream-PR diff cleanliness.
-- **Sweep DONE on master (PR #90):** 45 modified-derived files got the modifications line.
-- **Remaining, chaos stack:** `ManagedPCInstance` is registered as an upstream EXTRACTION so the
-  scanner requires Confluent + modifications line - PR #83 currently has it Confluent-only, so the
-  chaos stack needs that one-line addition (plus its already-committed fork-header fixes) once #90
-  merges and the check starts running on those PRs.
+- **Chaos stack must pass the new header check once PR #90 merges.** The scanner
+  (`bin/check-copyright-headers.sh`, policy in AGENTS.md) registers `ManagedPCInstance` as an
+  upstream EXTRACTION, requiring Confluent + the `Modifications Copyright (C) 2026 Antony Stubbs
+  and contributors` line - PR #83 currently has it Confluent-only, so add that line on the stack.
+  The stack's other fork-header fixes are already committed (#83) or in flight (#85).

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ExceptionInUserFunctionException.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ExceptionInUserFunctionException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/PCRetriableException.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/PCRetriableException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerException.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/EpochAndRecordsMap.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/EpochAndRecordsMap.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.internal;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.state.PartitionStateManager;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/InternalException.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/InternalException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.internal;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/InternalRuntimeException.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/internal/InternalRuntimeException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.internal;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.StringUtils;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/BitSetEncodingNotSupportedException.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/BitSetEncodingNotSupportedException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/EncodingNotSupportedException.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/EncodingNotSupportedException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.internal.InternalException;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/KafkaStreamsEncodingNotSupported.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/KafkaStreamsEncodingNotSupported.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/NoEncodingPossibleException.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/NoEncodingPossibleException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.internal.InternalException;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetDecodingError.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetDecodingError.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.internal.InternalException;

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/RunLengthV1EncodingNotSupported.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/RunLengthV1EncodingNotSupported.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/RunLengthV2EncodingNotSupported.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/RunLengthV2EncodingNotSupported.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionStateManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/state/PartitionStateManager.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.state;
 
 /*-
  * Copyright (C) 2020-2025 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerIntegrationTest.java
@@ -1,6 +1,7 @@
 
 /*-
  * Copyright (C) 2020-2025 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 /*-

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerPollerBackpressureTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/BrokerPollerBackpressureTest.java
@@ -1,6 +1,7 @@
 
 /*-
  * Copyright (C) 2020-2024 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 package io.confluent.parallelconsumer.integrationTests;
 

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/DrainCloseTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/DrainCloseTest.java
@@ -1,6 +1,7 @@
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 package io.confluent.parallelconsumer.integrationTests;
 

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/LargeVolumeInMemoryTests.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/LargeVolumeInMemoryTests.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.integrationTests;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.ProgressBarUtils;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceHighVolumeTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/MultiInstanceHighVolumeTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.integrationTests;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.ProgressBarUtils;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/PartitionOrderProcessingTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/PartitionOrderProcessingTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.integrationTests;
 
 /*-
  * Copyright (C) 2020-2024 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.ThreadUtils;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RebalanceTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RebalanceTest.java
@@ -1,6 +1,7 @@
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 package io.confluent.parallelconsumer.integrationTests;
 

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RetriesTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/RetriesTest.java
@@ -1,6 +1,7 @@
 
 /*-
  * Copyright (C) 2020-2024 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 package io.confluent.parallelconsumer.integrationTests;
 

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionMarkersTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionMarkersTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.integrationTests;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.FakeRuntimeException;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.integrationTests;
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.google.common.truth.Truth;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/VeryLargeMessageVolumeTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/VeryLargeMessageVolumeTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.integrationTests;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.ProgressBarUtils;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/state/PartitionStateCommittedOffsetIT.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/state/PartitionStateCommittedOffsetIT.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.integrationTests.state;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.google.common.truth.StringSubject;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/BrokerCommitAsserter.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/BrokerCommitAsserter.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.integrationTests.utils;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import lombok.AccessLevel;

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/utils/KafkaClientUtils.java
@@ -1,6 +1,7 @@
 
 /*-
  * Copyright (C) 2020-2024 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 package io.confluent.parallelconsumer.integrationTests.utils;
 

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorTestBase.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/AbstractParallelEoSStreamProcessorTestBase.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.google.common.truth.Truth;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/MockConsumerTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/MockConsumerTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.LongPollingMockConsumer;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/MockConsumerTestWithCommitTimeoutException.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/MockConsumerTestWithCommitTimeoutException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2024 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import lombok.extern.slf4j.Slf4j;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/MockConsumerTestWithEarlyClose.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/MockConsumerTestWithEarlyClose.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2024 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.LongPollingMockConsumer;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/MockConsumerTestWithSaslAuthenticationException.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/MockConsumerTestWithSaslAuthenticationException.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2024 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import lombok.extern.slf4j.Slf4j;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/PCMetricsTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/PCMetricsTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2025 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.metrics.PCMetricsDef;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSSStreamProcessorRebalancedTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/ParallelEoSSStreamProcessorRebalancedTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions.CommitMode;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/Quarantined.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/Quarantined.java
@@ -1,6 +1,6 @@
 package io.confluent.parallelconsumer;
 /*-
- * Copyright (C) 2020-2026 Antony Stubbs and contributors
+ * Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import org.junit.jupiter.api.Tag;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/RepoRoot.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/RepoRoot.java
@@ -1,6 +1,6 @@
 package io.confluent.parallelconsumer;
 /*-
- * Copyright (C) 2020-2026 Antony Stubbs and contributors
+ * Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import java.nio.file.Files;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/ProducerManagerTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/internal/ProducerManagerTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.internal;
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.google.common.truth.Truth;

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/offsets/RunLengthEncoderTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/offsets/RunLengthEncoderTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.google.common.truth.Truth;

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/src/main/java/io/confluent/parallelconsumer/examples/metrics/CoreApp.java
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/src/main/java/io/confluent/parallelconsumer/examples/metrics/CoreApp.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.examples.metrics;
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.sun.net.httpserver.HttpServer;

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/CoreAppMetricsIntegrationTest.java
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/CoreAppMetricsIntegrationTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.examples.metrics.integrationTests;
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/PrometheusContainer.java
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/src/test/java/io/confluent/parallelconsumer/examples/metrics/integrationTests/PrometheusContainer.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.examples.metrics.integrationTests;
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.github.dockerjava.api.command.InspectContainerResponse;

--- a/parallel-consumer-examples/parallel-consumer-example-streams/src/main/java/io/confluent/parallelconsumer/examples/streams/StreamsApp.java
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/src/main/java/io/confluent/parallelconsumer/examples/streams/StreamsApp.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.examples.streams;
 
 /*-
  * Copyright (C) 2020 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 

--- a/parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/integrationTests/StreamsAppTest.java
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/src/test/java/io/confluent/parallelconsumer/examples/streams/integrationTests/StreamsAppTest.java
@@ -1,6 +1,7 @@
 package io.confluent.parallelconsumer.examples.streams.integrationTests;
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.examples.streams.StreamsApp;

--- a/parallel-consumer-mutiny/src/test/java/io/confluent/parallelconsumer/mutiny/MutinyBatchTest.java
+++ b/parallel-consumer-mutiny/src/test/java/io/confluent/parallelconsumer/mutiny/MutinyBatchTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.mutiny;
 
 /*-
  * Copyright (C) 2020-2025 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.KafkaTestUtils;

--- a/parallel-consumer-mutiny/src/test/java/io/confluent/parallelconsumer/mutiny/MutinyPCTest.java
+++ b/parallel-consumer-mutiny/src/test/java/io/confluent/parallelconsumer/mutiny/MutinyPCTest.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.mutiny;
 
 /*-
  * Copyright (C) 2020-2025 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.csid.utils.LatchTestUtils;

--- a/parallel-consumer-vertx/src/test-integration/java/io/confluent/parallelconsumer/vertx/integrationTests/VertxConcurrencyIT.java
+++ b/parallel-consumer-vertx/src/test-integration/java/io/confluent/parallelconsumer/vertx/integrationTests/VertxConcurrencyIT.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.vertx.integrationTests;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import com.github.tomakehurst.wiremock.WireMockServer;

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,14 @@
         <jvm.location>${java.home}</jvm.location>
         <jvm8.location>-insert jvm8 location via environment variable-</jvm8.location>
         <jvm9.location>-insert jvm9 location via environment variable-</jvm9.location>
+        <!-- The mycila license plugin is SKIPPED BY DEFAULT for this fork: it knows only one header
+             template (the Confluent one), so its format goal used to rewrite fork-original files with
+             the wrong attribution, and its git-based year resolver auto-bumps years and breaks in git
+             worktrees. Header conformance is enforced by bin/check-copyright-headers.sh instead
+             (provenance-aware: upstream-derived files keep the Confluent header, fork-original files
+             use the fork header - see AGENTS.md "Copyright rules for this fork"). Re-enable the plugin
+             deliberately with -Dlicense.skip=false if you ever need its format goal on upstream files. -->
+        <license.skip>true</license.skip>
         <!-- default to format when on developer machines, check when in CI -->
         <license.mode>format</license.mode>
         <delombok.output>${project.basedir}/target/delombok</delombok.output>


### PR DESCRIPTION
## Why

The mycila license-maven-plugin knows only ONE header template (`Confluent, Inc. and contributors` + git-derived years) and its default mode is `format` - so any bare `mvn` build **rewrote fork-original files with the wrong attribution**. That is exactly how the chaos-suite files ended up claiming Confluent copyright (since corrected on their branches). The plugin's git-year resolver is also what auto-bumps years and breaks in git worktrees.

## What

- **Skip the plugin by default** (`<license.skip>true</license.skip>` in the root pom). `-Dlicense.skip` on command lines is no longer needed (harmless where it remains). Verified: `mvn process-sources` logs "License Plugin is Skipped".
- **`bin/check-copyright-headers.sh`** enforces the fork's real header policy (AGENTS.md), classifying every tracked java file by provenance against the pinned fork point (`7f290122`, the merge-base with upstream). Fully local and deterministic - no network, no upstream remote:
  - **fork-original** (added since the fork point): must carry `Copyright (C) <year> Antony Stubbs and contributors`, must not claim Confluent.
  - **upstream-derived, unmodified**: keeps the Confluent header untouched.
  - **upstream-derived, MODIFIED since the fork point** (incl. renames with changes, and extractions): retains the Confluent notice and must ADD `Modifications Copyright (C) <year> Antony Stubbs and contributors` - the Apache 2.0 §4(b)/§4(c) dual-notice convention (Corretto/MariaDB style). Nothing goes upstream from this fork, so no header is held back for diff cleanliness.
  - Years are deliberately NOT policed (never bump years incidentally).
- **Provenance-smart exceptions list**: renames registered as `newpath|oldpath` (verbatim rename = Confluent-only OK; changed rename = modifications line required); extractions always require the line. Registered: the 3 example ITs relocated in `fface195`, and `ManagedPCInstance` (chaos stack, pre-registered so the check doesn't ambush #83 at merge).
- **Sweep**: 45 modified-derived files on master received the modifications line; two fork-original files' year ranges tidied.
- **Self-tests**: `bin/test-check-copyright-headers.sh` - 13 assertions against fixture repos covering every rule, the exceptions mechanics, the clean path, and the shallow-clone guard. CI runs the self-test before the real scan.
- **`Copyright Headers` workflow**: self-test + scan on every PR and master push (push scoped to master, matching maven.yml, so PR commits run once - not twice). GitHub-hosted, under a minute, `fetch-depth: 0` for the fork-point commit.
- AGENTS.md + docs/inflight.md document the convention, the root cause, and the follow-ups.

## Verification

- Scanner self-tests: 13/13 green
- Real scan on master: 213 java files, 0 violations
- All-module `mvn test-compile` clean after the 45-file header sweep
- actionlint clean; `mvn validate` green with the pom change

Note: once this merges, the chaos-stack PRs (#83/#85/#87) will fail this check until their in-flight fork-header fixes land (plus `ManagedPCInstance` needing its modifications line on #83) - a deliberate forcing function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ALhTf1TRA2S6Ue5rkiQdK