### PR TITLE
fix #194: declare the Mutiny module's real Java 17 floor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,9 +326,11 @@ This is not hypothetical: astubbs#194's summary said the Mutiny dependency "requ
 bytecode level", while confluentinc#906's reporter had written *"I think the compiler target for
 that dependency is 17"* - the detail that actually mattered. A fix followed the summary, set
 `release.target=9`, compiled green, and shipped a jar that died with `UnsupportedClassVersionError`
-on Java 8 and 11. astubbs#171's summary likewise implied one shutdown timeout default where there
-are two different ones. When the mirror turns out to be wrong, say so in the PR **and correct the
-mirror**, or the next reader inherits the same error.
+on Java 8 and 11. astubbs#171 shows the same failure in its **Fork status** notes rather than its
+summary - "`shutdownTimeout` and `drainTimeout` (default 30s)" reads as one shared default, where the
+code has two (10s and 30s) - so check the mirror's added commentary as sceptically as its summary.
+When the mirror turns out to be wrong, say so in the PR **and correct the mirror**, or the next
+reader inherits the same error.
 
 **The convention: below #1000, say which repo you mean.** `astubbs#119` for this fork,
 `confluentinc#857` for the original - or a hyperlink, which qualifies it just as well. Add `PR` or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,18 @@ Every upstream issue now has a **fork mirror** (astubbs#44, astubbs#117-astubbs#
 reference has a fork-local number a reader can click. Find one with
 `gh issue list -R astubbs/parallel-consumer --label upstream-mirror --search "upstream #NNN"`.
 
+**Working a mirrored issue? Read the upstream original too - body and comments.**
+`gh issue view <N> -R confluentinc/parallel-consumer --json body,comments`. Every mirror says
+"Summarised, not copied", which makes it one agent's reading of the issue rather than the issue.
+Verify the summary against the original and against the code before fixing or documenting anything.
+This is not hypothetical: astubbs#194's summary said the Mutiny dependency "requires a higher
+bytecode level", while confluentinc#906's reporter had written *"I think the compiler target for
+that dependency is 17"* - the detail that actually mattered. A fix followed the summary, set
+`release.target=9`, compiled green, and shipped a jar that died with `UnsupportedClassVersionError`
+on Java 8 and 11. astubbs#171's summary likewise implied one shutdown timeout default where there
+are two different ones. When the mirror turns out to be wrong, say so in the PR **and correct the
+mirror**, or the next reader inherits the same error.
+
 **The convention: below #1000, say which repo you mean.** `astubbs#119` for this fork,
 `confluentinc#857` for the original - or a hyperlink, which qualifies it just as well. Add `PR` or
 `issue` where the distinction matters (`confluentinc PR #548`); both forms pass the gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ bin/performance-test.sh
 
 ## Key Architecture Decisions
 
-- **Jabel cross-compilation**: Source is Java 17, bytecode targets Java 8 via Jabel annotation processor. This means `--release 8` is set in the compiler plugin, which restricts available APIs to Java 8 surface. The Mutiny module overrides this to `--release 9` because Mutiny uses `java.util.concurrent.Flow` (Java 9+).
+- **Jabel cross-compilation**: Source is Java 17, bytecode targets Java 8 via Jabel annotation processor. This means `--release 8` is set in the compiler plugin, which restricts available APIs to Java 8 surface. The Mutiny module overrides this to 17, which is that module's real runtime floor: `Multi` needs `java.util.concurrent.Flow` (9+), and SmallRye Mutiny 2.8+ is itself compiled for Java 17. Its pom carries the full reasoning, including why the build cannot detect the second constraint.
 - **Offset encoding**: Custom offset map encoding (run-length, bitset) stored in Kafka commit metadata for tracking in-flight messages.
 - **Sharding**: Messages are distributed to processing shards by key or partition for ordering guarantees.
 
@@ -143,10 +143,6 @@ stagnation (Class 2, W4's prey), drain overruns, and record loss/duplication. Ta
   `@Quarantined` scenarios (`-Dexcluded.groups=` is empty), so known-RED detectors still fire locally.
   See `ChaosChurnStormIT`'s class javadoc for the full recipe.
 - A RED run is investigation food, not flake noise — the probes are calibrated against the real historical drain-zombie defect (RED on pre-fix compositions, GREEN on fixed; thresholds sit in measured gaps). Never loosen a probe to go green; tune the workload/conductor instead.
-
-## Known Issues
-
-- **Mutiny module requires Java 17**: it has a `release.target=17` override in its pom.xml, for two reasons. Mutiny's `Multi` implements `java.util.concurrent.Flow.Publisher`, which `--release 8` hides, so the module will not compile at 8; and SmallRye Mutiny 2.8.0+ is itself compiled for Java 17 (class-file major 61), so 17 is the module's real runtime floor. Because `--release` only constrains the platform API and not what javac reads off the classpath, that second constraint is invisible to the build - it was previously set to 9, which compiled fine but shipped an artefact that blew up with `UnsupportedClassVersionError` on Java 8 and 11. Every other module (core, vertx, reactor) stays on Java 8. If you change the Mutiny version, re-check its `maven-compiler-plugin.release` and this override together.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ stagnation (Class 2, W4's prey), drain overruns, and record loss/duplication. Ta
 
 ## Known Issues
 
-- **Mutiny module**: Has a `release.target=9` override in its pom.xml because Mutiny's `Multi` implements `java.util.concurrent.Flow.Publisher` which is not available with `--release 8`.
+- **Mutiny module requires Java 17**: it has a `release.target=17` override in its pom.xml, for two reasons. Mutiny's `Multi` implements `java.util.concurrent.Flow.Publisher`, which `--release 8` hides, so the module will not compile at 8; and SmallRye Mutiny 2.8.0+ is itself compiled for Java 17 (class-file major 61), so 17 is the module's real runtime floor. Because `--release` only constrains the platform API and not what javac reads off the classpath, that second constraint is invisible to the build - it was previously set to 9, which compiled fine but shipped an artefact that blew up with `UnsupportedClassVersionError` on Java 8 and 11. Every other module (core, vertx, reactor) stays on Java 8. If you change the Mutiny version, re-check its `maven-compiler-plugin.release` and this override together.
 
 ## Code Style
 

--- a/README.adoc
+++ b/README.adoc
@@ -1314,7 +1314,7 @@ here rather than upstream - see <<Support and Issues>>.
 == Usage Requirements
 
 * Client side
-** JDK 8
+** JDK 8, except for the Mutiny module - see <<java-version-per-module>> below
 ** SLF4J
 ** Apache Kafka (AK) Client libraries 2.5
 ** Supports all features of the AK client (e.g. security setups, schema registry etc)
@@ -1325,6 +1325,31 @@ here rather than upstream - see <<Support and Issues>>.
 * Server side
 ** Should work with any cluster that the linked AK client library works with
 *** If using EoS/Transactions, needs a cluster setup that supports EoS/transactions
+
+[[java-version-per-module]]
+=== Java Version per Module
+
+Most modules run on Java 8. The Mutiny module does not, because SmallRye Mutiny itself is built for Java 17.
+
+|===
+| Module | Minimum Java
+
+| `parallel-consumer-core`
+| 8
+
+| `parallel-consumer-vertx`
+| 8
+
+| `parallel-consumer-reactor`
+| 8
+
+| `parallel-consumer-mutiny`
+| 17
+|===
+
+WARNING: Adding `parallel-consumer-mutiny` to a Java 8 or Java 11 application will build without complaint and then fail at runtime with an `UnsupportedClassVersionError`, because its SmallRye Mutiny dependency is compiled for Java 17.
+Maven cannot warn you about this, so check the table before picking the module.
+The other modules are unaffected, and using them does not pull Mutiny in.
 
 == Development Information
 

--- a/parallel-consumer-mutiny/pom.xml
+++ b/parallel-consumer-mutiny/pom.xml
@@ -16,8 +16,25 @@
     <artifactId>parallel-consumer-mutiny</artifactId>
 
     <properties>
-        <!-- Mutiny's Multi implements java.util.concurrent.Flow.Publisher which requires Java 9+ -->
-        <release.target>9</release.target>
+        <!--
+            This module's real runtime floor is Java 17, and it must say so.
+
+            Two separate constraints push it above the project-wide release.target of 8:
+
+            1. Mutiny's Multi implements java.util.concurrent.Flow.Publisher, which a release level of 8
+               hides, so the module cannot even compile at 8. That alone only needs 9.
+            2. SmallRye Mutiny 2.8.0 and later are themselves compiled for Java 17 (class-file major 61;
+               their parent pom sets maven-compiler-plugin.release to 17). No Mutiny 2.x targets 8 or 9.
+
+            The release level only constrains the platform API, not what javac will read off the classpath,
+            so constraint 2 is invisible to the build: at release.target=9 this module compiled happily and
+            shipped bytecode claiming Java 9 while depending on Java 17 classes. Downstream users on
+            Java 8 or 11 then got a clean Maven build followed by an UnsupportedClassVersionError on
+            first touch of Multi. Declaring 17 makes the artefact honest about the JVM it needs.
+
+            Only this module is affected - core, vertx and reactor remain Java 8 (major 52).
+        -->
+        <release.target>17</release.target>
     </properties>
 
     <dependencies>

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -1056,7 +1056,7 @@ here rather than upstream - see <<Support and Issues>>.
 == Usage Requirements
 
 * Client side
-** JDK 8
+** JDK 8, except for the Mutiny module - see <<java-version-per-module>> below
 ** SLF4J
 ** Apache Kafka (AK) Client libraries 2.5
 ** Supports all features of the AK client (e.g. security setups, schema registry etc)
@@ -1067,6 +1067,31 @@ here rather than upstream - see <<Support and Issues>>.
 * Server side
 ** Should work with any cluster that the linked AK client library works with
 *** If using EoS/Transactions, needs a cluster setup that supports EoS/transactions
+
+[[java-version-per-module]]
+=== Java Version per Module
+
+Most modules run on Java 8. The Mutiny module does not, because SmallRye Mutiny itself is built for Java 17.
+
+|===
+| Module | Minimum Java
+
+| `parallel-consumer-core`
+| 8
+
+| `parallel-consumer-vertx`
+| 8
+
+| `parallel-consumer-reactor`
+| 8
+
+| `parallel-consumer-mutiny`
+| 17
+|===
+
+WARNING: Adding `parallel-consumer-mutiny` to a Java 8 or Java 11 application will build without complaint and then fail at runtime with an `UnsupportedClassVersionError`, because its SmallRye Mutiny dependency is compiled for Java 17.
+Maven cannot warn you about this, so check the table before picking the module.
+The other modules are unaffected, and using them does not pull Mutiny in.
 
 == Development Information
 


### PR DESCRIPTION
Closes #194 (astubbs#194, mirror of confluentinc/parallel-consumer#906).

## What the issue reports, and what is actually wrong

confluentinc/parallel-consumer#906 reports a build failure: parent `release.target` is 8, but the Mutiny module cannot compile at 8. The fork already worked around that with a module-local `release.target=9` override (`dc346dad`), so **the build is not broken here**. But that fix was aimed at only half of what the reporter described, and the artefact we would have shipped in 0.6.0.0 is broken.

**Credit where it is due:** @lutzh called this correctly in the original report - *"that uses `java.util.concurrent.Flow` and other classes that where only introduced in Java 9. In fact, I think the compiler target for that dependency is 17."* Both constraints, including the Java 17 one that actually matters. Our fork mirror (astubbs#194) compressed that to "requires a higher bytecode level" and the `=9` fix followed the summary rather than the source.

There are two separate constraints:

1. Mutiny's `Multi` implements `java.util.concurrent.Flow.Publisher`, which a release level of 8 hides. This is a **platform API** problem, and it alone only needs 9. This is what the `=9` override addressed.
2. **SmallRye Mutiny 2.8.0+ is itself compiled for Java 17** - class-file major 61, and its parent pom sets `maven-compiler-plugin.release` to 17. No Mutiny 2.x targets Java 8 or 9 at any version (2.0-2.7 are 11, 2.8+ are 17).

The release level only constrains the platform API, not what javac will read off the classpath. So constraint 2 is completely invisible to the build: at `=9` the module compiled clean and emitted bytecode claiming Java 9, while depending on classes that need Java 17.

## User-facing impact

Verified against real JREs (`eclipse-temurin:{8,11,17}-jre`, full transitive runtime classpath):

| JRE | result |
|---|---|
| 8 | `UnsupportedClassVersionError` on `io.smallrye.mutiny.Multi` (61.0 vs 52.0) **and** on `MutinyProcessor` (53.0 vs 52.0) |
| 11 | `UnsupportedClassVersionError` on `Multi` (61.0 vs 55.0) |
| 17 | OK |

A Java 8 or Java 11 user adding `parallel-consumer-mutiny` gets a **clean Maven build** and then blows up at runtime on first touch of `Multi`. Nothing in the poms, the manifest or the README warned them - `README.adoc` still said "Client side: JDK 8" flat out.

Core, vertx and reactor were checked the same way and are genuinely Java 8 clean. This is a Mutiny-only problem.

## The fix

`release.target=17` in `parallel-consumer-mutiny/pom.xml`, with a comment recording both constraints so the next person does not re-derive this. Jabel goes inert for that module, which is correct.

Verified after the change: `MutinyProcessor.class` is now major **61**, `ParallelEoSStreamProcessor.class` is still major **52**.

Also:
- **README** now carries a per-module Java version table plus a warning about the silent-build-then-runtime-failure mode (edited in `src/docs/README_TEMPLATE.adoc`, `README.adoc` regenerated, not hand-edited).
- **AGENTS.md** mentioned the override twice, and the Key Architecture Decisions bullet still said `--release 9`. After review, collapsed to one copy: that bullet is corrected, and the redundant Known Issues entry is gone (the pom comment sits next to the property and cannot drift from it).
- **AGENTS.md "Issue references"** gains the rule this PR is the argument for: when working a mirrored issue, read the upstream original and its comments, not just the mirror's summary - and correct the mirror when it turns out to be wrong. Twelve lines, kept here rather than split out because this PR is the worked example.

## Why now, and why this is safe

0.6.0.0 is not on Maven Central yet, so correcting the declared floor costs nothing in compatibility. Doing it after release would mean either shipping a knowingly broken artefact or making a breaking change later.

No conflict with the "0.6.x stays Java 8, move off Java 8 deferred to 0.7" plan: every other module stays at major 52. This only makes one new, opt-in integration module declare the floor it already had.

**Alternatives considered:** pin Mutiny to 2.7.0 (last Java 11 line) and set `release.target=11` - lowers the floor to 11, still not 8, and pins to an old line. Or drop the Mutiny module from 0.6.0.0. Being honest at 17 seems better than either, given the module is new and optional.

## Verification

- `./mvnw -pl parallel-consumer-mutiny -am -Dcopyright.skip=true test` - BUILD SUCCESS, 14 mutiny tests and 318 core tests green at the new target.
- Emitted bytecode after the change: `MutinyProcessor.class` major **61**, `ParallelEoSStreamProcessor.class` major **52**.
- Copyright header check clean.

## Checklist

- [x] Docs updated - README per-module Java table (via the template, README regenerated) and the corrected AGENTS.md architecture note
- [ ] Tests added/updated - `N/A` - the change is a single Maven compiler property, so there is no unit-testable behaviour; verified empirically instead, per the Verification section above. Worth flagging as possible follow-up: an enforcer rule comparing each module's `release.target` against the class-file version of its dependencies would have caught this automatically, and would catch the next Mutiny bump too. Out of scope for a release-blocking one-liner.
- [x] Title & body reflect the final content of this PR
- [ ] Self-hosted runner / security implications considered - `N/A` - no CI, workflow or runner changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



