### PR TITLE
ci(issue-refs): check the PR body for unqualified references, not just the diff

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,11 @@
 <!-- What does this PR change, and why? Keep it in sync with the actual content as the PR evolves. -->
 
+<!-- Issue references in this body are checked by the same gate as the diff: below the threshold, a
+     reference must name its repo. Use the FULLY qualified form here - astubbs/parallel-consumer#NN
+     or confluentinc/parallel-consumer#NN - because it is the only one that both names the repo and
+     auto-links on GitHub, and the only one `Fixes`/`Closes` will act on. Fenced code blocks are
+     skipped, so pasted logs and command output are fine. -->
+
 ## Description
 
 ...

--- a/.github/scripts/issue-ref-gate.js
+++ b/.github/scripts/issue-ref-gate.js
@@ -17,6 +17,12 @@
 //     --jq '.[0].number'   # state=all matters: the ceiling is often a merged PR
 // `upstream-sweep.sh` warns when it gets thin - do not rely on noticing unaided.
 //
+// THE PR BODY IS IN SCOPE TOO, via prBodyEntry() below. The body is the surface a human actually
+// reads on GitHub, and a bare `#200` renders there as a working link to the wrong issue - the exact
+// failure this gate exists to prevent, on the one page where it is most visible. The gate already
+// trusts the body enough to accept a *bypass* from it (`issue-refs: N/A`), so "bodies are out of
+// scope" was never a principle, just an omission.
+//
 // Pulled out of the workflow so it can be unit tested; issue-ref-gate.test.js runs first in CI.
 
 // Below this, a reference is ambiguous and must name its repo. At or above it, only this fork has
@@ -110,6 +116,60 @@ function suspectRefs(files, opts = {}) {
   return out;
 }
 
