### PR TITLE
test+docs: force the commit-timeout trigger, plus the rules and vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,6 +530,17 @@ Keep the existing subject convention for *upstream* references (`... (#893)`, `c
 
 ## PR Discipline
 
+- **Before merging a fix, look for other instances of the same defect - and say what you found,
+  including "none".** A fix that removes today's instance invites tomorrow's. Once you can name the
+  defect *class* (not the symptom), grep for it: the pattern, the API being misused, the shape of the
+  mistake. State which candidates you checked and dismissed, not just the hits - "I found none" is only
+  worth reading if it says where you looked. Do this at merge prep, when the class is understood;
+  doing it while still diagnosing just widens the investigation.
+  Worked example, astubbs#220: the class was *a test awaiting a consequence whose trigger it cannot
+  force*. The greppable proxy was sleep-as-synchronisation in integration tests plus awaits on a
+  failure outcome. That surfaced `DrainCloseTest` and `RetriesTest` as relatives, and - just as
+  usefully - confirmed the sibling `TransactionTimeoutsTest.produceTimeout` is **not** an instance,
+  because it latches its trigger with a real margin. Ruling one out is a result.
 - **Before merging, recommend a merge strategy - and say why.** A long-lived PR accumulates
   fix-ups, review responses and course corrections that nobody wants in the permanent log, but it
   usually also contains two or three genuinely separate pieces of work. Do not default; look at the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ owned that content all along.)
 | **`docs/refactoring.md`** | The deferred-work backlog: internal refactors grouped by file, **breaking changes queued for the next major** in their own release-gated section, and the **triage of `TODO`/`FIXME`/`XXX` markers** | In-flight work; anything already started |
 | **`docs/TODO_INDEX.md`** | Generated inventory of every marker in the tree (`bin/todo-index.sh`, `--check` fails when stale) | Priorities - it is deliberately unsorted; triage goes in `refactoring.md` |
 | **`docs/QUARANTINED_TESTS.md`** | CI-enforced registry of quarantined tests and their owning fix PR | Tests that merely flake - quarantine requires a diagnosis |
+| **`CONCEPTS.md`** (repo root) | Shared domain vocabulary: entities, named processes and status concepts whose meaning here is project-specific (the produce/commit lock pair, *dirty*, shard, in-flight work). Each entry stands alone - no file paths, class names or current config values. Relevant when orienting to the codebase or writing about it | A spec, an architecture doc, or general programming vocabulary |
 | **`docs/solutions/`** | Write-ups of problems already **solved**, by category, with frontmatter for searching | Open problems |
 | **`docs/plans/`** | Dated plan and investigation documents for a specific piece of work | Durable reference - a plan goes stale once its work lands |
 | **`docs/SELF_HOSTED_RUNNER.md`** | Setup and operation of the self-hosted highcpu runner | CI policy, which lives in the workflows |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,14 @@ bin/performance-test.sh
   genuine bug" question above before you start manual diagnosis. `probe clean` means the fault is likely in
   the test itself, not consumer-group progress. Disable via `-Dambient.probe=off` or `@NoAmbientProbe` only
   when the probe itself is the problem (see `AmbientProbeExtension` javadoc).
+  **`probe clean` is only informative when the probe's detectors could have fired.** Lag stagnation needs
+  `LAG_STAGNATION_MIN_LAG` (50) of real lag sustained past `LAG_STAGNATION_BOUND` (150s), and rebalance
+  dwell needs `REBALANCE_DWELL_BOUND` (15s). A test with a handful of records, or one that fails inside a
+  window shorter than those bounds, cannot trip either - so its autopsy prints `probe clean` and the
+  sentence "the fault is likely in the test itself" carries no evidence at all. Check the test's record
+  count and failure window against those constants before treating a clean probe as a finding. (This is
+  not hypothetical: the `commitTimeout` autopsy of 2026-08-07 read `probe clean` on a 15-record test that
+  failed in 35s, where the thresholds are 50 records and 150s.)
 - **Unit tests**: `mvn test` / surefire plugin. Source in `src/test/java/`.
 - **Integration tests**: `mvn verify` / failsafe plugin. Source in `src/test-integration/java/`. Uses TestContainers with `confluentinc/cp-kafka` Docker image.
 - **Test exclusion patterns**: `**/integrationTest*/**/*.java` and `**/*IT.java` are excluded from surefire, included in failsafe.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,66 @@ owned that content all along.)
 Rule of thumb: **is it happening now** → `docs/inflight/`; **should happen later** → `refactoring.md`;
 **already happened** → `CHANGELOG.adoc` or `docs/solutions/`.
 
+## Before you investigate anything
+
+Do all five checks below **before** forming a hypothesis, and say in your write-up what they returned
+- including "nothing". Prior art does not only tell you the answer; it tells you the *method* that
+settled the last question of this shape, and the traps that voided someone's earlier experiment.
+
+| Check | Command | What it catches |
+|---|---|---|
+| Prior investigations | `ls docs/plans/`, then grep them | The same question already answered, and how it was proved |
+| Solved problems | `grep -rl <mechanism> docs/solutions/` | A documented root cause with a signature you can rule in or out |
+| In-flight state | `ls docs/inflight/`, `grep -rl <mechanism> docs/inflight/` | A known-open defect you are about to rediscover |
+| Open PRs | `gh pr list -R astubbs/parallel-consumer`, then `gh pr diff <n> --name-only` | A fix already in flight, and files your change would collide with |
+| **Merged** PRs, by file | `gh pr list --state merged --limit 100 --json number,title,files --jq '.[] \| select(.files[]?.path \| test("<ClassName>")) \| "\(.number) \(.title)"'` | The PR that last fixed something in this exact file - the richest prior art there is, and invisible to a search on the *open* list |
+| Existing issues | `gh issue list -R astubbs/parallel-consumer --state all --limit 300` and filter by title - fork issues *and* the `upstream-mirror` ones | An upstream bug already triaged; read the upstream issue itself, not the mirror's summary |
+
+**Grep the mechanism, not the symptom.** The name of the failing test is the weakest search term
+available. Search the class, the lock, the option, the exception, the log line - whatever the failure
+actually turns on.
+
+**`--state open` is a collision check, not a prior-art search.** The PR that already solved something
+in your file is, by definition, merged. Searching only the open list feels like due diligence and
+finds nothing, which is worse than not looking - it produces false confidence. Same for issues:
+`--state all`, because the useful ones are usually closed.
+
+### Settling it: a fix that works is not evidence of the cause
+
+Promoted here from `docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md` §11, because a
+dated plan goes stale once its work lands and this method must not go with it.
+
+- **Confirm a cause with a control arm, not with a fix that appears to work.** Change the one term you
+  believe is responsible, hold everything else identical, and show the outcome flips. Same-magnitude,
+  different-position beats bigger-hammer. The worked example: an identical 400ms delay injected on
+  either side of a lock release - *after* it (opening the window) failed 8/8; *before* it (same added
+  latency, inside the lock) passed 8/8, against a ~1-in-6 baseline. The control arm is what ruled out
+  "it is just slower under load", which every previous look at that flake had concluded.
+- **State the prediction before running it, and report the refuted ones.** A prediction that fails is
+  the cheapest result you will get. If a fix works but its prediction was wrong, you have a symptom.
+- **Verify your instrumentation actually reached the run** - the failure mode is a silent false
+  negative that reads as "no effect":
+  - `./mvnw -pl <module>` **without `-am`** fails the `ReactorModuleConvergence` enforcer, so the test
+    never recompiles and both arms run the stale class.
+  - `surefire:test` alone **does not reprocess test resources**, so an edited `logback-test.xml` never
+    reaches `target/test-classes` and your new logging silently does not exist.
+  - Use `./mvnw -pl parallel-consumer-core -am verify` (what `bin/soak-test.sh` runs) and confirm
+    `BUILD SUCCESS` on the compile step. Better, assert the setting in the run's own output - PC logs
+    its full options at INFO on init, so the arm proves itself.
+- **Report the rate and the conditions, never a bare verdict.** "0 failures" is meaningless without N
+  and the load. `bin/soak-test.sh <Class#method> <runs>` at a low `SOAK_FREE_CORES` is the house
+  reproducer; its own closing line says it - no failures is not proof the flake is gone.
+- **A guard added with a fix must be verified by negative control.** Break the thing it guards and
+  confirm it fails deterministically. An assertion nobody has seen fail is decoration.
+
+Real example, 2026-08-07: the `TransactionTimeoutsTest.commitTimeout` handoff searched for the test's
+own name, found nothing, and classified the failure by analogy. Grepping the *mechanism*
+(`producerTransactionLock` / `commitLockAcquisitionTimeout`) finds
+`docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md`, the only prior investigation
+into that exact lock - which already documented the lock's ordering invariant, the controlled-experiment
+method for settling contention-vs-bug, and a build trap that had silently voided one earlier
+experiment. All of it applied; none of it was used.
+
 ## Overview
 
 Parallel Consumer is a Java library that enables concurrent message processing from Apache Kafka with a single consumer, avoiding the need to increase partition counts. It maintains ordering guarantees (by partition or key) while processing messages in parallel.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,98 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with
+project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and
+ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+Seeded from the transactional-commit learning of 2026-08-07, so it covers the concurrency and
+transactional-commit area. Other areas of the project are not yet described here.
+
+## Relationships
+
+The **produce lock** and the **commit lock** are the two sides of one readers-writer lock, and that
+pairing is the load-bearing structure of the transactional commit path: many workers may hold the
+produce side at once, but the controller's commit side excludes them all. Everything else in the
+commit cluster — **dirty**, **eager processing during commit**, **commit lock timeout** — is a rule
+about when one side may be taken or must wait.
+
+## Parallel consumption
+
+**Control loop**
+The project's single controller thread: it drains completions, decides when to commit, and hands work
+out to the worker pool. It is the only thread that commits, which is why commit decisions are
+described from its point of view.
+
+**Broker poller**
+The thread that fetches records from the broker and keeps the consumer's group membership alive,
+separately from the control loop. Keeping it distinct from the control loop matters: a stalled
+controller and a stalled poller are different failures with different symptoms.
+
+**Shard**
+The unit of ordering. Records are distributed to shards by key or by partition depending on the
+configured ordering, and a shard processes its records in order while different shards run in
+parallel. This is how the project gets concurrency without adding partitions.
+
+**In-flight work**
+Records handed to the worker pool and not yet resolved as succeeded or failed. Distinct from records
+merely fetched: in-flight work is what a commit must wait for, and what a shutdown must drain.
+
+## Transactional commit
+
+**Produce lock**
+The shared side of the transactional lock, taken by a worker for as long as it may still produce
+records into the current transaction. Many workers hold it concurrently. Whether it is taken before
+the user's function runs or only when the result is produced depends on eager processing during
+commit.
+
+It is released only once the completed work has been handed back to the controller — releasing it
+earlier would let a commit collect offsets that do not yet account for work already produced, which is
+the exactly-once invariant this lock exists to protect.
+
+**Commit lock**
+The exclusive side of the transactional lock, taken by the control loop before it collects offsets, so
+that no further records can enter the transaction while the offsets for it are being gathered. Because
+it is exclusive, acquiring it means waiting for every held produce lock to be released.
+
+Acquisition is bounded: if the wait exceeds the configured limit, the attempt fails rather than
+blocking forever, and the failure is fatal to the instance. That deliberate bound is what turns "a
+user function is taking too long to allow a commit" into a visible error instead of a hang.
+
+**Eager processing during commit**
+Whether workers may begin processing new records while a commit is in progress. When disallowed, a
+worker takes the produce lock before running the user's function, so a slow function blocks commits;
+when allowed, the lock is taken only at produce time, and processing overlaps the commit. The choice
+trades commit latency against throughput.
+
+**Dirty**
+A partition has at least one successfully completed record whose offset has not yet been committed.
+Only a *success* makes a partition dirty — a failure does not — and the controller attempts a commit
+only when something is dirty.
+
+The asymmetry is load-bearing: a partition whose records are all failing is never dirty, so no commit
+is attempted for it, and anything waiting on a commit-time behaviour will wait indefinitely.
+
+## Test reliability
+
+**Load-tightness flake**
+A test that fails because a deadline or assertion margin is too tight to survive a contended machine,
+rather than because the code under test is wrong. Named as a family here because its members look
+identical to real product stalls and must be told apart before either is "fixed".
+
+**Unforceable trigger**
+A test that awaits a consequence whose precondition it cannot guarantee will occur. Distinct from a
+load-tightness flake: the margin is not too small, the awaited event may simply never happen in some
+interleavings, so no timeout is long enough to make the test reliable.
+
+**Ambient probe**
+The always-on recorder attached to broker integration tests, which annotates a failure with
+consumer-group progress evidence so the contention-versus-product-bug question is answered before
+manual diagnosis starts. Its verdict is only informative when its detectors could have fired for the
+test in question — a short, low-volume test cannot trip them, and a clean reading there means nothing.
+
+## Flagged ambiguities
+
+- **"Stall", "load-tightness flake" and "unforceable trigger" had been used loosely for the same red
+  test.** They are distinct: a stall is the product failing to make progress, a load-tightness flake is
+  a real deadline missed under contention, and an unforceable trigger is an awaited event that never
+  occurred. All three present as the same expired await, and the whole diagnostic difficulty of this
+  area is telling them apart.

--- a/docs/inflight/bug-producing-lock-double-release.md
+++ b/docs/inflight/bug-producing-lock-double-release.md
@@ -1,0 +1,62 @@
+# Open question: two paths release the same `ProducingLock`, and nothing stops the second
+
+**Not confirmed a defect.** It is an unresolved invariant in the transactional poll-and-produce lock
+lifecycle. Recorded because the reasoning is cheap to lose and the code path is one that has already
+produced two flakes.
+
+## The question
+
+In transactional poll-and-produce, the produce read lock is released from **two** places, on the same
+worker thread, against the same `ProducingLock` instance held in the context:
+
+- `WorkContainer.onPostAddToMailBox` (`WorkContainer.java:271-276`) → `finishProducing` →
+  `ProducerManager.releaseProduceLock` → `ProducingLock.unlock()`
+- `AbstractParallelEoSStreamProcessor.cleanUpContext` (`AbstractParallelEoSStreamProcessor.java:1418-1419`),
+  in the `finally` of `runUserFunction`
+
+Nothing clears `PollContextInternal#producingLock` between them, so both see a present `Optional`.
+`ProducingLock.unlock()` calls `ReadLock.unlock()` unconditionally
+(`ProducerManager.java:456-459`). A thread holding zero read locks that calls `unlock()` on a
+`ReentrantReadWriteLock.ReadLock` throws `IllegalMonitorStateException`. So either both paths do not
+in fact both fire, or something is swallowing it.
+
+## What is measured (2026-08-07)
+
+Counted from a transactional integration run with
+`allowEagerProcessingDuringTransactionCommit=false` (`TransactionTimeoutsTest#commitTimeout`), with
+`io.confluent.parallelconsumer.internal.ProducerManager` at DEBUG:
+
+| Acquires | Releases | `IllegalMonitorStateException` |
+|---|---|---|
+| 340 | 340 | 0 |
+
+Exactly 1:1. So **no double release actually occurs** - only one of the two paths fires per context.
+That closes the "is it silently throwing" half of the question and leaves the other half open:
+
+- **which** path is skipped, and **why**;
+- whether that is guaranteed by construction or holds only for the paths exercised so far -
+  the error, retry and stale-work branches (`handleStaleWork`, and the failure branch that calls
+  `addToMailbox` before `finally { cleanUpContext(context); }`) were not separately measured.
+
+## Why it is worth someone's time
+
+The invariant this lock enforces is the EOS one: the controller must not collect offsets while a
+produce is in flight. `WorkContainer#onPostAddToMailBox` states it outright in its own comment. Two
+problems have already come out of this exact lock lifecycle - the resolved harness bug in
+`docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md`, and the trigger-margin flake in
+`test-transaction-commit-timeout-trigger-margin.md`. A release path that is correct by accident rather
+than by construction is how the next one arrives.
+
+## Provenance and a trap
+
+Raised, and deliberately not chased, in
+[`docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md`](../plans/2026-08-03-001-investigate-transactional-commit-flake.md)
+§11 ("Open question, deliberately not chased"). That investigation tried to count acquire/release
+pairs by turning on debug logging and got an invalid result: **`surefire:test` alone does not
+reprocess test resources**, so the edited `logback-test.xml` never reached `target/test-classes` and
+the run logged nothing new. The counts above were taken with `./mvnw -pl parallel-consumer-core -am
+verify` (as `bin/soak-test.sh` uses), which does reprocess them. Confirm `BUILD SUCCESS` on the
+compile step before believing any instrumented result here.
+
+Related, but a different bug: production commit-lock timeouts from a rebalance-vs-normal commit race,
+confluentinc#803 / astubbs#44 (maintainer-confirmed upstream).

--- a/docs/inflight/test-load-tightness-flakes.md
+++ b/docs/inflight/test-load-tightness-flakes.md
@@ -13,6 +13,31 @@ baseline for comparison is 15/20 runs fully clean, zero stall-class failures.
 | `KafkaSanityTests`, `TransactionMarkersTest` | singles | residual, uncategorised |
 | `PartitionStateCommittedOffsetIT.committedOffsetRemoved[3] none` | 1 sighting (2026-08-05) | `RebalanceInProgressException` out of the test's own setup |
 
+**A third member has now left the family, and it left by being reclassified rather than fixed-as-tight.**
+`TransactionTimeoutsTest.commitTimeout[1]` failed once on CI (2026-08-07,
+[job 92733771394](https://github.com/astubbs/parallel-consumer/actions/runs/31135433520/job/92733771394?pr=219);
+the run reports success because attempt 2 passed on the identical tree). It reads exactly like this
+family - an await that expired under load - and it is **not** a member. The 35s await is not the
+margin; it is the deadline for a *consequence*. The margin belongs to the **trigger**, and the trigger
+is a `TimeoutException` from `ProducerManager.acquireCommitLock` that only occurs if the controller
+attempts a commit *while* the slow record holds the produce lock. Two things stop that, neither of them
+tightness:
+
+1. too little margin between the record's sleep and `commitLockAcquisitionTimeout`;
+2. `wm.isDirty()` - AND-ed into the commit gate, single setter `PartitionState#onSuccess` - suppressing
+   the commit attempt entirely, so there is no deadline to widen.
+
+Fixed test-side by making the overlap deterministic. **The mechanism, the ruled-out readings and the
+experiment numbers live in
+[`docs/solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md`](../solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md)**
+- do not restate them here, or the two copies will drift.
+
+**What this means for the members still listed above, `produceTimeout` especially:** before filing any
+of them as a tight assertion, check whether the thing being awaited can be *triggered at all* in every
+interleaving. A test that waits on a consequence it cannot force is not tight - it is unsound, and
+raising its timeout will never fix it. (`produceTimeout` already latches its own trigger, so it is the
+worked example of doing this right.)
+
 **Classify before touching any of them** (the astubbs#68 lesson): this family is exactly where the upstream
 confluentinc#857 deadlock and the drain zombie were hiding, and both looked like tightness first. Two members have
 since been *solved* and left the family, which gives you their signatures to rule out - the nudge race

--- a/docs/solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md
+++ b/docs/solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md
@@ -1,0 +1,321 @@
+---
+title: "A test that awaits a trigger it cannot force: TransactionTimeoutsTest.commitTimeout waited 35s for a commit-lock timeout that was never guaranteed to fire"
+date: 2026-08-07
+category: test-flakiness
+module: parallel-consumer-core
+problem_type: flaky_test
+component: testing
+symptoms:
+  - "TransactionTimeoutsTest.commitTimeout[1]: ConditionTimeoutException after 35s on `assertThat(pc).isClosedOrFailed()`, one sighting on CI"
+  - "The whole 35s window is SILENT - no ERROR, no close-path logging, nothing from the PC instance"
+  - "A passing run of the same parameter takes ~2.9s; there is no middle ground, it either fires in seconds or eats the full 35s"
+  - "The CI run reports conclusion `success` - it is `run_attempt: 2`, and attempt 2 passed on the byte-identical tree"
+root_cause: awaited_trigger_unreachable_in_some_interleavings
+resolution_type: test_fix_deterministic_trigger_plus_guard
+severity: low
+status: "Test-side fix committed on branch test/commit-timeout-deterministic-trigger; PR astubbs#220 OPEN, pending merge as of 2026-08-07. PC is healthy; no product defect. Which of the two paths CI hit was NOT established (no DEBUG in that job); the fix closes both."
+last_updated: 2026-08-07
+related_prs:
+  - "astubbs#220 - this fix, plus the investigation rules and probe correction in AGENTS.md"
+  - "astubbs#110 - the SIBLING flake on this same producerTransactionLock (ProducerManagerTest), fixed 2026-08-03; source of the control-arm method"
+  - "astubbs#86 - introduced AmbientProbeExtension/ProgressProbe, whose 'probe clean' verdict this work qualified"
+  - "astubbs#98 - the backpressure test that only passed by racing its own setup (the sibling rule, opposite direction)"
+  - "astubbs#80 - drain-path zombie/busy-spin fix; its signature is what this failure was wrongly matched against"
+  - "astubbs#115 - the nudge race, the other flake-family member that was solved and left"
+  - "astubbs#68 - the forked per-broker integration work that produced the flake-family roster"
+  - "astubbs#219 - the unrelated PR this surfaced on, excluded by tree hash (see What Didn't Work)"
+related:
+  - "docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md - the only prior investigation into this same lock; its §11 control-arm method is what settled this one"
+  - "vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md - SIBLING rule, opposite failure direction (see Related)"
+  - "docs/inflight/test-load-tightness-flakes.md - the family this was wrongly filed under"
+upstream:
+  - "confluentinc#803 / astubbs#44 - a REAL production commit-lock timeout, but a different bug (rebalance-vs-normal-commit race)"
+  - "confluentinc#809 / astubbs#175 - sporadic ConsumerOffsetCommitter timeouts, likely the same defect as confluentinc#803"
+  - "confluentinc#833 / astubbs#177 - PC exits on InternalRuntimeException(Timeout), likely the same cluster"
+tags:
+  - flaky-tests
+  - awaitility
+  - unforceable-trigger
+  - transactional-commit
+  - commit-lock
+  - test-design
+  - ci
+---
+
+# A test that awaits a trigger it cannot force
+
+## Problem
+
+`TransactionTimeoutsTest.commitTimeout[1]` waits 35 seconds for PC to die from a commit-lock timeout.
+It failed on CI having waited the full 35s. PC was **healthy the whole time** - not stalled, not
+deadlocked, no product defect. The test was waiting for a *consequence* whose *trigger* it had only
+made possible, never guaranteed.
+
+## Symptoms
+
+- `org.awaitility.core.ConditionTimeoutException ... expected to be 'closed or failed'` after 35s,
+  at the `await()` in `commitTimeout`.
+- **35 seconds of complete silence** from the PC instance in the job log. No close path, no error.
+- Binary timing: a healthy run of param `[1]` finishes in ~2.9s. There is no gradual degradation.
+- The run's overall conclusion is `success`, because it is `run_attempt: 2` and the retry passed on
+  the identical tree.
+
+## What Didn't Work
+
+This section is the valuable one - five plausible reads, all wrong, and why.
+
+1. **"It's a stall, like confluentinc#857 / the astubbs#80 drain zombie."** The reasoning was: a 1s
+   mechanism cannot stretch past 35s, so PC must never have shut down - therefore a stall. The first
+   half is right and the conclusion does not follow. A trigger that *never fires* is externally
+   identical to one that stalls, and they have opposite fixes. This framing sends you into drain and
+   rebalance code, which is a dead end here.
+
+2. **"No ERROR was logged, so the failing record never ran."** Refuted by reading the code:
+   `FakeRuntimeException extends PCRetriableException`, and `AbstractParallelEoSStreamProcessor`
+   routes a `PCRetriableException` cause to **DEBUG**, not ERROR. Silence is the expected behaviour.
+   Absence of the line proves nothing.
+
+3. **"The commit interval pushes the attempt too late."** Tested and **refuted**: 0/6 failures at
+   `commitInterval=3s`. `requestCommitAsap()` sets `isCommandedToCommit`, which short-circuits the
+   interval check entirely - the interval was never gating this scenario.
+
+4. **Brute-force soaking.** 0/12 at stock settings under load. Repetition cannot reproduce a window
+   this narrow at any practical count. Only a controlled experiment could.
+
+5. **"The ambient probe says clean, so the fault is in the test."** The verdict was **vacuous**.
+   `ProgressProbe` needs `LAG_STAGNATION_MIN_LAG` (50) of lag sustained past `LAG_STAGNATION_BOUND`
+   (150s), or `REBALANCE_DWELL_BOUND` (15s). A 15-record test failing in 35s cannot trip either
+   detector. See `AGENTS.md` (Testing) for the standing caveat - **do not duplicate it here**.
+
+6. **Searching CI history filtered on `conclusion == "failure"`.** Structurally blind to this failure
+   class: a run whose first attempt fails and is retried green reports `success`. The scan has to walk
+   first-attempt job results.
+
+7. **"The PR it surfaced on must have caused it."** It surfaced on an unrelated tree-wide
+   issue-reference migration. Excluded by evidence rather than argument (session history): that branch
+   had been re-cut, so two heads shared a byte-identical tree hash, and the **same tree passed at
+   00:00:18Z and failed at 00:41:04Z**, 40 minutes apart. Worth copying as a technique - a tree-hash
+   comparison settles "did my change cause this" in one command, where reading the diff only ever
+   yields an opinion.
+
+**A re-run that passes is not a resolution** (session history). The job was re-run on the identical
+tree and went green, which establishes non-determinism and nothing else. It says the failure is not
+reproducible on demand; it says nothing about why it happened once.
+
+Also ruled out on principle: **widening a timeout**. It cannot fix path 2 below - there is no deadline
+to widen - and `docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md` §5 records timeouts already being widened once on this same
+lock, with the flake surviving.
+
+## Solution
+
+No production code changed. The test now *constructs* the overlap its trigger requires.
+
+The trigger is a `TimeoutException` from `ProducerManager.acquireCommitLock`, which needs the slow
+record to be holding the produce **read** lock at the moment the controller is inside its **write**
+lock acquisition. Two coordination points guarantee that:
+
+```java
+// 1. Signal the moment the controller actually enters commit-lock acquisition.
+//    Wired through PCModule - the DI - rather than around it. The cache matters: PCModule#producerManager()
+//    caches, and a fresh ProducerManager would mean a fresh producerTransactionLock.
+setup(new PCModule<>(options) {
+    private ProducerManager<String, String> instance;
+
+    @Override
+    protected ProducerManager<String, String> producerManager() {
+        if (instance == null) {
+            instance = new ProducerManager<>(producerWrap(), consumerManager(), workManager(), options()) {
+                @Override
+                protected void preAcquireOffsetsToCommit() throws TimeoutException, InterruptedException {
+                    // phase-one happy-path commits reach here too, and must not open the latch
+                    if (slowRecordHoldsProduceLock.getCount() == 0) {
+                        commitLockAcquisitionAttempted.countDown();
+                    }
+                    super.preAcquireOffsetsToCommit();
+                }
+            };
+        }
+        return instance;
+    }
+});
+```
+
+```java
+// 2. Time the sleep FROM THE ATTEMPT, and guarantee a success lands during the hold.
+if (offset == OFFSET_TO_GO_SLOW) {
+    slowRecordHoldsProduceLock.countDown();
+    awaitQuietly(commitLockAcquisitionAttempted);   // <- sleep now starts at the attempt
+    ThreadUtils.sleepQuietly(1000 * multiple);
+} else if (offset == OFFSET_TO_ERROR) {
+    throw new FakeRuntimeException("fail");
+} else if (offset == OFFSET_TO_MARK_DIRTY) {
+    awaitQuietly(slowRecordHoldsProduceLock);       // <- guarantees wm.isDirty() during the hold
+}
+```
+
+```java
+// 3. A guard, so a future regression fails in one line instead of returning as a 35s flake.
+Truth.assertWithMessage("controller must have attempted the commit lock while the slow record held the produce lock")
+        .that(commitLockAcquisitionAttempted.getCount())
+        .isEqualTo(0);
+```
+
+`awaitQuietly` deliberately does **not** throw on its own timeout: an exception inside the user
+function would be caught by PC as a user-function failure and retried, turning a diagnosable setup
+problem into noise.
+
+**The 35s await and `isClosedOrFailed` are untouched. No assertion was weakened.**
+
+## Why This Works
+
+Two independent paths defeated the old test, and the fix closes both.
+
+**Path 1 - margin.** With `allowEagerProcessingDuringTransactionCommit=false`,
+`ParallelEoSStreamProcessor` takes the produce read lock *before* running the user function, so the
+sleep holds it. The controller's `writeLock.tryLock(commitLockAcquisitionTimeout)` is **granted rather
+than timing out** whenever:
+
+```
+(T - S) + commitLockAcquisitionTimeout  >=  sleep
+```
+
+where `S` = when the record took the lock and `T` = when the commit attempt began. At stock settings
+(2s sleep, 1s lock timeout) that leaves 1000ms of headroom, usable exactly **once** - after the sleep
+ends there is no contention left, so the remaining ~33s of the await is dead time. Timing the sleep
+from the attempt makes the margin a property of the test, not of the scheduler.
+
+**Path 2 - no attempt at all.** `maybeAcquireCommitLock` (`AbstractParallelEoSStreamProcessor.java:956-957`) computes:
+
+```java
+final boolean shouldTryCommitNow = isTimeToCommitNow() && wm.isDirty() && !isRebalanceInProgress.get();
+```
+
+The no-arg `setDirty()` - the mark-true path, `PartitionState.java:232-234` - has **exactly one
+caller**: `PartitionState#onSuccess` (`:258-265`, call at `:265`). `onFailure` is a no-op (`:268-270`).
+(There is a second `setDirty(false)` overload used by `setClean()` at `:226-228`; it clears the flag
+and is not a second way to set it.) So if every other record of the batch succeeds *before* the slow
+one starts, nothing marks dirty during its hold, no commit is attempted, and no timeout can fire - not
+late, simply never. `requestCommitAsap()` cannot rescue this, because `isDirty` is AND-ed into the
+gate, not OR-ed. Deferring one record's success into the hold guarantees the controller has something
+to commit.
+
+## Evidence
+
+Established by controlled experiment, per the method in `docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md` §11 - a fix that
+works is not evidence of the cause:
+
+| Arm | Result |
+|---|---|
+| stock, before the fix | 0/12 fail |
+| `commitLockAcquisitionTimeout` 2.5s vs 2s sleep | **6/6 fail** |
+| `commitInterval` 3s - hypothesis **refuted** | 0/6 fail |
+| latch removed + 1500ms delayed commit attempt | **4/4 fail** |
+| latch present + *identical* 1500ms delay | **0/4 pass** |
+| fixed, stock settings, heavy load | 0/8 fail |
+| whole class, fixed, heavy load | 0/4 fail |
+| guard deliberately broken | **2/2 fail, on the guard's own message** |
+
+The 6/6 arm carries its own control: param `[2]` (50s sleep) fired correctly in the same JVM at the
+same instant, so machine speed is excluded by construction rather than by argument. The DEBUG timeline
+from a failing run shows the mechanism directly - `T-S = 3ms`, read lock released at `S+2005ms`, and
+`Commit lock acquired.` **granted**, not timed out.
+
+**Not established:** which path the CI failure actually hit. That job had no DEBUG logging.
+
+## Prevention
+
+1. **Before writing `await(...).untilAsserted(consequence)`, ask whether the test can *force* the
+   trigger in every interleaving.** If the trigger depends on two threads coinciding, or on a flag the
+   test does not set, the test is asserting on a race. Its failure rate is then a function of machine
+   load, and no timeout is long enough - path 2 here has no deadline at all.
+2. **Force the coincidence with a latch at the exact production hook**, not with sleep arithmetic.
+   Override the real method (`preAcquireOffsetsToCommit`) through the DI, so the test observes the
+   thing it claims to.
+3. **Verify any determinism guard by negative control.** Break the mechanism it guards and confirm the
+   test fails on *that assertion's message*. An assertion nobody has seen fail is decoration.
+4. **Treat silent logs as inconclusive, not exculpatory.** Check what level the failure path logs at
+   before using "nothing was logged" as evidence.
+5. **Check a detector can structurally fire before trusting a clean result** - thresholds against the
+   scenario's scale and duration.
+6. **When mining CI history for a flake, walk first-attempt results.** A retried run reports `success`.
+
+## Other instances of this defect (swept 2026-08-07)
+
+The class is **a test awaiting a consequence whose trigger it cannot force**. Two greppable proxies
+find candidates: *sleep-as-synchronisation* in integration tests, and *awaits on a failure outcome*
+(as opposed to `failFast(...)` guards, which are the opposite polarity and safe - most
+`isClosedOrFailed` uses in this repo are guards).
+
+**Explicitly NOT an instance - `TransactionTimeoutsTest.produceTimeout`.** This is the most important
+line in the section, because it is the nearest sibling: same file, same lock, and still listed as an
+open flake in `docs/inflight/test-load-tightness-flakes.md`. It **latches its trigger and keeps a real
+margin** - the injected `sendOffsetsToTransaction` counts its latch down while already holding the
+commit write lock and then sleeps 5s, and the worker attempts the produce read lock at `latch + 1s`
+against a 2s deadline. Its "tight assertion" classification stands. **Do not "fix" it the way
+`commitTimeout` was fixed** - it does not have this defect.
+
+Relatives found, neither the same defect:
+
+| Test | What it is |
+|---|---|
+| `DrainCloseTest` (`:57`, `:60`) | Closest relative. Two bare `sleep(2000)`/`sleep(5000)` sequence a close-drain race. Not this defect, because `closeDrainFirst` is *commanded* - which is itself the smell: the await's `isClosedOrFailed` disjunct is guaranteed to fire, so the await is pure synchronisation and the real check is the `assertEquals` after it. |
+| `RetriesTest` (`:78-80`) | Candidate. `throwOnHeader` and `checking` are flipped on 3s/2s sleeps against a running consumer; the test's premise holds only if the consumer got there inside those windows. |
+
+Checked and dismissed: the chaos and probe pacing loops, `OffsetCommittingSanityTest:135` (an explicit
+`JUST_SLEEP` check mode, not a synchronisation), `RebalanceEoSDeadlockTest:90` (the injected delay *is*
+the mechanism under test), `TransactionMarkersTest:160` (a deliberately blocked record).
+
+This is a point-in-time sweep, not a standing guarantee - re-run it if the class comes up again.
+
+## This test has a prior, different flake history (session history)
+
+`TransactionTimeoutsTest` was already known as a CI "repeat offender" in late July 2026 - **but for a
+different mechanism**. Then, cross-class broker contention was spuriously tripping its *intentional*
+1s/2s lock timeouts, and the fix was **forked-per-broker test isolation** (astubbs#68), not any change
+to the timeout values. That history matters twice over:
+
+- It is the reason this test's timeouts are deliberately tight, and why "just raise them" has been
+  rejected before.
+- It is a *third* distinct way this one test can go red. Contention tripping a real timeout, the
+  trigger never firing, and a genuine product stall all present as the same red X. Classify before
+  touching, every time.
+
+**Searching for prior sightings has a false-positive trap.** A keyword search for `commitTimeout`
+across sessions returns many hits that are the **`offsetCommitTimeout` config field**, or the title of
+an unrelated PR, rather than this test method. Checked and discounted on that basis: this remains a
+**single sighting**, not a recurrence.
+
+## Related
+
+- `docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md` - the only prior investigation
+  into this same `producerTransactionLock`. Different defect (the test released the produce lock too
+  early, opening a window production never opens), same discipline. Its §11 control-arm method is now
+  promoted into `AGENTS.md`.
+- `vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md` - **a sibling rule, not the same
+  one.** That doc's hazard is an await satisfied *too early* by a vacuously-true condition (a
+  false-pass). This one's hazard is an await whose trigger may *never fire* (a false-fail). Same
+  symptom, opposite direction; neither fix would have solved the other.
+- `pc-silent-stall-under-contention-2026-07-29.md` - names `TransactionTimeoutsTest` among the tests
+  that stall under `forkCount=16`, but that mechanism (drain-path busy-spin) is unrelated to this one.
+  Useful as a signature to **rule out**.
+- `docs/inflight/test-load-tightness-flakes.md` - the family this was wrongly filed under, and the
+  warning left for the members still in it.
+- confluentinc#803 / astubbs#44 - a real production commit-lock timeout, maintainer-confirmed as a
+  rebalance-vs-normal-commit race, with confluentinc#809 and confluentinc#833 likely the same defect.
+  Related area, different bug. It is why this test is worth keeping sharp. **Its fix is claimed by the
+  still-open astubbs#29**, described there as the same root cause - so anyone working this area should
+  read that PR before assuming the production bug is unowned.
+
+### What the prior-art search actually covered
+
+Recorded so the next reader knows where the gaps are rather than assuming none.
+
+- **Merged PRs**, by the files they touch (`TransactionTimeoutsTest`, `ProducerManager`,
+  `AmbientProbeExtension`, `ProgressProbe`) - this is what surfaced astubbs#110, astubbs#86 and
+  astubbs#98, none of which a symptom search would have found. Searching *open* PRs alone is a
+  collision check, not prior art.
+- **Issues, all states**, fork and upstream. Nothing matches this mechanism; the only commit-lock
+  issues are the confluentinc#803 cluster above, which is a production rebalance race, not this.
+- **Not covered:** the `highcpu` and `quarantine` CI lanes were not scanned for prior sightings of
+  this test, only the main `CI` workflow (120 failed runs, plus first-attempt results across 400 runs
+  - needed because a retried run reports `success`). One sighting is all that search found.

--- a/docs/solutions/workflow-issues/compound-tooling-breaks-in-worktrees-and-forks-2026-08-07.md
+++ b/docs/solutions/workflow-issues/compound-tooling-breaks-in-worktrees-and-forks-2026-08-07.md
@@ -1,0 +1,128 @@
+---
+title: "Knowledge-capture tooling silently misreads a worktree and a fork - three failures that all look like clean results"
+date: 2026-08-07
+category: workflow-issues
+module: tooling
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+status: "Known, unfixed upstream. Workarounds below are per-invocation; a plugin update discards any local patch."
+applies_when:
+  - Running any Compound Engineering skill from a git worktree rather than the main checkout
+  - Running any tool that derives a repo identity from the working directory's basename
+  - Running any `gh`-based verification in a fork whose upstream still exists
+  - Reading a tool's "clean" or "nothing found" result and deciding it is evidence
+tags:
+  - tooling
+  - worktrees
+  - fork
+  - gh-cli
+  - false-negative
+  - knowledge-capture
+---
+
+# Knowledge-capture tooling silently misreads a worktree and a fork
+
+## Context
+
+This repo mandates worktrees for all work (`AGENTS.md`, *Worktree ownership*) and is a hard fork whose
+upstream still exists. Both facts break tooling that infers identity from its surroundings, and all
+three failures found so far fail **quietly** - they report a clean or empty result that is
+indistinguishable from a genuine one.
+
+That is what makes them worth a doc. A tool that crashes gets fixed; a tool that returns "nothing
+found" gets believed.
+
+## Guidance
+
+### 1. A worktree's basename is not the repo name
+
+Anything computing `REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")` gets the **worktree**
+directory name. Here that is the branch-ish slug, not `parallel-consumer`, so a session-history search
+keyed on it matched **zero** sessions where the correct name matched **37**. The workflow then recorded
+"no relevant prior sessions" and carried on.
+
+Derive the repo name from the **common** git dir, not the working root:
+
+```bash
+# worktree-safe: same answer from the main checkout and from any worktree
+d=$(git rev-parse --path-format=absolute --git-common-dir); d=${d%/.git}; basename "$d"
+```
+
+`--git-common-dir` is the point: unlike `--show-toplevel`, it resolves to the *shared* git directory,
+so every worktree of a repo agrees on it. Take the **dirname** - the common dir is `…/<repo>/.git`, so
+a bare `basename` of it returns `.git`, not the repo name. (Verified from both a worktree and the main
+checkout; the obvious `basename … | sed 's/\.git$//'` returns an empty string, which is exactly the
+kind of silent-empty result this doc is about.)
+
+### 2. A worktree does not have the repo-root config
+
+A health check that looks for `.compound-engineering/` relative to `git rev-parse --show-toplevel`
+reports it missing when run from a worktree, because the directory lives in the main checkout. Run
+repo-config health checks **from the main checkout**, and treat a config complaint raised in a worktree
+as unproven until re-checked there.
+
+That path is deliberately unresolvable from here, in two ways at once: it is absent from this worktree,
+and it is gitignored so it is absent from the tree entirely. A path checker run against this doc will
+flag it - correctly, and beside the point. It is cited as a thing that is *not* where the tool looked,
+which is the whole subject of this section.
+
+### 3. Bare `gh` in a fork resolves upstream
+
+`gh pr view` with no `-R` resolved to the upstream repository and returned *"no pull requests found for
+branch …"* for a branch that has an open PR on the fork. Always pass the repo explicitly:
+
+```bash
+gh pr view -R <owner>/<repo> <n>        # not: gh pr view <n>
+gh pr list -R <owner>/<repo> --state merged
+```
+
+This one is worse than a missing result, because a verification step that treats "not found" as
+"unverified" will **downgrade a correct claim**: an open PR citation gets softened to "pending", and a
+doc that was right becomes wrong.
+
+## Why This Matters
+
+Each failure produces a *plausible* output, so nothing prompts a second look:
+
+| What the tool reports | What is actually true |
+|---|---|
+| "no relevant prior sessions" | the search never matched the repo |
+| "example config missing" | it exists, in the main checkout |
+| "no pull requests found" | the PR exists, on the fork |
+
+All three were caught only because the output contradicted something already known - an empty result
+where prior sessions were certain to exist, a config file seen minutes earlier, a PR opened in the same
+session. Absent that, each would have passed as a finding. The general rule: **when a tool reports
+absence, confirm it is looking where you think it is** before treating the absence as evidence.
+
+## When to Apply
+
+- Before believing any "nothing found" from a tool run inside a worktree.
+- Before believing any `gh` result in this repo that does not name `-R`.
+- When a tool's result would *weaken* a claim you have independent evidence for - the tool is the thing
+  to check first, not the claim.
+
+## Examples
+
+Diagnosing the session-history miss took one command:
+
+```
+$ git rev-parse --show-toplevel
+/Users/.../parallel-consumer/.claude/worktrees/commit-timeout
+$ basename ...            -> commit-timeout      # what the probe searched for
+$ discover-sessions.sh commit-timeout    7  ->  0 sessions
+$ discover-sessions.sh parallel-consumer 7  -> 37 sessions
+```
+
+The same shape works for the fork trap - run the command with and without `-R` and compare.
+
+## Related
+
+- `unforceable-trigger-commit-lock-timeout-2026-08-07.md` - the learning being captured when all three
+  surfaced. Its own lesson (verify instrumentation actually reached the run) is the same principle
+  applied to a build rather than to tooling.
+- `AGENTS.md` *Worktree ownership* - why every run here is in a worktree, which is what makes these
+  defects routine rather than rare.
+- `AGENTS.md` *Before you investigate anything* - the merged-PR search there depends on `-R` being
+  passed; without it the search silently returns nothing on this fork.

--- a/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/io/confluent/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -69,6 +70,13 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
     // allow the first offsets to succeed, which we can test
     private static final int OFFSET_TO_GO_SLOW = NUMBER_TO_SEND + 3;
 
+    /**
+     * The one record whose success is deliberately deferred into {@link #OFFSET_TO_GO_SLOW}'s lock hold, so
+     * that the controller is guaranteed to have something to commit while the lock is held. Any offset of the
+     * second batch that is neither the slow one nor the failing one will do.
+     */
+    private static final int OFFSET_TO_MARK_DIRTY = OFFSET_TO_GO_SLOW + 1;
+
 
     private ParallelEoSStreamProcessor<String, String> pc;
 
@@ -89,6 +97,19 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
         originalGroupId = getKcu().getConsumer().groupMetadata().groupId();
 
         assertConsumer = new BrokerCommitAsserter(getTopic(), getKcu().createNewConsumer(NEW_GROUP));
+    }
+
+    /**
+     * Bounded latch wait for use <em>inside</em> the user function. It deliberately does not throw: an
+     * exception here would be caught by PC as a user-function failure and retried, turning a diagnosable
+     * setup problem into noise. On timeout it logs and falls through, and the assertion on
+     * {@code commitLockAcquisitionAttempted} after the await then names what did not happen.
+     */
+    @SneakyThrows
+    private static void awaitQuietly(CountDownLatch latch) {
+        if (!latch.await(20, TimeUnit.SECONDS)) {
+            log.error("Latch not released within 20s - the commit/produce-lock overlap this test depends on did not happen");
+        }
     }
 
     private ParallelConsumerOptions.ParallelConsumerOptionsBuilder<String, String> createOptions() {
@@ -118,9 +139,13 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
      * <p>
      * Sleep time multiplier:
      * <p>
-     * 5: triggers a timeout
+     * {@value #SMALL_TIMEOUT_MULTIPLIER}: triggers a timeout
      * <p>
-     * 50: triggers a timeout with a much longer deadlock
+     * {@value #LONG_TIMEOUT_MULTIPLIER}: triggers a timeout with a much longer deadlock
+     * <p>
+     * The sleep is timed from the moment the controller enters its commit-lock acquisition, not from when
+     * the record acquired the produce lock - so the multiplier is a true margin over
+     * {@code commitLockAcquisitionTimeout} rather than a race against it.
      *
      * @param multiple Multiple values - but affect is the same. It's not worth trying to artificially create a scenario
      *                 where the sleep wakes up /after/ the commit lock has timed out - this would affectively be a semi
@@ -143,7 +168,40 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
                 .shutdownTimeout(Duration.ofSeconds(5))
                 .allowEagerProcessingDuringTransactionCommit(false)
                 .build();
-        setup(new PCModule<>(options));
+
+        // The commit-lock timeout this test waits for can only fire while the slow record is holding the
+        // produce lock AND the controller is inside its commit-lock acquisition. Nothing in PC guarantees
+        // that overlap, and when it is missed PC stays healthy and the await below burns its full 35s. So
+        // the test creates the overlap rather than hoping for it - see the two uses in the user function.
+        var slowRecordHoldsProduceLock = new CountDownLatch(1);
+        var commitLockAcquisitionAttempted = new CountDownLatch(1);
+
+        setup(new PCModule<>(options) {
+            private ProducerManager<String, String> instance;
+
+            /**
+             * Caching matters: {@link PCModule#producerManager()} caches, and a fresh {@link ProducerManager}
+             * per call would mean a fresh {@code producerTransactionLock} - the produce and commit locks would
+             * stop being the same lock - and would re-run {@code initTransactions()}.
+             */
+            @Override
+            protected ProducerManager<String, String> producerManager() {
+                if (instance == null) {
+                    instance = new ProducerManager<>(producerWrap(), consumerManager(), workManager(), options()) {
+                        @Override
+                        protected void preAcquireOffsetsToCommit() throws java.util.concurrent.TimeoutException, InterruptedException {
+                            // Only the attempt made while the slow record holds the lock is the one under test -
+                            // the happy-path commits of phase one reach here too, and must not open the latch.
+                            if (slowRecordHoldsProduceLock.getCount() == 0) {
+                                commitLockAcquisitionAttempted.countDown();
+                            }
+                            super.preAcquireOffsetsToCommit();
+                        }
+                    };
+                }
+                return instance;
+            }
+        });
 
 
 
@@ -155,10 +213,25 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
             if (offset == OFFSET_TO_GO_SLOW) {
                 // triggers deadlock as controller can't acquire commit lock fast enough due to this sleeping thread
                 log.debug("Processing offset {} - simulating a long processing phase with timeout multiple {}", OFFSET_TO_GO_SLOW, multiple);
+                slowRecordHoldsProduceLock.countDown();
+                // Hold the produce lock until the controller is actually inside its commit-lock acquisition, so
+                // the sleep below is measured FROM THE ATTEMPT. It used to start on lock acquisition instead,
+                // which left the trigger only `sleep - commitLockAcquisitionTimeout` of margin - and none at
+                // all when the attempt came a commit-interval later. Removing this wait reproduces that:
+                // 4/4 failures against a 1500ms-delayed commit attempt, where keeping it passes 4/4.
+                awaitQuietly(commitLockAcquisitionAttempted);
                 ThreadUtils.sleepQuietly(1000 * multiple);
                 log.debug("Processing offset {} - simulating a long processing phase COMPLETE", OFFSET_TO_GO_SLOW);
             } else if (offset == OFFSET_TO_ERROR) {
                 throw new FakeRuntimeException("fail");
+            } else if (offset == OFFSET_TO_MARK_DIRTY) {
+                // The controller only attempts a commit when a record has SUCCEEDED since the last one:
+                // PartitionState#onSuccess is the sole caller of setDirty, onFailure is a no-op, and
+                // wm.isDirty() is AND-ed into the commit gate - requestCommitAsap() cannot override it. So if
+                // every other record of this batch finishes before the slow one starts, no commit is attempted
+                // at all and no timeout can fire. Delaying this one success into the slow record's lock hold
+                // removes that possibility.
+                awaitQuietly(slowRecordHoldsProduceLock);
             }
             return new ProducerRecord<>(outputTopic, "output-value,source-offset: " + offset);
         });
@@ -174,6 +247,15 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
 
         // wait until pc dies from commit timeout
         await().atMost(Duration.ofSeconds(35)).untilAsserted(() -> assertThat(pc).isClosedOrFailed());
+
+        // Guard: PC must have died from the commit-lock attempt made WHILE the slow record held the produce
+        // lock, not from anything else that happens to mention "timeout". Verified by negative control - drop
+        // the countDown in producerManager() above and this fails deterministically, rather than the test
+        // returning as an occasional 35s flake.
+        Truth.assertWithMessage("controller must have attempted the commit lock while the slow record held the produce lock")
+                .that(commitLockAcquisitionAttempted.getCount())
+                .isEqualTo(0);
+
         assertThat(pc).getFailureCause().hasMessageThat().contains("timeout");
 
         // check what was committed at shutdown to the input topic, re-using same group id as PC, to access what was committed at shutdown commit attempt


### PR DESCRIPTION
<!-- What does this PR change, and why? Keep it in sync with the actual content as the PR evolves. -->

## Description

`TransactionTimeoutsTest.commitTimeout[1]` failed once on CI ([job 92733771394](https://github.com/astubbs/parallel-consumer/actions/runs/31135433520/job/92733771394?pr=219)) with a 35s `ConditionTimeoutException` waiting for `isClosedOrFailed`. The run reports success because attempt 2 passed on the identical tree.

**PC was healthy the whole time.** The test waits 35s for a consequence whose *trigger* it never guaranteed. The trigger is a `TimeoutException` from `ProducerManager.acquireCommitLock`, and it fires only while the slow record holds the produce lock **and** the controller is inside its commit-lock acquisition. Two independent things prevent that overlap, and neither is a stall or a tight assertion:

1. **Margin.** The sleep started when the record acquired the produce lock, so the trigger had only `sleep - commitLockAcquisitionTimeout` of margin - and none at all when the attempt arrived a commit-interval later. After the sleep ends there is no contention left, so there is exactly one chance and ~33s of dead time.
2. **No attempt at all.** `maybeAcquireCommitLock` is gated on `wm.isDirty()`, whose sole setter is `PartitionState#onSuccess` (`onFailure` is a no-op). If every other record of the batch succeeds *before* the slow one starts, nothing marks dirty during its hold, no commit is attempted, and no timeout can fire. `requestCommitAsap()` cannot override this - `isDirty` is AND-ed into the gate.

Widening a timeout cannot fix case 2: there is no deadline to widen. `docs/plans/2026-08-03-001` §5 records timeouts already being widened once on this same lock, and the flake surviving.

### The fix

The test creates the overlap instead of hoping for it, the way `produceTimeout` already does on the other side of this lock. A latch on `preAcquireOffsetsToCommit` - wired through `PCModule`, not around it - times the sleep from the commit attempt, and one record's success is deferred into the lock hold so a commit is always attempted. **The 35s await and `isClosedOrFailed` are untouched, and no assertion is weakened.**

A new guard asserts the failure came from the attempt made while the lock was held, so a regression that stops the overlap happening fails in one line instead of returning as an occasional 35s flake.

### Evidence

Controlled experiment rather than "the fix works":

| Arm | Result |
|---|---|
| stock, before the fix | 0/12 fail |
| `commitLockAcquisitionTimeout` 2.5s vs 2s sleep | **6/6 fail** |
| `commitInterval` 3s - hypothesis **refuted** | 0/6 fail |
| latch removed + 1500ms delayed commit attempt | **4/4 fail** |
| latch present + *identical* 1500ms delay | **0/4 pass** |
| fixed, stock settings, heavy load | 0/8 fail |
| whole class, fixed, heavy load | 0/4 fail |
| guard deliberately broken | **2/2 fail, on the guard's own message** |

The 6/6 arm carries its own control: param `[2]` (50s sleep) fired correctly in the same JVM at the same instant, so machine speed is ruled out by construction rather than by argument.

**Not established:** which of the two paths CI actually hit. That job has no DEBUG logging and I will not guess between them - the fix covers both.

### Docs

Three lessons, each in its own commit:

- **Investigation checklist + control-arm method** (`AGENTS.md`). The original handoff searched for the failing test's *name*, found nothing, and classified by analogy; grepping the *mechanism* finds `docs/plans/2026-08-03-001`, the only prior investigation into this exact lock, which already had both the ordering invariant and the method. The control-arm method is promoted out of that dated plan because `AGENTS.md` itself says a plan goes stale once its work lands. Carries the two build traps that silently void an experiment (`-pl` without `-am`; `surefire:test` not reprocessing test resources).
- **Ambient probe correction** (`AGENTS.md`). It told agents `probe clean` means the fault is in the test. Lag stagnation needs 50 records of lag sustained past 150s; rebalance dwell needs 15s. On a 15-record test that fails in 35s neither detector *can* fire, so the verdict is vacuous - and it was read as a finding here.
- **Ledger** (`docs/inflight/`). `commitTimeout` reclassified out of the load-tightness family, with the warning aimed at `produceTimeout` and the other members still listed.
- **Solution write-up** (`docs/solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md`). Promotes the analysis out of the ledger, the same path the drain zombie and the nudge race took once understood. Its most useful section is the seven plausible readings that were wrong and why. The ledger entry shrank to the classification and its warning, pointing here for the mechanism, so the two cannot drift.

Cross-linked to `vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md` as a **sibling rule, not the same one**: that hazard is an await satisfied too early by a vacuous condition (a false pass), this one is an await whose trigger never fires (a false fail). Neither fix would have solved the other, so they stay separate rather than being merged.

### Prior art, and how it was searched

The original investigation searched open PRs, which is a *collision* check - the PR that already solved something in your file is by definition merged. Searching **merged PRs by the files they touch** (not by title keywords - a PR that fixed the same class rarely describes the same symptom) found three that mattered and that no symptom search would surface: **astubbs#110**, the sibling flake on this same `producerTransactionLock` fixed four days earlier and the origin of the control-arm method; **astubbs#86**, which introduced the ambient probe whose verdict this work had to qualify; and **astubbs#98**, the backpressure test that only passed by racing its own setup. That lesson is now a rule in `AGENTS.md`, alongside a pre-merge step to look for other instances of the defect class.

That sweep ran. Its most useful result is a **negative**: `TransactionTimeoutsTest.produceTimeout` - same file, same lock, still listed as an open flake - is **not** an instance, because it latches its trigger and keeps a real margin. The write-up says so explicitly, so nobody "fixes" it the way `commitTimeout` was fixed. Two relatives that are also not this defect (`DrainCloseTest`, `RetriesTest`) are named, along with what was checked and dismissed.

### One open product-code question, recorded not fixed

Everything else here is test or docs. This is the exception, and the only item that touches main-code correctness, so it should not be skimmed past.

In transactional poll-and-produce, **two paths release the same `ProducingLock` on the same worker thread** - `WorkContainer#onPostAddToMailBox` and `cleanUpContext`'s `finally` - and nothing clears `PollContextInternal#producingLock` between them. A second `unlock()` by a thread holding zero read locks should throw `IllegalMonitorStateException`. It doesn't, and nobody has established why.

It was raised and deliberately not chased in `docs/plans/2026-08-03-001-investigate-transactional-commit-flake.md` §11, where the attempt to measure it was **void**: `surefire:test` does not reprocess test resources, so the debug logging never reached `target/test-classes`. Re-measured here with `-am verify`, which does: **340 acquires, 340 releases, 0 `IllegalMonitorStateException`**. Exactly 1:1, so no double release actually occurs and the "is it silently throwing" half is closed.

What stays open: *which* path is skipped and why, and whether that holds for the error, retry and stale-work branches, which were not separately measured. Recorded in `docs/inflight/bug-producing-lock-double-release.md` rather than fixed here - this lock enforces the EOS invariant and has already produced two problems, so a release path that is correct by accident rather than by construction is how the next one arrives.

### Also in this PR

- **`CONCEPTS.md`** (new) - shared domain vocabulary seeded from the area this work touched: the produce/commit lock pair and the rules for when each side may be taken, the parallel-consumption nouns those rules need, and the test-reliability vocabulary. Entries carry no file paths, class names, PR links or config values, so the file can't rot as the code moves. Its flagged-ambiguities tail records the distinction the whole investigation turned on - *stall*, *load-tightness flake* and *unforceable trigger* are three different things that present as the same red test. Indexed in `AGENTS.md`'s "Where things live" table.
- **`docs/solutions/workflow-issues/compound-tooling-breaks-in-worktrees-and-forks-…`** (new) - three ways the knowledge-capture tooling silently misreads this repo, all of which return a clean-looking result: a worktree's basename is not the repo name (a session search matched 0 where the correct name matched 37), a worktree has no repo-root config, and bare `gh` in a fork resolves upstream and reports "no pull requests found" for a branch that has one. That last one would downgrade a correct PR citation to "pending". Relevant here because `AGENTS.md` mandates worktrees and this is a fork with a live upstream, so both conditions hold on every run.

### Merge strategy

**Rebase-merge.** The branch has been **re-cut** for this: the original history recorded the order things were learned, not separable units - `AGENTS.md` was revised across five commits and the write-up across four, and two commit messages needed an "and also", which is the repo's own test for non-atomicity.

It is now nine commits in which **every file lands exactly once**, bar `AGENTS.md` - which appears four times as four *distinct ideas* (a taxonomy row, the investigation rules, a correction to the ambient-probe guidance, the pre-merge sweep), not four revisions of one. Each is independently revertable, which the old history was not: reverting the prior-art rule used to mean untangling a commit that also edited the write-up.

The re-cut was verified content-identical to the pre-re-cut tip (`git diff 4acbcdeb HEAD` empty), so history changed and content did not.

Squashing is the wrong call here: it would bury the only behaviour change - the test fix - under eight docs commits, and releases after 0.6.0.0 generate their notes from the commit log.

Rebased onto master after astubbs#219 landed (it had rewritten `AGENTS.md` and the flake ledger, which made this conflict; a conflicting PR has no merge ref, so only CodeQL could run).

## Checklist

- [x] Docs updated - `AGENTS.md` (investigation checklist, control-arm method, ambient-probe correction) and `docs/inflight/` (reclassification + new open-question entry)
- [x] Tests added/updated - `TransactionTimeoutsTest.commitTimeout` made deterministic, plus a guard verified by negative control
- [x] Title & body reflect the final content of this PR
- [x] N/A - touches no CI runners or workflows
