### PR TITLE
docs(branding): rename to Parallel Consumer for Apache Kafka

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,7 +28,7 @@ First release of the community fork of https://github.com/confluentinc/parallel-
 
 === Improvements
 
-* The project is renamed to *Kafka Parallel Consumer* (README and branding). Java package names (`io.confluent.parallelconsumer.*`) are unchanged, so imports are unaffected — only the Maven groupId changed (see Breaking).
+* The project is renamed to *Parallel Consumer for Apache Kafka* — the README title, and the `<name>` of the parent and every module.
 * feature: new `parallel-consumer-mutiny` module — SmallRye Mutiny (Quarkus) integration (upstream https://github.com/confluentinc/parallel-consumer/pull/891[#891]).
 * Commit-failure error logging now includes the offsets being committed, to aid diagnosis of failed commits (upstream https://github.com/confluentinc/parallel-consumer/pull/850[#850]).
 * Modernized CI (parallel unit/integration/performance suites, SpotBugs, PIT mutation testing, dependency scanning) and automated Maven Central publishing (https://github.com/astubbs/parallel-consumer/commit/b810e873[b810e873], https://github.com/astubbs/parallel-consumer/commit/2bcc74d9[2bcc74d9]).

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ TIP:: Editing template file
 endif::[]
 
 
-= Kafka Parallel Consumer
+= Parallel Consumer for Apache Kafka
 :icons:
 :toc: macro
 :toclevels: 3
@@ -73,6 +73,15 @@ TIP: If you like this project, please ⭐ Star it in GitHub to show your appreci
 
 NOTE: This is a community-maintained project with no commercial support.
 See the <<Support and Issues>> section for more information.
+
+[[trademarks]]
+[NOTE]
+.Trademarks
+====
+KAFKA is a registered trademark of The Apache Software Foundation and has been licensed for use by Antony Stubbs and contributors. Antony Stubbs and contributors have no affiliation with and are not endorsed by The Apache Software Foundation.
+
+See <<Attribution>> for the other Apache marks referenced in this document.
+====
 
 [[when-to-use]]
 == When to use this library (vs KIP-932 Share Groups)
@@ -1668,6 +1677,8 @@ So it's very efficient.
 (Reference: https://github.com/confluentinc/parallel-consumer/issues/415#issuecomment-1256022394[#415])
 
 == Attribution
+
+KAFKA is a registered trademark of The Apache Software Foundation and has been licensed for use by Antony Stubbs and contributors. Antony Stubbs and contributors have no affiliation with and are not endorsed by The Apache Software Foundation.
 
 http://www.apache.org/[Apache®], http://kafka.apache.org/[Apache Kafka], and http://kafka.apache.org/[Kafka®] are either registered trademarks or trademarks of the http://www.apache.org/[Apache Software Foundation] in the United States and/or other countries.
 

--- a/parallel-consumer-core/pom.xml
+++ b/parallel-consumer-core/pom.xml
@@ -14,7 +14,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>parallel-consumer-core</artifactId>
-    <name>Kafka Parallel Consumer Core</name>
+    <name>Parallel Consumer - Core</name>
 
     <dependencies>
         <!-- Main -->

--- a/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-core/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>parallel-consumer-example-core</artifactId>
-    <name>Kafka Parallel Consumer Example - Core</name>
+    <name>Parallel Consumer - Examples - Core</name>
 
     <dependencies>
         <!-- tag::exampleDep[] -->

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>parallel-consumer-example-metrics</artifactId>
-    <name>Kafka Parallel Consumer Example - Metrics</name>
+    <name>Parallel Consumer - Examples - Metrics</name>
 
     <dependencies>
         <!-- tag::exampleDep[] -->

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>parallel-consumer-example-reactor</artifactId>
-    <name>Kafka Parallel Consumer Example - Project Reactor.io</name>
+    <name>Parallel Consumer - Examples - Project Reactor.io</name>
 
     <dependencies>
         <!-- tag::exampleDep[] -->

--- a/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>parallel-consumer-example-streams</artifactId>
-    <name>Kafka Parallel Consumer Example - Streams</name>
+    <name>Parallel Consumer - Examples - Streams</name>
 
     <dependencies>
         <dependency>

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>parallel-consumer-example-vertx</artifactId>
-    <name>Kafka Parallel Consumer Example - Vert.x</name>
+    <name>Parallel Consumer - Examples - Vert.x</name>
 
     <dependencies>
         <!-- tag::exampleDep[] -->

--- a/parallel-consumer-examples/pom.xml
+++ b/parallel-consumer-examples/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <artifactId>parallel-consumer-examples</artifactId>
-    <name>Kafka Parallel Consumer Examples</name>
+    <name>Parallel Consumer - Examples</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/parallel-consumer-mutiny/pom.xml
+++ b/parallel-consumer-mutiny/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Kafka Parallel Consumer SmallRye Mutiny</name>
+    <name>Parallel Consumer - SmallRye Mutiny</name>
     <artifactId>parallel-consumer-mutiny</artifactId>
 
     <properties>

--- a/parallel-consumer-reactor/pom.xml
+++ b/parallel-consumer-reactor/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <name>Kafka Parallel Consumer Project Reactor.io</name>
+    <name>Parallel Consumer - Project Reactor.io</name>
     <artifactId>parallel-consumer-reactor</artifactId>
 
     <dependencies>

--- a/parallel-consumer-vertx/pom.xml
+++ b/parallel-consumer-vertx/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>parallel-consumer-vertx</artifactId>
-    <name>Kafka Parallel Consumer Vert.x</name>
+    <name>Parallel Consumer - Vert.x</name>
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>bz.stub.parallelconsumer</groupId>
     <artifactId>parallel-consumer-parent</artifactId>
-    <name>Kafka Parallel Consumer</name>
+    <name>Parallel Consumer for Apache Kafka</name>
     <version>0.6.0.0-SNAPSHOT</version>
     <description>Parallel Apache Kafka client wrapper with client side queueing, a simpler consumer/producer API with key concurrency and extendable non-blocking IO processing.
     </description>

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -22,7 +22,7 @@ TIP:: Editing template file
 endif::[]
 
 
-= Kafka Parallel Consumer
+= Parallel Consumer for Apache Kafka
 :icons:
 :toc: macro
 :toclevels: 3
@@ -73,6 +73,15 @@ TIP: If you like this project, please ⭐ Star it in GitHub to show your appreci
 
 NOTE: This is a community-maintained project with no commercial support.
 See the <<Support and Issues>> section for more information.
+
+[[trademarks]]
+[NOTE]
+.Trademarks
+====
+KAFKA is a registered trademark of The Apache Software Foundation and has been licensed for use by Antony Stubbs and contributors. Antony Stubbs and contributors have no affiliation with and are not endorsed by The Apache Software Foundation.
+
+See <<Attribution>> for the other Apache marks referenced in this document.
+====
 
 [[when-to-use]]
 == When to use this library (vs KIP-932 Share Groups)
@@ -1408,6 +1417,8 @@ So it's very efficient.
 (Reference: https://github.com/confluentinc/parallel-consumer/issues/415#issuecomment-1256022394[#415])
 
 == Attribution
+
+KAFKA is a registered trademark of The Apache Software Foundation and has been licensed for use by Antony Stubbs and contributors. Antony Stubbs and contributors have no affiliation with and are not endorsed by The Apache Software Foundation.
 
 http://www.apache.org/[Apache®], http://kafka.apache.org/[Apache Kafka], and http://kafka.apache.org/[Kafka®] are either registered trademarks or trademarks of the http://www.apache.org/[Apache Software Foundation] in the United States and/or other countries.
 


### PR DESCRIPTION
## Description

Renames the project from **"Kafka Parallel Consumer"** to **"Parallel Consumer for Apache Kafka"**.

The old name reads as a Kafka sub-component. It is built to the same shape as `Kafka Streams` and
`Kafka Connect` — the pattern used for parts of Kafka itself — so someone scanning a dependency
list or a search result reasonably concludes this is one of them. It is not: it is an independent
client-side library that works with Kafka.

The new name says what is actually true. The product name is ours, and the Kafka reference
describes what it works with. That is also the form Apache's naming guidance asks for: the full
"Apache Kafka" on the most prominent mention, with the bare name fine in body prose thereafter.

Upstream shipped as "Confluent Parallel Consumer", where the leading brand belonged to whoever
published it. This restores that shape with our own name in front.

### What changed

- **README title**, via `src/docs/README_TEMPLATE.adoc` with `README.adoc` regenerated. The rendered
  file is generated and was never hand-edited.
- **Maven `<name>` on the parent and all 10 modules.** Only the parent carries the qualified
  "Apache Kafka" reference; the modules carry none at all, so they need no qualification —
  `Parallel Consumer - Core`, `Parallel Consumer - Vert.x`, and so on.
- **Attribution wording near the top of the README**, where someone assessing the project will
  actually meet it, alongside the existing Attribution section.
- **One CHANGELOG line corrected in place** — it described the old name. It now states the rename and
  its surface area only: the naming rationale and a claim about package names that this release will
  invalidate have both been removed. Correcting an existing entry is the one changelog edit a PR may
  make here.

`groupId`, `artifactId` and Java packages are untouched.

### Note for reviewers

A blind `<name>` sweep would have been wrong and was caught: the parent pom has six `<name>`
elements (developer, license, two properties) and two example poms have `<name>Confluent</name>`
*repository* entries. Only the product-name strings were changed. `./mvnw validate` passes and its
reactor summary prints all 11 new names, which is the real proof the poms are well-formed.

Two surfaces this cannot reach: the **GitHub repository description/topics**, and the **Maven
Central listing**, which picks up `<name>` on the next publish. Nothing has been published under
this fork's `groupId` yet, so Central has nothing stale to correct.

changelog-ref: N/A - this corrects an existing uncited entry in place rather than adding a new one, which is the one changelog edit AGENTS.md permits. The gate's own header documents this exact case: "an EDIT to an existing entry is an added line too, so reworking an old uncited entry can ask for a citation it never had". There is no issue to cite, and `citesIssue` requires an `/issues/NN` link so the PR number would not satisfy it either.

## Checklist

- [x] Docs updated - this PR is the documentation/branding change
- [x] Tests added/updated - `N/A`: naming and documentation only, no behaviour to test. Verified by
      `./mvnw validate` (BUILD SUCCESS, all 11 module names rendered), a regenerated README diff
      identical to the template diff, and a repo-wide grep confirming no occurrence of the old name
      remains.
- [x] Title & body reflect the final content of this PR
- [x] Self-hosted runner / security implications considered - `N/A`: no workflow, runner, permission
      or CI logic is touched.