+// What a PR-body hit is attributed to in the failure listing, where every other row is a file path.
+// Angle brackets cannot occur in a path, so this can neither collide with a real file nor be caught
+// by EXEMPT_PATHS, and an author reading `<PR body>: #857` knows at once that no file is at fault.
+const PR_BODY_LABEL = "<PR body>";
+
+// ``` or ~~~, optionally indented up to three spaces, per CommonMark.
+const FENCE = /^ {0,3}(`{3,}|~{3,})/;
+
+/**
+ * Presents a PR body to suspectRefs as if it were a diff, so the body is judged by the SAME rule as
+ * every file - NO SECOND COPY OF THE RULE. This is an adapter, not a rule: it decides which text is
+ * in scope, and suspectRefs still decides, alone, whether a piece of text is a violation.
+ *
+ * Two adaptations are needed, and both are about presentation rather than judgement:
+ *
+ * 1. EVERY LINE IS AN "ADDED" LINE. suspectRefs reads only `+` lines, because in a diff that is what
+ *    this PR is responsible for; the whole body is what this PR is responsible for. The prefix is
+ *    `"+ "` and not `"+"` so that a body line beginning `++` cannot become `+++`, which suspectRefs
+ *    skips as a diff file header - a one-character hole an author could otherwise fall into (or hide
+ *    in) without ever knowing it existed. The extra space is invisible downstream: hits are trimmed
+ *    before display. Lines starting `-` need no such care; they are only diff markers in a diff.
+ *
+ * 2. FENCED CODE BLOCKS ARE DROPPED. GitHub does not autolink inside a fence, so `#123` there is
+ *    literal text and cannot become the wrong link - the same reasoning by which stripQualified
+ *    already drops code spans. Bodies routinely quote logs, `gh` output and this gate's own failure
+ *    message, all of which are full of bare numbers. This lives here rather than in stripQualified
+ *    because being fenced is a property of a whole document: a patch shows disconnected fragments,
+ *    so no line-at-a-time rule over a diff can know. An UNCLOSED fence swallows the rest of the
+ *    body, which is precisely how GitHub renders it.
+ *
+ * @param body  the PR body, possibly null
+ * @returns { filename, patch } - one more entry for the files array suspectRefs already takes
+ */
+function prBodyEntry(body) {
+  if (!body) return { filename: PR_BODY_LABEL, patch: "" };
+
+  let fence = null;
+  const lines = body.split(/\r?\n/).map((line) => {
+    const m = line.match(FENCE);
+    if (fence) {
+      // A closing fence is the same character, at least as long as the opening one.
+      if (m && m[1][0] === fence[0] && m[1].length >= fence.length) fence = null;
+      return "+";
+    }
+    if (m) {
+      fence = m[1];
+      return "+";
+    }
+    return "+ " + line;
+  });
+
+  return { filename: PR_BODY_LABEL, patch: lines.join("\n") };
+}
+
 /**
  * The single copy of what an author is told when the gate fires. Both callers render this - the CI
  * job in pr-checklist.yml and the local bin/check-issue-refs.sh - so the two cannot tell different
@@ -120,14 +180,27 @@ function suspectRefs(files, opts = {}) {
  *
  * @param hits  [{ file, ref, text }] from suspectRefs
  * @param opts  { repo }        owner/name used in the mirror-lookup hint
- *              { readsPrBody } false when the caller cannot honour the "issue-refs: N/A" opt-out
+ *              { readsPrBody } false when the caller has no PR body: it can neither honour the
+ *                              "issue-refs: N/A" opt-out nor scan the body for references
  * @returns string
  */
 function formatFailure(hits, opts = {}) {
   const repo = opts.repo ?? "astubbs/parallel-consumer";
   const optOutTail = opts.readsPrBody === false
-    ? "line in the PR body - the workflow honours that opt-out; this script does not read the PR body."
+    ? "line in the PR body - the workflow honours that opt-out, and also scans the body itself;\n" +
+      "this script does not read the PR body, so it does neither."
     : "line in the PR body.";
+
+  // The advice above is right for a file and incomplete for the body, because the body is rendered
+  // by GitHub: `astubbs#NN` satisfies this gate but is NOT cross-reference syntax, so it renders as
+  // plain text and the body silently loses the link it had. An author told only "name the repo"
+  // trades a wrong link for no link, which is not the trade this rule is asking for.
+  const bodyNote = hits.some((h) => h.file === PR_BODY_LABEL)
+    ? "\nIn the PR BODY, use the FULLY qualified form - `astubbs/parallel-consumer#NN` or\n" +
+      "`confluentinc/parallel-consumer#NN`. It is the only form that both names the repo and still\n" +
+      "auto-links on GitHub; `astubbs#NN` passes this gate but renders as plain text there. The same\n" +
+      "goes for closing keywords: `Fixes astubbs#NN` closes nothing.\n"
+    : "";
 
   return (
     `${hits.length} reference(s) below #${QUALIFY_BELOW} do not say which repo they mean.\n` +
@@ -138,11 +211,14 @@ function formatFailure(hits, opts = {}) {
     "Every confluentinc issue is mirrored here, and the mirror is usually the better number to cite:\n" +
     `  gh issue list -R ${repo} --label upstream-mirror --search "confluentinc#NN"\n` +
     'If a flagged reference genuinely needs no qualifier, put "issue-refs: N/A - <reason>" on its own\n' +
-    `${optOutTail}\n\n` +
+    `${optOutTail}\n` +
+    bodyNote +
+    "\n" +
     hits.map((h) => `  ${h.file}: ${h.ref}  ${h.text}`).join("\n")
   );
 }
 
 module.exports = {
-  suspectRefs, findOptOut, isExempt, stripQualified, formatFailure, EXEMPT_PATHS, QUALIFY_BELOW,
+  suspectRefs, findOptOut, isExempt, stripQualified, formatFailure, prBodyEntry,
+  EXEMPT_PATHS, QUALIFY_BELOW, PR_BODY_LABEL,
 };

--- a/.github/scripts/issue-ref-gate.js
+++ b/.github/scripts/issue-ref-gate.js
@@ -121,8 +121,10 @@ function suspectRefs(files, opts = {}) {
 // by EXEMPT_PATHS, and an author reading `<PR body>: #857` knows at once that no file is at fault.
 const PR_BODY_LABEL = "<PR body>";
 
-// ``` or ~~~, optionally indented up to three spaces, per CommonMark.
-const FENCE = /^ {0,3}(`{3,}|~{3,})/;
+// ``` or ~~~, optionally indented up to three spaces, per CommonMark. Group 1 is the delimiter run,
+// group 2 the rest of the line: the info string on an opening fence, and on a closing fence the
+// thing CommonMark does not permit at all.
+const FENCE = /^ {0,3}((?:`{3,})|(?:~{3,}))(.*)$/;
 
 /**
  * Presents a PR body to suspectRefs as if it were a diff, so the body is judged by the SAME rule as
@@ -144,7 +146,10 @@ const FENCE = /^ {0,3}(`{3,}|~{3,})/;
  *    message, all of which are full of bare numbers. This lives here rather than in stripQualified
  *    because being fenced is a property of a whole document: a patch shows disconnected fragments,
  *    so no line-at-a-time rule over a diff can know. An UNCLOSED fence swallows the rest of the
- *    body, which is precisely how GitHub renders it.
+ *    body, which is precisely how GitHub renders it. The open/close rules are CommonMark-exact
+ *    rather than approximate - see the two comments in the loop for which direction each one
+ *    fails in, and why "close enough" is not good enough for a rule whose entire premise is that a
+ *    plausible-looking wrong answer is worse than an obviously wrong one.
  *
  * @param body  the PR body, possibly null
  * @returns { filename, patch } - one more entry for the files array suspectRefs already takes
@@ -156,11 +161,22 @@ function prBodyEntry(body) {
   const lines = body.split(/\r?\n/).map((line) => {
     const m = line.match(FENCE);
     if (fence) {
-      // A closing fence is the same character, at least as long as the opening one.
-      if (m && m[1][0] === fence[0] && m[1].length >= fence.length) fence = null;
+      // A closing fence is the same character, at least as long as the opening run, and CommonMark
+      // allows it to "be followed only by spaces or tabs". So "``` see the note" does NOT close the
+      // block: GitHub goes on rendering the following lines as code, where nothing auto-links.
+      // Treating it as a closer resumed scanning early and flagged text no reader ever sees as a
+      // link - plausible, wrong, and quiet, which is the shape of failure this gate exists to end.
+      if (m && m[1][0] === fence[0] && m[1].length >= fence.length && /^[ \t]*$/.test(m[2])) {
+        fence = null;
+      }
       return "+";
     }
-    if (m) {
+    // The opening side has its own CommonMark rule, and it is the side that matters more: a BACKTICK
+    // fence may not carry a backtick in its info string, so "```a`b" opens nothing. Accepting it
+    // would drop the lines after it - and those lines DO auto-link on GitHub, so the miss would be
+    // silent. Erring toward "not a fence" here is erring toward flagging, which is the safe way
+    // round. A tilde fence has no such restriction.
+    if (m && !(m[1][0] === "`" && m[2].includes("`"))) {
       fence = m[1];
       return "+";
     }

--- a/.github/scripts/issue-ref-gate.test.js
+++ b/.github/scripts/issue-ref-gate.test.js
@@ -256,6 +256,26 @@ check("fence closing follows the opening fence's character and length", () => {
                          "nor does the other fence character");
 });
 
+// CommonMark lets a closing fence be followed "only by spaces or tabs". Accepting a closer with
+// trailing content closed the block earlier than GitHub does, so lines GitHub still renders as code
+// were scanned and flagged - a reference a reader never sees as a link. Raised in review on
+// astubbs#221 and fixed there.
+check("a closing fence with trailing content does not close the block", () => {
+  assert.deepStrictEqual(suspectRefs(body("```", "#857", "``` see the note", "#29 still fenced")),
+                         [], "trailing content means it is not a closer, so the block stays open");
+  assert.deepStrictEqual(suspectRefs(body("```", "#857", "```  \t", "and #29")).map((h) => h.ref),
+                         ["#29"], "spaces and tabs after the run are allowed, so this one closes");
+});
+
+// The opening side, which fails in the direction that actually costs something: treating a non-fence
+// as a fence drops lines GitHub DOES auto-link, and drops them silently.
+check("a backtick fence whose info string contains a backtick opens nothing", () => {
+  assert.deepStrictEqual(suspectRefs(body("```a`b", "#857 is prose here")).map((h) => h.ref),
+                         ["#857"]);
+  assert.deepStrictEqual(suspectRefs(body("~~~a`b", "#857")), [],
+                         "a tilde fence carries no such restriction");
+});
+
 check("an unclosed fence swallows the rest of the body, exactly as GitHub renders it", () => {
   assert.deepStrictEqual(
     suspectRefs(body("before #29", "```", "#857 and everything after")).map((h) => h.ref), ["#29"]);

--- a/.github/scripts/issue-ref-gate.test.js
+++ b/.github/scripts/issue-ref-gate.test.js
@@ -2,10 +2,14 @@
 // broken rule fails loudly rather than silently passing - or failing - every PR.
 const assert = require("assert");
 const {
-  suspectRefs, findOptOut, isExempt, stripQualified, formatFailure, QUALIFY_BELOW,
+  suspectRefs, findOptOut, isExempt, stripQualified, formatFailure, prBodyEntry,
+  QUALIFY_BELOW, PR_BODY_LABEL,
 } = require("./issue-ref-gate.js");
 
 const file = (filename, ...added) => [{ filename, patch: added.map((l) => "+" + l).join("\n") }];
+
+// A PR body, as the workflow feeds it in: one synthetic entry alongside the real files.
+const body = (...lines) => [prBodyEntry(lines.join("\n"))];
 
 let run = 0;
 function check(name, fn) {
@@ -175,6 +179,119 @@ check("opt-out is recognised, and needs a reason", () => {
   assert.ok(!findOptOut("issue-refs: N/A"), "bare N/A without a reason must not count");
 });
 
+// ---------------------------------------------------------------------------------------------
+// The PR body, which reaches the rule as a synthetic file rather than through a path of its own.
+// These pin the ADAPTER - which text reaches suspectRefs - rather than re-testing the rule; the
+// point of feeding the body through suspectRefs is that everything above already covers the rule.
+// ---------------------------------------------------------------------------------------------
+
+check("a bare ref in the PR body is flagged, and attributed to the body rather than a file", () => {
+  const hits = suspectRefs(body("This carries the fix for #123."));
+  assert.deepStrictEqual(hits.map((h) => h.ref), ["#123"]);
+  assert.strictEqual(hits[0].file, PR_BODY_LABEL);
+  assert.strictEqual(hits[0].text, "This carries the fix for #123.",
+                     "the prefix used to present the body as a diff must not leak into the report");
+});
+
+check("the body label cannot be an exempt path, and cannot be mistaken for one", () => {
+  assert.ok(!isExempt(PR_BODY_LABEL), PR_BODY_LABEL + " must not match EXEMPT_PATHS");
+  assert.ok(/[<>]/.test(PR_BODY_LABEL), "must contain a character no file path can");
+});
+
+check("a qualified ref in the PR body is not flagged", () => {
+  for (const s of ["Fixes astubbs/parallel-consumer#123.",
+                   "astubbs#123 mirrors confluentinc#857",
+                   "carried in confluentinc PR #548",
+                   "see [#233](https://github.com/confluentinc/parallel-consumer/issues/233)",
+                   "the literal `#857` marker"]) {
+    assert.deepStrictEqual(suspectRefs(body(s)), [], s);
+  }
+});
+
+check("a NOT_A_REF construct in the PR body is not flagged", () => {
+  assert.deepStrictEqual(suspectRefs(body("This changes {@link #close()} handling.")), []);
+  assert.deepStrictEqual(suspectRefs(body("It reworks #poll( and its callers.")), []);
+});
+
+check("the threshold applies in the PR body exactly as it does in a file", () => {
+  assert.deepStrictEqual(suspectRefs(body("Tracking issue: #1042.")), []);
+  assert.deepStrictEqual(suspectRefs(body("and #999 is still ambiguous")).map((h) => h.ref),
+                         ["#999"]);
+});
+
+// The workflow checks the opt-out BEFORE it calls suspectRefs, so a body that opts out skips the
+// whole gate - itself included. Both halves are pinned: the body would otherwise fail, and the
+// opt-out is what stops it mattering.
+check("the opt-out still skips the whole gate, body included", () => {
+  const b = "Depends on #205.\nissue-refs: N/A - that is a PR number in this repo, not an issue";
+  assert.ok(suspectRefs(body(b)).length > 0, "the body alone would fail");
+  assert.ok(findOptOut(b), "and the opt-out must short-circuit the gate before it does");
+});
+
+// GitHub does not autolink inside a fence, so a number there cannot become the wrong link - the
+// same reasoning by which stripQualified already drops code spans. Bodies quote logs, `gh` output
+// and this gate's own failure message, every one of them full of bare numbers.
+check("a fenced code block in the body is out of scope", () => {
+  assert.deepStrictEqual(
+    suspectRefs(body("Gate output:", "```", "  docs/x.md: #857  See #857", "```")), []);
+  assert.deepStrictEqual(suspectRefs(body("~~~text", "#857", "~~~")), []);
+  assert.deepStrictEqual(suspectRefs(body("```console", "$ gh issue view 857  # was #857", "```")),
+                         []);
+  assert.deepStrictEqual(suspectRefs(body("   ```", "#857", "   ```")), [],
+                         "a fence indented up to three spaces is still a fence");
+});
+
+check("prose after a fence closes is scanned again", () => {
+  assert.deepStrictEqual(
+    suspectRefs(body("```", "#857 inside", "```", "and #29 outside")).map((h) => h.ref), ["#29"]);
+});
+
+check("fence closing follows the opening fence's character and length", () => {
+  assert.deepStrictEqual(
+    suspectRefs(body("```", "#857", "````", "and #29")).map((h) => h.ref), ["#29"],
+    "a longer run of the same character closes the block");
+  assert.deepStrictEqual(suspectRefs(body("````", "#857", "```", "and #29")), [],
+                         "a shorter run does not close it");
+  assert.deepStrictEqual(suspectRefs(body("```", "#857", "~~~", "and #29")), [],
+                         "nor does the other fence character");
+});
+
+check("an unclosed fence swallows the rest of the body, exactly as GitHub renders it", () => {
+  assert.deepStrictEqual(
+    suspectRefs(body("before #29", "```", "#857 and everything after")).map((h) => h.ref), ["#29"]);
+});
+
+// A body is not a diff, but suspectRefs reads it as one. `++` is the trap: prefixing with a bare
+// "+" would produce "+++", which suspectRefs skips as a diff file header - silently exempting the
+// line, and handing anyone who noticed a way to hide a reference. Checklist items make `-` routine.
+check("body lines that look like diff markers are still scanned", () => {
+  for (const line of ["++ an asciidoc passthrough mentioning #857",
+                      "+++ #857",
+                      "+ #857",
+                      "- [ ] Docs updated for #857",
+                      "--- #857"]) {
+    assert.deepStrictEqual(suspectRefs(body(line)).map((h) => h.ref), ["#857"], line);
+  }
+});
+
+check("a CRLF body - what the API actually returns - splits into lines correctly", () => {
+  assert.deepStrictEqual(
+    suspectRefs([prBodyEntry("intro\r\n```\r\n#857\r\n```\r\nand #29")]).map((h) => h.ref), ["#29"]);
+});
+
+check("an absent or empty body contributes nothing", () => {
+  for (const b of [null, undefined, ""]) {
+    assert.strictEqual(prBodyEntry(b).patch, "");
+    assert.deepStrictEqual(suspectRefs([prBodyEntry(b)]), []);
+  }
+});
+
+check("the body is judged alongside the files, in the one call the workflow makes", () => {
+  const input = [...file("docs/x.md", "See #857 here."), prBodyEntry("and #29 in the body")];
+  assert.deepStrictEqual(suspectRefs(input).map((h) => `${h.file}: ${h.ref}`),
+                         ["docs/x.md: #857", `${PR_BODY_LABEL}: #29`]);
+});
+
 // The failure message is shared by the CI gate and bin/check-issue-refs.sh. Two hand-written copies
 // drifted apart within hours, so these pin the parts that made them disagree.
 const HITS = [{ file: "docs/x.md", ref: "#857", text: "See #857" }];
@@ -210,7 +327,27 @@ check("formatFailure takes the repo from its caller, and defaults to the fork", 
 
 check("the opt-out tail matches whether the caller can read the PR body", () => {
   assert.ok(!formatFailure(HITS).includes("does not read the PR body"));
-  assert.ok(formatFailure(HITS, { readsPrBody: false }).includes("does not read the PR body"));
+  const local = formatFailure(HITS, { readsPrBody: false });
+  assert.ok(local.includes("does not read the PR body"));
+  // CI now scans the body as well as honouring the opt-out from it, so a caller with no body is
+  // missing both. A tail naming only the opt-out would understate what the local run cannot see.
+  assert.ok(local.includes("scans the body itself"), "must say CI reads the body for references too");
+});
+
+check("a body hit reads as the body in the failure listing", () => {
+  const msg = formatFailure([{ file: PR_BODY_LABEL, ref: "#857", text: "Fixes #857" }]);
+  assert.ok(msg.includes(`  ${PR_BODY_LABEL}: #857  Fixes #857`), msg);
+});
+
+// The headline advice ("write astubbs#NN") is right for a file and a trap in the body: that form is
+// not cross-reference syntax, so GitHub renders it as plain text and the body loses its link. An
+// author who follows the message literally would trade a wrong link for no link.
+check("a body hit adds the fully-qualified advice; a file-only failure does not", () => {
+  const bodyMsg = formatFailure([{ file: PR_BODY_LABEL, ref: "#857", text: "Fixes #857" }]);
+  assert.ok(bodyMsg.includes("`astubbs/parallel-consumer#NN`"), "must name the auto-linking form");
+  assert.ok(bodyMsg.includes("closes nothing"), "must warn that Fixes astubbs#NN closes nothing");
+  assert.ok(!formatFailure(HITS).includes("In the PR BODY"),
+            "a failure with no body hit must not carry body-only advice");
 });
 
 check("every hit is listed, with its count in the first line", () => {

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -115,7 +115,14 @@ jobs:
       # Deliberately narrow: added lines only, and the files in EXEMPT_PATHS are skipped because a
       # bare number legitimately means confluentinc there. A naive sweep rewrote three of them
       # wrongly, which is why they are named in the gate module rather than left to judgement.
-      - name: Verify issue references name their repo
+      #
+      # THE PR BODY IS CHECKED TOO. It is the surface humans actually read, and a bare `#200` renders
+      # there as a working link to the wrong issue - the failure mode this gate exists for, on its
+      # most visible page. `gate.prBodyEntry` presents the body to the SAME suspectRefs call as a
+      # synthetic file, so there is no second copy of the matching rule; it only drops fenced code
+      # blocks, which GitHub does not autolink. The `edited` trigger above already re-runs this job
+      # when a body changes, so a body-only fix does not need a push.
+      - name: Verify issue references name their repo (diff and PR body)
         uses: actions/github-script@v7
         with:
           script: |
@@ -135,9 +142,10 @@ jobs:
               ...context.repo, pull_number: pr.number, per_page: 100,
             });
 
-            const hits = gate.suspectRefs(files);
+            const hits = gate.suspectRefs([...files, gate.prBodyEntry(pr.body)]);
             if (hits.length === 0) {
-              core.info(`No unqualified references below #${gate.QUALIFY_BELOW} on added lines.`);
+              core.info(
+                `No unqualified references below #${gate.QUALIFY_BELOW} on added lines or in the PR body.`);
               return;
             }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,7 @@ stack traces (see Testing).
   (which runs from `claude.yml`, unmodified, so it validates), or split the workflow edit into its
   own PR. Do not disable the gate to get a green check.
 - **`.github/workflows/repo-hygiene.yml`** — "Repo Hygiene", on every push/PR plus dispatch. Two independent jobs. `sigpipe` runs `bin/check-shell-sigpipe.sh` (its own self-test first) to catch a `bin/*.sh` piping into `grep -q` under `pipefail`, which silently inverts the script's answer. `actions` runs `bin/check-action-versions.sh`, keeping every GitHub Action pinned to a single version across all workflows. Neither gates the build - they exist because the failures they catch are invisible rather than loud.
-- **`.github/workflows/check-dependencies.yml`** — "PR Dependency Check". Reads `depends on #N` lines from the PR body and blocks the child until every parent has merged. Produces the **required** check `Check PR Dependencies`, so a stacked PR cannot merge out of order. See [PR Discipline](#pr-discipline) for the syntax.
+- **`.github/workflows/check-dependencies.yml`** — "PR Dependency Check". Reads `depends on astubbs/parallel-consumer#N` lines from the PR body and blocks the child until every parent has merged. Produces the **required** check `Check PR Dependencies`, so a stacked PR cannot merge out of order. See [PR Discipline](#pr-discipline) for the syntax.
 - **`.github/workflows/cancel-closed-pr-runs.yml`** — Cancels a PR's in-flight runs when it closes, so a withdrawn PR stops occupying runners. Housekeeping only; gates nothing.
 - **Self-hosted lanes** (see [`docs/SELF_HOSTED_RUNNER.md`](docs/SELF_HOSTED_RUNNER.md)). None of these gate merging - they are for speed and for work too heavy for a 2-core hosted runner. All are **skipped for PRs from forks** (`head.repo.full_name == github.repository`), because a fork PR must never run on our own hardware.
   **`highcpu` is the only self-hosted label** - six runners, all online. Declare labels in [`.github/actionlint.yaml`](.github/actionlint.yaml) or actionlint flags them.
@@ -366,7 +366,9 @@ is posted in.
 `Fixes #167` or `Fixes astubbs/parallel-consumer#167` - the `owner#NN` short form this section
 otherwise prefers is **not** cross-reference syntax, so `Fixes astubbs#167` renders as plain text and
 closes nothing. A bare number is what the convention above forbids, so in a PR body write the fully
-qualified form: `Fixes astubbs/parallel-consumer#167`.
+qualified form: `Fixes astubbs/parallel-consumer#167` - the one form that closes the issue, names the
+repo and auto-links. The gate reads PR bodies, so the other two spellings now fail it rather than
+failing silently.
 
 At or above #1000 a bare number is unambiguous, because only this fork can have one.
 
@@ -377,11 +379,11 @@ fix. The script applies the same rule as the gate, because it calls the same
 from CI. It judges the working tree, like `bin/check-copyright-headers.sh`, so uncommitted edits are
 caught too. Only lines you *add* are scanned; pre-existing bare refs in a file you touch are fine.
 
-The *inputs* can differ in one narrow case, and only in the safe direction: CI reads patches from
-GitHub's `pulls.listFiles`, which omits `patch` for a very large diff, and the gate skips a file it
-cannot see - while the local script builds its own patch with `git diff` and still checks it. So a
-green local run is not a promise that CI has looked at every file, but a red one is always real. It
-can flag something CI would silently pass; it cannot pass something CI would flag.
+The *inputs* differ in two narrow ways. CI reads patches from GitHub's `pulls.listFiles`, which omits
+`patch` for a very large diff, and the gate skips a file it cannot see - while the local script
+builds its own patch with `git diff` and still checks it. And CI additionally scans the **PR body**,
+which does not exist when you run the script. So a green local run promises neither that CI looked at
+every file nor that the description passes; a red one is always real.
 That holds only while confluentinc's numbering stays below 1000 - it is dormant rather than
 archived, so it still creeps. Measure the headroom rather than trusting a figure written here:
 `gh api 'repos/confluentinc/parallel-consumer/issues?state=all&per_page=1&sort=created&direction=desc' --jq '.[0].number'` -
@@ -422,9 +424,22 @@ amiss.
 What it checks is that a reference *names* a repo, not that it names the right one: `astubbs#857`
 passes the gate and is still wrong. Resolve the number in both repos before you write it.
 
+**The PR body is in scope too, and it is the one place the fully qualified form is mandatory.** The
+body is the surface people actually read on GitHub, and a bare `#200` renders there as a *working*
+link to the wrong issue - the exact failure the gate exists to prevent, on its most visible page. So
+write `astubbs/parallel-consumer#NN` or `confluentinc/parallel-consumer#NN` in a description: the
+short `astubbs#NN` satisfies the gate but is not cross-reference syntax, so GitHub renders it as
+plain text and the body loses the link it would otherwise have had. Same for closing keywords -
+`Fixes astubbs#167` closes nothing. This is not a second rule: the body is fed to the same
+`suspectRefs` as a synthetic entry (`prBodyEntry`), attributed as `<PR body>` in the failure. Fenced
+code blocks in the body are skipped, because GitHub does not auto-link inside one either, so a
+pasted log or a quoted gate failure is not a violation. Editing the body re-runs the job, so a fix
+there needs no push.
+
 The files listed in `EXEMPT_PATHS` are exempt, because a bare number legitimately means upstream in them: `CHANGELOG.adoc`,
 `upstream-map.yaml`, `upstream-pr-analysis.adoc`, and the gate's own test fixtures. If a flagged
-reference really is fork-local, put `issue-refs: N/A - <reason>` on its own line in the PR body.
+reference really is fork-local, put `issue-refs: N/A - <reason>` on its own line in the PR body -
+which skips the body's own references along with everything else.
 Logic and tests live in `.github/scripts/issue-ref-gate.js` and `issue-ref-gate.test.js`.
 
 **`Fixes #NNN` only closes on PRs targeting the default branch.** Discovered on astubbs#29, which targeted
@@ -493,7 +508,7 @@ Keep the existing subject convention for *upstream* references (`... (#893)`, `c
 - **Open PRs from the template and complete its checklist honestly.** `.github/PULL_REQUEST_TEMPLATE.md` is NOT auto-applied when a PR is created non-interactively (e.g. `gh pr create --body-file`), so base the PR body on it and resolve every box: check it `[x]`, or mark it `N/A - <reason>`. For human-authored PRs the `PR Checklist` CI gate (`.github/workflows/pr-checklist.yml`) fails when the checklist is missing entirely *or* when any box is left unchecked without an `N/A` - so dropping the template is not a bypass. Only real bot authors (GitHub user type `Bot`, e.g. Dependabot/Renovate) are exempt.
 - **Respond to review comments IN-THREAD and resolve the thread when addressed.** Reply to the specific review comment (its own thread), NOT as a separate top-level PR comment - a summary comment leaves the original conversation unresolved and blocks merge on "unresolved conversations." When a finding is fixed, reply in-thread with the fix + commit SHA and mark the thread resolved (`gh api graphql ... resolveReviewThread`). Leave a thread open only when it genuinely needs the author's decision, and say so in the reply.
 - **After opening a PR, follow up on the duplication reports.** The duplicate-code and file-similarity checks post comments flagging new clones/similarity. Read them, remove duplication introduced by *this* PR before it merges; ignore clones that already existed on the base branch (out of scope for this PR).
-- **Stacked PRs: put `depends on #N` in the description** (one line per parent). The PR-dependency gate blocks the child from merging until the parent does; keep the list current if the chain changes.
+- **Stacked PRs: put `depends on astubbs/parallel-consumer#N` in the description** (one line per parent). The PR-dependency gate blocks the child from merging until the parent does; keep the list current if the chain changes. Write the **owner/repo** form, not the bare `depends on #N` the action also accepts: the issue-reference gate reads the body too, and a bare number below the threshold fails it. Both forms are equally understood by `dependencies-action` (`partialLinkRegex`), so nothing is lost.
 
 ## Releasing
 

--- a/bin/check-issue-refs.sh
+++ b/bin/check-issue-refs.sh
@@ -23,12 +23,16 @@
 # judged too, so you find out before `git commit`, not after `git push`. CI necessarily sees only
 # what you pushed.
 #
-# WHERE IT CAN DISAGREE WITH CI, and why that is safe. The rule is shared, but the input is not: CI
-# reads patches from GitHub's `pulls.listFiles`, which omits `patch` on a very large diff, and the
-# gate skips a file it cannot see. This script builds its own patch with `git diff`, so it still
-# checks that file. The divergence is one-directional - this can flag something CI would silently
-# pass, never the reverse - so a red result here is always real, while a green one is not a promise
-# that CI examined every file.
+# WHERE IT CAN DISAGREE WITH CI. The rule is shared, but the input is not, in two ways:
+#
+#   * CI reads patches from GitHub's `pulls.listFiles`, which omits `patch` on a very large diff, and
+#     the gate skips a file it cannot see. This script builds its own patch with `git diff`, so it
+#     still checks that file - it flags something CI would silently pass.
+#   * CI also scans the PR BODY (`gate.prBodyEntry`), which does not exist yet when you run this. So
+#     a bare `#NN` written into the description is CI's to catch, and this cannot pre-empt it.
+#
+# So a red result here is always real, but a green one promises neither that CI examined every file
+# nor that the description you have not written yet will pass.
 #
 # Usage: bin/check-issue-refs.sh [base-ref]      (default base: origin/master, else master)
 # Exit codes: 0 = clean, 1 = unqualified refs found,


### PR DESCRIPTION
<!-- What does this PR change, and why? Keep it in sync with the actual content as the PR evolves. -->

## Description

The issue-reference gate checks the diff. It does not check the PR body - which is the one surface where an unqualified reference is not merely ambiguous but is **rendered as a working link to the wrong issue**.

That is exactly the failure the gate was built to prevent. Its own header puts it best:

> A wrong link that resolves is worse than a broken one, because nothing looks amiss.

The fork's numbers sit entirely inside confluentinc's range, so a bare `#200` in a description autolinks - to this fork's ManagedTruth docs issue - while the author meant confluentinc's shared-nothing architecture issue. Nothing about the rendered body looks wrong. A file at least has to be opened; a description is read by everyone who opens the PR.

And "bodies are out of scope" was never a position this gate actually held: it already reads `pr.body` to honour the `issue-refs` opt-out. It trusted the body enough to accept a **bypass** from it, and not enough to check it. This PR closes that.

## The design constraint: no second copy of the rule

`prBodyEntry(body)` hands the body to the **existing** `suspectRefs` as one more `{ filename, patch }` entry, so the matching regexes, the `NOT_A_REF` constructs, `stripQualified` and the threshold all stay in one place. The workflow's call becomes:

```js
const hits = gate.suspectRefs([...files, gate.prBodyEntry(pr.body)]);
```

The boundary I held to: the adapter decides **what text is in scope**; `suspectRefs` remains the only thing that decides **whether text is a violation**. Nothing about matching moved into it.

### Judgement call 1 - the synthetic name is `<PR body>`

Angle brackets cannot occur in a path, so the name can neither collide with a real file nor be accidentally caught by `EXEMPT_PATHS`, and it reads correctly in the failure listing where every other row is a path:

```
  docs/x.md: #857  see #857
  <PR body>: #123  Closes #123.
```

An author sees at once that no file is at fault. There is a test asserting `isExempt` rejects it, so a future `EXEMPT_PATHS` entry cannot silently swallow the body.

### Judgement call 2 - lines are prefixed `"+ "`, not `"+"`

`suspectRefs` reads only added lines, and skips anything starting `+++` as a diff file header. A body line beginning `++` (an asciidoc passthrough, say) would become `+++` under a naive prefix and be **silently exempted** - a hole nobody would ever notice, and a hiding place for anyone who did. The extra space closes it, costs nothing (hits are trimmed before display) and needs no change to the shared code. Lines starting `-` need no such care - a leading dash only means anything inside a diff, and markdown checklist items make it common. All four shapes are covered by tests.

### Judgement call 3 - fenced code blocks are dropped, escaped hashes are not

GitHub does not autolink inside a fence, so a number there cannot become the wrong link. That is the same reasoning by which `stripQualified` already drops code spans - it is the existing rule applied consistently, not a new exception. It matters in practice: bodies quote logs, `gh` output, and this gate's own failure message, all full of bare numbers.

This lives in the adapter rather than in `stripQualified` because being fenced is a property of a **whole document**. A patch shows disconnected fragments, so no line-at-a-time rule over a diff could ever answer it. An unclosed fence swallows the rest of the body, which is precisely how GitHub renders one.

I deliberately did **not** add an escape hatch for a backslash-escaped hash, which renders as literal text and does not autolink. It also names no repo, so a reader still cannot tell which one is meant - the gate's actual purpose. Escaping is a way to dodge the wrong link, not a way to write a correct reference.

**The open and close rules are CommonMark-exact**, after a review finding on this PR (third commit). A closing fence may be followed only by spaces or tabs, so `` ``` see the note `` does not close a block - accepting it resumed scanning early and flagged text GitHub still renders as code, which is a false positive the author cannot see the cause of. Fixing that exposed the same class on the opening side, failing the *other* way: a backtick fence may not carry a backtick in its info string, so `` ```a`b `` opens nothing, and the old regex dropped every following line - lines that do autolink. Both directions are closed together rather than one traded for the other.

## The failure message now says something different for the body

The headline advice - write `astubbs#NN` - is right for a file and a trap in a description. `astubbs#NN` is not GitHub cross-reference syntax: it renders as plain text, so following the message literally trades a wrong link for **no link**, and `Fixes astubbs#167` closes nothing at all. When any hit is in the body, `formatFailure` adds a paragraph pointing at the fully qualified `astubbs/parallel-consumer#NN`, the only form that names the repo, autolinks, and works with closing keywords. Still one copy of the message, shared by CI and the local script.

## Fallout, found by running the new gate against 40 real PR bodies

- **`depends on #N`** for stacked PRs would now fail. Both AGENTS.md mentions switch to `depends on astubbs/parallel-consumer#N`. Verified against the pinned revision of `astubbs/dependencies-action`: its `partialLinkRegex` matches `owner/repo#N` identically, so nothing is lost by qualifying it.
- **`bin/check-issue-refs.sh` was claiming something no longer true** - that its divergence from CI is one-directional and "it cannot pass something CI would flag". CI now reads a body the local script cannot see. Corrected in the script header and in the matching AGENTS.md paragraph. Its behaviour is unchanged, and it keeps its `readsPrBody: false` message.

The script cannot check a body, so this rule is CI-only by construction. That is tolerable because the `edited` trigger already re-runs the job on a body change: fixing a flagged description costs an edit, not a push.

## Not done on purpose

- **HTML comments in the body are still scanned.** They are invisible when rendered, so a number in one is arguably a false positive, but multi-line comment tracking is more state for a case this repo's bodies do not exercise - the template's own comments carry no references. Left out rather than half-built.
- **No CHANGELOG entry.** AGENTS.md says a PR does not add one, and this is invisible to users.
- **Bot PRs stay exempt**, unchanged - the `pr.user.type === "Bot"` check runs first. That matters more than before: Dependabot bodies are full of upstream release-note numbers.

## Verification

- `node .github/scripts/issue-ref-gate.test.js` - green
- `node .github/scripts/changelog-ref-gate.test.js` - green
- `bash bin/check-issue-refs.sh` - clean across this branch
- `bin/todo-index.sh --check` and `bin/check-copyright-headers.sh` - clean
- Workflow YAML parses; step list unchanged apart from the renamed step
- Hand-checked the new path end to end: a body containing a bare number is flagged and attributed to the body; `astubbs#123`, `confluentinc#123`, `astubbs/parallel-consumer#167` and a fenced paste of the gate's own failure output are all clean; the real PR template is clean
- **This PR is its own first subject.** `pull_request` runs the gate from the merge ref, so the version in this branch judges this description
- The fence fix is verified by a **controlled experiment with matched control arms**, run against the workflow step's own script text extracted from the YAML rather than a paraphrase, comparing the pre-fix and post-fix module:

| body shape | before | after |
|---|---|---|
| invalid closer (trailing content) | FAIL | **PASS** |
| valid closer (control) | FAIL | FAIL |
| illegal opener (backtick in info) | PASS | **FAIL** |
| legal opener (control) | PASS | PASS |

Both terms under test flip and neither control moves, which is what rules out a wholesale loosening of when scanning resumes

New tests cover: a bare ref in the body flagged and attributed; qualified, linked and code-span forms accepted; a `NOT_A_REF` construct ignored; the threshold applying identically; the opt-out still short-circuiting a body that would otherwise fail; fences opened, closed, mismatched, indented and left unclosed; a closer with trailing content and an illegal backtick info string; the four diff-marker line shapes; CRLF bodies; an absent body; the body judged alongside files in one call; and both halves of the new failure-message paragraph.

## Merge strategy

**Rebase-merge as-is.** Three commits, already atomic and separately revertible: one changes behaviour (gate, tests, workflow), one syncs the documentation and the two conventions the new scope invalidates, and one fixes the fence state machine against CommonMark after review. None needs an "and also". The third is deliberately *not* squashed into the first: it is a correctness fix that should be revertible without taking the feature with it, and the review exchange that produced it is worth keeping legible in the log. Squashing would merge a CI change, a docs change and a bug fix for no gain; re-cutting has nothing to re-cut.

## Checklist

<!-- Keep this checklist and resolve EVERY box: tick it [x], or mark it "N/A - <reason>". The "PR Checklist"
     CI check fails a human PR when the checklist is missing entirely, or when a box has no [x] and no N/A. -->

- [x] Docs updated - AGENTS.md gains the PR-body scope under "A CI gate enforces this", the closing-keyword note now says the qualified form is enforced rather than merely advised, both `depends on` mentions are qualified, the `bin/check-issue-refs.sh` header's divergence claim is corrected, and the PR template carries the rule where bodies are actually written.
- [x] Tests added/updated - `issue-ref-gate.test.js` gains a PR-body section covering the adapter, the fence state machine in both directions, the diff-marker traps, and the new failure-message paragraph. Suite green.
- [x] Title & body reflect the final content of this PR
- [x] Self-hosted runner / security implications considered - this edits `.github/workflows/pr-checklist.yml`, which runs on `ubuntu-latest`, not a self-hosted runner. No permissions change: the body comes from the existing `context.payload.pull_request`, so no new API call and no new scope. The body is untrusted input, and it is only ever pattern-matched and echoed into a failure message - never executed, never interpolated into a shell command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
