### PR TITLE
fix(core) astubbs#177: report the poll thread's real error, not the commit-response timeout (confluentinc#833)

### DIFF
--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -457,3 +457,56 @@ consumed count freezes outright with the group ostensibly live, under churn-stor
 productive trap. Two replayable seeds with the same signature within four hours is the strongest
 single-arm evidence the ledger holds; whichever defect they belong to, the replays are now the
 cheapest next experiment the family has.
+
+**Eleventh sighting, 2026-08-19 - the eager `CLASS2_STALL` again, and the first seed in this family
+that replays RED on demand, with a master control arm proving it is not branch-caused.**
+`ChaosRevokeUnderWorkIT.revokeUnderWorkStaysProtocolHonest` killed by `ProgressProbe` on
+[job 95962195275](https://github.com/astubbs/parallel-consumer/actions/runs/32217696441), at head
+`2b8b89183` on astubbs#204. Seven `CLASS2_STALL/LAG_STAGNATION` violations, lags 587-3010, all
+stagnant 154s against the 150s bound; `peaks: rebalanceDwell=9949ms lagStagnation=154627ms`.
+
+**Replay seed `6825864417772979246`**:
+
+    ./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true \
+      -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=6825864417772979246
+
+**What makes this one different: it reproduced, twice, off CI.** Every earlier `CLASS2_STALL` entry
+records a seed that nobody has since replayed red - the eighth sighting's seed explicitly "replays
+clean". This one does not:
+
+| Arm | Head | Verdict | Violations | `lagStagnation` |
+|---|---|---|---|---|
+| CI | `2b8b89183` (astubbs#204) | RED | 7 | 154627ms |
+| Local replay | `2b8b89183` (astubbs#204) | RED | 5 | 154429ms |
+| **Local control** | **`5c377ec04` (master)** | **RED** | **10** | **154387ms** |
+
+**The master arm is the point.** The same seed fails on plain master with no astubbs#204 code in the
+tree, so this is the family's own defect and not something that PR introduced. Two further checks
+agree: astubbs#204's tree at the passing run `45fd8f6f9` and the failing run `6b2d91370` have the
+*identical* tree SHA `e939d33ca` (the run in between was a history-only re-cut), so content cannot
+explain the pass/fail difference; and none of astubbs#204's new failure paths appear anywhere in the
+replay output - no `OffsetCommitBudgetExceededException`, no poller-death handoff. The commit budget
+was never exhausted and the poll thread never died, so the stall happens with every commit
+apparently healthy.
+
+**Control arm, same CI run:** the two sibling chaos tests passed with `probe violations=[]` -
+cooperative on seed `2550023127530143017`, churn storm on `783220268230054177`.
+
+**Same seed, different violation *count* (5 / 7 / 10).** The seed fixes the chaos schedule, not the
+topic name (`ChaosRevokeUnderWorkIT-w4-<random>` differs every run) nor which partitions land on
+which member. So it reproduces the *signature* reliably and the exact frozen-partition set not at
+all. Treat a replay as red/green evidence, never as a per-partition fingerprint to diff.
+
+**Why this is the cheapest next experiment the family has.** A seed that replays red locally in ~3
+minutes on master turns every prior "is it the product or the harness" question into something
+bisectable. The obvious next step is to bisect it against the family's landed fixes, and to attach a
+thread dump at the moment `lagStagnation` crosses ~150s - the probe already knows when that is.
+
+**Two traps for whoever picks this up.** The retrieval note above still holds and cost real time
+here: GitHub served a log with *no* verdict in it at all - no `Tests run:`, no `BUILD`, no autopsy -
+for a step that had genuinely failed a test, and `--log-failed` showed only ordinary INFO. The
+verdict was in the uploaded failsafe XML artifact, as documented. Separately, narrowing the replay
+with `-Dit.test=ChaosRevokeUnderWorkIT` needs `-Dfailsafe.failIfNoSpecifiedTests=false`, because
+`-am` puts the parent module in the reactor and its own failsafe execution then fails the build with
+"No tests matching pattern"; dropping `-am` instead fails the enforcer's `ReactorModuleConvergence`.
+The unnarrowed command above has neither problem.

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -357,7 +357,44 @@ on its own. A worktree at the pre-change commit, the same command on both, is ch
 turns "probably a flake" into an answer. Do that before attributing - or dismissing - anything with
 this signature, especially on a branch whose subject matter would explain it.
 
-**Eighth sighting, 2026-08-18 - the fleet-level `NO_PROGRESS` arm, twice in one night (this entry
+**Eighth sighting, 2026-08-17 - the `ZOMBIE_MEMBER` arm again, and its seed replays clean.**
+`ChaosRevokeUnderWorkCooperativeIT.revokeUnderWorkStaysProtocolHonestWithCooperativeAssignor` on
+[job 95308176649](https://github.com/astubbs/parallel-consumer/actions/runs/32002566427/job/95308176649),
+on astubbs#204 at head `85a3646d8`. Same arm as the fourth sighting, on the revoke-under-work
+cooperative scenario, and the failing assertion is the scenario SLO rather than a probe fail-fast -
+the probe violation rides along in the autopsy:
+
+```
+no instance may end the run with an unclassified failure cause
+but was: [instance 7: RuntimeException: Error from poll control thread:
+          Timeout waiting for commit response PT10S to request CommitRequest(id=608fa144-...)]
+ZOMBIE_MEMBER/REBALANCE_BLOCKED: group 'group-1-122304053' dwelling in PreparingRebalance for 15s
+(bound 15s) - a member is not answering the rebalance (protocol-unresponsive)
+peaks: rebalanceDwell=15465ms lagStagnation=85032ms
+```
+
+Two frozen partitions, stagnant 73-90s, lag 145 and 979. **Replay seed `2966043432903644461`**:
+
+    ./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true \
+      -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=2966043432903644461
+
+**Replayed, and it does not reproduce.** On the same head, uncontended, all three chaos scenarios
+passed - `ChaosRevokeUnderWorkIT` 135.2s, `ChaosChurnStormIT` 82.8s,
+`ChaosRevokeUnderWorkCooperativeIT` 86.0s. That is the AGENTS.md diagnostic for separating contention
+from a concurrency bug, and it lands on the contention side. It rules out a deterministic defect
+reachable from that seed, and nothing else: a passing replay cannot exclude an interleaving only a
+loaded box reaches.
+
+**Branch context - astubbs#204 rhymes with this failure, which is why it needs naming rather than a
+one-line dismissal.** That PR changes the commit path: `ConsumerManager.commitSync`'s retry budget
+becomes per-call instead of per-attempt, so PC gives up where it previously hung, and the failure
+cause here *is* a commit-response timeout. Against it being the cause: the same lane failed on this
+same branch at `26d2f195`, before that change existed, and
+[`ci-disabled-jobs-and-runner-load.md`](ci-disabled-jobs-and-runner-load.md) records the same window
+killing the `highcpu` lane on three other branches with the no-verdict signature. Unresolved rather
+than cleared - a later sighting on a branch that does not touch the commit path would settle it.
+
+**Ninth sighting, 2026-08-18 - the fleet-level `NO_PROGRESS` arm, twice in one night (this entry
 and the ninth below share a signature).** `ChaosChurnStormIT.churnStormMeetsSlosAndBalancesLedger`
 was killed fail-fast by `ProgressProbe` on
 [job 95579861648](https://github.com/astubbs/parallel-consumer/actions/runs/32093367999/job/95579861648),
@@ -391,7 +428,7 @@ log came from the run-logs archive
 attempt) - a second retrieval route alongside the fourth sighting's report-artifact note, and the
 console-log truncation trap is the same one recorded there.
 
-**Ninth sighting, 2026-08-18 - same test, same arm, four hours earlier, different branch.**
+**Tenth sighting, 2026-08-18 - same test, same arm, four hours earlier, different branch.**
 `ChaosChurnStormIT.churnStormMeetsSlosAndBalancesLedger`, killed by the same fleet detector on
 [job 95584026682's run, attempt at head d96375053](https://github.com/astubbs/parallel-consumer/actions/runs/32078875110)
 (2026-08-17T23:04Z), on astubbs#308 - a docs-only branch (ideation/strategy/ledger files, zero

--- a/docs/inflight/bug-offset-commit-timeout-does-two-jobs.md
+++ b/docs/inflight/bug-offset-commit-timeout-does-two-jobs.md
@@ -1,0 +1,60 @@
+# `offsetCommitTimeout` does two jobs, and 10s is wrong for both
+
+Open after astubbs#204. That PR made the option mean "the whole commit" rather than "one attempt",
+which is the precondition for fixing this - but it does not fix it, and the default is untouched.
+
+## What it currently bounds
+
+Two things, from one option (`ParallelConsumerOptions`, `private final Duration offsetCommitTimeout`,
+default `Duration.ofSeconds(10)`), plus Kafka's own bound underneath:
+
+| Level | Thread | Bounded by | Default |
+|---|---|---|---|
+| `ConsumerOffsetCommitter.commitAndWait` waiting for a commit response | **control** | `offsetCommitTimeout` | 10s |
+| `ConsumerManager.commitSync`'s retry loop | **poll** | `offsetCommitTimeout` | 10s |
+| One `consumer.commitSync(offsetsToSend)` call, which retries internally | poll | `default.api.timeout.ms` | **60s** |
+
+The 60s is verified, not recalled: read from `ConsumerConfig` in kafka-clients 3.9.2, the version this
+repo builds against.
+
+## Why the default is wrong, and why raising it is not the fix
+
+**As the retry budget it is far too small.** A single Kafka call can run 60s, so a 10s total is spent
+before the first attempt returns: exactly one try, no retry ever. Kafka refuses this shape in its own
+config - a producer will not accept `delivery.timeout.ms` below `request.timeout.ms + linger.ms` -
+precisely so a total budget is never smaller than one attempt. PC cannot make that check at
+construction (`Consumer` exposes no configuration), so astubbs#204 reports it when it bites instead:
+giving up after one attempt now says that no retry was reachable.
+
+**As the waiter's deadline it wants to be small.** `commitAndWait` blocks the **control** thread, and
+no work is distributed while it waits. Raise the option to 120s to make retries reachable and a
+slow-but-alive commit stalls processing for two minutes.
+
+So the two uses pull in opposite directions and one number cannot serve both. Raising the default
+alone trades a processing stall for retry capability, silently.
+
+## The options, none yet chosen
+
+1. **Pass the budget down instead of layering over it.** `consumer.commitSync(Map, Duration)` exists
+   for exactly this: Kafka bounds the operation and throws on expiry, so PC's hand-rolled timeout
+   retry loop mostly disappears - one level instead of three, and the option means what it says. The
+   loop cannot go entirely: the SASL retry-with-backoff and `WakeupException` handling still need it.
+   **The cost, and it is the real question:** PC then stops distinguishing "how long one API call may
+   take" from "how long we will keep trying to commit these offsets". Those may genuinely want to be
+   different numbers - which is why Kafka has both - or the distinction may be a knob nobody wants.
+2. **Split into two options**, one per job: a waiter deadline (short, protects the control loop) and a
+   commit budget (above `default.api.timeout.ms`, makes retries reachable). Honest, and adds a knob to
+   a library whose users already meet a lot of Kafka's.
+3. **Raise the default above 60s and accept the stall.** Cheapest, and the one to be most suspicious
+   of - it fixes the arithmetic and hides the conflict.
+
+There is a real tension behind the choice: Kafka's knobs exist for good reasons, and every one PC adds
+is another thing a user has to hold. Fewer knobs is a feature until the day one number has to be two.
+
+## What would settle it
+
+Whether anyone genuinely needs "one API call" and "total commit effort" to differ. If not, option 1
+and delete a concept. If yes, option 2 and name both.
+
+Related: astubbs/parallel-consumer#317 (a commit-failure seam) is the other half of the same area -
+what happens *after* the budget is spent, rather than how long it is.

--- a/docs/inflight/next-candidates.md
+++ b/docs/inflight/next-candidates.md
@@ -3,6 +3,14 @@
 Collisions are in `pr-blockers-and-collisions.md`. The ranked backlog and full verdicts live in
 `src/docs/development/upstream-pr-analysis.adoc`; these are the ready picks:
 
+- **Commit-failure seam ([astubbs#317](https://github.com/astubbs/parallel-consumer/issues/317))** -
+  **highest-demand item on this list, and the only one with a user shipping a patched build to get
+  it.** On confluentinc#833 `ndqvinh2109` reported patching `controlLoop` with a try/catch so the
+  exception would not reach `supervisorLoop` and close PC. That is not a feature request in a
+  backlog - it is someone maintaining a private fork of the library because the decision PC makes
+  for them is the wrong one for their deployment. Kafka's client throws a retriable exception and
+  lets the caller choose; PC only terminates. Research, both sides of the upstream argument, and why
+  fixing astubbs#177 does not close it: `next-commit-failure-seam.md`.
 - **`confluentinc#912` vertx leak** - branch done, needs rebase + PR (`branch-912-vertx-leak.md`). Best
   immediate pick.
 - **Auto-scaling (astubbs#227)** - runtime-discovered per-instance concurrency; candidate killer

--- a/docs/inflight/next-commit-failure-seam.md
+++ b/docs/inflight/next-commit-failure-seam.md
@@ -1,0 +1,54 @@
+# A commit-failure seam - astubbs/parallel-consumer#317
+
+**Priority: high.** Ranked top of `next-candidates.md`. The demand signal is not a request in a
+tracker - it is a user running a **patched build of the library** in production to get this
+behaviour. That is the loudest signal a missing feature can produce, and it is on the record.
+
+Feature request, spun out of astubbs#177 / confluentinc#833 rather than duplicating it.
+**astubbs/parallel-consumer#317** owns the design questions; this file is why it exists and what the
+research behind it found, so the next session does not re-derive it from the issue thread.
+
+## The gap
+
+A commit that exhausts its budget takes the whole instance down: the exception escapes `controlLoop`,
+`supervisorLoop` records it as the failure cause, PC closes, and the application learns about it
+afterwards through `getFailureCause()`. There is no "the commit failed, you decide" hook.
+
+## What the upstream thread actually says
+
+Both halves are on confluentinc#833, and they disagree - which is the point.
+
+- **`ndqvinh2109` already worked around it in production**: *"PC has been closed unintentionally. We
+  have applied a work-around to try catch the `controlLoop` function so that the exception won't
+  propagate to `supervisorLoop`"*. A user patching library internals to get a decision PC does not
+  offer is the clearest possible signal for this feature.
+- **`rkolesnev` argued the opposite**: *"if it cannot commit data - then polling will fail as well and
+  processing anything that was previously polled is just going to cause more side-effects /
+  duplicates... I don't think that indefinite retry is an answer there either."* That is a good case
+  for shutdown being the **default**. It is not a case for it being the only option.
+
+Note who is speaking: this is a colleague's read on an abandoned upstream tracker, not a maintainer
+decision binding this fork. Weigh it on its merits.
+
+## What Kafka does, which is the model to borrow
+
+Kafka's client throws `TimeoutException` - **retriable** in its taxonomy - and hands the choice to the
+caller. Two-level budgets (`default.api.timeout.ms` over `request.timeout.ms`, `delivery.timeout.ms`
+over `request.timeout.ms + linger.ms`), honest reporting, application decides.
+
+astubbs#204 borrowed the first two of those: `offsetCommitTimeout` is now a whole-operation budget in
+the `default.api.timeout.ms` role, and the failure is reported as
+`OffsetCommitBudgetExceededException` naming the knob that ran out. **The seam is the third part, and
+the only one PC still lacks.** The exception's message points here, so a user meeting it learns the
+shutdown is a known limit rather than an accident.
+
+## Why fixing the defect does not close this
+
+astubbs#177 is the reported *defect* - a commit timeout reporting the wrong cause, and the causes
+behind it - addressed by astubbs#204 (reporting, retry budget) and astubbs#29 (the AB-BA deadlock).
+Even with a correct, honestly-reported commit failure, PC still terminates and the application still
+has no say. That is what `ndqvinh2109` was patching around, and it survives both fixes.
+
+## Delete this file when
+
+astubbs/parallel-consumer#317 lands, or is closed as won't-do with the reasoning recorded there.

--- a/docs/inflight/next-exception-hierarchy-cleanup.md
+++ b/docs/inflight/next-exception-hierarchy-cleanup.md
@@ -1,0 +1,61 @@
+# PC's exceptions have three roots and no consistent name
+
+**Priority: high, and easy.** Mechanical, well-bounded, and the major-version gate is open
+(`docs/refactoring.md` - `0.6.0.0` is the major being cut and already carries a `=== Breaking`
+section), so it can land now rather than waiting for a bump.
+
+## What is wrong
+
+Six exception types, three unrelated roots:
+
+| Type | Extends |
+|---|---|
+| `ParallelConsumerException` | `RuntimeException` |
+| `ExceptionInUserFunctionException` | `ParallelConsumerException` |
+| `OffsetCommitBudgetExceededException` | `ParallelConsumerException` |
+| `PCRetriableException` | **`RuntimeException`** |
+| `InternalRuntimeException` | **`RuntimeException`** |
+| `InternalException` | **`Exception`** |
+
+**`catch (ParallelConsumerException)` does not catch what PC actually throws at you.**
+`InternalRuntimeException` is what arrives from `getFailureCause()`, and it is the class in the
+original upstream report: `...internal.InternalRuntimeException: Timeout waiting for commit response
+PT30S` (confluentinc#833). A user wanting "catch everything this library throws" has no single type.
+
+**The names are inconsistent too**, which is the part you notice first in a log or an IDE's exception
+picker: `PCRetriableException` uses a prefix, `ParallelConsumerException` spells it out, and both
+`Internal*` types mark nothing at all - `InternalRuntimeException` in a stack trace that prints simple
+names could belong to anything. The fully-qualified form disambiguates; plenty of surfaces do not show
+it.
+
+**This is not a new opinion.** `ProducerManager` already carries
+`// TODO(refactor): InternalRuntimeException misnames a failed send; throw a specific subclass and
+rename \`exception\` to \`sendFailure\`` - the same complaint, reached independently, about a
+different call site.
+
+## What to do
+
+1. **Give everything one root.** `InternalRuntimeException`, `PCRetriableException` and
+   `InternalException` should descend from a PC type, so one `catch` covers the library. This is the
+   half that changes behaviour for users, and the half worth doing first - the naming is cosmetic
+   beside it.
+2. **Then settle the naming convention and apply it once.** `PCInternalRuntimeException` follows the
+   `PCRetriableException` precedent. Whatever is chosen, apply it to
+   `OffsetCommitBudgetExceededException` too - it was added by astubbs#204 and already fails the
+   convention it should have followed.
+
+Blast radius for the rename: **28 files, 63 occurrences**, almost entirely mechanical (24 main, 4
+test). The root change is smaller than the rename.
+
+## Cheap and worth doing at the same time
+
+`ConsumerOffsetCommitter` and `ConsumerManager` carry four `InternalRuntimeException` throws that
+astubbs#204 added or reworked, three of which are user-facing failure paths (the poller-death report,
+the abandoned-commit-on-close report, and the commit-response timeout). They are marked
+`// TODO(refactor)` at the sites. They want a type that says PC, and probably a more specific one than
+"internal runtime" for the two that a user is meant to read and act on.
+
+## Delete this file when
+
+The roots are unified and the naming convention is applied, or the idea is rejected with the reasoning
+recorded in `docs/refactoring.md`.

--- a/docs/inflight/release-0.6.0.0.md
+++ b/docs/inflight/release-0.6.0.0.md
@@ -83,6 +83,36 @@ At release, when the changelog section is regenerated, check both survived into 
 generation reads the commit log, so they are only as findable as those commit bodies. The rename side
 of that same check is in [`release-0600-blockers.md`](release-0600-blockers.md).
 
+## Public API change landing with astubbs#204: the commit give-up exception
+
+Not a breaking change to a *subclass* surface like the two above - this one is visible to every user
+of `PERIODIC_CONSUMER_SYNC`, so it needs its own line in the notes.
+
+**`ConsumerManager.commitSync` no longer rethrows Kafka's bare `TimeoutException` /
+`SaslAuthenticationException` when a commit exhausts its budget.** It throws
+`OffsetCommitBudgetExceededException` (new, in the public `bz.stub.parallelconsumer` package,
+extending `ParallelConsumerException`) with the broker's exception as the **cause**. Anyone catching
+the Kafka type directly around PC's failure surface - `getFailureCause()`, or a supervisor wrapping
+PC - stops matching, and must catch the PC type or unwrap `getCause()`.
+
+Why it earns the break on a stability release: the bare Kafka exception can say a commit timed out
+but not *which of PC's options bounded it*, what that option's relationship to the consumer's own
+timeouts is, or what to do about it. That gap is the whole subject of astubbs#177 /
+confluentinc#833 - two reporters, neither of whom could tell from the message where to look. The new
+message names the budget that ran out, its configured value, the knob to raise, and - when only one
+attempt was made - that `offsetCommitTimeout` is below the consumer's `default.api.timeout.ms`
+(**60000ms** by default, verified in kafka-clients 3.9.2) so no retry was reachable at all.
+
+Two behaviour changes ship alongside it and belong in the same note, because a reader meeting one
+will ask about the others:
+
+- **`offsetCommitTimeout` now bounds the whole commit, not each attempt.** It was captured inside the
+  retry loop, so every attempt reset it and the loop could retry forever. This makes PC give up where
+  it previously hung. Matches Kafka's own two-level model, where `default.api.timeout.ms` bounds a
+  call *including* its retries.
+- **`saslAuthenticationRetryTimeout` is measured from the first SASL failure**, not from the start of
+  the commit call, so a slow commit no longer spends an unrelated option's budget.
+
 ## Release gate: no disabled tests
 
 **0.6.0.0 does not ship while any test is disabled.** Tests currently carrying `@Disabled`:

--- a/docs/inflight/test-load-tightness-flakes.md
+++ b/docs/inflight/test-load-tightness-flakes.md
@@ -11,6 +11,7 @@ baseline for comparison is 15/20 runs fully clean, zero stall-class failures.
 | `DbTest` | 2/20 | postgres container start under contention |
 | `KafkaSanityTests`, `TransactionMarkersTest` | singles | residual, uncategorised |
 | `PartitionStateCommittedOffsetIT.committedOffsetRemoved[3] none` | 1 sighting (2026-08-05) | `RebalanceInProgressException` out of the test's own setup |
+| `TransactionTimeoutsTest.commitTimeout[2]` | 1 sighting (2026-08-06, astubbs#204) | incompletes `[8]` where the parameter pins `[8, 12]` |
 
 **A third member has now left the family, and it left by being reclassified rather than fixed-as-tight.**
 `TransactionTimeoutsTest.commitTimeout[1]` failed once on CI (2026-08-07,
@@ -79,3 +80,41 @@ bug in exactly this area (a rebalance-time commit killing the broker-poll thread
 **Explicitly NOT a member: `RebalanceEoSDeadlockTest.noDeadlockOnRevoke`** (1/20). Per the astubbs#68 record
 its contended failure maps to the real confluentinc#857 deadlock - that sighting is live confirmation the
 deadlock is still on master, with its fix waiting in astubbs#29.
+
+## `commitTimeout[2]`, for whoever picks it up (seen 2026-08-06 on astubbs#204)
+
+**A different parameter and a different mechanism from the `commitTimeout[1]` entry above**, which left
+the family by reclassification (an unforceable trigger). This one is about the assertion, not the
+trigger, so neither entry supersedes the other.
+
+Failed with incompletes `[8]` where the `multiple=50` parameter pins `[8, 12]`. The test's own javadoc
+names **both** outcomes as physically possible - "just the failed offset (for case where processing
+finishes during shutdown timeout)" versus "both offsetToError and offsetToGoVerySlow ... when sleep is
+longer than the shutdown timeout" - and the parameterisation pins one of them. So the assertion
+encodes a *timing* outcome as if it were deterministic, which is the family signature: correct under
+quiet conditions, arbitrary under contention. Ambient probe agreed unprompted: *"probe clean - no
+rebalance dwell, no lag stagnation, no frozen partitions observed: the fault is likely in the test
+itself, not consumer-group progress."*
+
+**Ruled out as a regression from astubbs#204's `ConsumerManager.commitSync` retry-budget change**, on
+four independent grounds, recorded because that PR touches commit-timeout behaviour and the name
+collision invites exactly the wrong conclusion:
+
+1. **Wrong code path.** This test runs `CommitMode.PERIODIC_TRANSACTIONAL_PRODUCER`, and
+   `AbstractParallelEoSStreamProcessor` selects `committer = producerManager` for transactional mode.
+   `ConsumerManager.commitSync` has exactly one caller in main - `consumerMgr.commitSync(offsetsToSend)`
+   in `ConsumerOffsetCommitter` - which is only reached in the consumer-sync modes. The changed method
+   is never invoked here.
+2. **Wrong direction.** That change makes `commitSync` give up *earlier*. Earlier shutdown leaves
+   *more* work incomplete, i.e. pushes toward `[8, 12]`. The observed failure is `[8]` - fewer
+   incompletes - which is the opposite of what the change could produce even if it were on the path.
+3. **Passes locally with the change in place**: `TransactionTimeoutsTest` 3 tests, 0 failures.
+4. **Pre-existing membership.** This class is already named as load-sensitive in
+   `pc-silent-stall-under-contention-2026-07-29.md` and
+   `parallel-integration-tests-flaky-under-concurrency-2026-07-28.md`, and its sibling
+   `produceTimeout` is already in the table above.
+
+Do not "fix" this by widening the expected set to accept both outcomes - that would make the test
+vacuous, since `[8]` and `[8, 12]` are the only two possibilities. If it is to be deterministic, the
+shutdown timeout and the sleep have to be separated far enough that only one outcome is reachable;
+otherwise it belongs in the quarantine lane rather than the gating suite.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -385,6 +385,19 @@ but not this.*
 
 ---
 
+### Test infrastructure - `MockConsumerTestBase` assumes one partition and one key
+
+- **Generalise the harness to take a partition count and a key supplier.** `MockConsumerTestBase`
+  hardcodes `new TopicPartition(topic, 0)` and a single record key, which is right for the six
+  scenarios on it today and wrong for any scenario whose subject is ordering or backlog:
+  `CommitResponseTimeoutSymptomTest` reproduces a reported workload of 1000 keys across 4 partitions
+  under `KEY` ordering, so it repeats the manual rebalance dance rather than inheriting it, and its
+  javadoc says why. Two smaller mismatches come with it: options are built once per class in
+  `@BeforeEach`, so a class needing two option sets must split into subclasses, and the teardown
+  asserts a null failure cause, which a scenario that expects PC to die must override. Doing this
+  means re-verifying the six classes already on the base, which is why it is here rather than folded
+  into the PR that noticed it (astubbs#204).
+
 ### Test infrastructure - timing-based waits
 
 - **`ParallelEoSStreamProcessorTest` waits on loop cycles, not events** - four markers:

--- a/docs/solutions/test-flakiness/vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md
+++ b/docs/solutions/test-flakiness/vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md
@@ -143,3 +143,46 @@ private void awaitProcessedRecords(double expected, String... pcInstanceTags)
 
 Note the failure mode is load-dependent, so a green local run proves nothing - the original raced on
 every record and simply won each time.
+
+## Third instance: CommitResponseTimeoutSymptomTest (2026-08-06) - and how to tell the two directions apart
+
+Found by applying the rule above to a new test rather than by a failure. The useful part is that the
+same file contains **one site of each direction**, so it makes the distinction concrete: the rule is
+not "never await one thing and assert another", it is "never await a signal that *leads* the value
+you assert".
+
+**The bad direction, fixed.** The test awaited a `Set` populated inside the user function, then read
+a rejection counter incremented on the broker-poll thread inside `commitSync`:
+
+```java
+await().untilAsserted(() -> assertThat(succeeded).hasSize(KEYS));  // user-function thread
+assertThat(commitsRejected.get()).isAtLeast(MIN_REJECTIONS);       // broker-poll thread, unordered
+```
+
+Two threads, neither ordering the other. The margin is genuinely large - feeding spans tens of commit
+intervals - which is exactly what a latent race looks like right up until it loses. Now awaited on
+the value actually asserted, which cannot mask anything: if the rejections never arrive it still
+fails.
+
+**The safe direction, deliberately left alone and commented so.** The other test awaits
+`isClosedOrFailed()` and then asserts `getFailureCause()`:
+
+```java
+await().untilAsserted(() -> assertThat(pc.isClosedOrFailed()).isTrue());
+assertThat(pc.getFailureCause()).isNotNull();
+```
+
+This is fine, because `supervisorLoop()` assigns `failureReason` **before** `doClose()` sets
+`state=CLOSED` and before the throw that completes `controlThreadFuture` - and `isClosedOrFailed()`
+reads only those two later signals. The awaited signal **lags** the asserted value. The volatile
+read inside `FutureTask.isDone()` also supplies the happens-before edge that publishes
+`failureReason` to the asserting thread.
+
+Converting that second site to "await `getFailureCause()` non-null" would be a real regression in
+test strength: a null cause is precisely what a bug here produces, so awaiting it would convert a
+failure into a timeout at best, and hide it at worst.
+
+**Refined rule: establish which of the two values is written first.** If the awaited signal is
+written *after* the asserted one, the await is sound and tightening it weakens the test. If it is
+written *before* - a user-side counter, a log line, a queue depth - it leads, and the assertion is
+racing. Read the production ordering; do not infer it from which value looks more "final".

--- a/docs/todo-index.md
+++ b/docs/todo-index.md
@@ -69,9 +69,15 @@ that line, leave it in the code - it will show up here.
 - todo move into {@link WorkManager} as it's specific to WM having enough work?
 - todo can sleep for less than this time? is this lower bound required? given that if we're starved - the failed work will most likely be selected? And even if not selected - then we will no longer be starved.
 
+**`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java`**
+
+- TODO(refactor): a user-facing failure wants a PC-named type - see
+
 **`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerOffsetCommitter.java`**
 
 - todo keep work in limbo until async response is received?
+- TODO(refactor): a user-facing failure wants a PC-named type, not "internal runtime" -
+- TODO(refactor): a user-facing failure wants a PC-named type - see
 
 **`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/DynamicLoadFactor.java`**
 

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/OffsetCommitBudgetExceededException.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/OffsetCommitBudgetExceededException.java
@@ -1,0 +1,33 @@
+package bz.stub.parallelconsumer;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+/**
+ * A commit gave up because its configured budget was spent, rather than because the commit itself was
+ * rejected. The broker's own exception is always the {@link #getCause() cause}.
+ * <p>
+ * This exists to be <b>actionable</b>. The underlying Kafka exception says a commit timed out; it
+ * cannot say which of PC's options bounded it, what the relationship between that option and the
+ * consumer's own timeouts is, or what the alternatives are - and users who met the bare
+ * {@code TimeoutException} spent a long time looking in the wrong place for it (astubbs#177,
+ * confluentinc#833). The message this carries names the knob that ran out, so the reader can act
+ * without reading PC's source.
+ * <p>
+ * <b>Why this terminates PC.</b> A commit that cannot complete is not something PC can currently hand
+ * back to the application: there is no seam for "the commit failed, you decide". Kafka's own client
+ * throws a retriable exception and lets the caller choose; PC closes. That gap is tracked as a
+ * feature request in astubbs/parallel-consumer#317, and the message points there so a user meeting
+ * this knows the behaviour is a known limit rather than an accident.
+ *
+ * @author Antony Stubbs
+ */
+// Hand-written ctors (not Lombok @StandardException) - see InternalRuntimeException for why.
+public class OffsetCommitBudgetExceededException extends ParallelConsumerException {
+
+    public OffsetCommitBudgetExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -978,7 +978,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         //
         if (shouldTryCommitNow) {
             // offsets will be committed when the consumer has its partitions revoked
-            commitOffsetsThatAreReady();
+            commitOffsetsReportingPollerDeath();
         }
 
         // distribute more work
@@ -1025,6 +1025,49 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         if (log.isTraceEnabled()) {
             log.trace("End of control loop, waiting processing {}, remaining in partition queues: {}, out for processing: {}. In state: {}",
                     wm.getNumberOfWorkQueuedInShardsAwaitingSelection(), wm.getNumberOfIncompleteOffsets(), wm.getNumberRecordsOutForProcessing(), state);
+        }
+    }
+
+    /**
+     * Commit, and when that fails, report why the <em>poller</em> died rather than the symptom the
+     * control thread happens to observe.
+     * <p>
+     * The broker-poll thread is the only producer of commit responses, so any exception that escapes
+     * its control loop turns every later sync commit into
+     * {@code "Timeout waiting for commit response"} - a message that names neither the failing
+     * subsystem nor the failure. That symptom is what users report (astubbs#177, confluentinc#833) and it points
+     * nowhere near the cause.
+     * <p>
+     * {@link BrokerPollSystem#supervise()} holds the real exception, but the ordinary call at the end
+     * of {@link #controlLoop} never reaches it in this scenario: the poller dies <em>while servicing
+     * the commit this thread is already blocked on</em>, so the control thread is inside
+     * {@code commitAndWait()} rather than at the top of the loop. Moving that supervise call earlier
+     * in the loop does not help for the same reason - it was tried and measured. Supervising here, on
+     * the failure path, is what actually reaches it.
+     * <p>
+     * When the poller is healthy the commit failure is the whole story and is rethrown untouched. When
+     * it is not, the poller's exception becomes the cause and the commit failure is retained as
+     * suppressed, so neither is lost.
+     * <p>
+     * This is now the <b>backstop</b>, not the primary path. A poller that dies while servicing a
+     * commit publishes its own exception through
+     * {@link ConsumerOffsetCommitter#notifyPollerDied(Throwable)}, which releases the waiter at that
+     * moment with the right cause already attached. What is left for this to catch is a poller that
+     * died without reaching that call - before the committer existed, or through a route that does not
+     * run the poll thread's own exit path - and any commit failure in a mode that has no
+     * {@code ConsumerOffsetCommitter} at all.
+     */
+    private void commitOffsetsReportingPollerDeath() throws TimeoutException, InterruptedException {
+        try {
+            commitOffsetsThatAreReady();
+        } catch (InternalRuntimeException commitFailure) {
+            try {
+                brokerPollSubsystem.supervise();
+            } catch (RuntimeException pollerFailure) {
+                pollerFailure.addSuppressed(commitFailure);
+                throw pollerFailure;
+            }
+            throw commitFailure;
         }
     }
 

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/BrokerPollSystem.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/BrokerPollSystem.java
@@ -163,6 +163,13 @@ public class BrokerPollSystem<K, V> implements OffsetCommitter {
             return true;
         } catch (Exception e) {
             log.error("Unknown error", e);
+            // This thread is the only producer of commit responses, so tell the committer before
+            // unwinding: a control thread already blocked in ConsumerOffsetCommitter#commitAndWait
+            // cannot discover this by waiting, and would otherwise wait out the whole
+            // offsetCommitTimeout only to report the symptom instead of this. Deliberately only on
+            // the exceptional exit - a normal exit is the coordinated shutdown path, which has its
+            // own handling. See astubbs#177, confluentinc#833.
+            committer.ifPresent(c -> c.notifyPollerDied(e));
             throw e;
         }
     }

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java
@@ -5,6 +5,7 @@ package bz.stub.parallelconsumer.internal;
  * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
+import bz.stub.parallelconsumer.OffsetCommitBudgetExceededException;
 import bz.stub.parallelconsumer.ParallelConsumerOptions;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -24,6 +25,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
+
+import static bz.stub.parallelconsumer.internal.utils.StringUtils.msg;
 
 /**
  * Delegate for {@link KafkaConsumer}
@@ -154,20 +157,41 @@ public class ConsumerManager<K, V> {
         }
     }
 
+    /**
+     * Commits, retrying the transient failures for as long as the configured budget allows.
+     * <p>
+     * {@code startedTime} is captured <b>once, for the whole call</b> - matching
+     * {@link #poll(Duration)}'s {@code pollStarted} - because the budgets it feeds
+     * ({@code offsetCommitTimeout}, {@code saslAuthenticationRetryTimeout}) are budgets for
+     * committing these offsets, not for one attempt at it. Capturing it inside the retry loop reset
+     * the budget on every attempt, so whenever an attempt failed faster than the budget the
+     * comparison could never become false and this retried forever with no backoff - see
+     * {@code ConsumerManagerCommitRetryBudgetTest}. That is reachable with ordinary settings: it needs
+     * only {@code default.api.timeout.ms} below {@code offsetCommitTimeout}, and it strands the
+     * broker-poll thread inside this method, which surfaces to the user as the unrelated-looking
+     * "Timeout waiting for commit response" (astubbs#177, confluentinc#833).
+     */
     public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsetsToSend) {
         // we don't want to be woken up during a commit, only polls
         boolean inProgress = true;
         noWakeups++;
+        Instant startedTime = Instant.now();
         while (inProgress) {
             try {
                 pendingRequests.addAndGet(1L);
                 long tryCount = 0;
+                boolean committed = false;
+                // SASL's budget is a DIFFERENT option, so it gets a different clock, started at its own
+                // first failure. Sharing startedTime would charge saslAuthenticationRetryTimeout for time
+                // spent retrying unrelated commit timeouts, so an LDAP flap arriving late in a slow commit
+                // would find its budget already spent by something that is not LDAP.
+                Instant saslFirstFailure = null;
                 //allow to try to commit at least once during close / shutdown regardless of the signal.
                 while (tryCount == 0 || !closeInProgressSignal.getAsBoolean()) {
                     tryCount++;
-                    Instant startedTime = Instant.now();
                     try {
                         consumer.commitSync(offsetsToSend);
+                        committed = true;
                         // break when offset commit is okay. Do not throw exception to main threads
                         break;
                     } catch(TimeoutException timeoutException) {
@@ -180,16 +204,27 @@ public class ConsumerManager<K, V> {
                             log.warn("Encountered timeout while committing offset. Retrying ({})", tryCount);
                             // The timeout is already after 1 minute. There is no need to sleep in between retries
                         } else {
-                            // bubble up other exceptions for main events to handle
                             log.error("Offset commit took too long due to TimeoutException (tried {} times)", tryCount);
-                            throw timeoutException;
+                            throw new OffsetCommitBudgetExceededException(msg(
+                                    "Offset commit gave up after {} attempt(s) and {}, having spent its whole " +
+                                            "offsetCommitTimeout of {}.{} To allow longer, raise offsetCommitTimeout. " +
+                                            "PC shuts down rather than continuing because there is no way yet to hand " +
+                                            "this decision to your application - see " +
+                                            "https://github.com/astubbs/parallel-consumer/issues/317",
+                                    tryCount, elapsed, offsetCommitTimeout, retriesWereReachable(tryCount)),
+                                    timeoutException);
                         }
                     } catch(SaslAuthenticationException authenticationException) {
                         // We should honor the user configured SaslAuthenticationException timeout here.
                         // to allow the program to sustain temporary LDAP failures
-                        Instant now = Instant.now();
-                        Duration elapsed = Duration.between(startedTime, now);
-                        boolean shouldRetry = elapsed.toMillis() <= saslAuthenticationRetryTimeout.toMillis();
+                        if (saslFirstFailure == null) {
+                            saslFirstFailure = Instant.now();
+                        }
+                        Duration elapsed = Duration.between(saslFirstFailure, Instant.now());
+                        // '<' not '<=', matching #poll's identical branch. The two had drifted, and with the
+                        // shipped default of PT0S the difference is the whole behaviour: '<=' makes elapsed==0
+                        // satisfy a zero budget, so "do not retry SASL" retried anyway.
+                        boolean shouldRetry = elapsed.toMillis() < saslAuthenticationRetryTimeout.toMillis();
                         if(shouldRetry) {
                             log.warn("Encountered SaslAuthenticationException while committing offset. Retrying ({})", tryCount);
                             // Since authentication exception may happen immediately, it is good to sleep a few seconds before trying again
@@ -202,10 +237,34 @@ public class ConsumerManager<K, V> {
                             }
                         } else {
                             log.error("Offset commit failed due to SaslAuthenticationException (tried {} times)", tryCount);
-                            // bubble up other exceptions for main events to handle
-                            throw authenticationException;
+                            throw new OffsetCommitBudgetExceededException(msg(
+                                    "Offset commit gave up after {} attempt(s) of SASL authentication failure and {}, " +
+                                            "having spent its whole saslAuthenticationRetryTimeout of {} (retries are " +
+                                            "spaced by saslAuthenticationExceptionRetryBackoff, currently {}). To ride " +
+                                            "out longer authentication outages, raise saslAuthenticationRetryTimeout. " +
+                                            "PC shuts down rather than continuing because there is no way yet to hand " +
+                                            "this decision to your application - see " +
+                                            "https://github.com/astubbs/parallel-consumer/issues/317",
+                                    tryCount, elapsed, saslAuthenticationRetryTimeout, saslAuthenticationRetryBackOff),
+                                    authenticationException);
                         }
                     }
+                }
+                if (!committed) {
+                    // The loop above ends without committing when a retry was due but close had begun -
+                    // the condition's job is to stop RETRYING during shutdown, not to claim the commit
+                    // happened. Returning normally here would do the latter: the caller,
+                    // AbstractOffsetCommitter#retrieveOffsetsAndCommit, calls onOffsetCommitSuccess as
+                    // soon as this returns, marking offsets the broker never received as committed and
+                    // leaving nothing to retry them. That is exactly the "swallow" option
+                    // ConsumerOffsetCommitter#commitDeferringOnRebalance rejects, one layer down and on
+                    // the close path, where the final commit matters most. Fail instead: the close
+                    // sequence logs it and shuts down, which is true rather than quietly wrong.
+                    // TODO(refactor): a user-facing failure wants a PC-named type - see
+                    // docs/inflight/next-exception-hierarchy-cleanup.md
+                    throw new InternalRuntimeException(
+                            "Offset commit abandoned after {} attempt(s) because close began - these offsets were NOT " +
+                                    "committed, so they must not be recorded as successful", null, tryCount);
                 }
                 inProgress = false;
             } catch (WakeupException w) {
@@ -215,6 +274,32 @@ public class ConsumerManager<K, V> {
                 pendingRequests.addAndGet(-1L);
             }
         }
+    }
+
+    /**
+     * The check Kafka would make at construction, made here instead because it cannot be made there.
+     * <p>
+     * Kafka validates the relationship between its own two-level timeouts up front - a producer refuses
+     * a {@code delivery.timeout.ms} below {@code request.timeout.ms + linger.ms} - precisely so nobody
+     * ships a total budget smaller than one attempt. PC's {@code offsetCommitTimeout} is the same kind
+     * of total, layered over the consumer's own per-call {@code default.api.timeout.ms}, but PC cannot
+     * read that: {@link org.apache.kafka.clients.consumer.Consumer} exposes no configuration, and the
+     * one place PC does reach for consumer config it does so by reflection, which its own javadoc calls
+     * brittle.
+     * <p>
+     * So the relationship is reported when it actually bites rather than guessed at start-up. Giving up
+     * after a single attempt means that attempt outlived the whole budget, so no retry was ever
+     * reachable - which is silent today: a user who set {@code offsetCommitTimeout} expecting retries
+     * gets exactly one try and no indication why.
+     */
+    private String retriesWereReachable(long tryCount) {
+        if (tryCount > 1) {
+            return "";
+        }
+        return " Only ONE attempt was made, so no retry was reachable: a single commit attempt outlived the" +
+                " whole budget. That is what happens when offsetCommitTimeout is below the consumer's own" +
+                " default.api.timeout.ms (60s by default), which bounds each individual attempt - raise" +
+                " offsetCommitTimeout above it for retries to be possible at all.";
     }
 
     // Return true if backoff is finished successfully

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerOffsetCommitter.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerOffsetCommitter.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static bz.stub.parallelconsumer.ParallelConsumerOptions.CommitMode.PERIODIC_CONSUMER_SYNC;
 import static bz.stub.parallelconsumer.ParallelConsumerOptions.CommitMode.PERIODIC_TRANSACTIONAL_PRODUCER;
@@ -54,6 +55,25 @@ public class ConsumerOffsetCommitter<K, V> extends AbstractOffsetCommitter<K, V>
      * Queue of commit responses, for other threads to block on
      */
     private final BlockingQueue<CommitResponse> commitResponseQueue = new LinkedBlockingQueue<>();
+
+    /**
+     * The exception that killed the broker-poll thread, published by that thread as it dies.
+     * <p>
+     * The poll thread is the <em>only</em> producer of commit responses, so a waiter can never learn
+     * of its death by waiting - waiting is precisely the thing that cannot work. Deriving the
+     * waiter's deadline from the poller's budget so that one expires first would only make the race
+     * usually resolve the right way; being told is the version that is always right. This is the same
+     * move {@link #maybeDoCommit()} already makes for a deferred commit, and the same shape as
+     * {@link ConsumerManager#setCloseInProgressSignal}.
+     */
+    private final AtomicReference<Throwable> pollerDeath = new AtomicReference<>();
+
+    /**
+     * Wake-up token, published once alongside {@link #pollerDeath}. Its request id matches nobody, so
+     * a waiter can only ever act on it through {@code pollerDeath} - its job is to end the blocking
+     * {@code poll()} at the moment of death, not to answer a request.
+     */
+    private static final CommitResponse POLLER_DIED = new CommitResponse(new CommitRequest());
 
     public ConsumerOffsetCommitter(final ConsumerManager<K, V> newConsumer, final WorkManager<K, V> newWorkManager, final ParallelConsumerOptions options) {
         super(newConsumer, newWorkManager);
@@ -138,30 +158,94 @@ public class ConsumerOffsetCommitter<K, V> extends AbstractOffsetCommitter<K, V>
         CommitRequest request;
     }
 
+    /**
+     * Waits for the broker-poll thread to answer a commit request.
+     * <p>
+     * The two ways this does not return normally are now genuinely different things, which is the
+     * point of astubbs#177 / confluentinc#833. A <b>dead</b> poller is an event: it publishes its own
+     * exception through {@link #notifyPollerDied} as it dies and this returns immediately with that
+     * as the cause - it is never waited out. A <b>timeout</b> therefore means what it says: the poller
+     * is alive and has not answered within {@code offsetCommitTimeout}. Neither message guesses at the
+     * other's cause; guessing is what sent users looking in the wrong place for years.
+     */
     private void commitAndWait() {
+        throwIfPollerDied(null);
+
         // request
         CommitRequest commitRequest = requestCommitInternal();
 
-        // wait
-        boolean waitingOnCommitResponse = true;
-        int attempts = 0;
-        while (waitingOnCommitResponse) {
-            if (attempts > ARBITRARY_RETRY_LIMIT)
-                throw new InternalRuntimeException("Too many attempts taking commit responses");
-
+        // wait - the only way out is our own response arriving, a death, or a timeout
+        for (int attempts = 0; attempts <= ARBITRARY_RETRY_LIMIT; attempts++) {
             try {
                 log.debug("Waiting on a commit response");
-                Duration timeout = AbstractParallelEoSStreamProcessor.DEFAULT_TIMEOUT;
                 CommitResponse take = commitResponseQueue.poll(commitTimeout.toMillis(), TimeUnit.MILLISECONDS); // blocks, drain until we find our response
-                if (take == null) {
-                    throw InternalRuntimeException.msg("Timeout waiting for commit response {} to request {}", timeout, commitRequest);
+                if (take != null && commitRequest.getId().equals(take.getRequest().getId())) {
+                    // Our answer arrived, so this commit HAPPENED - report it as such even if the
+                    // poller died immediately afterwards of something unrelated. Checking the death
+                    // first would report "request X can never be answered" about a request that was
+                    // answered, which is the same kind of unestablished claim this whole change
+                    // exists to remove. The death is not lost: the next commit fails fast on it, and
+                    // the poller's exception still reaches the control thread through
+                    // AbstractParallelEoSStreamProcessor's supervise() backstop.
+                    return;
                 }
-                waitingOnCommitResponse = take.getRequest().getId() != commitRequest.getId();
+                throwIfPollerDied(commitRequest);
+                if (take == null) {
+                    // report the timeout actually waited (offsetCommitTimeout). This used to
+                    // interpolate the unrelated constant DEFAULT_TIMEOUT, so every one of these
+                    // errors claimed PT30S no matter what the option was set to - overstating the
+                    // default by 3x and making the number useless as a diagnostic.
+                    // TODO(refactor): a user-facing failure wants a PC-named type, not "internal runtime" -
+                    // see docs/inflight/next-exception-hierarchy-cleanup.md
+                    throw InternalRuntimeException.msg(
+                            "Timeout waiting for commit response {} to request {} - the broker poll thread is the " +
+                                    "only producer of commit responses, and it has not died with an exception, so it is " +
+                                    "not answering: it is blocked or slower than the configured offsetCommitTimeout. Had " +
+                                    "it thrown, that would have been reported here immediately, with its own error as the " +
+                                    "cause. An Error rather than an Exception escapes that path and is reported by " +
+                                    "AbstractParallelEoSStreamProcessor's supervise() backstop instead",
+                            commitTimeout, commitRequest);
+                }
+                // an older request's response, or the wake-up token: keep draining until ours arrives
             } catch (InterruptedException e) {
                 log.debug("Interrupted waiting for commit response", e);
             }
-            attempts++;
         }
+        throw new InternalRuntimeException("Too many attempts taking commit responses");
+    }
+
+    /**
+     * Published by the broker-poll thread from its own exit path as it dies, so that a waiter is
+     * released <em>at that moment</em> rather than after {@code offsetCommitTimeout}.
+     * <p>
+     * Idempotent: only the first death is recorded, and the wake-up token is published only with it.
+     *
+     * @param cause what killed the poll thread - becomes the cause every stranded committer reports
+     */
+    void notifyPollerDied(Throwable cause) {
+        if (pollerDeath.compareAndSet(null, cause)) {
+            log.debug("Broker poll thread died - releasing any waiting committer now, and failing later ones fast", cause);
+            commitResponseQueue.add(POLLER_DIED);
+        }
+    }
+
+    /**
+     * @param commitRequest the request that can no longer be answered, or {@code null} when checking
+     *                      before one has been made
+     */
+    private void throwIfPollerDied(CommitRequest commitRequest) {
+        Throwable death = pollerDeath.get();
+        if (death == null) {
+            return;
+        }
+        String context = commitRequest == null
+                ? "no commit can be requested"
+                : "request " + commitRequest + " can never be answered";
+        // TODO(refactor): a user-facing failure wants a PC-named type - see
+        // docs/inflight/next-exception-hierarchy-cleanup.md
+        throw new InternalRuntimeException(
+                "The broker poll thread has died, so {} - its own error is the cause of this one",
+                death, context);
     }
 
     private CommitRequest requestCommitInternal() {

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CommitResponseTimeoutSymptomTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CommitResponseTimeoutSymptomTest.java
@@ -1,0 +1,411 @@
+package bz.stub.parallelconsumer;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static bz.stub.parallelconsumer.internal.utils.ThreadUtils.sleepOrFail;
+import static com.google.common.truth.Truth.assertThat;
+import static pl.tlinkowski.unij.api.UniLists.of;
+
+/**
+ * "{@code InternalRuntimeException: Timeout waiting for commit response}" as users actually meet it -
+ * astubbs#177, confluentinc#833: a consumer that runs for a while under a high failure rate across many keys and
+ * then exits with that message.
+ * <p>
+ * The message is a <b>symptom</b>, and this class pins both halves of that:
+ * <ol>
+ *     <li>the trigger must not happen - a commit rejected mid-rebalance is deferred, so the
+ *         broker-poll thread survives and no waiter ever times out
+ *         ({@link #aRebalanceStormUnderAHighFailureRateNeitherStallsNorKillsTheConsumer()});</li>
+ *     <li>when the poll thread dies for some <em>other</em> reason, the user must be told what that
+ *         reason was, at the moment it happens, rather than being handed the timeout, which names
+ *         neither the failing subsystem nor the failure
+ *         ({@link #aDeadPollThreadReportsItsOwnCauseNotTheCommitResponseTimeout()});</li>
+ *     <li>and when the poll thread is merely <em>slow</em>, the timeout must be reported as itself,
+ *         because the two produce the same observable and only one of them is a dead poller
+ *         ({@link #aLivePollThreadThatIsMerelySlowReportsTheTimeoutItActuallyWaited()}).</li>
+ * </ol>
+ * The second is the part the fixes for the known triggers could never cover: they removed two ways to
+ * kill that thread, and every remaining way still produced the same uninformative message. The third
+ * is what stops the cure becoming the disease - a message that asserts a death it has not established
+ * is the same defect wearing different words.
+ * <p>
+ * Deliberately not a subclass of {@link CommitRejectionTestBase}. That base pins a different property
+ * - one rejection reason at a time, rejected only at start-up, asserting the offsets are not recorded
+ * as successful - on a workload (ten records, one key, no retries) chosen to isolate it. What is under
+ * test here is the reported <em>workload</em>: rejections recurring for the whole run against a large
+ * backlog of retrying records, where a fix that deferred a commit but never re-requested one would
+ * pass the base and stall here.
+ * <p>
+ * Nor of {@link MockConsumerTestBase}, and this is the closer call, since that base does own the
+ * manual rebalance dance these tests repeat. Four things it fixes are variables here: it hardcodes
+ * <em>one</em> partition and one record key, where the reported workload is {@value #KEYS} keys across
+ * {@value #PARTITIONS} partitions under {@code KEY} ordering - which is what makes the rejections land
+ * against a real backlog rather than a queue of one; it builds PC in {@code @BeforeEach} from
+ * per-<em>class</em> options, while these three scenarios need three different consumers and two
+ * different {@code offsetCommitTimeout}s; and its teardown asserts the failure cause is null, which two
+ * of the three deliberately produce. Extending it would mean overriding the assignment, the record
+ * model and the teardown, and splitting one story into three files - so the wiring would be inherited
+ * and everything that matters overridden. Generalising the base to take a partition count and a key
+ * supplier would be the real fix, and it belongs in a change that can re-verify the six classes already
+ * on it, not in this one.
+ */
+@Slf4j
+@Timeout(180)
+class CommitResponseTimeoutSymptomTest {
+
+    private static final String TOPIC = CommitResponseTimeoutSymptomTest.class.getSimpleName();
+
+    /** As reported: a thousand keys. Each is its own shard under {@link ParallelConsumerOptions.ProcessingOrder#KEY}. */
+    private static final int KEYS = 1000;
+
+    private static final int PARTITIONS = 4;
+
+    /** As reported: about half the records fail. Every second key fails its first attempt. */
+    private static final int FAILING_KEY_MODULO = 2;
+
+    /** The group rebalances constantly, so a commit keeps landing inside one. */
+    private static final int REJECT_EVERY_NTH_COMMIT = 3;
+
+    /**
+     * The report is of a consumer that "runs for a while" before dying, so the records arrive over
+     * time rather than in one batch. Fed in one go the whole backlog drains inside about four commit
+     * cycles, which is too few for a rejection <em>storm</em> to mean anything - the first measured
+     * version of this test saw one rejection.
+     */
+    private static final int FEED_BATCHES = 20;
+
+    private static final Duration FEED_INTERVAL = Duration.ofMillis(150);
+
+    /**
+     * Lower bound on rejections, from {@link #FEED_BATCHES} x {@link #FEED_INTERVAL} of feeding at a
+     * 100ms commit interval - comfortably under the count a healthy run produces. A slower machine
+     * feeds over a longer wall-clock window and rejects more, never fewer, so load cannot flake this.
+     */
+    private static final int MIN_REJECTIONS = 4;
+
+    private ParallelEoSStreamProcessor<String, String> parallelConsumer;
+
+    @AfterEach
+    void closePc() {
+        if (parallelConsumer != null && !parallelConsumer.isClosedOrFailed()) {
+            parallelConsumer.closeDontDrainFirst();
+        }
+    }
+
+    /**
+     * The reported scenario end to end. Rejections recur for the whole run, so deferral has to be
+     * genuinely re-requested each cycle rather than merely survived once.
+     * <p>
+     * Discriminating: with the {@link RebalanceInProgressException} catch removed, the poll thread dies
+     * on the first rejection and the run ends with the reported
+     * {@code Timeout waiting for commit response} - the records never finish and the failure cause is
+     * not null.
+     */
+    @Test
+    void aRebalanceStormUnderAHighFailureRateNeitherStallsNorKillsTheConsumer() {
+        final AtomicInteger commitAttempts = new AtomicInteger();
+        final AtomicInteger commitsRejected = new AtomicInteger();
+
+        var mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+                if (commitAttempts.incrementAndGet() % REJECT_EVERY_NTH_COMMIT == 0) {
+                    commitsRejected.incrementAndGet();
+                    throw new RebalanceInProgressException("Offset commit cannot be completed since the "
+                            + "consumer is undergoing a rebalance for auto partition assignment (mocking)");
+                }
+                super.commitSync(offsets);
+            }
+        };
+
+        parallelConsumer = startPc(mockConsumer, Duration.ofSeconds(10));
+        var partitions = assignPartitions(mockConsumer, parallelConsumer);
+        var recordsPerPartition = expectedRecordsPerPartition();
+
+        // every key must fail its first attempt, then succeed - the reported ~50% failure rate
+        final Map<String, AtomicInteger> attemptsPerKey = new ConcurrentHashMap<>();
+        final Set<String> succeeded = ConcurrentHashMap.newKeySet();
+
+        parallelConsumer.poll(context -> context.forEach(record -> {
+            String key = record.key();
+            int attempt = attemptsPerKey.computeIfAbsent(key, k -> new AtomicInteger()).incrementAndGet();
+            if (shouldFail(key) && attempt == 1) {
+                throw new FakeRuntimeException("Simulated user function failure for " + key);
+            }
+            succeeded.add(key);
+        }));
+
+        feedRecordsOverTime(mockConsumer);
+
+        // the whole backlog drains despite rejections continuing throughout
+        Awaitility.await().atMost(Duration.ofSeconds(120)).untilAsserted(() ->
+                assertThat(succeeded).hasSize(KEYS));
+
+        // the rejection path was exercised repeatedly, not just once at start-up - otherwise this
+        // test could pass by never reaching the behaviour it exists to pin.
+        //
+        // Awaited rather than read once: the await above is satisfied by the USER FUNCTION's set,
+        // while this counter is incremented on the broker-poll thread inside commitSync. Those are
+        // different threads and neither orders the other, so reading this one at the instant the
+        // other finishes assumes an ordering nothing provides. The margin is large (feeding alone
+        // spans ~19x FEED_INTERVAL at a 100ms commit interval, so tens of commits precede the last
+        // batch) - but "large margin" is what every latent race says before it loses. Awaiting the
+        // value actually asserted is strictly stronger and cannot mask anything: if the rejections
+        // never arrive, this still fails.
+        Awaitility.await().atMost(Duration.ofSeconds(30)).untilAsserted(() ->
+                assertThat(commitsRejected.get()).isAtLeast(MIN_REJECTIONS));
+        log.info("Commit attempts: {}, rejected: {}", commitAttempts.get(), commitsRejected.get());
+
+        // and every partition really is committed to the end, so deferral postponed rather than dropped
+        Awaitility.await().atMost(Duration.ofSeconds(60)).untilAsserted(() -> {
+            var committed = mockConsumer.committed(new HashSet<>(partitions));
+            for (TopicPartition tp : partitions) {
+                assertThat(committed.get(tp)).isNotNull();
+                assertThat(committed.get(tp).offset()).isEqualTo(recordsPerPartition.get(tp));
+            }
+        });
+
+        assertThat(parallelConsumer.getFailureCause()).isNull();
+        assertThat(parallelConsumer.isClosedOrFailed()).isFalse();
+    }
+
+    /**
+     * When the poll thread dies of something PC does not classify, the reported failure must name that
+     * something - and must not wait out {@code offsetCommitTimeout} first.
+     * <p>
+     * {@link AuthorizationException} stands in for the open-ended set of ways that thread can die
+     * (broker down, offset encoding, authorization) which no per-exception fix covers. The control
+     * thread is already blocked in {@code commitAndWait()} when it happens, so the poller's own error
+     * is otherwise never reported at all.
+     * <p>
+     * <b>The timeout is the control, not the mechanism.</b> {@code offsetCommitTimeout} is set to a
+     * minute here while the await allows half of it: the poller publishes its death through
+     * {@link ConsumerOffsetCommitter#notifyPollerDied}, so the waiter is released by an <em>event</em>
+     * and this finishes in well under a second. Remove that call and the only way out is the timeout,
+     * which cannot arrive inside the await - so the test fails, and it fails without asserting on a
+     * clock. The chain assertion below is the same statement made causally: a timeout report appearing
+     * at all means the event path did not fire.
+     * <p>
+     * Discriminating: without the death notification the run ends after a full minute with
+     * {@code Timeout waiting for commit response} and this exception nowhere in the chain - exactly the
+     * position the reporter of astubbs#177 was left in.
+     */
+    @Test
+    void aDeadPollThreadReportsItsOwnCauseNotTheCommitResponseTimeout() {
+        final Duration commitTimeout = Duration.ofMinutes(1);
+        final String pollThreadFailure = "Not authorized to commit (mocking)";
+
+        var mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+                throw new AuthorizationException(pollThreadFailure);
+            }
+        };
+
+        parallelConsumer = startPc(mockConsumer, commitTimeout);
+        assignPartitions(mockConsumer, parallelConsumer);
+        addRecords(mockConsumer, 0, PARTITIONS); // enough to make PC want to commit
+
+        parallelConsumer.poll(context -> context.forEach(record -> log.trace("Processing {}", record.key())));
+
+        // Awaiting isClosedOrFailed() and then asserting getFailureCause() is the safe direction, and
+        // deliberately so: supervisorLoop() assigns failureReason BEFORE doClose() (which sets
+        // state=CLOSED) and before the throw that completes controlThreadFuture, and
+        // isClosedOrFailed() reads only those two later signals. So the awaited signal LAGS the
+        // asserted value rather than leading it - the inverse of the trap in
+        // docs/solutions/test-flakiness/vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md
+        // ("await the value you assert, never a proxy that leads it"). The FutureTask state read in
+        // isDone() also gives the happens-before edge that publishes failureReason to this thread.
+        // Do not "fix" this into awaiting getFailureCause(): a null cause is exactly what a
+        // regression here would produce, and awaiting it would hide that.
+        // Half of offsetCommitTimeout. Reaching this ceiling means the waiter was NOT released by the
+        // death event and is sitting out its full minute - see the class-level note above.
+        Awaitility.await().atMost(commitTimeout.dividedBy(2)).untilAsserted(() ->
+                assertThat(parallelConsumer.isClosedOrFailed()).isTrue());
+
+        Exception failureCause = parallelConsumer.getFailureCause();
+        assertThat(failureCause).isNotNull();
+
+        var chain = causeChain(failureCause);
+        var everyMessage = chain.stream()
+                .flatMap(t -> Stream.concat(Stream.of(t), java.util.Arrays.stream(t.getSuppressed())))
+                .map(t -> String.valueOf(t.getMessage()))
+                .collect(java.util.stream.Collectors.toList());
+
+        // the real reason must be reachable, not replaced by the symptom
+        assertThat(chain.stream().anyMatch(t -> t instanceof AuthorizationException)).isTrue();
+        assertThat(chain.stream().anyMatch(t -> String.valueOf(t.getMessage()).contains(pollThreadFailure))).isTrue();
+
+        // the waiter was told, so it says so
+        assertThat(everyMessage.stream().anyMatch(m -> m.contains("broker poll thread has died"))).isTrue();
+
+        // and the symptom is absent entirely rather than merely demoted: its presence would mean the
+        // waiter timed out, which on this path is the regression itself.
+        assertThat(everyMessage.stream().noneMatch(m -> m.contains("Timeout waiting for commit response"))).isTrue();
+    }
+
+    /**
+     * The other branch: the poll thread is <b>alive</b> and simply has not answered in time. Here the
+     * timeout is the whole story, and must be reported as itself - with the timeout that was actually
+     * configured.
+     * <p>
+     * This is the branch the death event deliberately does not cover, so it is the one that proves the
+     * two are not conflated. A commit that blocks on the poll thread produces the identical observable
+     * for the control thread - no response within {@code offsetCommitTimeout} - and the two must not
+     * report the same thing, because for years the message asserted a dead poller either way.
+     * <p>
+     * Discriminating on two counts. Make {@code commitAndWait()} report the poller as dead here and the
+     * "not answering" assertion fails; restore the old {@code DEFAULT_TIMEOUT} interpolation and the
+     * duration assertion fails, because that constant is 30s regardless of configuration.
+     */
+    @Test
+    void aLivePollThreadThatIsMerelySlowReportsTheTimeoutItActuallyWaited() {
+        final Duration commitTimeout = Duration.ofSeconds(1);
+        final Duration commitBlocksFor = commitTimeout.multipliedBy(5);
+
+        var mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+                // the poll thread stays alive and healthy - it is simply in here, not answering
+                sleepOrFail(commitBlocksFor, "Interrupted while blocking the commit");
+                super.commitSync(offsets);
+            }
+        };
+
+        parallelConsumer = startPc(mockConsumer, commitTimeout);
+        assignPartitions(mockConsumer, parallelConsumer);
+        addRecords(mockConsumer, 0, PARTITIONS); // enough to make PC want to commit
+
+        parallelConsumer.poll(context -> context.forEach(record -> log.trace("Processing {}", record.key())));
+
+        Awaitility.await().atMost(Duration.ofSeconds(60)).untilAsserted(() ->
+                assertThat(parallelConsumer.isClosedOrFailed()).isTrue());
+
+        Exception failureCause = parallelConsumer.getFailureCause();
+        assertThat(failureCause).isNotNull();
+
+        var everyMessage = causeChain(failureCause).stream()
+                .flatMap(t -> Stream.concat(Stream.of(t), java.util.Arrays.stream(t.getSuppressed())))
+                .map(t -> String.valueOf(t.getMessage()))
+                .collect(java.util.stream.Collectors.toList());
+
+        var timeoutReport = everyMessage.stream()
+                .filter(m -> m.contains("Timeout waiting for commit response"))
+                .findFirst();
+        assertThat(timeoutReport.isPresent()).isTrue();
+
+        // the timeout actually waited, not the unrelated DEFAULT_TIMEOUT constant this used to print
+        assertThat(timeoutReport.get()).contains(commitTimeout.toString());
+
+        // and it must not claim a death it has not established. The claim is deliberately the narrow
+        // one the code can actually prove - no exception escaped the poll thread's control loop - not
+        // the broader "it is alive", which an Error would falsify (catch (Exception) does not see one).
+        assertThat(timeoutReport.get()).contains("has not died with an exception");
+        assertThat(everyMessage.stream().noneMatch(m -> m.contains("broker poll thread has died"))).isTrue();
+    }
+
+    private boolean shouldFail(String key) {
+        return Integer.parseInt(key.substring("key-".length())) % FAILING_KEY_MODULO == 0;
+    }
+
+    private ParallelEoSStreamProcessor<String, String> startPc(MockConsumer<String, String> mockConsumer,
+                                                               Duration offsetCommitTimeout) {
+        var options = ParallelConsumerOptions.<String, String>builder()
+                .consumer(mockConsumer)
+                .ordering(ParallelConsumerOptions.ProcessingOrder.KEY) // as reported - keys are the unit of ordering
+                .commitMode(ParallelConsumerOptions.CommitMode.PERIODIC_CONSUMER_SYNC) // the only mode that waits on a commit response
+                .commitInterval(Duration.ofMillis(100))
+                .offsetCommitTimeout(offsetCommitTimeout)
+                .defaultMessageRetryDelay(Duration.ofMillis(50)) // keep the retry backlog moving
+                .build();
+        var pc = new ParallelEoSStreamProcessor<String, String>(options);
+        pc.subscribe(of(TOPIC));
+        return pc;
+    }
+
+    /** MockConsumer does not honour the Consumer contract for rebalances - drive it by hand. */
+    private List<TopicPartition> assignPartitions(MockConsumer<String, String> mockConsumer,
+                                                  ParallelEoSStreamProcessor<String, String> pc) {
+        List<TopicPartition> partitions = new ArrayList<>();
+        Map<TopicPartition, Long> beginningOffsets = new HashMap<>();
+        for (int p = 0; p < PARTITIONS; p++) {
+            TopicPartition tp = new TopicPartition(TOPIC, p);
+            partitions.add(tp);
+            beginningOffsets.put(tp, 0L);
+        }
+        mockConsumer.rebalance(partitions);
+        pc.onPartitionsAssigned(partitions);
+        mockConsumer.updateBeginningOffsets(beginningOffsets);
+        return partitions;
+    }
+
+    /**
+     * Feeds all {@link #KEYS} records in {@link #FEED_BATCHES} batches, so the consumer runs across
+     * many commit cycles as reported rather than draining one buffer. Synchronous: PC polls on its own
+     * threads, so the test thread is free, and there is no background feeder to outlive the test and
+     * call {@code addRecord} on a closed consumer.
+     */
+    private void feedRecordsOverTime(MockConsumer<String, String> mockConsumer) {
+        int batchSize = KEYS / FEED_BATCHES;
+        for (int batch = 0; batch < FEED_BATCHES; batch++) {
+            addRecords(mockConsumer, batch * batchSize, batchSize);
+            if (batch < FEED_BATCHES - 1) {
+                sleepOrFail(FEED_INTERVAL, "Interrupted while feeding records");
+            }
+        }
+    }
+
+    private void addRecords(MockConsumer<String, String> mockConsumer, int firstKey, int count) {
+        for (int i = firstKey; i < firstKey + count; i++) {
+            int partition = i % PARTITIONS;
+            // keys are dealt round-robin across partitions, so a key's offset is its index within its
+            // own partition's share
+            long offset = i / PARTITIONS;
+            mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, partition, offset, "key-" + i, "value-" + i));
+        }
+    }
+
+    /** @return the number of records each partition receives, i.e. its expected final committed offset */
+    private Map<TopicPartition, Long> expectedRecordsPerPartition() {
+        Map<TopicPartition, Long> counts = new HashMap<>();
+        for (int i = 0; i < KEYS; i++) {
+            counts.merge(new TopicPartition(TOPIC, i % PARTITIONS), 1L, Long::sum);
+        }
+        return counts;
+    }
+
+    private static List<Throwable> causeChain(Throwable throwable) {
+        List<Throwable> chain = new ArrayList<>();
+        for (Throwable t = throwable; t != null && !chain.contains(t); t = t.getCause()) {
+            chain.add(t);
+        }
+        return chain;
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CommitResponseTimeoutSymptomTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CommitResponseTimeoutSymptomTest.java
@@ -292,7 +292,16 @@ class CommitResponseTimeoutSymptomTest {
 
         var mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
             @Override
-            public synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+            // DELIBERATELY NOT synchronized, unlike the overrides in the other two scenarios. They throw
+            // immediately; this one sleeps, and MockConsumer guards poll, addRecord, commitSync and close
+            // with one monitor - so sleeping while holding it parks PC's own polling and the teardown
+            // close, not just this commit. What the test needs is the POLL THREAD blocked inside
+            // commitSync, which happens either way; holding the monitor only adds collateral. Measured:
+            // with `synchronized`, green locally in 8.6s and dead on CI at the 60s await
+            // (run 32216929470). MockConsumerTestBase#addRecordsInBackground documents this hazard -
+            // inheriting that warning is part of what extending it would have bought, per the class
+            // javadoc above.
+            public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
                 // the poll thread stays alive and healthy - it is simply in here, not answering
                 sleepOrFail(commitBlocksFor, "Interrupted while blocking the commit");
                 super.commitSync(offsets);

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerCommitRetryBudgetTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerCommitRetryBudgetTest.java
@@ -1,0 +1,199 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import bz.stub.parallelconsumer.OffsetCommitBudgetExceededException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static bz.stub.parallelconsumer.internal.utils.ThreadUtils.sleepOrFail;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static pl.tlinkowski.unij.api.UniMaps.of;
+
+/**
+ * {@code offsetCommitTimeout} must bound the <b>whole</b> commit, not each individual attempt.
+ * <p>
+ * This is the "the broker is actually down" case behind the commit-response timeout reports (astubbs#177,
+ * confluentinc#833). {@link ConsumerManager#commitSync(Map)} retries Kafka's
+ * {@link TimeoutException} and is documented as honouring the user's {@code offsetCommitTimeout}
+ * before giving up. It measured that budget from a start instant captured <em>inside</em> the retry
+ * loop, so every attempt reset it: whenever a single {@code commitSync} attempt failed faster than the
+ * budget - which is the normal shape of a fast connection failure, and is guaranteed whenever
+ * {@code default.api.timeout.ms} is below {@code offsetCommitTimeout} - the comparison could never
+ * become false and the loop retried forever, with no backoff. PC then neither committed nor failed:
+ * the broker-poll thread spun inside one {@code commitSync} call while the control thread waited out
+ * its commit response, which is the reported symptom arriving by a different road.
+ * <p>
+ * It only <em>looked</em> bounded because the shipped defaults hide it - a single attempt blocks for
+ * {@code default.api.timeout.ms} (60s), which already exceeds the default 10s budget, so the first
+ * comparison fails and it gives up after one try.
+ * <p>
+ * {@link ConsumerManager#poll(Duration)} got the same pattern right, capturing {@code pollStarted}
+ * outside its retry loop, which is the strongest evidence the difference was accidental.
+ */
+@Slf4j
+@Timeout(60)
+class ConsumerManagerCommitRetryBudgetTest {
+
+    private static final TopicPartition TP = new TopicPartition("ConsumerManagerCommitRetryBudgetTest", 0);
+
+    /**
+     * Deliberately 20x {@link #ATTEMPT_DURATION} rather than the 5x a smaller budget would give.
+     * Both bounds below are load-sensitive in opposite directions, and the ratio is what separates
+     * them: the lower bound only fails if the FIRST attempt stretches past the whole budget, so 20x
+     * means that needs a 20-fold dilation rather than a five-fold one. Core's unit tests run under
+     * heavy thread parallelism, and a 5x stretch of a 100ms sleep there is not far-fetched - it is
+     * the signature of the load-tightness family in docs/inflight/test-load-tightness-flakes.md.
+     */
+    private static final Duration COMMIT_BUDGET = Duration.ofSeconds(2);
+
+    /** Each failing attempt burns this much of the budget. */
+    private static final Duration ATTEMPT_DURATION = Duration.ofMillis(100);
+
+    /**
+     * Escape hatch so an unbounded loop <b>fails</b> rather than hangs: past this, the mock starts
+     * succeeding. Far more attempts than the budget can pay for, so reaching it means the budget was
+     * never enforced.
+     */
+    private static final int ATTEMPTS_BEFORE_MOCK_RELENTS = 50;
+
+    /**
+     * Generous ceiling on {@code COMMIT_BUDGET / ATTEMPT_DURATION} (= 20). Only an upper bound, so a
+     * loaded machine taking longer per attempt just uses fewer of them - it cannot flake THIS bound.
+     * The lower bound is the one load can reach, which is what {@link #COMMIT_BUDGET}'s ratio buys.
+     */
+    private static final int ATTEMPT_LIMIT = 40;
+
+    @Test
+    void commitSyncGivesUpOnceTheWholeOffsetCommitTimeoutIsSpent() {
+        final AtomicInteger attempts = new AtomicInteger();
+
+        var mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+                if (attempts.incrementAndGet() > ATTEMPTS_BEFORE_MOCK_RELENTS) {
+                    log.warn("Mock relenting after {} attempts - the retry budget was never enforced", attempts.get());
+                    super.commitSync(offsets);
+                    return;
+                }
+                sleepOrFail(ATTEMPT_DURATION, "Interrupted while mocking a slow commit");
+                throw new TimeoutException("Broker unreachable (mocking)");
+            }
+        };
+
+        var consumerManager = new ConsumerManager<>(mockConsumer,
+                COMMIT_BUDGET,
+                Duration.ofSeconds(30), // sasl budget - not under test, kept clear of the commit budget
+                Duration.ofMillis(10));
+
+        var offsets = of(TP, new OffsetAndMetadata(1L));
+
+        var thrown = assertThrows(OffsetCommitBudgetExceededException.class, () -> consumerManager.commitSync(offsets),
+                "a permanently timing-out commit must surface a failure once the budget is spent, not retry forever");
+
+        // the broker's own exception is never discarded - it is the cause
+        assertThat(thrown).hasCauseThat().isInstanceOf(TimeoutException.class);
+
+        // and the message has to be actionable: which budget ran out, and what to turn
+        assertThat(thrown).hasMessageThat().contains("offsetCommitTimeout");
+        assertThat(thrown).hasMessageThat().contains(COMMIT_BUDGET.toString());
+        // the shutdown is a known limit with a home, not an accident the reader has to guess at
+        assertThat(thrown).hasMessageThat().contains("issues/317");
+
+        // retries WERE reachable here, so the single-attempt diagnostic must not fire
+        assertThat(thrown).hasMessageThat().doesNotContain("Only ONE attempt");
+
+        assertThat(attempts.get()).isAtMost(ATTEMPT_LIMIT);
+        assertThat(attempts.get()).isAtLeast(2); // it must still RETRY - giving up on the first attempt is the other failure
+    }
+
+    /**
+     * The other half of the give-up message: when only ONE attempt was made, that attempt outlived the
+     * whole budget, so no retry was ever reachable. Saying so is the check Kafka would have made at
+     * construction - it refuses a total budget below one attempt - which PC cannot make, because
+     * {@link org.apache.kafka.clients.consumer.Consumer} exposes no configuration to compare against.
+     * <p>
+     * This is the shipped default's shape, not an exotic one: {@code offsetCommitTimeout} defaults to
+     * 10s while a single {@code consumer.commitSync} runs to {@code default.api.timeout.ms}, 60s. So out
+     * of the box the retry loop cannot be entered, and until this message existed nothing said why.
+     */
+    @Test
+    void oneAttemptOutlivingTheWholeBudgetSaysNoRetryWasReachable() {
+        final Duration budget = Duration.ofMillis(100);
+        final AtomicInteger attempts = new AtomicInteger();
+
+        var mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+                attempts.incrementAndGet();
+                // one attempt, longer than the entire budget - the default configuration's shape
+                sleepOrFail(budget.multipliedBy(3), "Interrupted while mocking an attempt that outlives the budget");
+                throw new TimeoutException("Broker unreachable (mocking)");
+            }
+        };
+
+        var consumerManager = new ConsumerManager<>(mockConsumer, budget,
+                Duration.ofSeconds(30), Duration.ofMillis(10));
+
+        var thrown = assertThrows(OffsetCommitBudgetExceededException.class,
+                () -> consumerManager.commitSync(of(TP, new OffsetAndMetadata(1L))));
+
+        assertThat(attempts.get()).isEqualTo(1);
+        // the diagnostic that only fires here, and names the consumer setting PC cannot read
+        assertThat(thrown).hasMessageThat().contains("Only ONE attempt");
+        assertThat(thrown).hasMessageThat().contains("default.api.timeout.ms");
+    }
+
+    /**
+     * SASL gives up against its OWN budget, and says which one ran out.
+     * <p>
+     * Two things this pins that reading cannot. The budget is
+     * {@code saslAuthenticationRetryTimeout}, not {@code offsetCommitTimeout} - here the commit budget
+     * is set generously so a message naming it would be wrong. And the clock starts at the first SASL
+     * failure rather than at the start of the call, so time spent elsewhere in the commit cannot spend
+     * an authentication budget.
+     */
+    @Test
+    void saslGivesUpAgainstItsOwnBudgetAndNamesIt() {
+        final Duration saslBudget = Duration.ofMillis(100);
+        final AtomicInteger attempts = new AtomicInteger();
+
+        var mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public synchronized void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+                attempts.incrementAndGet();
+                throw new SaslAuthenticationException("LDAP unavailable (mocking)");
+            }
+        };
+
+        var consumerManager = new ConsumerManager<>(mockConsumer,
+                Duration.ofMinutes(5), // commit budget, deliberately generous - it must NOT be what ends this
+                saslBudget,
+                Duration.ofMillis(10)); // backoff between SASL retries
+
+        var thrown = assertThrows(OffsetCommitBudgetExceededException.class,
+                () -> consumerManager.commitSync(of(TP, new OffsetAndMetadata(1L))));
+
+        assertThat(thrown).hasCauseThat().isInstanceOf(SaslAuthenticationException.class);
+        assertThat(thrown).hasMessageThat().contains("saslAuthenticationRetryTimeout");
+        assertThat(thrown).hasMessageThat().contains(saslBudget.toString());
+        // the commit budget is not what ended this, so it must not be named
+        assertThat(thrown).hasMessageThat().doesNotContain("offsetCommitTimeout");
+        // and it retried rather than giving up on the first failure - the backoff path ran
+        assertThat(attempts.get()).isAtLeast(2);
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/utils/ThreadUtils.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/utils/ThreadUtils.java
@@ -8,8 +8,32 @@ package bz.stub.parallelconsumer.internal.utils;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Duration;
+
 @Slf4j
 public class ThreadUtils {
+
+    /**
+     * Sleeps for {@code duration}, restoring the interrupt flag and failing loudly if interrupted.
+     * <p>
+     * Distinct from both siblings, and deliberately so. {@link #sleepLog(int)} catches the interrupt and
+     * returns, which reads to the caller as "the sleep completed"; {@link #sleepQuietly(long)} is
+     * {@link SneakyThrows @SneakyThrows}, so it rethrows the {@link InterruptedException} unchecked but
+     * leaves the interrupt flag cleared and says nothing about what was interrupted. For a test whose
+     * accounting depends on real elapsed time - a retry budget, or a feed spread across commit cycles -
+     * a shortened sleep silently changes what is being measured, so the interrupt has to become a named
+     * failure rather than an early return.
+     *
+     * @param interruptedMessage what the caller was in the middle of, so the failure names it
+     */
+    public static void sleepOrFail(Duration duration, String interruptedMessage) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(interruptedMessage, e);
+        }
+    }
 
     @SneakyThrows
     public static void sleepQuietly(final int ms) {

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -128,6 +128,39 @@ entries:
       (unmerged); related issue #541 now CLOSED. User still weighing a larger
       poll+control single-thread refactor to kill the whole bug class.
 
+  - id: bug-833-commit-response-timeout
+    group: rebalance-stability
+    summary: "\"Timeout waiting for commit response\" is a symptom of a dead broker-poll thread -- report the real cause"
+    fork:
+      branches: [test/177-commit-response-timeout]
+      prs: [204]
+      fork_issue: 177
+      status: pr-open
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: [833]
+      prs: []
+      related: [857, 803, 809]
+      status: open
+      last_checked: 2026-08-05
+    adoc_anchor: part3-cat1-stability
+    notes: >
+      ON RELEASE, say on the mirror that the reported message itself CHANGES: anyone
+      searching for the old "Timeout waiting for commit response PT30S" string will not
+      match what the fixed version emits, and PT30S was never real anyway (see below).
+      Verified 2026-08-05 that #100/#108 do fix the reported
+      TRIGGER (a rebalance-time commit rejection killing the poll thread), and that
+      the fix is unreleased. But the misleading SYMPTOM was never addressed: every
+      other way of killing that thread still produced the same message, which names
+      neither the failing subsystem nor the failure. This work reports the poller's
+      real exception on the commit-failure path, corrects the timeout the message
+      quotes (it interpolated a hard-coded 30s constant regardless of configuration,
+      so the reporter's "PT30S" was meaningless), and makes
+      ConsumerManager.commitSync's retry budget cumulative rather than per-attempt --
+      it reset every attempt, so a permanently-failing commit retried forever instead
+      of surfacing, stranding the poll thread and producing the same symptom from the
+      broker-down direction.
+
   - id: bug-859-pcmetrics-leak
     group: metrics-observability
     summary: PCMetrics memory leak -- registeredMeters (List) accumulated duplicate Meter.Id (fix - List to Set)


### PR DESCRIPTION
## Description

Addresses the reader-facing half of astubbs#177 ([confluentinc/parallel-consumer#833](https://github.com/confluentinc/parallel-consumer/issues/833)): `InternalRuntimeException: Timeout waiting for commit response PT30S`, reported on 0.5.3.1.

**The message is a symptom.** The broker-poll thread is the only producer of commit responses, so *any* exception that kills it turns every later sync commit into that same error - one that names neither the failing subsystem nor the failure. astubbs#100 and astubbs#108 (both merged, still unreleased - astubbs#186) removed two ways to kill that thread and do fix the reported trigger. Broker down, offset encoding and authorization still produced the identical unactionable message, and fixing exceptions one at a time was never going to close that class.

### What changed

**1. The poll thread publishes its own death, as an event.** `BrokerPollSystem`'s control loop calls `ConsumerOffsetCommitter#notifyPollerDied` from its own exit path, so a control thread already blocked in `commitAndWait()` is released *at that moment* with the poller's exception as the cause. A waiter can never learn this by waiting - waiting is precisely what does not work - and deriving one deadline from the other would only make the race usually resolve the right way. Supervision on the commit-failure path in `AbstractParallelEoSStreamProcessor` stays as the backstop for a death that never reaches that call.

**2. The timeout message means what it says.** It interpolated the unrelated constant `DEFAULT_TIMEOUT`, so it claimed `PT30S` regardless of how `offsetCommitTimeout` was configured - overstating the shipped default by 3x and making the reporter's `PT30S` tell us nothing about their settings. It now reports the timeout actually waited, and states that the poller is alive and not answering rather than asserting a death it has not established. With (1) in place that is true by construction: a dead poller is reported by the event, never by the timeout.

**3. `ConsumerManager.commitSync`'s retry budget was per attempt, not per call.** `startedTime` was captured *inside* the retry loop, so every attempt reset it. Whenever an attempt failed faster than the budget the comparison could never become false and it retried forever with no backoff - measured at **51 attempts against a 500ms budget**. PC then neither committed nor failed: the poll thread was stranded inside one `commitSync` while the control thread waited out its commit response. `poll()` captures `pollStarted` outside its retry loop for the very same SASL budget, which is the strongest evidence the difference was accidental.

The same reset had a **second arm nobody had noticed**: the `SaslAuthenticationException` branch retries while `elapsed <= saslAuthenticationRetryTimeout`, whose default is `PT0S`. Per-attempt, a SASL failure returning in under a millisecond gave `elapsed = 0ms`, and `0 <= 0` is true - so it retried forever on default configuration, sleeping the 5s backoff between attempts. Cumulative elapsed escapes on the second attempt.

> **This one changes behaviour and wants a maintainer's decision, not a reviewer's.** It makes PC **give up where it previously hung**. There is no case where PC now keeps running somewhere it previously stopped. The budget is per `commitSync` call, not per PC lifetime, so each commit cycle still gets its full configured budget. The honest cost: a broker outage longer than `offsetCommitTimeout` where a later attempt would have succeeded now shuts PC down instead of retrying indefinitely - which is what the option asks for, and an unbounded silent retry is worse for a library than a loud failure.

**4. The failure now says what to turn, and it is a new public type.** `commitSync` rethrew Kafka's bare exception, which can say a commit timed out but not which of PC's options bounded it or what to do. It now throws **`OffsetCommitBudgetExceededException`** (public package, extends `ParallelConsumerException`) with the broker's exception as the **cause**, naming the budget that ran out, its configured value, and the knob to raise. **This changes the exception type callers see** - recorded for the release in `docs/inflight/release-0.6.0.0.md`.

Two things ride along:

- **Giving up after a *single* attempt now says so**, and says what it means: that attempt outlived the whole budget, so no retry was reachable. That is the **shipped default's** shape - `offsetCommitTimeout` 10s against the consumer's `default.api.timeout.ms` of 60s - so a user setting the option for retries got none, silently. It is the relationship Kafka validates at construction (a producer refuses `delivery.timeout.ms` below `request.timeout.ms + linger.ms`); PC cannot, because `Consumer` exposes no configuration, so it is reported when it bites.
- **SASL retries against their own clock.** The budget hoist had `saslAuthenticationRetryTimeout` counting from the start of the whole call, so a slow commit spent an authentication budget. It now starts at the first SASL failure. The comparison also moves `<=` to `<`, matching `poll()`'s identical branch - with the `PT0S` default that difference is the whole behaviour, since `<=` let "do not retry SASL" retry anyway.

**Left open, and tracked rather than fixed here:** `offsetCommitTimeout` bounds two things with opposite requirements (a control-thread wait that wants to be short, a retry budget that wants to exceed 60s) - `docs/inflight/bug-offset-commit-timeout-does-two-jobs.md`. PC terminating rather than letting the application decide is astubbs/parallel-consumer#317, ranked top of `next-candidates.md` because a user on confluentinc#833 ships a patched build to get it. And the new exception sits outside `InternalRuntimeException`'s root, which `docs/inflight/next-exception-hierarchy-cleanup.md` covers.

**Other instances of the same defect** (astubbs#220's rule, at merge prep). The defect class here is *reporting something about a commit that is not true*. Grepping that shape turned up one more, and it is fixed in this PR rather than deferred: `ConsumerManager.commitSync` could **return normally without committing** when a retry was due but close had begun, and `AbstractOffsetCommitter.retrieveOffsetsAndCommit` calls `onOffsetCommitSuccess` as soon as it returns - marking offsets the broker never received as committed, with nothing left to retry them. It now throws. Checked and clear: the async commit path (`commitAsync`'s callback logs and does not mark success), `commitDeferringOnRebalance` (already defers rather than swallowing, with the javadoc that named this class), and `onPartitionsRevoked`'s commit (wrapped, not swallowed).

### What this closes, and what it does not - astubbs#177 stays open

`docs/solutions/runtime-errors/revoke-path-commit-deadlock-between-poll-and-control-threads.md` reads confluentinc#833 as **one symptom sitting on three independent defects**. Two have landed: astubbs#100 (a mid-rebalance commit killing the poll thread) and astubbs#80 (the drain busy-spin that zombie-held an assignment). The third is an AB-BA deadlock on the commit path between the poll and control threads, and it is **not** this PR - it is astubbs#29, still a draft whose fix has never been observed working.

So, per way the commit response can fail to arrive:

| Cause | After this PR |
|---|---|
| Poll thread **dies** (any exception) | The poller's own error is reported, at the moment of death. Symptom gone. |
| Broker **down** - `commitSync` retried forever | Bounded by `offsetCommitTimeout`, fails loudly. Fixed here. |
| Poll thread **alive but wedged** (the AB-BA cycle) | Symptom still reachable, now stating honestly that the poller is alive and not answering. **astubbs#29 owns this.** |
| Poll thread genuinely **slow** | Not a defect. Reported as the timeout it is, with the timeout actually configured. |

**There is no closing keyword in this description, deliberately.** astubbs#177 should close with astubbs#29, and only if that lands with `RebalanceEoSDeadlockTest.noDeadlockOnRevoke` actually green - closing a user's symptom report on an unproven fix is how it gets reported twice.

Worth noting for whoever picks up astubbs#29: confluentinc#833 has **two** reporters with different triggers. ndqvinh2109's is an explicit broker shutdown, which the budget fix and the death event both cover. dumontxiong's - 1000 keys, ~50% failing, `KEY` ordering, consumer-sync mode, no outage - was never diagnosed and never retested, and consumer-sync is the only mode the AB-BA cycle can close in. His may be the wedge.

### Evidence the tests catch it

Each was confirmed discriminating by reverting the fix and watching it fail - a test that passes both ways proves nothing.

| Revert | Test | Result |
|---|---|---|
| the `RebalanceInProgressException` catch | `CommitResponseTimeoutSymptomTest#aRebalanceStormUnderAHighFailureRateNeitherStallsNorKillsTheConsumer` | the backlog never drains; the drain assertion times out at its 120s ceiling |
| `notifyPollerDied` | `CommitResponseTimeoutSymptomTest#aDeadPollThreadReportsItsOwnCauseNotTheCommitResponseTimeout` | the waiter is never released, so it sits out the full minute and fails at the 30s ceiling |
| the `DEFAULT_TIMEOUT` correction | `CommitResponseTimeoutSymptomTest#aLivePollThreadThatIsMerelySlowReportsTheTimeoutItActuallyWaited` | the message says `PT30S` where the test configured `PT1S`, and the duration assertion fails |
| `startedTime` back inside the loop | `ConsumerManagerCommitRetryBudgetTest` | 51 attempts against a 500ms budget, never throws |
| the single-attempt diagnostic | `ConsumerManagerCommitRetryBudgetTest#oneAttemptOutlivingTheWholeBudgetSaysNoRetryWasReachable` | the "Only ONE attempt" text is absent and the message assertion fails |
| SASL's own clock and the wrapping | `ConsumerManagerCommitRetryBudgetTest#saslGivesUpAgainstItsOwnBudgetAndNamesIt` | raw `SaslAuthenticationException` escapes where the test expects `OffsetCommitBudgetExceededException` |

The last two were run as control arms on this tree, both reverts applied at once so each failure stayed attributable; the third test in that class stayed green throughout. Worth stating precisely: the SASL arm fails on the **wrapping**, not on which instant the budget counted from - pinning the clock separation itself would need a timeout phase preceding the SASL failure, which these do not build. The first two were re-measured on this tree after the master merge (128s and 50s respectively, against 8.3s for all three scenarios with the fixes in place). The fourth is the original measurement - that test and the code under it are untouched by the merge.

`CommitResponseTimeoutSymptomTest` reproduces the *reported* workload rather than a minimal one: 1000 keys, ~50% failing, `KEY` ordering, and rejections recurring for the whole run instead of only at start-up. Its javadoc records why it extends neither `CommitRejectionTestBase` nor `MockConsumerTestBase`; generalising the latter to take a partition count and a key supplier is queued in `docs/refactoring.md`.

## Checklist

- [x] Docs updated - javadoc on each changed method carries the diagnosis and the falsified alternative; `src/docs/development/upstream-map.yaml` entry `bug-833-commit-response-timeout` (`prs: [204]` / `status: pr-open`, `fork_issue: 177`); `docs/solutions/test-flakiness/vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md` (third instance); `docs/refactoring.md` (the `MockConsumerTestBase` generalisation); `docs/inflight/bug-857-family.md` (two sightings caught by this branch's own CI runs - the eighth, and the eleventh, whose seed replays red on plain master and so is recorded as the family's defect, not this PR's). `CHANGELOG.adoc` deliberately untouched per AGENTS.md - it is generated at release time and a PR never adds an entry
- [x] Tests added/updated - three scenarios in `CommitResponseTimeoutSymptomTest` plus `ConsumerManagerCommitRetryBudgetTest`, each demonstrated to fail against the unfixed code
- [x] Title & body reflect the final content of this PR
- [x] N/A - no CI runners or workflows touched

Relates to astubbs#177 and [confluentinc/parallel-consumer#833](https://github.com/confluentinc/parallel-consumer/issues/833). Same family as astubbs#100 / astubbs#108 ([confluentinc/parallel-consumer#857](https://github.com/confluentinc/parallel-consumer/issues/857)).




