### PR TITLE
docs #197: fix the two release-blocking factual errors in the 0.6.0.0 artefacts

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -48,7 +48,7 @@ First release of the community fork of https://github.com/confluentinc/parallel-
 === Dependencies
 
 * Dependencies and build plugins refreshed to their latest non-major versions (https://github.com/astubbs/parallel-consumer/pull/73[#73]): JUnit 5.10.2 → 5.14.4, Mockito 5.12.0 → 5.23.0, Testcontainers 1.19.8 → 1.21.4, AssertJ 3.24.2 → 3.27.7, SLF4J 2.0.13 → 2.0.18, Project Reactor 3.6.2 → 3.8.6, SmallRye Mutiny 2.9.4 → 2.9.5, Vert.x 4.5.7 → 4.5.31, Lombok 1.18.28 → 1.18.46, plus Guava, commons-lang3, Logback and the PostgreSQL driver.
-* The Kafka client stays on **3.9.1** — Kafka 4.x (and the other majors JUnit 6, Testcontainers 2, Vert.x 5, Mutiny 3, WireMock 3) were deliberately deferred to keep the release low-risk. See link:docs/inflight/[docs/inflight/].
+* The Kafka client moves 3.9.1 → **3.9.2**, a patch bump within the same 3.9 line - no API or behaviour change for callers. Kafka 4.x (and the other majors JUnit 6, Testcontainers 2, Vert.x 5, Mutiny 3, WireMock 3) were deliberately deferred to keep the release low-risk. See link:docs/inflight/[docs/inflight/].
 
 === Build & CI
 

--- a/README.adoc
+++ b/README.adoc
@@ -1255,10 +1255,18 @@ NOTE:: any additional binders / metrics need to be cleaned up appropriately - fo
 [[roadmap]]
 == Roadmap
 
-For released changes, see the link:CHANGELOG.adoc[CHANGELOG].
+*Yes, this is maintained - and this repository is where the maintenance happens.*
+{base_url}[astubbs/parallel-consumer] is the active line of development: it is what is published to
+Maven Central as `bz.stub.parallelconsumer`, and it is where fixes, releases and issue triage land.
+The original {base_confluent_url}[confluentinc/parallel-consumer] is no longer actively maintained.
 
-For features in development and a more accurate view on the roadmap, have a look at the
-https://github.com/confluentinc/parallel-consumer/issues[GitHub issues], and clone https://github.com/astubbs/parallel-consumer[Antony's fork].
+For what has already shipped, see the link:CHANGELOG.adoc[CHANGELOG].
+
+For what is planned, in progress, or known-broken, the {issues_link}[issue tracker on this repository]
+is the single place to look. We mirrored every open issue from the upstream tracker into it (all 78 of
+them, labelled `upstream-mirror` and titled `upstream #NNN: ...`), so an upstream report you are
+following has a counterpart here that reflects its real status on this fork. Please raise new issues
+here rather than upstream - see <<Support and Issues>>.
 
 == Usage Requirements
 

--- a/docs/inflight/release-0600-blockers.md
+++ b/docs/inflight/release-0600-blockers.md
@@ -16,6 +16,12 @@ Release mechanics live in [`release-0.6.0.0.md`](release-0.6.0.0.md); the tracki
   curated changelog never reaches the release page.
 - **After it ships:** ~11 mirrored issues describe 0.6.0.0 in the future tense and need the real
   coordinate; #186, #188 and #195 close with a pointer to the release.
+- **Two stale `3.9.1` references survive outside the published artefacts**, left alone here to keep
+  this PR scoped to what 0.6.0.0 publishes. `AGENTS.md:183` says PRs run "split suites on default
+  Kafka 3.9.1" - genuinely wrong, CI's default comes from `pom.xml`, which is `3.9.2`; it is a
+  one-word fix in a file this PR does not otherwise touch. `AGENTS.md:58` and the
+  `bin/ci-build.sh 3.9.1` line in `src/docs/README_TEMPLATE.adoc` are illustrative command examples
+  where the argument is the point, not the version, so they are arguably fine either way.
 
 ## Context worth inheriting
 

--- a/docs/inflight/release-0600-blockers.md
+++ b/docs/inflight/release-0600-blockers.md
@@ -16,12 +16,15 @@ Release mechanics live in [`release-0.6.0.0.md`](release-0.6.0.0.md); the tracki
   curated changelog never reaches the release page.
 - **After it ships:** ~11 mirrored issues describe 0.6.0.0 in the future tense and need the real
   coordinate; #186, #188 and #195 close with a pointer to the release.
-- **Two stale `3.9.1` references survive outside the published artefacts**, left alone here to keep
-  this PR scoped to what 0.6.0.0 publishes. `AGENTS.md:183` says PRs run "split suites on default
-  Kafka 3.9.1" - genuinely wrong, CI's default comes from `pom.xml`, which is `3.9.2`; it is a
-  one-word fix in a file this PR does not otherwise touch. `AGENTS.md:58` and the
-  `bin/ci-build.sh 3.9.1` line in `src/docs/README_TEMPLATE.adoc` are illustrative command examples
-  where the argument is the point, not the version, so they are arguably fine either way.
+- **Three `3.9.1` references survive this PR - one is wrong, two are not.** The genuine defect is
+  `AGENTS.md:183`, which tells contributors PRs run "split suites on default Kafka 3.9.1" when CI's
+  default is whatever `pom.xml` says - now `3.9.2`. It is a one-word fix, left alone only to keep this
+  PR scoped to what 0.6.0.0 publishes: `AGENTS.md` is contributor documentation, not a release
+  artefact. The other two are `bin/ci-build.sh 3.9.1` command examples - `AGENTS.md:58`, and
+  `src/docs/README_TEMPLATE.adoc:1133`, which does reach the published `README.adoc:1382`. Being
+  inside a published artefact does not make that one an error: it demonstrates that the script *takes*
+  a version argument and asserts nothing about which version CI defaults to, so it stays correct
+  whatever the pom says. Do not "fix" either of them.
 
 ## Context worth inheriting
 

--- a/docs/inflight/release-0600-blockers.md
+++ b/docs/inflight/release-0600-blockers.md
@@ -1,0 +1,33 @@
+# Release 0.6.0.0 - correctness of the artefacts we are about to publish
+
+Scope: are the things 0.6.0.0 *publishes* (`CHANGELOG.adoc`, `README.adoc`) true on the day we cut it?
+Release mechanics live in [`release-0.6.0.0.md`](release-0.6.0.0.md); the tracking issue is #197.
+
+## Still open
+
+- **The rest of #197's triage list.** Four non-blocking defects were found while checking the two
+  blocking ones and none are fixed: `PCModule` builds `DynamicLoadFactor(static, static)` when
+  `messageBufferSize` is set, so "Max loading factor steps reached" WARNs on every control-loop pass
+  for anyone following the README's own tuning advice (#155); MDC context is not captured at submit
+  time, so a caller's `trace_id` is lost into the worker pool and the vert.x event loop;
+  `OffsetEncoding` throws on an unknown magic byte *before* `invalidOffsetMetadataPolicy` is consulted,
+  so a future encoding kills an older reader regardless of policy - a forward-compatibility hazard in a
+  wire format this fork now owns; and `release.yml` publishes an empty GitHub Release body, so the
+  curated changelog never reaches the release page.
+- **After it ships:** ~11 mirrored issues describe 0.6.0.0 in the future tense and need the real
+  coordinate; #186, #188 and #195 close with a pointer to the release.
+
+## Context worth inheriting
+
+- **`README.adoc` is generated - never hand-edit it.** Edit `src/docs/README_TEMPLATE.adoc` and
+  regenerate with `./mvnw -N asciidoc-template:build` (or `mvn process-sources`). Every README change
+  is therefore a two-file diff, and a PR that touches only the template has silently not changed the
+  published README.
+- **`CHANGELOG.adoc` is frozen up to `== 0.6.0.0`.** It is not a per-PR chore (AGENTS.md → *Changelog*),
+  so a PR editing it is either fixing a factual error in a frozen section or is wrong. When several
+  agents work in parallel, exactly one may hold that file - it is the highest-collision file in the
+  repo and conflicts in it are pure noise.
+- **Anything asserting a dependency version in prose can drift silently.** The `3.9.1`/`3.9.2` mismatch
+  arose because a Dependabot group bump moved `kafka.version` after the release note was written, and
+  nothing cross-checks prose against `pom.xml`. Re-read the `=== Dependencies` section against the pom
+  immediately before cutting, not weeks earlier.

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -1006,10 +1006,18 @@ NOTE:: any additional binders / metrics need to be cleaned up appropriately - fo
 [[roadmap]]
 == Roadmap
 
-For released changes, see the link:CHANGELOG.adoc[CHANGELOG].
+*Yes, this is maintained - and this repository is where the maintenance happens.*
+{base_url}[astubbs/parallel-consumer] is the active line of development: it is what is published to
+Maven Central as `bz.stub.parallelconsumer`, and it is where fixes, releases and issue triage land.
+The original {base_confluent_url}[confluentinc/parallel-consumer] is no longer actively maintained.
 
-For features in development and a more accurate view on the roadmap, have a look at the
-https://github.com/confluentinc/parallel-consumer/issues[GitHub issues], and clone https://github.com/astubbs/parallel-consumer[Antony's fork].
+For what has already shipped, see the link:CHANGELOG.adoc[CHANGELOG].
+
+For what is planned, in progress, or known-broken, the {issues_link}[issue tracker on this repository]
+is the single place to look. We mirrored every open issue from the upstream tracker into it (all 78 of
+them, labelled `upstream-mirror` and titled `upstream #NNN: ...`), so an upstream report you are
+following has a counterpart here that reflects its real status on this fork. Please raise new issues
+here rather than upstream - see <<Support and Issues>>.
 
 == Usage Requirements
 


### PR DESCRIPTION
## Description

Fixes the two release-blocking factual errors tracked in #197. Both are statements in the artefacts
0.6.0.0 publishes, read by exactly the person deciding whether to adopt this library.

**1. `CHANGELOG.adoc` claimed the Kafka client "stays on 3.9.1".** `pom.xml` has said `3.9.2` since
d0217053 (a Dependabot `maven-non-major` group bump, 2026-07-30) - the pom moved after the release
note was written, and nothing cross-checks prose against it. The `0.5.3.3` tag did ship 3.9.1, so the
true statement is a patch move `3.9.1 → 3.9.2` inside the same 3.9 line, with no API or behaviour
change for callers. The Kafka 4.x / other-majors deferral was and remains accurate, so that half is
kept verbatim.

**2. The README Roadmap sent readers to the *upstream* issue tracker** and referred to this repository
in the third person as "Antony's fork" - wording inherited from when it was one. That section is what
someone opens to answer "is this maintained?", so it now answers that question first, names this
repository as where maintenance happens, and points at this tracker. It also records that all 78 open
upstream issues were mirrored here, so a report someone is following upstream has a counterpart that
reflects its real status on the fork.

`README.adoc` is generated. The edit is in `src/docs/README_TEMPLATE.adoc`; the committed `README.adoc`
is the output of `./mvnw -N asciidoc-template:build`, and re-running it produces no further diff.

**Also:** `docs/inflight/release-0600-blockers.md` records what is still open from the same triage -
#197's four non-blocking defects (the `DynamicLoadFactor` WARN storm #155, lost MDC context, the
`OffsetEncoding` magic-byte forward-compatibility hazard, the empty GitHub Release body), the
post-ship follow-ups, and the two pieces of context that let this rot: a README change is always a
two-file diff, and nothing validates version prose against the pom. It also records the stale `3.9.1`
references that survive *outside* the published artefacts - `AGENTS.md:183` is the same defect
(contributor docs, so out of scope here rather than wrong to fix), and two `bin/ci-build.sh 3.9.1`
command examples that are not errors at all.

`CHANGELOG.adoc` is frozen up to `== 0.6.0.0` and is not a per-PR chore - this edit is a correction to
a frozen section, which is the case AGENTS.md leaves the `changelog-ref-gate` guard in place for. It
cites #197.

## Checklist

- [x] Docs updated - this PR is entirely documentation: `CHANGELOG.adoc`, the README template + its
      regenerated output, and a `docs/inflight/` note
- [x] Tests added/updated - N/A, no product code changes; verification is that
      `./mvnw -N process-sources` regenerates `README.adoc` byte-identical to the committed file and
      the copyright scanner passes (232 files, 0 violations)
- [x] Title & body reflect the final content of this PR
- [x] Self-hosted runner / security implications considered - N/A, no CI runners or workflows touched

