### PR TITLE
fix(core) #118: foreign offset metadata no longer kills the consumer on assignment

### DIFF
--- a/docs/inflight/release-0.6.0.0.md
+++ b/docs/inflight/release-0.6.0.0.md
@@ -35,12 +35,23 @@ survive the release.
    but never captures the caller's context map at submit time (no `copyOfContextMap` anywhere), so a
    caller's `trace_id` is lost crossing into the worker threads and the vert.x event loop. Raised by
    a user in the `confluentinc#907` thread (astubbs#195).
-5. **`OffsetEncoding` throws on an unknown magic byte *before* `invalidOffsetMetadataPolicy` is
-   consulted.** `OffsetEncoding:66` `throw new RuntimeException("Unexpected magic: " + magic)` is
-   reached from `EncodedOffsetPair.unwrap()`, while the policy is only honoured later at
-   `EncodedOffsetPair:123-130`. So if a future PC version introduces a new encoding, an older PC
-   reading that commit metadata dies **regardless of how the policy is configured** - and the fork
-   now owns this wire format. Forward-compatibility hazard, worth fixing before more encodings exist.
+5. ~~**`OffsetEncoding` throws on an unknown magic byte *before* `invalidOffsetMetadataPolicy` is
+   consulted.**~~ **FIXED** while debugging astubbs#118 (confluentinc#326). `OffsetEncoding:66`
+   `throw new RuntimeException("Unexpected magic: " + magic)` was reached from
+   `EncodedOffsetPair.unwrap()`, while the policy was only honoured later at `EncodedOffsetPair:123-130`.
+   Two symptoms, one defect: a future PC encoding killed an older reader regardless of policy
+   (forward-compatibility), and metadata left by a *previous non-PC owner* of the consumer group killed
+   PC on assignment (the reported bug - the bare `RuntimeException` slipped past the
+   `catch (OffsetDecodingError)` recovery in `loadPartitionStateForAssignment` and escaped the rebalance
+   listener, which Kafka turns into a fatal "User rebalance callback throws an error").
+   `OffsetEncoding.decode` now throws `OffsetDecodingError`, so both land in the existing recovery path:
+   log, drop the offset map, resume from the committed offset. The policy now governs only
+   recognisably-Kafka-Streams metadata. `OffsetMapCodecManager.errorPolicy` was also de-staticed - it had
+   made the policy JVM-global, so with two PC instances the last one constructed set it for both.
+   Same treatment applied to the one remaining unchecked escape on that path: `EncodedOffsetPair`'s
+   `default ->` branch threw `UnsupportedOperationException` for an encoding that *has* a registered magic
+   byte but no decoder - currently the `ByteArray` pair, which `OffsetSimultaneousEncoder` no longer emits.
+   Covered by `ForeignOffsetMetadataOnAssignmentTest`.
 
 ## Marked for 0.6.0.0
 

--- a/docs/inflight/release-0.6.0.0.md
+++ b/docs/inflight/release-0.6.0.0.md
@@ -35,23 +35,6 @@ survive the release.
    but never captures the caller's context map at submit time (no `copyOfContextMap` anywhere), so a
    caller's `trace_id` is lost crossing into the worker threads and the vert.x event loop. Raised by
    a user in the `confluentinc#907` thread (astubbs#195).
-5. ~~**`OffsetEncoding` throws on an unknown magic byte *before* `invalidOffsetMetadataPolicy` is
-   consulted.**~~ **FIXED** while debugging astubbs#118 (confluentinc#326). `OffsetEncoding:66`
-   `throw new RuntimeException("Unexpected magic: " + magic)` was reached from
-   `EncodedOffsetPair.unwrap()`, while the policy was only honoured later at `EncodedOffsetPair:123-130`.
-   Two symptoms, one defect: a future PC encoding killed an older reader regardless of policy
-   (forward-compatibility), and metadata left by a *previous non-PC owner* of the consumer group killed
-   PC on assignment (the reported bug - the bare `RuntimeException` slipped past the
-   `catch (OffsetDecodingError)` recovery in `loadPartitionStateForAssignment` and escaped the rebalance
-   listener, which Kafka turns into a fatal "User rebalance callback throws an error").
-   `OffsetEncoding.decode` now throws `OffsetDecodingError`, so both land in the existing recovery path:
-   log, drop the offset map, resume from the committed offset. The policy now governs only
-   recognisably-Kafka-Streams metadata. `OffsetMapCodecManager.errorPolicy` was also de-staticed - it had
-   made the policy JVM-global, so with two PC instances the last one constructed set it for both.
-   Same treatment applied to the one remaining unchecked escape on that path: `EncodedOffsetPair`'s
-   `default ->` branch threw `UnsupportedOperationException` for an encoding that *has* a registered magic
-   byte but no decoder - currently the `ByteArray` pair, which `OffsetSimultaneousEncoder` no longer emits.
-   Covered by `ForeignOffsetMetadataOnAssignmentTest`.
 
 ## Marked for 0.6.0.0
 

--- a/docs/inflight/release-0600-blockers.md
+++ b/docs/inflight/release-0600-blockers.md
@@ -5,24 +5,14 @@ Release mechanics live in [`release-0.6.0.0.md`](release-0.6.0.0.md); the tracki
 
 ## Still open
 
-- **The rest of #197's triage list.** Four non-blocking defects were found while checking the two
-  blocking ones; **one is now fixed** (the `OffsetEncoding` magic-byte hazard - see below), three
-  remain: `PCModule` builds `DynamicLoadFactor(static, static)` when
+- **The rest of astubbs#197's triage list.** Four non-blocking defects were found while checking the
+  two blocking ones; three are still open (the fourth, an `OffsetEncoding` magic-byte hazard, was
+  fixed in astubbs#217): `PCModule` builds `DynamicLoadFactor(static, static)` when
   `messageBufferSize` is set, so "Max loading factor steps reached" WARNs on every control-loop pass
-  for anyone following the README's own tuning advice (#155); MDC context is not captured at submit
-  time, so a caller's `trace_id` is lost into the worker pool and the vert.x event loop;
+  for anyone following the README's own tuning advice (astubbs#155); MDC context is not captured at
+  submit time, so a caller's `trace_id` is lost into the worker pool and the vert.x event loop;
   and `release.yml` publishes an empty GitHub Release body, so the
   curated changelog never reaches the release page.
-- ~~`OffsetEncoding` throws on an unknown magic byte before `invalidOffsetMetadataPolicy` is
-  consulted.~~ **Fixed** while debugging astubbs#118 (confluentinc#326): `OffsetEncoding.decode` now
-  throws `OffsetDecodingError`, which routes an unreadable magic byte into the recovery path
-  `loadPartitionStateForAssignment` already had - log, drop the offset map, resume from the committed
-  offset - instead of escaping the rebalance listener and shutting PC down. This closes the
-  forward-compatibility hazard *and* the originally reported bug, which was the same defect reached
-  from the other direction (metadata written by a previous, non-PC owner of the consumer group rather
-  than by a future PC). The policy now governs only recognisably-Kafka-Streams metadata, which is what
-  it was actually added for. Also de-staticed `OffsetMapCodecManager.errorPolicy`, which had made the
-  policy JVM-global across PC instances.
 - **After it ships:** ~11 mirrored issues describe 0.6.0.0 in the future tense and need the real
   coordinate; #186, #188 and #195 close with a pointer to the release.
 - **Three `3.9.1` references survive this PR - one is wrong, two are not.** The genuine defect is

--- a/docs/inflight/release-0600-blockers.md
+++ b/docs/inflight/release-0600-blockers.md
@@ -6,14 +6,23 @@ Release mechanics live in [`release-0.6.0.0.md`](release-0.6.0.0.md); the tracki
 ## Still open
 
 - **The rest of #197's triage list.** Four non-blocking defects were found while checking the two
-  blocking ones and none are fixed: `PCModule` builds `DynamicLoadFactor(static, static)` when
+  blocking ones; **one is now fixed** (the `OffsetEncoding` magic-byte hazard - see below), three
+  remain: `PCModule` builds `DynamicLoadFactor(static, static)` when
   `messageBufferSize` is set, so "Max loading factor steps reached" WARNs on every control-loop pass
   for anyone following the README's own tuning advice (#155); MDC context is not captured at submit
   time, so a caller's `trace_id` is lost into the worker pool and the vert.x event loop;
-  `OffsetEncoding` throws on an unknown magic byte *before* `invalidOffsetMetadataPolicy` is consulted,
-  so a future encoding kills an older reader regardless of policy - a forward-compatibility hazard in a
-  wire format this fork now owns; and `release.yml` publishes an empty GitHub Release body, so the
+  and `release.yml` publishes an empty GitHub Release body, so the
   curated changelog never reaches the release page.
+- ~~`OffsetEncoding` throws on an unknown magic byte before `invalidOffsetMetadataPolicy` is
+  consulted.~~ **Fixed** while debugging astubbs#118 (confluentinc#326): `OffsetEncoding.decode` now
+  throws `OffsetDecodingError`, which routes an unreadable magic byte into the recovery path
+  `loadPartitionStateForAssignment` already had - log, drop the offset map, resume from the committed
+  offset - instead of escaping the rebalance listener and shutting PC down. This closes the
+  forward-compatibility hazard *and* the originally reported bug, which was the same defect reached
+  from the other direction (metadata written by a previous, non-PC owner of the consumer group rather
+  than by a future PC). The policy now governs only recognisably-Kafka-Streams metadata, which is what
+  it was actually added for. Also de-staticed `OffsetMapCodecManager.errorPolicy`, which had made the
+  policy JVM-global across PC instances.
 - **After it ships:** ~11 mirrored issues describe 0.6.0.0 in the future tense and need the real
   coordinate; #186, #188 and #195 close with a pointer to the release.
 - **Three `3.9.1` references survive this PR - one is wrong, two are not.** The genuine defect is

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/ParallelConsumerOptions.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer;
 
 /*-
  * Copyright (C) 2020-2024 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
@@ -331,8 +332,12 @@ public class ParallelConsumerOptions<K, V> {
     public static final Duration SASL_AUTHENTICATION_EXCEPTION_RETRY_BACKOFF = Duration.ofSeconds(5);
 
     /**
-     * Error handling strategy to use when invalid offsets metadata is encountered. This could happen accidentally or
-     * deliberately if the user attempts to reuse an existing consumer group id.
+     * Error handling strategy to use when <em>recognisably Kafka Streams</em> offset metadata is encountered. This could
+     * happen accidentally or deliberately if the user attempts to reuse an existing consumer group id.
+     * <p>
+     * This policy applies only to metadata PC can positively identify as Kafka Streams'. Metadata it cannot decode at
+     * all - written by some other framework, by operator tooling, or simply corrupt - is never fatal under either
+     * policy: PC logs it, drops the offset map, and resumes from the committed offset.
      */
     public enum InvalidOffsetMetadataHandlingPolicy {
         /**
@@ -346,9 +351,11 @@ public class ParallelConsumerOptions<K, V> {
     }
 
     /**
-     * Controls the error handling behaviour to use when invalid offsets metadata from a pre-existing consumer group is
-     * encountered. A potential scenario where this could occur is when a consumer group id from a Kafka Streams
-     * application is accidentally reused.
+     * Controls the error handling behaviour to use when Kafka Streams offset metadata from a pre-existing consumer group
+     * is encountered - the scenario where a consumer group id from a Kafka Streams application is reused.
+     * <p>
+     * Note this does not govern metadata PC cannot decode at all; that is always recovered from rather than being fatal.
+     * See {@link InvalidOffsetMetadataHandlingPolicy}.
      * <p>
      * Default is {@link InvalidOffsetMetadataHandlingPolicy#FAIL}
      */

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/EncodedOffsetPair.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/EncodedOffsetPair.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2023 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import io.confluent.parallelconsumer.ParallelConsumerOptions;
@@ -74,7 +75,7 @@ public final class EncodedOffsetPair implements Comparable<EncodedOffsetPair> {
         return bytes;
     }
 
-    static EncodedOffsetPair unwrap(byte[] input) {
+    static EncodedOffsetPair unwrap(byte[] input) throws OffsetDecodingError {
         ByteBuffer wrap = ByteBuffer.wrap(input).asReadOnlyBuffer();
         byte magic = wrap.get();
         OffsetEncoding decode = decode(magic);
@@ -127,8 +128,12 @@ public final class EncodedOffsetPair implements Comparable<EncodedOffsetPair> {
                     throw new KafkaStreamsEncodingNotSupported();
                 }
             }
+            // Reachable for encodings that have a registered magic byte but no decoder here - currently the ByteArray
+            // pair (see OffsetSimultaneousEncoder, which no longer emits them). Same hazard as an unknown magic byte:
+            // an OffsetDecodingError routes it to the drop-the-map recovery, where an unchecked exception would escape
+            // the rebalance listener and shut the consumer down.
             default ->
-                    throw new UnsupportedOperationException("Encoding (" + encoding.description() + ") not supported");
+                    throw new OffsetDecodingError("Encoding (" + encoding.description() + ") not supported", null);
         };
         return binaryArrayString;
     }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetEncoding.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetEncoding.java
@@ -2,6 +2,7 @@ package io.confluent.parallelconsumer.offsets;
 
 /*-
  * Copyright (C) 2020-2022 Confluent, Inc.
+ * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
 import lombok.Getter;
@@ -60,10 +61,19 @@ public enum OffsetEncoding {
 
     private static final Map<Byte, OffsetEncoding> magicMap = Arrays.stream(values()).collect(Collectors.toMap(OffsetEncoding::getMagicByte, Function.identity()));
 
-    public static OffsetEncoding decode(byte magic) {
+    /**
+     * The metadata field of a committed offset is free-form - a consumer group previously used by another framework, or
+     * by operator tooling, may hold bytes that match none of our magic numbers. That is a decoding failure, not a fatal
+     * condition: callers drop the offset map and resume from the committed offset. Throwing {@link OffsetDecodingError}
+     * (rather than a bare {@link RuntimeException}) is what routes it to that recovery path instead of letting it
+     * escape the rebalance listener and take the consumer down.
+     *
+     * @see OffsetMapCodecManager#loadPartitionStateForAssignment
+     */
+    public static OffsetEncoding decode(byte magic) throws OffsetDecodingError {
         OffsetEncoding encoding = magicMap.get(magic);
         if (encoding == null) {
-            throw new RuntimeException("Unexpected magic: " + magic);
+            throw new OffsetDecodingError("Unexpected magic: " + magic, null);
         } else {
             return encoding;
         }

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
@@ -188,11 +188,37 @@ public class OffsetMapCodecManager<K, V> {
         return deserialiseIncompleteOffsetMapFromBase64(offsetData.offset(), offsetData.metadata(), errorPolicy);
     }
 
+    /**
+     * Decodes an offset payload under the default {@link ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy#FAIL}
+     * policy.
+     * <p>
+     * The policy only decides what happens for metadata identifiable as Kafka Streams'. Metadata that cannot be decoded
+     * at all raises {@link OffsetDecodingError} under either policy, so callers must handle it regardless of which they
+     * pass.
+     *
+     * @throws OffsetDecodingError if the payload is not valid base64, or holds an encoding this version cannot read
+     * @see #deserialiseIncompleteOffsetMapFromBase64(long, String, ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy)
+     */
     public static HighestOffsetAndIncompletes deserialiseIncompleteOffsetMapFromBase64(long committedOffsetForPartition, String base64EncodedOffsetPayload) throws OffsetDecodingError {
         return deserialiseIncompleteOffsetMapFromBase64(committedOffsetForPartition, base64EncodedOffsetPayload,
                 ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL);
     }
 
+    /**
+     * Decodes the base64 offset payload committed against a partition, into the highest offset seen and the set of
+     * incomplete offsets below it.
+     *
+     * @param committedOffsetForPartition the committed offset the payload is relative to - incompletes are encoded as
+     *                                    offsets from this base
+     * @param base64EncodedOffsetPayload  the {@code metadata} field of the committed offset
+     * @param errorPolicy                 what to do about metadata recognisable as Kafka Streams'. Does <em>not</em>
+     *                                    govern metadata that cannot be decoded at all, which always raises
+     *                                    {@link OffsetDecodingError}
+     * @throws OffsetDecodingError if the payload is not valid base64, or its leading magic byte matches no encoding this
+     *                             version knows - both of which callers are expected to recover from by dropping the
+     *                             offset map, not by failing
+     * @see #loadPartitionStateForAssignment
+     */
     public static HighestOffsetAndIncompletes deserialiseIncompleteOffsetMapFromBase64(long committedOffsetForPartition,
                                                                                        String base64EncodedOffsetPayload,
                                                                                        ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy) throws OffsetDecodingError {
@@ -278,15 +304,32 @@ public class OffsetMapCodecManager<K, V> {
     }
 
     /**
-     * Print out all the offset status into a String, and potentially use zstd to effectively do run length encoding
-     * compression
+     * Decodes an offset map under the default {@link ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy#FAIL}
+     * policy.
      *
      * @return Set of offsets which are not complete, and the highest offset encoded.
+     * @throws OffsetDecodingError if the bytes hold an encoding this version cannot read
+     * @see #decodeCompressedOffsets(long, byte[], ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy)
      */
     static HighestOffsetAndIncompletes decodeCompressedOffsets(long nextExpectedOffset, byte[] decodedBytes) throws OffsetDecodingError {
         return decodeCompressedOffsets(nextExpectedOffset, decodedBytes, ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL);
     }
 
+    /**
+     * Decodes the offset map out of already-base64-decoded bytes, whose leading byte is the {@link OffsetEncoding}
+     * magic number.
+     * <p>
+     * Empty input is not an error: it means the commit carried no offset map, so nothing was incomplete below the
+     * committed offset.
+     *
+     * @param nextExpectedOffset the committed offset the map is relative to
+     * @param decodedBytes       the payload, magic byte first
+     * @param errorPolicy        what to do about metadata recognisable as Kafka Streams'. Does <em>not</em> govern an
+     *                           unreadable magic byte, which always raises {@link OffsetDecodingError} so the caller
+     *                           can drop the offset map rather than die - see {@link OffsetEncoding#decode(byte)}
+     * @return Set of offsets which are not complete, and the highest offset encoded.
+     * @throws OffsetDecodingError if the magic byte matches no encoding this version knows
+     */
     static HighestOffsetAndIncompletes decodeCompressedOffsets(long nextExpectedOffset,
                                                                byte[] decodedBytes,
                                                                ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy) throws OffsetDecodingError {

--- a/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
+++ b/parallel-consumer-core/src/main/java/io/confluent/parallelconsumer/offsets/OffsetMapCodecManager.java
@@ -75,7 +75,11 @@ public class OffsetMapCodecManager<K, V> {
 
     private final PCMetrics pcMetrics;
 
-    private static ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy = ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL;
+    /**
+     * Per-instance: two {@link io.confluent.parallelconsumer.ParallelConsumer}s in one JVM may be configured with
+     * different policies, and previously the last one constructed silently set it for all of them.
+     */
+    private ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy = ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL;
 
     /**
      * Decoding result for encoded offsets
@@ -157,7 +161,9 @@ public class OffsetMapCodecManager<K, V> {
                     PartitionState<K, V> state = decodePartitionState(tp, offsetAndMeta);
                     partitionStates.put(tp, state);
                 } catch (OffsetDecodingError offsetDecodingError) {
-                    log.error("Error decoding offsets from assigned partition, dropping offset map (will replay previously completed messages - partition: {}, data: {})",
+                    log.error("Error decoding offsets from assigned partition, dropping offset map (will replay previously completed messages - partition: {}, data: {}). " +
+                                    "If this consumer group was previously used by another application, its offset metadata isn't ours to read - " +
+                                    "processing resumes from the committed offset, and PC will write its own metadata from now on.",
                             tp, offsetAndMeta, offsetDecodingError);
                 }
             }
@@ -179,17 +185,24 @@ public class OffsetMapCodecManager<K, V> {
     }
 
     private HighestOffsetAndIncompletes deserialiseIncompleteOffsetMapFromBase64(OffsetAndMetadata offsetData) throws OffsetDecodingError {
-        return deserialiseIncompleteOffsetMapFromBase64(offsetData.offset(), offsetData.metadata());
+        return deserialiseIncompleteOffsetMapFromBase64(offsetData.offset(), offsetData.metadata(), errorPolicy);
     }
 
     public static HighestOffsetAndIncompletes deserialiseIncompleteOffsetMapFromBase64(long committedOffsetForPartition, String base64EncodedOffsetPayload) throws OffsetDecodingError {
+        return deserialiseIncompleteOffsetMapFromBase64(committedOffsetForPartition, base64EncodedOffsetPayload,
+                ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL);
+    }
+
+    public static HighestOffsetAndIncompletes deserialiseIncompleteOffsetMapFromBase64(long committedOffsetForPartition,
+                                                                                       String base64EncodedOffsetPayload,
+                                                                                       ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy) throws OffsetDecodingError {
         byte[] decodedBytes;
         try {
             decodedBytes = OffsetSimpleSerialisation.decodeBase64(base64EncodedOffsetPayload);
         } catch (IllegalArgumentException a) {
             throw new OffsetDecodingError(msg("Error decoding offset metadata, input was: {}", base64EncodedOffsetPayload), a);
         }
-        return decodeCompressedOffsets(committedOffsetForPartition, decodedBytes);
+        return decodeCompressedOffsets(committedOffsetForPartition, decodedBytes, errorPolicy);
     }
 
     PartitionState<K, V> decodePartitionState(TopicPartition tp, OffsetAndMetadata offsetData) throws OffsetDecodingError {
@@ -270,7 +283,13 @@ public class OffsetMapCodecManager<K, V> {
      *
      * @return Set of offsets which are not complete, and the highest offset encoded.
      */
-    static HighestOffsetAndIncompletes decodeCompressedOffsets(long nextExpectedOffset, byte[] decodedBytes) {
+    static HighestOffsetAndIncompletes decodeCompressedOffsets(long nextExpectedOffset, byte[] decodedBytes) throws OffsetDecodingError {
+        return decodeCompressedOffsets(nextExpectedOffset, decodedBytes, ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL);
+    }
+
+    static HighestOffsetAndIncompletes decodeCompressedOffsets(long nextExpectedOffset,
+                                                               byte[] decodedBytes,
+                                                               ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy errorPolicy) throws OffsetDecodingError {
 
         // if no offset bitmap data
         if (decodedBytes.length == 0) {

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/offsets/ForeignOffsetMetadataOnAssignmentTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/offsets/ForeignOffsetMetadataOnAssignmentTest.java
@@ -1,0 +1,130 @@
+package io.confluent.parallelconsumer.offsets;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.internal.PCModuleTestEnv;
+import io.confluent.parallelconsumer.state.WorkManager;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniLists;
+import pl.tlinkowski.unij.api.UniMaps;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * When PC is assigned a partition whose committed offset metadata was written by something that isn't PC, decoding that
+ * metadata must not take the whole consumer down.
+ * <p>
+ * The metadata field of a committed offset is free-form - anything sharing the consumer group (a previous Kafka Streams
+ * app, another framework, an operator's tooling) may have written bytes there that PC cannot decode. PC's own recovery
+ * path already exists: {@link OffsetMapCodecManager#loadPartitionStateForAssignment} logs and drops an undecodable
+ * offset map, falling back to a default partition state. These tests pin that the recovery path is actually reached,
+ * rather than the error escaping the rebalance listener.
+ *
+ * @see <a href="https://github.com/astubbs/parallel-consumer/issues/118">astubbs#118</a>
+ * @see <a href="https://github.com/confluentinc/parallel-consumer/issues/326">confluentinc#326</a>
+ */
+@Slf4j
+class ForeignOffsetMetadataOnAssignmentTest {
+
+    static final TopicPartition TP = new TopicPartition("myTopic", 0);
+
+    static final long COMMITTED_OFFSET = 100L;
+
+    MockConsumer<String, String> mockConsumer;
+
+    /**
+     * Builds a PC module whose consumer already has {@code metadata} committed against {@link #TP}, as if a previous
+     * owner of this consumer group had left it behind.
+     */
+    private PCModuleTestEnv moduleWithCommittedMetadata(String metadata,
+                                                        ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy policy) {
+        mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        mockConsumer.assign(UniLists.of(TP));
+        mockConsumer.commitSync(UniMaps.of(TP, new OffsetAndMetadata(COMMITTED_OFFSET, metadata)));
+
+        var options = ParallelConsumerOptions.<String, String>builder()
+                .consumer(mockConsumer)
+                .invalidOffsetMetadataPolicy(policy)
+                .build();
+        return new PCModuleTestEnv(options);
+    }
+
+    /**
+     * Base64 of a payload whose leading magic byte matches no {@link OffsetEncoding} - neither one of PC's own codecs
+     * nor either of the Kafka Streams magic numbers PC recognises.
+     */
+    private static String foreignMetadata() {
+        return Base64.getEncoder().encodeToString(new byte[]{(byte) 42, 0, 0, 0});
+    }
+
+    /**
+     * The reported failure: unrecognised metadata is encountered during the rebalance callback, and the resulting error
+     * escapes {@code onPartitionsAssigned}, which Kafka turns into a fatal "User rebalance callback throws an error"
+     * and PC shuts down.
+     */
+    @Test
+    void unknownMagicByteDoesNotEscapeOnPartitionsAssigned() {
+        var module = moduleWithCommittedMetadata(foreignMetadata(),
+                ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.FAIL);
+        WorkManager<String, String> wm = module.workManager();
+
+        assertThatCode(() -> wm.onPartitionsAssigned(UniLists.of(TP)))
+                .as("undecodable offset metadata must not escape the rebalance listener")
+                .doesNotThrowAnyException();
+
+        assertThat(wm.getPm().getPartitionState(TP))
+                .as("partition should still be assigned, with a default (dropped offset map) state")
+                .isNotNull();
+    }
+
+    /**
+     * {@link ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy#IGNORE} is documented as the escape hatch for
+     * reusing a consumer group that already has metadata in it. It must cover any foreign metadata, not only the two
+     * Kafka Streams magic numbers PC happens to recognise.
+     */
+    @Test
+    void ignorePolicyCoversForeignMetadataNotJustKafkaStreams() {
+        var module = moduleWithCommittedMetadata(foreignMetadata(),
+                ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.IGNORE);
+        WorkManager<String, String> wm = module.workManager();
+
+        assertThatCode(() -> wm.onPartitionsAssigned(UniLists.of(TP)))
+                .as("IGNORE policy must tolerate foreign metadata from any source")
+                .doesNotThrowAnyException();
+
+        assertThat(wm.getPm().getPartitionState(TP))
+                .as("partition should still be assigned")
+                .isNotNull();
+    }
+
+    /**
+     * Kafka Streams metadata under the IGNORE policy - the case upstream 0.5.2.6 added the option for. Pinned here at
+     * the assignment level (existing coverage only exercises {@link EncodedOffsetPair} directly).
+     */
+    @Test
+    void kafkaStreamsMetadataUnderIgnorePolicyDoesNotEscapeOnPartitionsAssigned() {
+        var ksMetadata = Base64.getEncoder().encodeToString(new byte[]{(byte) 1, 0, 0, 0, 0, 0, 0, 0, 0});
+        var module = moduleWithCommittedMetadata(ksMetadata,
+                ParallelConsumerOptions.InvalidOffsetMetadataHandlingPolicy.IGNORE);
+        WorkManager<String, String> wm = module.workManager();
+
+        assertThatCode(() -> wm.onPartitionsAssigned(UniLists.of(TP)))
+                .as("IGNORE policy must tolerate Kafka Streams metadata")
+                .doesNotThrowAnyException();
+
+        assertThat(wm.getPm().getPartitionState(TP))
+                .as("partition should still be assigned")
+                .isNotNull();
+    }
+}

--- a/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/offsets/WorkManagerOffsetMapCodecManagerTest.java
+++ b/parallel-consumer-core/src/test/java/io/confluent/parallelconsumer/offsets/WorkManagerOffsetMapCodecManagerTest.java
@@ -492,6 +492,7 @@ class WorkManagerOffsetMapCodecManagerTest {
      * Compare compression performance on different types of inputs, and tests that each encoding type is decompressed
      * again correctly
      */
+    @SneakyThrows
     @ParameterizedTest
     @MethodSource
     void differentInputsAndCompressions(String input) {


### PR DESCRIPTION
## Description

Point PC at a consumer group that already has offset metadata in it — the first thing anyone adopting PC does — and if that metadata wasn't written by PC, the whole consumer dies during the rebalance callback:

```
java.lang.RuntimeException: Unexpected magic: 1
    at OffsetEncoding.decode(OffsetEncoding.java:66)
    at EncodedOffsetPair.unwrap(EncodedOffsetPair.java:80)
    at OffsetMapCodecManager.loadPartitionStateForAssignment(OffsetMapCodecManager.java:154)
    at PartitionStateManager.onPartitionsAssigned(PartitionStateManager.java:107)
    ...
-> org.apache.kafka.common.KafkaException: User rebalance callback throws an error
-> BrokerPollSystem dies, PC shuts down
```

### What this settles about astubbs#118

astubbs#118 mirrors confluentinc#326, reported in 2022 against 0.5.1.0. It was **deliberately left open**, and its Fork status section said why:

> Neither is confirmed to be the failure this reporter hit. The fork's changelog records the commit as *relating to* this issue, not fixing it, and nobody has reproduced the original report against either change. **A stack trace against a current version would settle it.**

This PR is that stack trace. The answer is that **the fork still had the bug** — the reproduction is the reporter's own trace, frame for frame, differing only in which unrecognised magic byte triggers it (`42` instead of `1`).

Two corrections to what the issue and changelog currently assert:

1. **The `EpochAndRecordsMap` null-epoch fix (`afde8c5e`) is unrelated to this failure.** It's a genuine fix for a different defect. `CHANGELOG.adoc` lists it as *"relates to upstream #326"* — that attribution is speculative and wrong, and should be dropped when the 0.6.0.0 section is generated. I've left the file alone since it's generated at release time, and noted it in the commit body so it surfaces then.
2. **0.5.2.6 did partially fix it**, and the fork carries that work — `OffsetEncoding` knows the two Kafka Streams magic bytes and `invalidOffsetMetadataPolicy` exists. So the reporter's literal `magic: 1` genuinely no longer happens. That fix just didn't go far enough.

I've also corrected the mirror issue itself, per AGENTS.md → *Issue references*.

The other failure in that upstream thread — the null-key NPE in `ShardManager.addWorkContainer` under KEY ordering — is a separate defect (confluentinc#318) and is already fixed here; `ShardKey` handles null keys with null-safe `equals`/`hashCode`. Nothing in astubbs#118's scope is left outstanding, hence `Fixes`.

### The defect

The offset metadata field is free-form. A previous owner of the group — a Kafka Streams app, another framework, operator tooling — may leave bytes there PC can't decode.

PC already had exactly the right recovery. `loadPartitionStateForAssignment` logs, drops the offset map, and resumes from the committed offset:

```java
} catch (OffsetDecodingError offsetDecodingError) {
    log.error("Error decoding offsets from assigned partition, dropping offset map ...");
}
```

But `OffsetEncoding.decode` threw a bare `RuntimeException`. **The one path built to survive this was the one path the error skipped**, so it escaped the rebalance listener instead.

### Why 0.5.2.6's fix didn't cover it

That fix was keyed to Kafka Streams specifically. The `IGNORE` branch sits *inside* a `switch` on the **decoded** encoding, so it's only reachable once the magic byte has already mapped successfully. Any other foreign byte never gets that far — meaning a user who sets `IGNORE` precisely so they can reuse an existing group **still crashed**.

That matters because it's the exact scenario @colinkuo raised in the upstream thread: he needed to reuse the group to avoid losing or duplicating messages during migration, and was promised an opt-in reducing the error to a first-time-only warning. `IGNORE` was that promise, half-kept. This PR keeps the rest of it.

### Changes

- **`OffsetEncoding.decode` throws `OffsetDecodingError`** instead of a bare `RuntimeException`, routing unreadable metadata into the recovery that already existed.
- **`EncodedOffsetPair`'s `default ->` branch** threw an unchecked `UnsupportedOperationException` for an encoding that *has* a registered magic byte but no decoder — the `ByteArray` pair, which `OffsetSimultaneousEncoder` no longer emits. Same escape route, same treatment.
- **`OffsetMapCodecManager.errorPolicy` de-staticed.** A static field assigned from the *instance* constructor, so two PC instances in one JVM silently shared whichever was constructed last.
- **Policy javadoc narrowed** to what it actually governs: recognisably-Kafka-Streams metadata. Undecodable metadata is never fatal under either policy.
- **Recovery log line** now explains the likely cause and what happens next.

### Also closes a recorded 0.6.0.0 hazard

`docs/inflight/release-0.6.0.0.md` item 5 tracked the mirror image of this bug independently: a *future* PC encoding would kill an *older* reader regardless of policy — a forward-compatibility hazard in a wire format this fork now owns. Same line of code, reached from the opposite direction, so one fix closes both. Both ledger files updated.

Worth landing **in** 0.6.0.0 rather than 0.6.1: 0.6.0.0 is the version that will be in the field when a future encoding is added, so the forward-compat half is only capturable now.

### Testing

New `ForeignOffsetMetadataOnAssignmentTest` asserts at the `onPartitionsAssigned` frame from the reported trace. Existing coverage stopped at `EncodedOffsetPair` unit level for the two KS bytes only, which is why this survived.

- Reproduced the original stack trace frame-for-frame before fixing, then confirmed green.
- 52 offsets tests pass.
- Full core suite: 321 tests, 2 failures — `PCMetricsTest` (gauge read one ahead of a concurrently-incremented counter) and `ProducerManagerTest` (`PT19.973S` vs `PT20S`). Both pre-existing load-sensitive flakes: verified they pass in isolation **both with and without** this change, and neither touches the decode path.

Behaviour is unchanged for every valid encoding — the only difference is for magic bytes that previously threw.

## Checklist

- [x] Docs updated - `ParallelConsumerOptions` policy javadoc corrected, both `docs/inflight/` ledger files updated. No `CHANGELOG.adoc` entry: it is generated from the commit log at release time and its header forbids per-PR entries.
- [x] Tests added/updated - new `ForeignOffsetMetadataOnAssignmentTest` (3 cases) at the `onPartitionsAssigned` frame; reproduced the reported failure before fixing.
- [x] Title & body reflect the final content of this PR
- [x] Self-hosted runner / security implications considered - `N/A`, no CI runners or workflows touched.

Fixes #118. confluentinc#326 stays open — nothing in this PR changes that tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BK8ufGWcjXWJNyQ7WUzWer
