### PR TITLE
docs: add STRATEGY.md, and re-source the Share Groups comparison from KIP-932

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ owned that content all along.)
 | Document | Owns | Explicitly NOT for |
 |---|---|---|
 | **`AGENTS.md`** (this file) | Conventions, build/test commands, and the rules agents must follow | Work items of any kind |
+| **`STRATEGY.md`** (repo root) | What the product is and why: the target problem, the guiding choice to solve it client-side, who it is for, the metrics that would show the approach working, and the tracks under investment | A roadmap, a schedule, or a feature list. It is a *claims* document that nothing tests, so work which falsifies one of its claims has to update it - the open branches that will are named in `docs/inflight/pr-strategy-doc-merge-triggers.md` |
 | **`docs/inflight/`** | *Transient* cross-branch state, **one file per item**, named `<category>-<slug>.md` (`bug-`, `test-`, `ci-`, `deps-`, `pr-`, `branch-`, `release-`, `parked-`, `next-`). Rules in [`docs/inflight/AGENTS.md`](docs/inflight/AGENTS.md) | A backlog. A file is deleted when its work lands - and **never** a committed index file, which every PR would edit |
 | **`docs/refactoring.md`** | The deferred-work backlog: internal refactors grouped by file, **breaking changes queued for the next major** in their own release-gated section, and the **triage of `TODO`/`FIXME`/`XXX` markers** | In-flight work; anything already started |
 | **`docs/TODO_INDEX.md`** | Generated inventory of every marker in the tree (`bin/todo-index.sh`, `--check` fails when stale) | Priorities - it is deliberately unsorted; triage goes in `refactoring.md` |

--- a/README.adoc
+++ b/README.adoc
@@ -85,10 +85,46 @@ The Kafka landscape has shifted since this library's 2021 stable release. *KIP-9
 
 The two are not strict alternatives -- they solve different problems.
 
+=== How they differ
+
+[cols="1,2,2", options="header"]
+|===
+| | Share Groups | Parallel Consumer
+
+| Ordering
+| None guaranteed. Records in a share-partition "can be delivered out of order to a consumer, in particular when redeliveries occur", and only offsets *within a single batch* ascend -- there are "no guarantees about the ordering of offsets between different batches"
+| Per key, per partition, or unordered -- your choice. See <<ordering-guarantees,Ordering Guarantees>>
+
+| Exactly-once
+| Not supported. There is no transactional read-process-write for share consumers
+| Supported. Produced records and their source offsets commit as one atomic transaction -- see <<transaction-system,the EoS transaction model>>
+
+| Slow processing
+| Each record carries an acquisition lock (`share.record.lock.duration.ms`, default 30s). Overrun it and the record is redelivered to another consumer while you are still processing it
+| A record stays in flight until your function returns. There is no clock
+
+| Poison messages
+| Broker-side: after `group.share.delivery.attempt.limit` attempts (default 5) the record is Archived and never redelivered
+| In your code: a configurable retry delay function, record skipping, or a circuit breaker
+
+| Broker cost
+| Per-record state is persisted to the internal `__share_group_state` topic through a share coordinator, plus acknowledgement RPCs
+| None beyond an ordinary consumer group. State is client-side, piggybacked onto commit metadata -- see <<offset_map,the offset map>>
+
+| Requires
+| KRaft, and Apache Kafka 4.2 / Confluent Platform 8.2. The 4.0 release was early access and explicitly not for production clusters
+| Nothing. The broker does not know you are using it
+
+| Scaling axis
+| *Out.* Several consumers may share one partition, so throughput can scale past the partition count across machines
+| *Up.* One instance processes its whole assignment concurrently; add instances for availability as usual
+|===
+
 [TIP]
 ====
-* If you want unordered queue semantics on Kafka 4.2+, reach for *Share Groups*. The "partitions are fixed, I need more consumers" motivation is now solved at the broker.
+* If you want unordered queue semantics on Kafka 4.2+, reach for *Share Groups*. The "partitions are fixed, I need more consumers" motivation is now solved at the broker -- and if you need a *single* partition's throughput spread across several machines, they are the only option.
 * If you need *key-level ordering with concurrency beyond partition count*, reach for *Parallel Consumer*. Nothing else does that cleanly today.
+* Also reach for *Parallel Consumer* if you need exactly-once together with parallelism, if your processing step can outlive a 30 second lock, or if you are not on Kafka 4.2 yet -- which includes every cluster still running 3.x.
 ====
 
 [[intro]]

--- a/README.adoc
+++ b/README.adoc
@@ -108,8 +108,8 @@ The two are not strict alternatives -- they solve different problems.
 | In your code: a configurable retry delay function, record skipping, or a circuit breaker
 
 | Broker cost
-| Per-record state is persisted to the internal `__share_group_state` topic through a share coordinator, plus acknowledgement RPCs
-| None beyond an ordinary consumer group. State is client-side, piggybacked onto commit metadata -- see <<offset_map,the offset map>>
+| Per-record state is persisted to the internal `__share_group_state` topic through a share coordinator, plus acknowledgement RPCs -- but that topic is theirs alone, so the state is isolated
+| None beyond an ordinary consumer group: no coordinator, no per-record RPCs. The trade is isolation rather than load -- the state rides in the commit metadata field, which is free-form and shared with anything else that has ever owned the group, so foreign bytes there have to be survived rather than prevented -- see <<offset_map,the offset map>>
 
 | Requires
 | KRaft, and Apache Kafka 4.2 / Confluent Platform 8.2. The 4.0 release was early access and explicitly not for production clusters

--- a/README.adoc
+++ b/README.adoc
@@ -122,9 +122,9 @@ The two are not strict alternatives -- they solve different problems.
 
 [TIP]
 ====
