### PR TITLE
docs #167: fix the retry-delay example, and the reference conventions it ran into

### DIFF
--- a/.github/scripts/issue-ref-gate.js
+++ b/.github/scripts/issue-ref-gate.js
@@ -98,6 +98,39 @@ function suspectRefs(files, opts = {}) {
   return out;
 }
 
+/**
+ * The single copy of what an author is told when the gate fires. Both callers render this - the CI
+ * job in pr-checklist.yml and the local bin/check-issue-refs.sh - so the two cannot tell different
+ * stories. They did exactly that once: hand-written copies disagreed in *both* directions within
+ * hours of the second one being created, each carrying a correction the other lacked. The script's
+ * own header already says "NO SECOND COPY OF THE RULE" about the matching logic; the message an
+ * author actually reads is part of that rule.
+ *
+ * @param hits  [{ file, ref, text }] from suspectRefs
+ * @param opts  { repo }        owner/name used in the mirror-lookup hint
+ *              { readsPrBody } false when the caller cannot honour the "issue-refs: N/A" opt-out
+ * @returns string
+ */
+function formatFailure(hits, opts = {}) {
+  const repo = opts.repo ?? "astubbs/parallel-consumer";
+  const optOutTail = opts.readsPrBody === false
+    ? "line in the PR body - the workflow honours that opt-out; this script does not read the PR body."
+    : "line in the PR body.";
+
+  return (
+    `${hits.length} reference(s) below #${QUALIFY_BELOW} do not say which repo they mean.\n` +
+    "The fork's numbers sit inside confluentinc's range, so a bare number there is a coin flip.\n" +
+    "Write `astubbs#NN` for this repo or `confluentinc#NN` for the original - or link it.\n" +
+    "(`upstream #NN` still passes, for compatibility with older docs - but it names a role,\n" +
+    "not a repo. Do not use it in new text; it is being swept out.)\n" +
+    "Every confluentinc issue is mirrored here, and the mirror is usually the better number to cite:\n" +
+    `  gh issue list -R ${repo} --label upstream-mirror --search "upstream #NN"\n` +
+    'If a flagged reference genuinely needs no qualifier, put "issue-refs: N/A - <reason>" on its own\n' +
+    `${optOutTail}\n\n` +
+    hits.map((h) => `  ${h.file}: ${h.ref}  ${h.text}`).join("\n")
+  );
+}
+
 module.exports = {
-  suspectRefs, findOptOut, isExempt, stripQualified, EXEMPT_PATHS, QUALIFY_BELOW,
+  suspectRefs, findOptOut, isExempt, stripQualified, formatFailure, EXEMPT_PATHS, QUALIFY_BELOW,
 };

--- a/.github/scripts/issue-ref-gate.js
+++ b/.github/scripts/issue-ref-gate.js
@@ -124,7 +124,7 @@ function formatFailure(hits, opts = {}) {
     "(`upstream #NN` still passes, for compatibility with older docs - but it names a role,\n" +
     "not a repo. Do not use it in new text; it is being swept out.)\n" +
     "Every confluentinc issue is mirrored here, and the mirror is usually the better number to cite:\n" +
-    `  gh issue list -R ${repo} --label upstream-mirror --search "upstream #NN"\n` +
+    `  gh issue list -R ${repo} --label upstream-mirror --search "confluentinc#NN"\n` +
     'If a flagged reference genuinely needs no qualifier, put "issue-refs: N/A - <reason>" on its own\n' +
     `${optOutTail}\n\n` +
     hits.map((h) => `  ${h.file}: ${h.ref}  ${h.text}`).join("\n")

--- a/.github/scripts/issue-ref-gate.test.js
+++ b/.github/scripts/issue-ref-gate.test.js
@@ -146,9 +146,11 @@ check("the failure message names the owner in its prose too, not the role", () =
   assert.ok(!msg.includes("Every upstream issue"), "prose must say Every confluentinc issue");
 });
 
