### PR TITLE
ci(review): enable track_progress for the automatic Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Post visible "review in progress" status on the PR (sticky tracking comment) so it's clear a
+          # review is running, not just silent until it finishes.
+          track_progress: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           # --comment is REQUIRED for the review to be posted: without it the plugin's step 7


### PR DESCRIPTION
## Description

Enable `track_progress: true` on the automatic Claude review (`anthropics/claude-code-action` in `claude-code-review.yml`), so a visible sticky "review in progress" status is posted on the PR while the review runs, rather than the PR staying silent until the review finishes. Optional one-liner; no change to the review behaviour itself.

## Checklist

- [ ] Changelog entry added - `N/A` - trivial CI config toggle, no operator/user-facing effect
- [ ] Docs updated - `N/A`
- [ ] Tests added/updated - `N/A` - workflow config
- [x] Title & body reflect the final content of this PR
- [ ] Self-hosted runner / security implications considered - `N/A` - runs on the existing GitHub-hosted review job

🤖 Generated with [Claude Code](https://claude.com/claude-code)