-* If you want unordered queue semantics on Kafka 4.2+, reach for *Share Groups*. The "partitions are fixed, I need more consumers" motivation is now solved at the broker -- and if you need a *single* partition's throughput spread across several machines, they are the only option.
-* If you need *key-level ordering with concurrency beyond partition count*, reach for *Parallel Consumer*. Nothing else does that cleanly today.
-* Also reach for *Parallel Consumer* if you need exactly-once together with parallelism, if your processing step can outlive a 30 second lock, or if you are not on Kafka 4.2 yet -- which includes every cluster still running 3.x.
+* *Both* solve "partitions are fixed, I need more consumers" -- so the choice between them is about *ordering*, not about concurrency. Reach for *Share Groups* on Kafka 4.2+ when ordering genuinely does not matter to you: that condition is the whole trade, not a footnote to it. You get consumers decoupled from partition count at the broker, in exchange for delivery that may be out of order, and for redelivery of a record another consumer may still be working on.
+* Reach for *Parallel Consumer* when you need *key-level ordering with concurrency beyond partition count* -- nothing else does that cleanly today. Also when you need exactly-once together with parallelism, when a processing step can outlive a 30 second lock, or when you are simply not on Kafka 4.2 yet, which includes every cluster still running 3.x.
+* Spreading a *single* partition's throughput across several machines is genuinely theirs alone. Worth putting in perspective, though: that requirement is largely inherited from an era when adding consumers was the only way to add concurrency at all. Parallel Consumer already drives one partition at high concurrency inside a single instance, so what actually remains is throughput beyond what one instance can carry, or a deliberate want for machine-level isolation.
 ====
 
 NOTE: For the reasoning behind the project as a whole -- the problem it exists to solve, why it is solved in the client rather than the broker, and where effort is currently going -- see link:STRATEGY.md[STRATEGY.md].

--- a/README.adoc
+++ b/README.adoc
@@ -127,6 +127,8 @@ The two are not strict alternatives -- they solve different problems.
 * Also reach for *Parallel Consumer* if you need exactly-once together with parallelism, if your processing step can outlive a 30 second lock, or if you are not on Kafka 4.2 yet -- which includes every cluster still running 3.x.
 ====
 
+NOTE: For the reasoning behind the project as a whole -- the problem it exists to solve, why it is solved in the client rather than the broker, and where effort is currently going -- see link:STRATEGY.md[STRATEGY.md].
+
 [[intro]]
 This library lets you process messages in parallel via a single Kafka Consumer meaning you can increase consumer parallelism without increasing the number of partitions in the topic you intend to process.
 For many use cases this improves both throughput and latency by reducing load on your brokers.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -17,7 +17,7 @@ low latency and guaranteed per-key ordering at the same time.
 
 We win by doing it in the client. Modifying the broker is extremely difficult, politically and
 engineering-wise, and no broker-side answer to high-performance key ordering exists or may ever.
-Parallel Consumer is a client-side sub-broker: a library you add to a pom, invisible to the
+Parallel Consumer works like a client-side sub-broker: a library you add to a pom, invisible to the
 cluster, needing no broker version, no feature flag, and nobody's permission to deploy.
 
 ## Who it's for
@@ -74,4 +74,4 @@ application does not. This is where the backflips are.
 
 ## Marketing
 
-**One-liner:** A client-side sub-broker that can do backflips.
+**One-liner:** Like a client-side sub-broker that can do backflips.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -1,0 +1,77 @@
+---
+name: Parallel Consumer
+last_updated: 2026-08-07
+---
+
+# Parallel Consumer Strategy
+
+## Target problem
+
+Teams processing Kafka records where concurrency is welded to partition count, and one slow
+record blocks everything behind it in its partition. Adding partitions is often prohibitive and
+still doesn't remove the head-of-line block - and a single-partition topic can't be sped up at
+all. Share Groups decouple scaling from partitions but deliver out of order, so nothing gives
+low latency and guaranteed per-key ordering at the same time.
+
+## Our approach
+
+We win by doing it in the client. Modifying the broker is extremely difficult, politically and
+engineering-wise, and no broker-side answer to high-performance key ordering exists or may ever.
+Parallel Consumer is a client-side sub-broker: a library you add to a pom, invisible to the
+cluster, needing no broker version, no feature flag, and nobody's permission to deploy.
+
+## Who it's for
+
+**Primary:** Teams whose downstream - a service, or just a processing step - scales further
+horizontally than their broker partitions do, and who need per-key ordering while it happens.
+They're hiring Parallel Consumer to decouple how fast they process from how many partitions they
+have, without giving up the ordering guarantee Kafka gave them.
+
+## Key metrics
+
+- **Head-of-line blocking avoided** - per partition, highest completed offset minus highest
+  sequential succeeded offset: the records processed that vanilla Kafka would still be waiting
+  on. Derivable today from two existing gauges; not emitted as its own meter.
+- **End-to-end record latency, median and p99** - poll to completion, not just user function
+  time. Not measured today - `pc.user.function.processing.time` covers only part of it.
+- **Achieved fan-out vs configured max** - whether the concurrency asked for is the concurrency
+  delivered. Partly derivable from `pc.shards` and `pc.inflight.records`.
+- **Production deployments with a public story** - the lagging signal that the library is trusted
+  in anger. Counted by hand.
+
+## Tracks
+
+### Performance
+
+The main track. Minimum per-record latency and maximum concurrency, including the offset encoding
+and buffering work that sets the ceiling.
+
+_Why it serves the approach:_ The client-side bet only pays if the client is fast - a sub-broker
+that adds latency has no reason to exist.
+
+### Reliability
+
+Bug squashing, with a bias to the correctness bugs: stalls, rebalance handling, offset tracking.
+
+_Why it serves the approach:_ This bet asks users to trust a library with delivery semantics the
+broker normally owns, and every lost-record bug is a withdrawal from that one account.
+
+### Observability
+
+Metrics that actually exist end-to-end, plus a web GUI to see inside a running PC.
+
+_Why it serves the approach:_ Moving the queue into the client moves it out of the cluster's view
+- PC's state lives in a JVM where standard Kafka tooling cannot reach it, so visibility is the
+bill that comes with the choice.
+
+### Flexibility
+
+Let users process records how they want: richer batch modes, and candidates like an HTTP endpoint
+server.
+
+_Why it serves the approach:_ A broker has to be generic; a library living inside your
+application does not. This is where the backflips are.
+
+## Marketing
+
+**One-liner:** A client-side sub-broker that can do backflips.

