### PR TITLE
build(copyright): run the header scanner in mvn validate, not just CI

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -42,4 +42,8 @@ jobs:
         run: bash bin/test-check-copyright-headers.sh
 
       - name: Check copyright headers
+        # Strict: hard-fail (not warn+skip) if the fork point is missing - this job fetches full
+        # history, so a missing fork point means something is wrong rather than an expected shallow clone.
+        env:
+          COPYRIGHT_CHECK_REQUIRE_FORK_POINT: "1"
         run: bash bin/check-copyright-headers.sh

--- a/bin/check-copyright-headers.sh
+++ b/bin/check-copyright-headers.sh
@@ -65,9 +65,17 @@ ${COPYRIGHT_CHECK_EXTRA_EXTRACTIONS:-}
 "
 
 if ! git cat-file -e "${FORK_POINT}^{commit}" 2>/dev/null; then
-    echo "ERROR: fork-point commit ${FORK_POINT} not found in history." >&2
-    echo "       Fetch full history first (CI: actions/checkout with fetch-depth: 0)." >&2
-    exit 2
+    # Provenance can't be determined without the fork-point commit (e.g. a shallow clone, or a
+    # `mvn validate` build in an environment without full history). Default: WARN and skip rather
+    # than fail the build - the authoritative gate is copyright.yml, which fetches full history
+    # (fetch-depth: 0). Set COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1 to hard-fail instead (CI does).
+    msg="fork-point commit ${FORK_POINT} not in history - need full history (CI: actions/checkout fetch-depth: 0)."
+    if [ "${COPYRIGHT_CHECK_REQUIRE_FORK_POINT:-0}" = "1" ]; then
+        echo "ERROR: ${msg}" >&2
+        exit 2
+    fi
+    echo "WARNING: ${msg} Skipping copyright header check." >&2
+    exit 0
 fi
 
 upstream_files=$(git ls-tree -r --name-only "$FORK_POINT")

--- a/bin/test-check-copyright-headers.sh
+++ b/bin/test-check-copyright-headers.sh
@@ -24,7 +24,8 @@
 #   12. fork-original file claiming Confluent copyright            -> FAIL
 #   13. fork-original file with no recognised header               -> FAIL
 #   14. clean repo                                                 -> exit 0
-#   15. fork-point commit missing from history (shallow clone)     -> exit 2
+#   15. fork-point commit missing from history (shallow clone)     -> exit 0 (warn+skip);
+#       exit 2 only with COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1 (strict, as CI sets)
 #
 # Run: bin/test-check-copyright-headers.sh   (CI runs it before the real scan)
 
@@ -156,10 +157,17 @@ assert "clean repo exits 0" 0 "$rc"
 assert_contains "clean repo reports zero violations" "0 violation(s)" "$out"
 
 # --- Fixture C: fork point not in history (rule 15) ---------------------------------
+# Default: WARN and skip (exit 0) - can't determine provenance, so degrade gracefully (e.g. a
+# shallow clone or a `mvn validate` build); the authoritative gate is copyright.yml (fetch-depth: 0).
 out=$( (cd "$repoB" && COPYRIGHT_CHECK_FORK_POINT=0000000000000000000000000000000000000000 \
         bash "$SCANNER") 2>&1 ) && rc=0 || rc=$?