-check("the mirror-lookup hint keeps the literal upstream #NN search key", () => {
-  // The mirror titles are `upstream #NNN: ...`, so this string is an index key, not a reference.
-  assert.ok(formatFailure(HITS).includes('--search "upstream #NN"'));
+check("the mirror-lookup hint searches the owner form, matching the mirror titles", () => {
+  // Mirror titles are `confluentinc#NNN: ...`, so the hint must search that. They used to read
+  // `upstream #NNN:` - an import that deviated from its own plan - and the hint followed it.
+  assert.ok(formatFailure(HITS).includes('--search "confluentinc#NN"'));
+  assert.ok(!formatFailure(HITS).includes('--search "upstream'), "no stale role-form lookup");
 });
 
 check("formatFailure takes the repo from its caller, and defaults to the fork", () => {

--- a/.github/scripts/issue-ref-gate.test.js
+++ b/.github/scripts/issue-ref-gate.test.js
@@ -2,7 +2,7 @@
 // broken rule fails loudly rather than silently passing - or failing - every PR.
 const assert = require("assert");
 const {
-  suspectRefs, findOptOut, isExempt, stripQualified, QUALIFY_BELOW,
+  suspectRefs, findOptOut, isExempt, stripQualified, formatFailure, QUALIFY_BELOW,
 } = require("./issue-ref-gate.js");
 
 const file = (filename, ...added) => [{ filename, patch: added.map((l) => "+" + l).join("\n") }];
@@ -127,6 +127,46 @@ check("opt-out is recognised, and needs a reason", () => {
   assert.ok(findOptOut("blah\nissue-refs: N/A - all refs here are upstream by construction\nblah"));
   assert.ok(!findOptOut("no marker here"));
   assert.ok(!findOptOut("issue-refs: N/A"), "bare N/A without a reason must not count");
+});
+
+// The failure message is shared by the CI gate and bin/check-issue-refs.sh. Two hand-written copies
+// drifted apart within hours, so these pin the parts that made them disagree.
+const HITS = [{ file: "docs/x.md", ref: "#857", text: "See #857" }];
+
+check("the failure message recommends the owner forms, never the role form", () => {
+  const msg = formatFailure(HITS);
+  assert.ok(msg.includes("`astubbs#NN` for this repo or `confluentinc#NN`"), "must lead with owners");
+  assert.ok(!/Write .*`upstream #NN` for/.test(msg), "must not tell the author to write the role form");
+  assert.ok(msg.includes("it is being swept out"), "must say the tolerance is temporary");
+});
+
+check("the failure message names the owner in its prose too, not the role", () => {
+  const msg = formatFailure(HITS);
+  assert.ok(!msg.includes("upstream's range"), "prose must say confluentinc's range");
+  assert.ok(!msg.includes("Every upstream issue"), "prose must say Every confluentinc issue");
+});
+
+check("the mirror-lookup hint keeps the literal upstream #NN search key", () => {
+  // The mirror titles are `upstream #NNN: ...`, so this string is an index key, not a reference.
+  assert.ok(formatFailure(HITS).includes('--search "upstream #NN"'));
+});
+
+check("formatFailure takes the repo from its caller, and defaults to the fork", () => {
+  assert.ok(formatFailure(HITS, { repo: "acme/thing" }).includes("gh issue list -R acme/thing"));
+  assert.ok(formatFailure(HITS).includes("gh issue list -R astubbs/parallel-consumer"));
+});
+
+check("the opt-out tail matches whether the caller can read the PR body", () => {
+  assert.ok(!formatFailure(HITS).includes("does not read the PR body"));
+  assert.ok(formatFailure(HITS, { readsPrBody: false }).includes("does not read the PR body"));
+});
+
+check("every hit is listed, with its count in the first line", () => {
+  const two = [...HITS, { file: "a.md", ref: "#29", text: "and #29" }];
+  const msg = formatFailure(two);
+  assert.ok(msg.startsWith("2 reference(s) below #" + QUALIFY_BELOW));
+  assert.ok(msg.includes("  docs/x.md: #857  See #857"));
+  assert.ok(msg.includes("  a.md: #29  and #29"));
 });
 
 console.log("\n" + run + " assertions passed");

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -141,16 +141,9 @@ jobs:
               return;
             }
 
-            core.setFailed(
-              `${hits.length} reference(s) below #${gate.QUALIFY_BELOW} do not say which repo they mean.\n` +
-              `The fork's numbers sit inside upstream's range, so a bare number there is a coin flip.\n` +
-              `Write \`astubbs#NN\` for this repo or \`upstream #NN\` for confluentinc - or link it.\n` +
-              `Every upstream issue has a mirror here, which is usually the better number to cite:\n` +
-              `  gh issue list -R ${context.repo.owner}/${context.repo.repo} --label upstream-mirror --search "upstream #NN"\n` +
-              `If a flagged reference genuinely needs no qualifier, put "issue-refs: N/A - <reason>" ` +
-              `on its own line in the PR body.\n\n` +
-              hits.map(h => `  ${h.file}: ${h.ref}  ${h.text}`).join("\n")
-            );
+            core.setFailed(gate.formatFailure(hits, {
+              repo: `${context.repo.owner}/${context.repo.repo}`,
+            }));
 
       - name: Verify new changelog entries cite an issue
         uses: actions/github-script@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,7 +316,7 @@ at the cost of an opt-out on every correction.
 
 Every upstream issue now has a **fork mirror** (astubbs#44, astubbs#117-astubbs#195, label `upstream-mirror`), so a
 reference has a fork-local number a reader can click. Find one with
-`gh issue list -R astubbs/parallel-consumer --label upstream-mirror --search "upstream #NNN"`.
+`gh issue list -R astubbs/parallel-consumer --label upstream-mirror --search "confluentinc#NNN"`.
 
 **Working a mirrored issue? Read the upstream original too - body and comments.**
 `gh issue view <N> -R confluentinc/parallel-consumer --json body,comments`. Every mirror says
@@ -352,14 +352,7 @@ Same reasoning that rules out "fork" as a qualifier. In anything
 does not auto-link there, and a bare `#NN` in a comment silently resolves against whichever repo it
 is posted in.
 
-**The `upstream #NNN:` mirror-title prefix is exempt, and so is anything quoting it.** That the
-prefix never changes is [Mirror format](#mirror-format)'s rule; what matters here is the consequence
-for a sweep. The prefix is an **index key**, so the `--search "upstream #NNN"` strings above and in
-the reference gate's failure message are *quoting* a key rather than making a reference. Rewriting
-them to the owner form breaks every one of those lookups at once. Before changing any match, decide
-whether it names an issue or quotes a search.
-
-**Closing keywords are another exception, and getting this one wrong fails silently.** GitHub honours only
+**Closing keywords are the exception, and getting this one wrong fails silently.** GitHub honours only
 `Fixes #167` or `Fixes astubbs/parallel-consumer#167` - the `owner#NN` short form this section
 otherwise prefers is **not** cross-reference syntax, so `Fixes astubbs#167` renders as plain text and
 closes nothing. A bare number is what the convention above forbids, so in a PR body write the fully
@@ -559,7 +552,7 @@ This is a maintained hard fork of the effectively-archived `confluentinc/paralle
 
 **When you start work that maps to an upstream PR, add or update its entry in `upstream-map.yaml`** (don't just note it in prose). Design follows Debian DEP-3, Yocto `Upstream-Status:`, and OpenShift's `UPSTREAM:` fork conventions.
 
-**If the work maps to an upstream *issue*, the fork mirror is where status goes** - diagnosis, labels, and closing all belong on the mirror, because this manifest tracks upstream **PRs** only (every upstream issue has one: astubbs#44, astubbs#117-astubbs#195, label `upstream-mirror`). Find it with `gh issue list -R astubbs/parallel-consumer --label upstream-mirror --search "upstream #NNN"`, and cite both numbers, fork first - see [Issue references](#issue-references).
+**If the work maps to an upstream *issue*, the fork mirror is where status goes** - diagnosis, labels, and closing all belong on the mirror, because this manifest tracks upstream **PRs** only (every upstream issue has one: astubbs#44, astubbs#117-astubbs#195, label `upstream-mirror`). Find it with `gh issue list -R astubbs/parallel-consumer --label upstream-mirror --search "confluentinc#NNN"`, and cite both numbers, fork first - see [Issue references](#issue-references).
 
 **Keeping it in sync is the agent's job, and it does not stop at "start work".** Nothing automated checks the *fork* side: `upstream-map.py validate` only checks the schema, and `upstream-sweep.sh` only watches upstream — so a manifest that says `prs: []` while a fork PR is open still passes every check, and the mapping quietly rots (a 2026-08-04 audit found five such entries). Update the entry **at every lifecycle transition of your own work**, in the same commit that causes it: opening a PR (`prs:` + `status: pr-open`), finishing on a branch without a PR (`status: ready`), merging (`merged`), releasing (`released`), abandoning (`superseded`/`wontfix`). Loose ends do **not** go in this manifest - it has no `todo:` field. Anything a command can answer ("how far behind is PR #N?" - `git rev-list --left-right --count`) should be asked of the command rather than cached here, where it rots. Record what no command knows in `docs/inflight/`; keep this manifest to the mapping itself.
 
@@ -571,8 +564,13 @@ Branch naming and commit trailers are git conventions rather than upstream-mappi
 
 Every open upstream issue has a mirror here. When you create one, or edit one:
 
-- **Title `upstream #NNN: <description>`.** The `upstream #NNN:` prefix is the join to upstream and
-  never changes. The description half started as upstream's own title, but it is **ours to rewrite** -
+- **Title `confluentinc#NNN: <description>`.** The `confluentinc#NNN:` prefix is the join to
+  upstream and never changes. It uses the owner form for the same reason everything else does - see
+  [Issue references](#issue-references). It read `upstream #NNN:` until astubbs#196: the bulk import
+  deviated from its own plan, which had specified the owner form, and the deviation was written up
+  afterwards as if it were the intent. Neither form auto-links in a title, so nothing was gained by
+  the role word; all 78 mirrors were retitled. The description half started as upstream's own title,
+  but it is **ours to rewrite** -
   many upstream titles name only where a failure surfaced ("Error in onPartitionsAssigned") and
   contain no term anyone would search for. Retitle once the cause is actually known.
 - **Always record the upstream title verbatim in the body header**, whether or not the mirror's title
@@ -585,9 +583,10 @@ Every open upstream issue has a mirror here. When you create one, or edit one:
   notifies people who never opted in.
 - **Labels:** `upstream-mirror`, one area label, one type label.
 - **Cross-repo references in the body are fully qualified** - `confluentinc/parallel-consumer#NN`.
-  This is the one place the house prose form does not apply: `upstream #NN` does not auto-link on
-  GitHub, and a bare `#NN` resolves against the fork's own numbering. See
-  [Issue references](#issue-references).
+  This is the one place the house prose form does not apply: `confluentinc#NN` does not auto-link on
+  GitHub - only `owner/repo#NN` does - and a bare `#NN` resolves against the fork's own numbering.
+  Titles are different again: nothing auto-links there, which is why they use the short owner form.
+  See [Issue references](#issue-references).
 - **Read the upstream original before acting on a mirror** - see [Issue references](#issue-references)
   for why the summary is not a substitute, and correct the mirror when it turns out to be wrong.
 
@@ -612,8 +611,9 @@ there is no value in a bulk backfill pass.
 
 `docs/plans/2026-08-04-001-chore-mirror-upstream-issues-plan.md` carries the original bulk-import plan
 and what the run taught. Read it for *why*, not *how* - it is a dated record, so its own copy of this
-format has since drifted (it proposed a `confluentinc#NNN:` title prefix; the import shipped
-`upstream #NNN:`, which is what the mirrors actually use). This section is the live one.
+format has since drifted. Its title prefix was right and the run was wrong: it specified
+`confluentinc#NNN:`, the import shipped `upstream #NNN:`, and that deviation stood until astubbs#196
+retitled all 78 back to the planned form. This section is the live one.
 
 ### Backlinking upstream
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,17 +332,38 @@ code has two (10s and 30s) - so check the mirror's added commentary as sceptical
 When the mirror turns out to be wrong, say so in the PR **and correct the mirror**, or the next
 reader inherits the same error.
 
-**The convention: below #1000, say which repo you mean.** `astubbs#119` for this fork,
+**The convention: below the threshold, say which repo you mean.** `astubbs#119` for this fork,
 `confluentinc#857` for the original - or a hyperlink, which qualifies it just as well. Add `PR` or
 `issue` where the distinction matters (`confluentinc PR #548`); both forms pass the gate.
+
+> **The threshold was #1000 when this was written, but `QUALIFY_BELOW` in
+> [`.github/scripts/issue-ref-gate.js`](.github/scripts/issue-ref-gate.js) is the source of truth.**
+> It is expected to move - confluentinc's numbering still creeps, as the headroom note below says -
+> and prose cannot read a constant, so every `1000` in this file is a snapshot. If they disagree, the
+> constant is right and this document is stale. Change it there, then sweep the prose.
 
 **Name the owner, not the role.** `confluentinc#857`, not `upstream #857` - "upstream" describes a
 relationship rather than a repository, and it is not stable: this fork is itself upstream to anyone
 who forks it. `upstream #NN` still passes the gate so older text is not broken, but new writing uses
-the owner. Same reasoning that rules out "fork" as a qualifier. In anything
+the owner - and that tolerance is temporary: `docs/inflight/next-qualify-remaining-refs.md` carries
+the sweep that removes the remaining uses and then tightens the gate to reject the form outright.
+Same reasoning that rules out "fork" as a qualifier. In anything
 **posted to GitHub**, use the fully qualified `confluentinc/parallel-consumer#857`: upstream prose
 does not auto-link there, and a bare `#NN` in a comment silently resolves against whichever repo it
 is posted in.
+
+**The `upstream #NNN:` mirror-title prefix is exempt, and so is anything quoting it.** That the
+prefix never changes is [Mirror format](#mirror-format)'s rule; what matters here is the consequence
+for a sweep. The prefix is an **index key**, so the `--search "upstream #NNN"` strings above and in
+the reference gate's failure message are *quoting* a key rather than making a reference. Rewriting
+them to the owner form breaks every one of those lookups at once. Before changing any match, decide
+whether it names an issue or quotes a search.
+
+**Closing keywords are another exception, and getting this one wrong fails silently.** GitHub honours only
+`Fixes #167` or `Fixes astubbs/parallel-consumer#167` - the `owner#NN` short form this section
+otherwise prefers is **not** cross-reference syntax, so `Fixes astubbs#167` renders as plain text and
+closes nothing. A bare number is what the convention above forbids, so in a PR body write the fully
+qualified form: `Fixes astubbs/parallel-consumer#167`.
 
 At or above #1000 a bare number is unambiguous, because only this fork can have one.
 
@@ -377,7 +398,7 @@ names (`bugs/857-...`) and the upstream threads all use. Dropping either breaks 
 **Fix references in any file a PR touches.** Not a bulk rewrite - opportunistic, as files are
 touched. In a file being changed anyway:
 
-- every unqualified `#NNN` below 1000 gains its repo - `astubbs#NNN` or `upstream #NNN` -
+- every unqualified `#NNN` below the threshold gains its repo - `astubbs#NNN` or `confluentinc#NNN` -
   **hyperlinked** where the format allows (markdown link, javadoc `<a href>`; a raw URL in a `//`
   comment, which every IDE linkifies)
 - resolve the number in **both** repos before choosing the prefix; it very likely exists in each
@@ -498,6 +519,20 @@ Snapshots publish automatically on every push to `master` (`publish.yml`). Workf
 - `MAVEN_GPG_PASSPHRASE` — Passphrase for the GPG key
 
 ## Worktree ownership
+
+**Never do any work in the main checkout. Every task gets a worktree.** The main clone at the repo
+root is shared mutable state - several agent sessions run against it at once, so its HEAD can move
+between two of *your own* commands. Work only under `.claude/worktrees/<name>`, and reach a task by
+`cd`-ing into its worktree. `git worktree list` tells you which one holds a branch; create one if
+none does.
+
+**Reaching for `git checkout <branch>` is the tell that you are in the wrong directory** - and it is
+how the rule gets broken silently. Git refuses to check out a branch another worktree already holds,
+so the command *fails*; if you piped it into `tail`/`head`, the pipeline still exits 0 and a
+following `&& git rebase …` runs against whatever branch you were really on. On 2026-08-06 that
+rebased an unrelated PR's branch by accident. Two habits prevent it: change directory rather than
+branch, and never pipe a git command whose failure must stop an `&&` chain (or test
+`${PIPESTATUS[0]}`).
 
 Multiple agents/sessions often work in parallel git worktrees (kept under `.claude/worktrees/`). Neither git nor the Claude UI records **which agent is using which worktree**, so this repo uses a convention:
 

--- a/README.adoc
+++ b/README.adoc
@@ -806,7 +806,9 @@ You can access the retry count of a record through it's wrapped `WorkContainer` 
 .Example retry delay function implementing exponential backoff
 [source,java,indent=0]
 ----
-        final double multiplier = 0.5;
+        // Exponential backoff: the multiplier must be > 1 so the delay GROWS with each failed
+        // attempt. Here: 1s, 2s, 4s, 8s ...
+        final double multiplier = 2;
         final int baseDelaySecond = 1;
 
         ParallelConsumerOptions.<String, String>builder()

--- a/README.adoc
+++ b/README.adoc
@@ -1309,7 +1309,7 @@ For what has already shipped, see the link:CHANGELOG.adoc[CHANGELOG].
 
 For what is planned, in progress, or known-broken, the {issues_link}[issue tracker on this repository]
 is the single place to look. We mirrored every open issue from the upstream tracker into it (all 78 of
-them, labelled `upstream-mirror` and titled `upstream #NNN: ...`), so an upstream report you are
+them, labelled `upstream-mirror` and titled `confluentinc#NNN: ...`), so an upstream report you are
 following has a counterpart here that reflects its real status on this fork. Please raise new issues
 here rather than upstream - see <<Support and Issues>>.
 

--- a/bin/check-issue-refs.sh
+++ b/bin/check-issue-refs.sh
@@ -83,15 +83,6 @@ if (hits.length === 0) {
   process.exit(0);
 }
 
-console.error(
-  `${hits.length} reference(s) below #${gate.QUALIFY_BELOW} do not say which repo they mean.\n` +
-  `The fork's numbers sit inside confluentinc's range, so a bare number there is a coin flip.\n` +
-  `Write \`astubbs#NN\` for this repo or \`confluentinc#NN\` for the original - or link it.\n` +
-  `Every confluentinc issue is mirrored here, and the mirror is usually the better number to cite:\n` +
-  `  gh issue list -R astubbs/parallel-consumer --label upstream-mirror --search "upstream #NN"\n` +
-  `If a flagged reference genuinely needs no qualifier, put "issue-refs: N/A - <reason>" on its own\n` +
-  `line in the PR body - the workflow honours that opt-out; this script does not read the PR body.\n\n` +
-  hits.map((h) => `  ${h.file}: ${h.ref}  ${h.text}`).join("\n")
-);
+console.error(gate.formatFailure(hits, { readsPrBody: false }));
 process.exit(1);
 NODE

--- a/docs/inflight/next-qualify-remaining-refs.md
+++ b/docs/inflight/next-qualify-remaining-refs.md
@@ -108,12 +108,12 @@ git grep -nE '\bupstream (PR |issue )?#[0-9]+' -- '*.md' '*.adoc' '*.yml' '*.jav
 Convert each to `confluentinc#NNN`, or to the fork mirror where one exists - the mirror is the number
 a reader of *this* repo can act on.
 
-**The carve-out: mirror issue titles are an index key, not prose.** Every `upstream-mirror` issue is
-titled `upstream #622: <original title>`, and both AGENTS.md and the gate's own failure message
-search that literal string (`--label upstream-mirror --search "upstream #NNN"`). Rewriting those
-search strings to the owner form breaks every documented lookup at once. It is the same class of
-mistake as the three the previous sweep made: a reference that is *shown* rather than *made*. Check
-before rewriting whether a match is naming an issue or quoting a search.
+**The mirror titles are already done** - astubbs#196 retitled all 78 from `upstream #NNN:` to
+`confluentinc#NNN:` and moved the `--search` strings with them, so there is no carve-out here and no
+index key to preserve. Keep the general habit that produced the question though: a match that is
+*shown* rather than *made* - a search string, a template, an example of a wrong form - is not a
+reference, and rewriting it can break the thing it documents. That is the class of mistake the
+previous sweep made three times; see the trap below.
 
 ## How, and the trap
 

--- a/docs/inflight/next-qualify-remaining-refs.md
+++ b/docs/inflight/next-qualify-remaining-refs.md
@@ -1,6 +1,6 @@
 # Next: qualify the remaining issue references tree-wide
 
-The reference gate requires any `#NNN` below 1000 to name its repo (`astubbs#NNN` / `upstream #NNN`),
+The reference gate requires any `#NNN` below 1000 to name its repo (`astubbs#NNN` / `confluentinc#NNN`),
 because the fork's numbers sit entirely inside upstream's range - **48 of the 51 numbers cited in one
 PR's files existed in *both* repos, meaning different things**. It checks **added lines only**, so it
 never fires on text nobody is editing.
@@ -24,7 +24,7 @@ for (const f of cp.execSync("git ls-files", {encoding:"utf8"}).trim().split("\n"
   if (gate.isExempt(f) || !/\.(md|adoc|java|ya?ml|sh|js)$/.test(f) || !fs.existsSync(f)) continue;
   for (const l of fs.readFileSync(f, "utf8").split("\n"))
     for (const m of gate.stripQualified(l).matchAll(/(?<![\w\/#])#(\d+)\b/g))
-      if (+m[1] < 1000) byExt[f.split(".").pop()] = (byExt[f.split(".").pop()] || 0) + 1;
+      if (+m[1] < gate.QUALIFY_BELOW) byExt[f.split(".").pop()] = (byExt[f.split(".").pop()] || 0) + 1;
 }
 console.log(byExt);'
 ```
@@ -93,6 +93,28 @@ Three worth knowing before you start:
 Mostly mechanical, but resolve each one rather than prefixing blind. `#29`, `#100` and `#114` all
 exist in both repos meaning different things.
 
+## Phase 2: `upstream #NNN` -> the owner form
+
+Everything above turns *bare* numbers into qualified ones. `upstream #NNN` is qualified enough for
+the gate but is not the house form: "upstream" names a relationship rather than a repository, and
+this fork is itself upstream to anyone who forks it (AGENTS.md -> Issue references). Around a dozen
+files still use it, concentrated in `docs/inflight/`, `docs/plans/` and `docs/solutions/`. Count
+fresh rather than trusting that number:
+
+```bash
+git grep -nE '\bupstream (PR |issue )?#[0-9]+' -- '*.md' '*.adoc' '*.yml' '*.java' '*.sh' '*.js'
+```
+
+Convert each to `confluentinc#NNN`, or to the fork mirror where one exists - the mirror is the number
+a reader of *this* repo can act on.
+
+**The carve-out: mirror issue titles are an index key, not prose.** Every `upstream-mirror` issue is
+titled `upstream #622: <original title>`, and both AGENTS.md and the gate's own failure message
+search that literal string (`--label upstream-mirror --search "upstream #NNN"`). Rewriting those
+search strings to the owner form breaks every documented lookup at once. It is the same class of
+mistake as the three the previous sweep made: a reference that is *shown* rather than *made*. Check
+before rewriting whether a match is naming an issue or quoting a search.
+
 ## How, and the trap
 
 `git grep` for candidates, but **classify each before rewriting it**. A previous mechanical sweep
@@ -113,9 +135,28 @@ Reuse the gate's own definition of "unqualified", so the sweep and CI agree:
 
 ```js
 const gate = require("./.github/scripts/issue-ref-gate.js");
-gate.stripQualified(line).matchAll(/(?<![\w\/#])#(\d+)\b/g)   // hits < 1000 need qualifying
+gate.stripQualified(line).matchAll(/(?<![\w\/#])#(\d+)\b/g)   // hits < gate.QUALIFY_BELOW need qualifying
 ```
 
 Resolve numbers in both repos with `gh issue view N -R astubbs/parallel-consumer` and
 `-R confluentinc/parallel-consumer`. Where the fork mirrors the upstream issue, cite the mirror - it
 is the number a reader of this repo can act on.
+
+## Finishing: tighten the gate, so the form cannot come back
+
+The sweep is only durable if the gate stops accepting what it just removed. Once phase 2 is clean:
+
+- Drop the `upstream` alternation from `stripQualified()` (`issue-ref-gate.js:71`), so `upstream #NNN`
+  is flagged like any other unqualified reference.
+- Replace the `allows upstream prose, including 'PR #N' and 'issue #N'` assertion in
+  `issue-ref-gate.test.js` with one asserting the form is now **flagged**. Without that, the
+  tolerance silently returns the next time someone edits the regex.
+- Drop the interim clause from the failure message, which until then tells authors the form still
+  passes. One edit: the message is `formatFailure()` in `issue-ref-gate.js`, rendered by both the CI
+  gate and `bin/check-issue-refs.sh`. It used to be a copy in each, and they drifted apart within
+  hours of the second being written - each carrying a correction the other lacked - which is why it
+  is shared now. Its assertions in `issue-ref-gate.test.js` pin the wording, so update those too.
+
+**Order matters: sweep first, tighten second, both in the same PR.** Tightening first would fail
+every subsequent edit to `docs/inflight/` against text the sweep has not reached yet - and those
+files are edited constantly, so the gate would be training people to work around it within a day.

--- a/parallel-consumer-examples/parallel-consumer-example-core/src/main/java/io/confluent/parallelconsumer/examples/core/CoreApp.java
+++ b/parallel-consumer-examples/parallel-consumer-example-core/src/main/java/io/confluent/parallelconsumer/examples/core/CoreApp.java
@@ -123,7 +123,9 @@ public class CoreApp {
 
     void customRetryDelay() {
         // tag::customRetryDelay[]
-        final double multiplier = 0.5;
+        // Exponential backoff: the multiplier must be > 1 so the delay GROWS with each failed
+        // attempt. Here: 1s, 2s, 4s, 8s ...
+        final double multiplier = 2;
         final int baseDelaySecond = 1;
 
         ParallelConsumerOptions.<String, String>builder()

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -1049,7 +1049,7 @@ For what has already shipped, see the link:CHANGELOG.adoc[CHANGELOG].
 
 For what is planned, in progress, or known-broken, the {issues_link}[issue tracker on this repository]
 is the single place to look. We mirrored every open issue from the upstream tracker into it (all 78 of
-them, labelled `upstream-mirror` and titled `upstream #NNN: ...`), so an upstream report you are
+them, labelled `upstream-mirror` and titled `confluentinc#NNN: ...`), so an upstream report you are
 following has a counterpart here that reflects its real status on this fork. Please raise new issues
 here rather than upstream - see <<Support and Issues>>.
 


### PR DESCRIPTION
## Description

The README's retry-delay example demonstrated the opposite of backoff. Fixing it meant touching the
issue-reference conventions, and those turned out to be wrong in four places, duplicated in two, and
enshrining an accident on 78 issue titles. This PR does the fix and the cleanup it ran into.

## The original bug

```java
final double multiplier = 0.5;
...
long delayMillis = (long) (baseDelaySecond * Math.pow(multiplier, numberOfFailedAttempts) * 1000);
```

`0.5^n` **halves** the wait on every failed attempt - 1000ms, 500ms, 250ms, 125ms - so a record that
keeps failing is retried faster and faster, exactly when you want it retried slower. This is the
snippet people copy into their own code.

Multiplier is now `2`, giving 1s, 2s, 4s, 8s, with a comment stating why it must be greater than 1.

**Why the change is in Java, not the docs.** The README embeds this snippet through an asciidoc
`tag::customRetryDelay[]` include, so `CoreApp.java` **is** the documentation. `README.adoc` is
regenerated from it, which is the only reason a generated file appears in this diff.

## Issues

Fixes astubbs/parallel-consumer#167 - the fork mirror of
[confluentinc/parallel-consumer#622](https://github.com/confluentinc/parallel-consumer/issues/622).
Merging this closes it.

Reported upstream on 2023-08-08. It *was* patched there, by
[confluentinc PR #864](https://github.com/confluentinc/parallel-consumer/pull/864) (2025-10-27) - but
only in the generated `README.adoc`, not in the `CoreApp.java` the docs are generated from. Upstream's
source still reads `0.5` today, so their rendered README and their code disagree, and the patch
reverts on the next regeneration.

Which is not hypothetical: this fork inherited that `2.0`, and then commit `c2b6b434` (2026-04-09)
regenerated the README during unrelated CI work and put `0.5` straight back. Fixing the source is the
only fix that survives - the reason the generated file moves in this diff instead of being
hand-edited. Full analysis in astubbs/parallel-consumer#167.

---

# The conventions the fix ran into

## The reference gate told authors to write the form the house style rejects

`AGENTS.md` says *"name the owner, not the role - `confluentinc#857`, not `upstream #857`"*, and
`issue-ref-gate.js` says the same in its own comment. But the gate's **failure message** - the only
text anyone reads about this, because you see it exactly when you have got it wrong - said:

> Write `astubbs#NN` for this repo or **`upstream #NN`** for confluentinc

The deprecated pair appeared in **four** places:

| Where | |
|---|---|
| the gate's failure message | fixed |
| `next-qualify-remaining-refs.md`, opening line | fixed - and this one is the **instruction sheet for a mechanical tree-wide pass**, so it would have spread the deprecated form at scale |
| `bin/check-issue-refs.sh` | already correct on master |
| `AGENTS.md`'s own "do this" bullet | fixed - the most actionable of the four |

## That message was duplicated, and had already drifted

`bin/check-issue-refs.sh` landed on master mid-PR with **its own copy** of the message. The two had
already disagreed **in both directions** within hours: the script had purged `upstream's range` and
`Every upstream issue` from its prose, which the workflow had not; the workflow carried a clause the
script lacked. The script's own header says, in capitals, **"NO SECOND COPY OF THE RULE"** - written
about the matching regex, while the sentence an author actually reads sat duplicated beneath it.

Both callers now render `formatFailure()` from `issue-ref-gate.js`, the module they already both
`require`, parameterised by repo slug and by whether the caller can honour the `issue-refs: N/A`
opt-out. Six new assertions pin exactly what drifted. Hand-syncing the copies would have been the
third instance of the same mistake.

## 78 mirror titles were enshrining an accident

My first pass *exempted* the `upstream #NNN:` mirror-title prefix from the owner-not-role rule.
Challenged, the exemption did not survive - `docs/plans/2026-08-04-001-...-plan.md:265` records that
the bulk import **deviated from its own plan**, which had specified `confluentinc#NNN:`. The
deviation was later written into `AGENTS.md` as a rule that the prefix *"never changes."*

| Argument for keeping it | Verdict |
|---|---|
| Titles must stay short | `confluentinc#903:` is **3 characters** longer than `upstream #903:` |
| `upstream #NN` doesn't auto-link | True of **bodies**. GitHub renders no links in titles, so neither form links - the role word bought nothing |
| Tooling parses the prefix | Nothing executable does |
| Retitling breaks the lookups | **Tested, false** - `--search "confluentinc#622"` finds the mirror by body text |

All **78 mirrors retitled** to `confluentinc#NNN: <description>` (0 failures, 0 skips, none left on
the old form), with the documented lookups moved to match. The exemption paragraph is **deleted
rather than reworded**: one rule, no carve-out. `Mirror format` now records what the prefix used to
be and why it changed.

## The threshold has one source of truth, and now says so

`1000` is written **14 times across six files**; exactly one - `QUALIFY_BELOW` in
`issue-ref-gate.js` - decides anything. Prose cannot read a constant, so the repetition stays, but
the canonical statement now records which one is real and that the rest are snapshots. `AGENTS.md`
already documents the number as expected to move, since confluentinc's numbering creeps.

Two of the fourteen were not prose but **runnable snippets** in the ledger that `require` the gate
and then hardcoded `1000` anyway. They now read `gate.QUALIFY_BELOW`.

## Two silent failures now documented

- **Closing keywords.** `Fixes astubbs#167` is not GitHub cross-reference syntax - it renders as
  plain text and closes nothing. Only `Fixes #167` or `Fixes astubbs/parallel-consumer#167` work, and
  the bare number is what the convention forbids. This PR's own `Fixes` line was wrong.
- **Worktree ownership** documented how to *coordinate* worktrees but never said not to work in the
  main checkout, so an agent could follow every bullet and still get it wrong. It now leads with the
  prohibition and the failure mode: the main clone is shared between concurrent sessions, so its HEAD
  moves under you; `git checkout <branch>` is the tell you are in the wrong directory; and a failed
  `git checkout … | tail` still exits 0, so a following `&& git rebase` hits whatever branch you were
  really on. That happened while preparing this PR and rebased an unrelated branch.

## What is deliberately *not* here

Converting the remaining `upstream #NNN` uses in prose (about a dozen files) belongs to the sweep
that already owns it. `next-qualify-remaining-refs.md` gains **phase 2** for the conversion and a
**finishing step** - drop the `upstream` alternation from `stripQualified()`, flip the
*"allows upstream prose"* assertion to expect a flag, and remove the interim clause from
`formatFailure()`. Sweep first, tighten second, same PR: tightening first would fail every subsequent
edit to `docs/inflight/` against text the sweep has not reached.

## Checklist

- [x] Docs updated - this PR *is* the docs fix. `README.adoc` regenerated from the tagged source via `src/docs/README_TEMPLATE.adoc`, never hand-edited; `AGENTS.md` and the sweep ledger updated for every rule changed here
- [x] Tests added/updated - **yes**. `formatFailure()` is new shared code, so `issue-ref-gate.test.js` gains six assertions pinning the wording that drifted, plus the mirror-lookup assertion updated to require the owner form and reject a stale role-form hint. 26 assertions pass. `N/A` for the retry-delay snippet itself - it is illustrative, asserts nothing, and `customRetryDelay()` is never called
- [x] Title & body reflect the final content of this PR
- [x] Self-hosted runner / security implications considered - yes. `.github/workflows/pr-checklist.yml` is changed, but only to call the shared formatter in place of an inline string: no trigger, permission, runner label, action version or gate condition is touched, and what the gate accepts or rejects is unchanged

changelog-ref: N/A - `CHANGELOG.adoc` states everything through `0.6.0.0` is frozen and later sections
are generated at release time, so feature PRs must not add entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