--- a/docs/inflight/pr-strategy-doc-merge-triggers.md
+++ b/docs/inflight/pr-strategy-doc-merge-triggers.md
@@ -44,6 +44,16 @@ the client-side bet stops being about your application and starts being about th
 it. Whichever of these lands first should decide whether the persona widens or a second persona is
 named, so the later one inherits a decision rather than reopening it.
 
+**Watch the commit-metadata field as these progress.** PC keeps its state in the commit metadata
+field, which is free-form and shared with anything else that has ever owned the group. astubbs#118
+names Kafka Streams *first* among the things that leave bytes PC cannot decode - and the Streams
+spike is putting PC underneath Kafka Streams. Today that exposure is a handled robustness issue and
+belongs nowhere near `STRATEGY.md`: the crash is fixed, the recovery path works, and a guiding policy
+should not carry a caveat for a risk that has not materialised. But if PC becomes the engine hosting
+frameworks that also want that field, an isolation footnote turns into a question about whether the
+client-side bet holds in the substrate role - and *that* is a claim in "Our approach". The trigger to
+revisit is a spike hitting a metadata collision it cannot simply survive, not the spikes merging.
+
 ## Change what the tracks contain
 
 **`feats/web-gui`** - the Observability track names a web GUI as an investment. Once the branch