-assert          "missing fork point exits 2"            2 "$rc"
-assert_contains "missing fork point explains the fix"   "fetch-depth: 0" "$out"
+assert          "missing fork point skips (exit 0) by default" 0 "$rc"
+assert_contains "missing fork point warns + explains the fix"  "fetch-depth: 0" "$out"
+# Strict mode: COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1 hard-fails (exit 2) - what CI sets.
+out=$( (cd "$repoB" && COPYRIGHT_CHECK_FORK_POINT=0000000000000000000000000000000000000000 \
+        COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1 bash "$SCANNER") 2>&1 ) && rc=0 || rc=$?
+assert          "missing fork point hard-fails (exit 2) in strict mode" 2 "$rc"
+assert_contains "strict-mode missing fork point explains the fix"       "fetch-depth: 0" "$out"
 
 echo
 if [ "$failures" -eq 0 ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,14 @@
              the wrong attribution, and its git-based year resolver auto-bumps years and breaks in git
              worktrees. Header conformance is enforced by bin/check-copyright-headers.sh instead
              (provenance-aware: upstream-derived files keep the Confluent header, fork-original files
-             use the fork header - see AGENTS.md "Copyright rules for this fork"). Re-enable the plugin
-             deliberately with -Dlicense.skip=false if you ever need its format goal on upstream files. -->
+             use the fork header - see AGENTS.md "Copyright rules for this fork"). That scanner runs
+             in the `validate` phase via exec-maven-plugin (below), so a local `mvn` build catches
+             header violations too, not only the copyright.yml GitHub Action. Re-enable the mycila
+             plugin deliberately with -Dlicense.skip=false if you ever need its format goal on upstream files. -->
         <license.skip>true</license.skip>
+        <!-- Skip the in-build copyright-header scanner (exec-maven-plugin, validate phase) with
+             -Dcopyright.skip=true. Runs by default; unlike the mycila plugin it is worktree-safe. -->
+        <copyright.skip>false</copyright.skip>
         <!-- default to format when on developer machines, check when in CI -->
         <license.mode>format</license.mode>
         <delombok.output>${project.basedir}/target/delombok</delombok.output>
@@ -720,6 +725,34 @@
                             <goal>${license.mode}</goal>
                         </goals>
                         <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Provenance-aware copyright-header conformance IN THE BUILD (fork policy, AGENTS.md).
+                 Runs bin/check-copyright-headers.sh in `validate` so `mvn` catches header violations
+                 locally, not only via the copyright.yml GitHub Action. Once at the root (inherited=false).
+                 The script cd's to the git top-level itself, so ${project.basedir} (the root) is fine.
+                 Skip with -Dcopyright.skip=true. Needs the fork-point commit in history; on a shallow
+                 clone the scanner warns and skips (CI's copyright.yml uses fetch-depth: 0 + strict mode). -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>check-copyright-headers</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${copyright.skip}</skip>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>${project.basedir}/bin/check-copyright-headers.sh</argument>
+                            </arguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Why

The provenance-aware copyright-header check (`bin/check-copyright-headers.sh`, added in #90/#91) only ran via the `copyright.yml` GitHub Action and manual invocation. A local `mvn validate`/`install` did **zero** header enforcement - the mycila license plugin is `-Dlicense.skip=true` by default for this fork. So header mistakes only surfaced in CI. This wires the check into the build so `mvn` catches them locally too.

## What

- **`exec-maven-plugin`** runs the scanner in the **`validate`** phase, once at the root (`inherited=false`; the script `cd`s to the git top-level itself). Skippable with **`-Dcopyright.skip=true`** (new property, default `false`). This is only safe because the scanner is worktree-safe (unlike the mycila plugin, which is why that one is skipped).
- **Graceful shallow-clone handling:** the scanner needs the fork-point commit to classify provenance. It now **warns and skips (exit 0)** when that commit is absent instead of hard-failing, so it never breaks a shallow-clone / no-full-history build. **`COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1`** forces the hard-fail; **`copyright.yml` sets it** (it fetches full history, so a missing fork point there is a genuine error) - the CI gate stays strict.
- **Self-test** updated: fixture C asserts both the default warn+skip (exit 0) and strict hard-fail (exit 2).

## Verification

- `mvn validate` runs the scanner and passes on a clean tree (`Checked 213 java files … 0 violations`).
- A fork-original file wrongly claiming Confluent **fails the build** (`exec-maven-plugin … Process exited with an error: 1`).
- `-Dcopyright.skip=true` bypasses it.
- `bin/test-check-copyright-headers.sh` passes (both fork-point modes).

Standalone, off `master` - not related to the highcpu-runner PR (#75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
