### PR TITLE
fix(copyright): SIGPIPE + pipefail race randomly misclassifies files in the header scanner

### DIFF
--- a/bin/check-copyright-headers.sh
+++ b/bin/check-copyright-headers.sh
@@ -86,10 +86,13 @@ fails=0
 checked=0
 
 require_confluent() { # <file> <header>
-    if ! printf '%s' "$2" | grep -q "Copyright (C)"; then
+    # Membership/pattern tests use herestrings, never `printf | grep -q`: grep -q exits at first
+    # match, printf takes SIGPIPE, and under pipefail the pipeline then reads as FALSE - randomly
+    # misclassifying files that DID match (seen in CI: an upstream file flagged as fork-original).
+    if ! grep -q "Copyright (C)" <<< "$2"; then
         echo "FAIL (upstream-derived file has no copyright header): $1"
         return 1
-    elif ! printf '%s' "$2" | grep -q "Confluent"; then
+    elif ! grep -q "Confluent" <<< "$2"; then
         echo "FAIL (upstream-derived file lost its Confluent header): $1"
         return 1
     fi
@@ -99,7 +102,7 @@ require_modifications_line() { # <file> <header> <reason>
     # The phrase and the holder must be on the SAME line: a mere mention of the
     # holder elsewhere in the header (e.g. an @author byline) is not a notice.
     # Years are deliberately not policed (see above).
-    if ! printf '%s' "$2" | grep -q "Modifications Copyright (C).*${FORK_HOLDER}"; then
+    if ! grep -q "Modifications Copyright (C).*${FORK_HOLDER}" <<< "$2"; then
         echo "FAIL ($3 but missing 'Modifications Copyright ... ${FORK_HOLDER}' line): $1"
         return 1
     fi
@@ -112,7 +115,9 @@ while IFS= read -r f; do
 
     # exact match on the newpath field - a substring match would misroute files
     # whose path is a tail-substring of a registered newpath into the rename branch
-    rename_entry=$(printf '%s\n' "$RENAMED_FROM_UPSTREAM" | awk -F'|' -v f="$f" '$1 == f {print; exit}')
+    # herestring, not `printf | awk`: awk's early `exit` would SIGPIPE printf, and under
+    # `set -e` a failed $() assignment kills the whole script
+    rename_entry=$(awk -F'|' -v f="$f" '$1 == f {print; exit}' <<< "$RENAMED_FROM_UPSTREAM")
     if [ -n "$rename_entry" ]; then
         old_path=${rename_entry#*|}
         require_confluent "$f" "$header" || { fails=$((fails + 1)); continue; }
@@ -120,22 +125,22 @@ while IFS= read -r f; do
             require_modifications_line "$f" "$header" \
                 "renamed upstream file modified since the fork point" || fails=$((fails + 1))
         fi
-    elif printf '%s\n' "$EXTRACTED_FROM_UPSTREAM" | grep -qxF "$f"; then
+    elif grep -qxF "$f" <<< "$EXTRACTED_FROM_UPSTREAM"; then
         require_confluent "$f" "$header" || { fails=$((fails + 1)); continue; }
         require_modifications_line "$f" "$header" \
             "extraction of upstream-derived code" || fails=$((fails + 1))
-    elif printf '%s\n' "$upstream_files" | grep -qxF "$f"; then
+    elif grep -qxF "$f" <<< "$upstream_files"; then
         require_confluent "$f" "$header" || { fails=$((fails + 1)); continue; }
-        if printf '%s\n' "$modified_since_fork" | grep -qxF "$f"; then
+        if grep -qxF "$f" <<< "$modified_since_fork"; then
             require_modifications_line "$f" "$header" \
                 "upstream-derived file modified since the fork point" || fails=$((fails + 1))
         fi
     else
         # fork-original: fork header required, Confluent claim forbidden
-        if printf '%s' "$header" | grep -q "Confluent"; then
+        if grep -q "Confluent" <<< "$header"; then
             echo "FAIL (fork-original file claims Confluent copyright): $f"
             fails=$((fails + 1))
-        elif ! printf '%s' "$header" | grep -q "$FORK_HOLDER"; then
+        elif ! grep -q "$FORK_HOLDER" <<< "$header"; then
             echo "FAIL (fork-original file missing '${FORK_HOLDER}' header): $f"
             fails=$((fails + 1))
         fi

--- a/bin/test-check-copyright-headers.sh
+++ b/bin/test-check-copyright-headers.sh
@@ -169,6 +169,18 @@ out=$( (cd "$repoB" && COPYRIGHT_CHECK_FORK_POINT=000000000000000000000000000000
 assert          "missing fork point hard-fails (exit 2) in strict mode" 2 "$rc"
 assert_contains "strict-mode missing fork point explains the fix"       "fetch-depth: 0" "$out"
 
+# --- Structural guard: no SIGPIPE-prone pipes in the scanner ------------------------
+# `printf | grep -q` (or piping into awk that `exit`s early) under `set -euo pipefail`
+# randomly evaluates a MATCH as false when the reader exits before the writer finishes
+# (SIGPIPE -> pipefail), misclassifying files. Seen live in CI: an upstream file flagged
+# as fork-original. Membership tests must use herestrings (<<<), never pipes.
+if grep -vE '^[[:space:]]*#' "$SCANNER" | grep -nE '\|[[:space:]]*grep -q|\|[[:space:]]*awk '; then
+    echo "FAIL: scanner pipes into an early-exiting reader (SIGPIPE + pipefail misclassification risk) - use a herestring"
+    failures=$((failures + 1))
+else
+    echo "ok:   scanner has no SIGPIPE-prone pipes into grep -q / awk"
+fi
+
 echo
 if [ "$failures" -eq 0 ]; then
     echo "All scanner self-tests passed."


### PR DESCRIPTION
## Why

Seen live on PR #93's Copyright Headers check: upstream's `ParallelStreamProcessor.java` was flagged as *"fork-original file claims Confluent copyright"* alongside `printf: write error: Broken pipe`.

Root cause: membership tests of the form `printf '%s\n' "$list" | grep -qxF "$f"`. `grep -q` exits at the first match; if `printf` is still writing it takes SIGPIPE, and under `set -o pipefail` (added by the #91 hardening) the pipeline then reports failure **even though grep matched** - so a file that IS in the upstream list randomly reads as not-found and falls through to the fork-original branch. Timing-dependent, so it passes most runs and fails at random.

The rename lookup had a worse variant: `$(printf … | awk '… exit')` - awk's early `exit` SIGPIPEs printf inside a command substitution, and under `set -e` a failed `$()` assignment kills the whole script silently.

Urgency: #92 wired the scanner into `mvn validate`, so the race would have intermittently broken every local build, not just the CI check.

## What

- All 9 pipe sites converted to herestrings (`grep -qxF "$f" <<< "$list"`) - no pipe, no concurrent writer, no SIGPIPE, no race. Same semantics, correct by construction.
- Structural regression guard in the self-test: fails if any non-comment line in the scanner pipes into `grep -q` / `awk` again.

## Verification

- Self-tests 17/17 (including #92's new cases: header-swap, @author byline, tail-substring rename, warn-and-skip fork point)
- Full scan on master: 213 files, 0 violations
- Rebased onto current master (includes #91 + #92)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ALhTf1TRA2S6Ue5rkiQdK