--- a/docs/inflight/pr-strategy-doc-merge-triggers.md
+++ b/docs/inflight/pr-strategy-doc-merge-triggers.md
@@ -1,0 +1,81 @@
+# Branches that must re-check `STRATEGY.md` before they merge
+
+`STRATEGY.md` is a claims document, and unlike the README nothing tests it. The branches below either
+**change what it should say** or **can falsify a claim already in it**. Each one should re-read the
+named section as part of its own merge prep - not afterwards, when nobody is looking.
+
+This file exists because the coupling runs the wrong way for tooling to catch: the work lives in
+product code and spikes, the consequence lives in a root-level prose document, and no gate connects
+them. `git rm` this file when the last branch below has merged and the doc reflects them.
+
+Named here is *why* each branch touches the strategy, which no command can answer. For their status,
+titles, or divergence, ask `gh` and `git`.
+
+## Can falsify a claim already published
+
+**`test/transactional-mode-battle-test`** - proves or falsifies every documented transactional
+guarantee. `STRATEGY.md` ("Our approach") and the README's Share Groups table both rest on PC being
+the only way to get exactly-once *together with* parallelism. If that suite falsified any documented
+guarantee, the strongest claim in the comparison is the one that has to move, and the README table's
+`Exactly-once` row moves with it. Read the branch's own inflight note mapping reported transactional
+issues against what it proved.
+
+Same family, same section: **`fix/transactional-produce-callback-abort`** and
+**`fix/produce-lock-double-release`**. A transactional guarantee that needed a fix to hold is still a
+guarantee that holds - but the doc should not claim it more strongly than the fixed code supports.
+See [`bug-producing-lock-double-release.md`](bug-producing-lock-double-release.md).
+
+## Change who the product is for
+
+**`feats/ks-on-pc-spike`** (astubbs#255) and **`feats/connect-on-pc-spike`** (astubbs#240, plus its
+codex variant), with **`docs/assess-kafka-streams-pc-integration`** behind the first.
+
+These are the largest strategic movers on the board. `STRATEGY.md`'s primary persona is a team whose
+downstream scales further horizontally than their partitions do. Somebody reaching for Kafka Streams
+or Kafka Connect does not describe themselves that way: they arrive with a topology or a sink
+connector and one slow stage. If PC becomes the execution engine *underneath* another framework, then
+
+- **"Who it's for"** gains a population the current sentence excludes, and
+- **"Our approach"** gains a second clause - not only a library you add to a pom, but an engine other
+  Kafka frameworks run on.
+
+That is a larger change than anything in the Share Groups comparison, and it is a change of *kind*:
+the client-side bet stops being about your application and starts being about the framework hosting
+it. Whichever of these lands first should decide whether the persona widens or a second persona is
+named, so the later one inherits a decision rather than reopening it.
+
+## Change what the tracks contain
+
+**`feats/web-gui`** - the Observability track names a web GUI as an investment. Once the branch
+lands, the doc is describing something that exists, and the track's wording should stop reading as
+intent.
+
+**`feats/health-check-api`** (astubbs#126) - same track. A health-check surface is the other half of
+"you moved the queue into the client, so you owe the operator visibility".
+
+**`features/enable-virtual-threads`** - Performance track. The doc's concurrency-ceiling story
+currently rests on the non-blocking modules; virtual threads change what the core alone can reach.
+
+**`docs/v6-release-ideas`, `docs/v6-module-maturity-table`** and the `next-` ideation notes beside
+this file - these are strategy artefacts in their own right. A living roadmap of high-level themes
+overlaps `STRATEGY.md`'s **Tracks**; per-module maturity and what pre-1.0 reserves overlap
+**Milestones**, which `STRATEGY.md` currently omits entirely. The risk is not contradiction, it is
+two documents owning the same question. Settle the division of labour when the first of them merges.
+
+**`next-testing-suite-as-product-docs.md`** - promoting the test suite from hygiene to a positioning
+asset is a strategy-level move, not a chore. If it holds, Reliability is no longer only an internal
+track.
+
+## Narrows an argument the comparison leans on
+
+**`feat/java-17-baseline`** (Java baseline + Kafka 4). The README argues that Share Groups need KRaft
+and Kafka 4.2, so 3.x estates cannot reach them at all - with the unstated premise that PC can. As
+PC's own floor rises that gap narrows from both ends. The argument does not disappear, but it stops
+being free and needs restating in terms of what PC still supports.
+
+## Explicitly not triggers
+
+Correctness, CI and hygiene branches make the Reliability and Performance tracks *true* without
+changing what the document says. A strategy doc that moved for those would be a changelog. That
+includes the offset-encoding, logging, load-factor, MDC, long-polling, test-dedup, plugin-pinning,
+issue-automation and mirror-sweep work, and the JStream buffer bound.

--- a/docs/solutions/documentation-gaps/competitor-comparison-docs-must-cite-the-primary-spec.md
+++ b/docs/solutions/documentation-gaps/competitor-comparison-docs-must-cite-the-primary-spec.md
@@ -1,0 +1,276 @@
+---
+title: Competitor-comparison docs must be sourced from the primary spec, not summary awareness
+date: 2026-08-07
+category: documentation-gaps
+module: src/docs
+problem_type: documentation_gap
+component: documentation
+severity: medium
+root_cause: inadequate_documentation
+resolution_type: documentation_update
+applies_when:
+  - Writing or reviewing a section that positions this project against a competing technology
+  - A competitor ships a release, GA milestone, or version gate that the comparison already mentions
+  - A comparison concedes a capability without citing where that limit is specified
+  - Preparing README or docs changes that describe another system's semantics or guarantees
+  - Reviewing docs that no test, CI gate, or build step can validate
+symptoms:
+  - Comparison prose paraphrases a competitor from general awareness with no citation to its spec
+  - The doc concedes a whole motivating use case to the competitor and stops there
+  - Checkable competitor limits (ordering, EoS, timeouts, state cost) are absent from the comparison
+  - No test or CI gate fails, so the under-armed section survives indefinitely
+  - Version and maturity gates in the comparison drift behind the competitor's releases
+related_components:
+  - development_workflow
+tags:
+  - documentation
+  - readme
+  - competitive-positioning
+  - primary-sources
+  - kip-932
+  - share-groups
+  - kafka
+  - doc-decay
+---
+
+# Competitor-comparison docs must be sourced from the primary spec, not summary awareness
+
+## Context
+
+The README carries a section titled `When to use this library (vs KIP-932 Share Groups)`, positioning
+Parallel Consumer against Kafka's broker-native queueing feature. It exists because Share Groups cover
+a large part of what people historically reached for this library to do, and a reader arriving at the
+project deserves an honest answer about which one they want.
+
+That section had been authored from general awareness of Share Groups rather than from KIP-932 itself.
+It summarised them as "many-to-many consumer↔partition mapping, per-message ack, broker-side delivery
+counts with poison-message protection, elastic scaling decoupled from partition count. Unordered queue
+semantics -- 'RabbitMQ on Kafka'", handed them the entire "partitions are fixed, I need more consumers"
+motivation, and stopped. The reader-facing advice was two bullets: use Share Groups if you want
+unordered queue semantics on Kafka 4.2+, use Parallel Consumer if you need key-level ordering with
+concurrency beyond partition count.
+
+Nothing in it was false. It was simply under-armed. It named the one axis the author already knew
+(ordered vs unordered) and conceded everything else by silence.
+
+The gap surfaced during a `ce-strategy` interview, when the user asked a question the doc could not
+answer from its own sources: *"can you verify the 'random ordering' by reading the actual share groups
+kip?"* Reading the primary spec turned up six further axes of difference -- five of them advantages the
+doc had never claimed, one a concession it had never made -- all sitting unstated for as long as the
+section had existed. The rewrite shipped in PR astubbs#223 (unmerged as of this writing), edited in
+`src/docs/README_TEMPLATE.adoc` and regenerated into `README.adoc`.
+
+### How it got there, and why the rule that would have caught it did not (session history)
+
+The section was added on 2026-04-23 in commit `a597a384`, whose subject is
+*"docs: rebrand audit (README template + pom) and landscape context"*. Its diff touches only
+`README.adoc`, `RELEASE.adoc` and `src/docs/README_TEMPLATE.adoc`: it arrived as the second half of a
+README rebrand pass -- fork notice, badges, copyright -- not as a piece of researched comparison work.
+The prose names the KIP in its heading but **does not link it**, and the commit body argues entirely at
+release-note altitude (Share Groups are GA, they cover most partition-count use cases) rather than from
+mechanics.
+
+The more useful finding is what happened next. On 2026-08-05, astubbs#208 wrote the counter-practice
+down, explicitly:
+
+> Categories to enumerate (each needs its facts checked at writing time, not taken from this issue)
+
+> Check KIP-932's exact release status at writing time rather than trusting this issue - it has been
+> moving through early access across the Kafka 4.x line, and the honest version of this page depends on
+> which brokers actually have it.
+
+That rule was written **over three months after** the text it would have corrected, and it was aimed at
+the manual chapter the section would *become* rather than at the paragraph as it stood -- astubbs#208
+says *"the README's `When to use` already carries the seed, so it migrates with everything else in step
+1 and then gets extended"*. The comparison was then deferred out of the first docs-site phase in that
+issue's 2026-08-06 discussion, on the reasoning that it *"may turn out to be mostly migrating what `When
+to use` already says rather than new research"*.
+
+That last sentence is the whole failure in one line: the published text was treated as adequate raw
+material precisely because nobody had checked it against the spec. The weakness was written up as a
+rule and parked as work; what nobody did was apply the rule backwards to the paragraph already shipped.
+
+The rule existing in a plan is not the same as the rule reaching the text.
+
+## Guidance
+
+**Source every competitor comparison from the competitor's primary specification, and prefer claims
+that are falsifiable and datable over adjectives.**
+
+Concretely, when a doc positions this project against an external system:
+
+1. **Read the spec, not the summary.** The KIP, the RFC, the release notes, the official config
+   reference. Blog posts, conference talks, and your own memory of a feature announcement are all
+   downstream of it and lossy in the direction that flatters the competitor's headline claim.
+
+2. **Prefer claims with a name and a number.** `share.record.lock.duration.ms` defaults to 30s.
+   `group.share.delivery.attempt.limit` defaults to 5. GA in Apache Kafka 4.2 / Confluent Platform
+   8.2, KRaft only. Each of these can be checked by a reader in five minutes and can be *seen to age*
+   when the competitor changes it. "Unordered queue semantics" can do neither: it is unfalsifiable
+   prose that will read as current forever.
+
+3. **Quote the spec where the spec is stronger than your paraphrase.** The pre-rewrite section said
+   "unordered". KIP-932 actually says records "can be delivered out of order to a consumer, in
+   particular when redeliveries occur", and that while offsets ascend within a single batch, there are
+   "no guarantees about the ordering of offsets between different batches". The quoted text is a
+   sharper claim than the summary word, and it is attributable.
+
+4. **Cover the whole surface, not just the axis you already knew.** The rewrite's table has seven rows:
+   ordering, exactly-once, slow processing, poison messages, broker cost, requirements, scaling axis.
+   Only ordering was stated as a *difference* in the original prose. Poison messages and elastic scaling
+   did appear there -- but as Share Groups features, with no counterpart named and no checkable fact
+   attached, which is worse than omitting them. Exactly-once was a whole capability the original doc
+   never mentioned the competitor lacks.
+
+5. **Concede what is genuinely theirs, explicitly.** Share Groups can spread a *single* partition's
+   throughput across several machines; Parallel Consumer scales up within one instance's assignment and
+   cannot. The rewrite states this in the table ("Scaling axis: *Out.*" vs "*Up.*") and repeats it in
+   the recommendation bullet. A comparison that concedes nothing reads as marketing and the reader
+   discounts the whole table.
+
+6. **Do not let comparison content ride along in an unrelated commit.** This section entered as
+   "landscape context" appended to a rebranding pass. Content describing someone else's system needs
+   its own change, with its own sources, or it inherits the research budget of whatever it was bolted
+   onto -- which is zero.
+
+7. **When you write the verification rule, apply it to what is already published.** astubbs#208 stated
+   the rule correctly, then aimed it at the chapter the section would become. The already-shipped
+   paragraph it called "the seed" was never re-checked -- and was in fact judged adequate to migrate
+   as-is. A rule aimed only forward leaves every existing instance untouched, and a seed nobody
+   verified propagates rather than gets fixed.
+
+8. **Note the generated-file constraint.** In this repo the README is generated: edit
+   `src/docs/README_TEMPLATE.adoc` and regenerate with `asciidoc-template:build`. Never hand-edit
+   `README.adoc`.
+
+## Why This Matters
+
+Competitor-comparison documentation **degrades silently**. It is close to the only kind of
+documentation with no failure detector at all.
+
+- No test breaks when it is wrong.
+- No CI gate fires. There is nothing to lint against, because the ground truth lives in another
+  project's repository.
+- No reviewer notices, because the reviewer's knowledge of the competitor is drawn from the same
+  summary-level awareness that produced the text.
+- The competitor ships a release and the doc gets *further* from true without anyone touching it.
+
+The direction of the decay is not random. An under-sourced comparison always errs in the competitor's
+favour, because the parts you did not read are the parts you cannot claim. The original section handed
+Share Groups the whole "partitions are fixed, I need more consumers" motivation without qualification.
+Reading the KIP showed that the motivating use case in this library's own README -- a slow consumer
+calling a web service -- is one Share Groups handle badly: overrun the 30 second acquisition lock and
+the record is redelivered to another consumer *while the first is still processing it*. That is not a
+subtlety at the edge of the comparison. It is the central case, and the doc was silently conceding it.
+
+Falsifiability is what makes the fix durable rather than one-off. A table full of config names, defaults
+and version gates carries its own expiry date. A future reader (or agent) who checks
+`share.record.lock.duration.ms` and finds the default has changed knows immediately that the row is
+stale. Nobody can ever discover that "unordered queue semantics" has gone stale, which is precisely why
+it survived unchallenged for over three months across at least two sessions that discussed it.
+
+This is the same failure family as two existing lessons: *read linked content first* (citing an
+unopened link produced four wrong artefacts on astubbs#125) and *mirrored issues: read upstream too*
+(never trust a fork mirror's summary of an upstream issue) (auto memory [claude]). In all three, a
+summary stood in for a primary source and the summary was confidently wrong in a way nothing detected.
+
+## When to Apply
+
+Apply when writing or reviewing:
+
+- Any "X vs Y", "when to use this", "alternatives", or "comparison" section, in README, docs, or
+  `STRATEGY.md`.
+- Any claim about what an external system *cannot* do, or about limits, defaults, and version
+  requirements you did not read in that system's own reference.
+- Any positioning statement that a competitor's new feature supersedes part of this project.
+
+Apply as a *review trigger*, not only at authoring time:
+
+- When the compared system ships a major release. Share Groups went from early access in Apache
+  Kafka 4.0 (explicitly not for production) to GA in 4.2, and any comparison written against 4.0 is now
+  wrong about availability.
+- When a comparison section is more than a release cycle old and has not been re-sourced.
+- When someone asks a question the doc cannot answer from its own citations. That is the strongest
+  signal available that the section was written from summary awareness. Here the trigger was literally
+  "can you verify this by reading the actual KIP?"
+- When you park comparison work for a later phase. Parking is fine; parking without recording that the
+  *current* text is unverified is how a known weakness reads as settled content.
+
+It does *not* apply to comparisons of things inside this repo, where tests and CI already keep the doc
+honest, nor to subjective positioning ("simpler", "easier to adopt") where there is no spec to cite --
+though the absence of a citable source is itself a reason to write less.
+
+## Examples
+
+**Before** -- `src/docs/README_TEMPLATE.adoc`, the entire reader-facing recommendation:
+
+```asciidoc
+[TIP]
+====
+* If you want unordered queue semantics on Kafka 4.2+, reach for *Share Groups*. The "partitions are fixed, I need more consumers" motivation is now solved at the broker.
+* If you need *key-level ordering with concurrency beyond partition count*, reach for *Parallel Consumer*. Nothing else does that cleanly today.
+====
+```
+
+Two bullets, one axis, no citations, nothing datable, and no mention that Share Groups have no
+exactly-once at all.
+
+**After** -- a `How they differ` table sourced from the KIP, of which four representative rows:
+
+```asciidoc
+| Ordering
+| None guaranteed. Records in a share-partition "can be delivered out of order to a consumer, in particular when redeliveries occur", and only offsets *within a single batch* ascend -- there are "no guarantees about the ordering of offsets between different batches"
+| Per key, per partition, or unordered -- your choice. See <<ordering-guarantees,Ordering Guarantees>>
+
+| Exactly-once
+| Not supported. There is no transactional read-process-write for share consumers
+| Supported. Produced records and their source offsets commit as one atomic transaction -- see <<transaction-system,the EoS transaction model>>
+
+| Slow processing
+| Each record carries an acquisition lock (`share.record.lock.duration.ms`, default 30s). Overrun it and the record is redelivered to another consumer while you are still processing it
+| A record stays in flight until your function returns. There is no clock
+
+| Broker cost
+| Per-record state is persisted to the internal `__share_group_state` topic through a share coordinator, plus acknowledgement RPCs
+| None beyond an ordinary consumer group. State is client-side, piggybacked onto commit metadata -- see <<offset_map,the offset map>>
+```
+
+Note what each row now carries: a quoted spec line, a named config with its default, a named internal
+topic. Every one of those is checkable by a reader and visibly ages.
+
+**The concession, stated rather than omitted:**
+
+```asciidoc
+| Scaling axis
+| *Out.* Several consumers may share one partition, so throughput can scale past the partition count across machines
+| *Up.* One instance processes its whole assignment concurrently; add instances for availability as usual
+```
+
+and, in the recommendation, extending rather than deleting the original Share Groups bullet:
+
+```asciidoc
+* If you want unordered queue semantics on Kafka 4.2+, reach for *Share Groups*. The "partitions are fixed, I need more consumers" motivation is now solved at the broker -- and if you need a *single* partition's throughput spread across several machines, they are the only option.
+```
+
+**A precision worth copying:** the exactly-once row claims what the project actually delivers and no
+more. The library's EoS is Kafka-to-Kafka -- produced records and their source offsets commit as one
+atomic bulk transaction -- and the README says elsewhere that external side effects still require the
+usual idempotency, exactly as with core Kafka EoS. Sharpening a comparison is an invitation to
+overclaim; the guard is that your own side of the table must be as spec-sourced as theirs.
+
+## Related
+
+- astubbs#223 -- the PR that re-sourced the section from KIP-932 and added `STRATEGY.md`. Open and
+  unmerged as of this writing.
+- astubbs#208 -- the docs-site issue that stated this rule prospectively (*"each needs its facts checked
+  at writing time, not taken from this issue"*) and named the README's `When to use` section as the seed
+  to expand. It postdates the section by over three months and was aimed at the chapter that section
+  would become, which is why the existing text went unchecked. Worth updating to record that the seed
+  has since been sharpened.
+- astubbs#222 -- the same move in a different medium: having established what the library provides over
+  the competitor, make the advantage *measurable* rather than merely asserted.
+- `docs/inflight/release-0600-blockers.md` -- the sibling concern for version claims: "are the things
+  0.6.0.0 publishes true on the day we cut it?" Same class (nothing tests prose), different trigger
+  (a fact changed underneath static text, rather than text that was under-sourced when written).
+- `docs/inflight/parked-docs-site.md` -- parks the KIP-932 chapter as future work and points at
+  astubbs#208.

--- a/docs/solutions/documentation-gaps/competitor-comparison-docs-must-cite-the-primary-spec.md
+++ b/docs/solutions/documentation-gaps/competitor-comparison-docs-must-cite-the-primary-spec.md
@@ -258,6 +258,22 @@ atomic bulk transaction -- and the README says elsewhere that external side effe
 usual idempotency, exactly as with core Kafka EoS. Sharpening a comparison is an invitation to
 overclaim; the guard is that your own side of the table must be as spec-sourced as theirs.
 
+**And the guard failed, in the same change that wrote it down.** The `Broker cost` row first shipped
+as: *"None beyond an ordinary consumer group. State is client-side, piggybacked onto commit
+metadata."* Every word true, and incomplete in the flattering direction. What it omits is that the
+commit metadata field is free-form and shared -- astubbs#118 exists because a Kafka Streams app,
+another framework or operator tooling that previously owned the group can leave bytes there that PC
+cannot decode. Share Groups have no equivalent exposure: `__share_group_state` is theirs alone. So on
+that row they hold an isolation property PC lacks, while the row read as though the whole cost were
+theirs. The corrected version names the real shape -- they pay load, PC pays isolation.
+
+Two things this instance is worth remembering for. First, the failure was **asymmetric attention**,
+not ignorance: the competitor's column was researched from the spec and our own column was written
+from familiarity, which is the same summary-awareness failure pointed inward. Second, it was caught
+only by reading what had merged to `master` while the branch was open -- the fix that proves the cost
+had already landed. A comparison's own project moves too, and re-sourcing only the competitor's side
+leaves half the table stale.
+
 ## Related
 
 - astubbs#223 -- the PR that re-sourced the section from KIP-932 and added `STRATEGY.md`. Open and

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -85,10 +85,46 @@ The Kafka landscape has shifted since this library's 2021 stable release. *KIP-9
 
 The two are not strict alternatives -- they solve different problems.
 
+=== How they differ
+
+[cols="1,2,2", options="header"]
+|===
+| | Share Groups | Parallel Consumer
+
+| Ordering
+| None guaranteed. Records in a share-partition "can be delivered out of order to a consumer, in particular when redeliveries occur", and only offsets *within a single batch* ascend -- there are "no guarantees about the ordering of offsets between different batches"
+| Per key, per partition, or unordered -- your choice. See <<ordering-guarantees,Ordering Guarantees>>
+
+| Exactly-once
+| Not supported. There is no transactional read-process-write for share consumers
+| Supported. Produced records and their source offsets commit as one atomic transaction -- see <<transaction-system,the EoS transaction model>>
+
+| Slow processing
+| Each record carries an acquisition lock (`share.record.lock.duration.ms`, default 30s). Overrun it and the record is redelivered to another consumer while you are still processing it
+| A record stays in flight until your function returns. There is no clock
+
+| Poison messages
+| Broker-side: after `group.share.delivery.attempt.limit` attempts (default 5) the record is Archived and never redelivered
+| In your code: a configurable retry delay function, record skipping, or a circuit breaker
+
+| Broker cost
+| Per-record state is persisted to the internal `__share_group_state` topic through a share coordinator, plus acknowledgement RPCs
+| None beyond an ordinary consumer group. State is client-side, piggybacked onto commit metadata -- see <<offset_map,the offset map>>
+
+| Requires
+| KRaft, and Apache Kafka 4.2 / Confluent Platform 8.2. The 4.0 release was early access and explicitly not for production clusters
+| Nothing. The broker does not know you are using it
+
+| Scaling axis
+| *Out.* Several consumers may share one partition, so throughput can scale past the partition count across machines
+| *Up.* One instance processes its whole assignment concurrently; add instances for availability as usual
+|===
+
 [TIP]
 ====
-* If you want unordered queue semantics on Kafka 4.2+, reach for *Share Groups*. The "partitions are fixed, I need more consumers" motivation is now solved at the broker.
+* If you want unordered queue semantics on Kafka 4.2+, reach for *Share Groups*. The "partitions are fixed, I need more consumers" motivation is now solved at the broker -- and if you need a *single* partition's throughput spread across several machines, they are the only option.
 * If you need *key-level ordering with concurrency beyond partition count*, reach for *Parallel Consumer*. Nothing else does that cleanly today.
+* Also reach for *Parallel Consumer* if you need exactly-once together with parallelism, if your processing step can outlive a 30 second lock, or if you are not on Kafka 4.2 yet -- which includes every cluster still running 3.x.
 ====
 
 [[intro]]

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -108,8 +108,8 @@ The two are not strict alternatives -- they solve different problems.
 | In your code: a configurable retry delay function, record skipping, or a circuit breaker
 
 | Broker cost
-| Per-record state is persisted to the internal `__share_group_state` topic through a share coordinator, plus acknowledgement RPCs
-| None beyond an ordinary consumer group. State is client-side, piggybacked onto commit metadata -- see <<offset_map,the offset map>>
+| Per-record state is persisted to the internal `__share_group_state` topic through a share coordinator, plus acknowledgement RPCs -- but that topic is theirs alone, so the state is isolated
+| None beyond an ordinary consumer group: no coordinator, no per-record RPCs. The trade is isolation rather than load -- the state rides in the commit metadata field, which is free-form and shared with anything else that has ever owned the group, so foreign bytes there have to be survived rather than prevented -- see <<offset_map,the offset map>>
 
 | Requires
 | KRaft, and Apache Kafka 4.2 / Confluent Platform 8.2. The 4.0 release was early access and explicitly not for production clusters

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -122,9 +122,9 @@ The two are not strict alternatives -- they solve different problems.
 
 [TIP]
 ====
-* If you want unordered queue semantics on Kafka 4.2+, reach for *Share Groups*. The "partitions are fixed, I need more consumers" motivation is now solved at the broker -- and if you need a *single* partition's throughput spread across several machines, they are the only option.
-* If you need *key-level ordering with concurrency beyond partition count*, reach for *Parallel Consumer*. Nothing else does that cleanly today.
-* Also reach for *Parallel Consumer* if you need exactly-once together with parallelism, if your processing step can outlive a 30 second lock, or if you are not on Kafka 4.2 yet -- which includes every cluster still running 3.x.
+* *Both* solve "partitions are fixed, I need more consumers" -- so the choice between them is about *ordering*, not about concurrency. Reach for *Share Groups* on Kafka 4.2+ when ordering genuinely does not matter to you: that condition is the whole trade, not a footnote to it. You get consumers decoupled from partition count at the broker, in exchange for delivery that may be out of order, and for redelivery of a record another consumer may still be working on.
+* Reach for *Parallel Consumer* when you need *key-level ordering with concurrency beyond partition count* -- nothing else does that cleanly today. Also when you need exactly-once together with parallelism, when a processing step can outlive a 30 second lock, or when you are simply not on Kafka 4.2 yet, which includes every cluster still running 3.x.
+* Spreading a *single* partition's throughput across several machines is genuinely theirs alone. Worth putting in perspective, though: that requirement is largely inherited from an era when adding consumers was the only way to add concurrency at all. Parallel Consumer already drives one partition at high concurrency inside a single instance, so what actually remains is throughput beyond what one instance can carry, or a deliberate want for machine-level isolation.
 ====
 
 NOTE: For the reasoning behind the project as a whole -- the problem it exists to solve, why it is solved in the client rather than the broker, and where effort is currently going -- see link:STRATEGY.md[STRATEGY.md].

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -127,6 +127,8 @@ The two are not strict alternatives -- they solve different problems.
 * Also reach for *Parallel Consumer* if you need exactly-once together with parallelism, if your processing step can outlive a 30 second lock, or if you are not on Kafka 4.2 yet -- which includes every cluster still running 3.x.
 ====
 
+NOTE: For the reasoning behind the project as a whole -- the problem it exists to solve, why it is solved in the client rather than the broker, and where effort is currently going -- see link:STRATEGY.md[STRATEGY.md].
+
 [[intro]]
 This library lets you process messages in parallel via a single Kafka Consumer meaning you can increase consumer parallelism without increasing the number of partitions in the topic you intend to process.
 For many use cases this improves both throughput and latency by reducing load on your brokers.


### PR DESCRIPTION
<!-- What does this PR change, and why? Keep it in sync with the actual content as the PR evolves. -->

## Description

Writing down what the library is for, discovering the README was underselling it, recording why that
happened - and then catching the same mistake in this PR's own work.

### `STRATEGY.md`

A new anchor document at the repo root, peer of `README.adoc`, produced through the `ce-strategy`
interview. It records the target problem (concurrency welded to partition count, and one slow record
blocking everything behind it), the guiding choice, the primary user, four key metrics, and the four
tracks under investment: performance, reliability, observability, flexibility.

The guiding choice is the part worth reading: solve this in the client, because modifying the broker
is prohibitive politically and technically, and no broker-side answer to high-performance key ordering
exists or may ever.

The metrics section doubles as a gap report - three of the four are not measured today, which is now
astubbs#222.

### README Share Groups comparison

The `When to use this library (vs KIP-932 Share Groups)` section named the difference (ordered vs
unordered) and stopped, which conceded considerably more than the facts require. Verified against
KIP-932 and replaced with a comparison table:

| | Finding |
|---|---|
| Ordering | Not merely unordered. The KIP guarantees ascending offsets only *within a single batch*, with "no guarantees about the ordering of offsets between different batches" |
| Exactly-once | Share groups have no transactional read-process-write at all, so PC is currently the only way to get EoS together with parallelism |
| Slow processing | `share.record.lock.duration.ms` defaults to 30s; overrun it and the record is redelivered to another consumer while the first is still processing it - exactly the slow-consumer case this library exists for |
| Broker cost | They pay load (per-record state through a share coordinator); PC pays isolation (its state rides in the free-form commit metadata field, shared with anything that has ever owned the group) |
| Poison messages | `group.share.delivery.attempt.limit` (default 5) then Archived and silently dropped, against PC's configurable retry/skip/circuit-break in user code |
| Requires | KRaft and Kafka 4.2 / CP 8.2, so 3.x clusters cannot reach it at all |

Edited in `src/docs/README_TEMPLATE.adoc` and regenerated with `asciidoc-template:build`, so template
and generated README stay in sync. A short `NOTE` at the end of that section links `STRATEGY.md`, which
nothing else pointed at.

### The recommendation block that follows it

Rewritten for the same reason in the opposite direction - it read as a concession letter, in three
separate places:

- It handed Share Groups the whole "partitions are fixed, I need more consumers" motivation, as though
  the broker had settled it. **Both** solve that; the choice between them is about *ordering*, not
  concurrency, and the block now leads with that.
- The ordering price was implied by the phrase "unordered queue semantics" and never stated. It is the
  whole trade: records may arrive out of order, and a record another consumer is still working on may
  be redelivered. A reader choosing on the old text could not see what they were giving up.
- Spreading a *single* partition across machines stood unqualified as something only they can do.
  Still conceded - but that requirement is largely inherited from an era when adding consumers was the
  only way to add concurrency at all. PC already drives one partition at high concurrency inside one
  instance, so what actually remains is throughput beyond a single instance, or deliberate
  machine-level isolation.

### The learning: why the comparison was under-armed

Opens `docs/solutions/documentation-gaps/` - the learnings store's first non-engineering category.

A competitor comparison is the one kind of documentation with no failure detector. No test breaks, no
CI gate fires, and the reviewer's knowledge of the competitor comes from the same summary-level
awareness that produced the text. It only ever errs in the competitor's favour, because the parts you
did not read are the parts you cannot claim.

The record, established from the tree and prior sessions rather than recollection:

- The section entered on 2026-04-23 as the second half of a README rebrand commit, so it inherited that
  commit's research budget.
- astubbs#208 wrote the verification rule down over three months *later* ("each needs its facts checked
  at writing time, not taken from this issue"), and aimed it at the chapter the section would become.
  The published paragraph was then judged fit to migrate as-is, "mostly migrating what `When to use`
  already says rather than new research".
- So an unverified seed was set to propagate rather than be fixed.

**The learning then caught this PR.** Its own guard - *"your own side of the table must be as
spec-sourced as theirs"* - had not been applied to our column. The `Broker cost` row shipped reading
PC's client-side state as pure upside, omitting that the commit metadata field is free-form and shared;
astubbs#118 exists precisely because another framework can leave undecodable bytes there. Both columns
are corrected above. The failure mode was asymmetric attention rather than ignorance, and it surfaced
only from reading what had merged to `master` while the branch was open - so the instance is written
into the learning.

### Keeping it honest as work lands

`STRATEGY.md` is a claims document and nothing tests it, so two mechanisms ship with it:

- `docs/inflight/pr-strategy-doc-merge-triggers.md` names the open branches that must re-check it
  before merging - the transactional battle test (which can falsify the exactly-once claim), the
  Streams and Connect spikes (which change who the product is for), and the web GUI, health-check,
  virtual-threads and v6 ideation work. It also names what is explicitly *not* a trigger, so the
  hygiene branches are not re-litigated.
- A `STRATEGY.md` row in AGENTS.md's "Where things live" table, whose whole purpose is to be read
  before concluding something isn't tracked.

The sub-broker framing is also loosened from an identity claim to a likeness, in both the approach
sentence and the one-liner - it is an analogy that earns its keep by being evocative, not by being
exact.

## Checklist

- [x] Docs updated - this PR is entirely documentation
- [ ] Tests added/updated - N/A - no code changes; the only generated artefact (`README.adoc`) is regenerated from its template in the same commit
- [x] Title & body reflect the final content of this PR
- [ ] Self-hosted runner / security implications considered - N/A - no CI, workflow or runner changes
