### PR TITLE
docs(agents): state who owns each topic, from both ends of the pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ an older one has been superseded, absorbed by tooling, or is now stated twice.
 - **Never state a fact twice** - duplicates drift apart. Cross-reference whichever doc owns it, and
   **name the owner in the pointer**: "X owns this; what is here is the part that binds every
   session". A pointer that only lists adjacent topics reads as *further detail*, so a reader who
-  found a complete-looking rule here stops - and then edits the copy instead of the original.
+  found a complete-looking rule here stops - and then edits the copy instead of the original. The
+  doc it routes to states the same contract from its side, so either entrance reveals the owner.
 - **Do not pre-empt misreadings.** A rule needing three paragraphs to defend it against
   misinterpretation is a rule that needs rewriting.
 - **Before you move or rename any labelled block, grep the whole repo for its text** -
@@ -111,7 +112,8 @@ config key, a quoted literal; a long quotation is brittle the other way, breakin
 the grep before you commit the citation.
 
 Repairing one that has already gone stale in a dated record is its own procedure, because those
-documents may not be rewritten to match today's code: [`docs/citations.md`](docs/citations.md).
+documents may not be rewritten to match today's code - [`docs/citations.md`](docs/citations.md)
+**owns that procedure**.
 
 ## `gh` defaults to the WRONG repo here - fix it before your first command
 
@@ -235,8 +237,8 @@ bin/performance-test.sh      # performance tests (substantial hardware)
 
 ## Testing
 
-Suite mechanics, the quarantine lane, the chaos suite and the ambient probe are in
-[`docs/testing.md`](docs/testing.md). Four rules bind regardless:
+[`docs/testing.md`](docs/testing.md) **owns this topic** - suite mechanics, the quarantine lane, the
+chaos suite, the ambient probe - and wins where the two disagree. Four rules bind regardless:
 
 - **⚠️ Be EXTREMELY careful modifying tests to make them pass, especially under
   parallelism/stress.** A test failing under concurrent load may be exposing a **real main-code bug
@@ -275,7 +277,8 @@ Unit tests are surefire (`src/test/java/`); integration tests are failsafe and n
 - **Google Truth** for test assertions, with JUnit 5 and Mockito.
 - **License headers** are enforced by `bin/check-copyright-headers.sh`, and there is no tool that
   writes them - which header a new, modified, renamed or extracted file gets depends on its
-  provenance: [`docs/copyright.md`](docs/copyright.md). Two rules bind before you get there: do not
+  provenance, and [`docs/copyright.md`](docs/copyright.md) **owns that call**. Two rules bind
+  before you get there: do not
   touch an existing file's header unless that commit also changes the file substantively, and never
   bump a copyright year as an incidental or standalone change.
 
@@ -291,8 +294,9 @@ the model: an entry claimed a dependency version the pom had moved past). The te
 are *changing an existing claim to be true* (allowed) or *adding information about a change* (the
 generator's job).
 
-Write commit messages that can feed that generator - see [Commits](#commits). How generation works,
-and the state of each section: [`docs/releasing.md`](docs/releasing.md).
+Write commit messages that can feed that generator - see [Commits](#commits).
+[`docs/releasing.md`](docs/releasing.md) **owns the rest** - how generation works, the state of each
+section - and wins where the two disagree.
 
 ## Issue references
 
@@ -309,7 +313,8 @@ flip - `#29` and `#114` mean different things in each repo.
 - **Run `bin/check-issue-refs.sh` before you push.** It calls the same gate module CI does, so the
   rule cannot drift; a red run is always real. CI additionally scans the PR body.
 
-The threshold, the exemptions, and the reasoning: [`docs/issue-references.md`](docs/issue-references.md).
+[`docs/issue-references.md`](docs/issue-references.md) **owns this topic** - the threshold, the
+exemptions, the reasoning - and wins where the two disagree.
 
 ## Commits
 

--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -1,6 +1,8 @@
 # `bin/` - how these scripts relate to CI and to the reviewer
 
-Repo scripts. Two conventions live here because nothing else enforces them.
+Repo scripts. This doc owns the conventions for writing a script in `bin/`; the root AGENTS.md
+routes here and keeps only what binds every session. Two conventions live here because nothing else
+enforces them.
 
 ## Naming a script here can grant it to the PR reviewer
 

--- a/docs/inflight/AGENTS.md
+++ b/docs/inflight/AGENTS.md
@@ -1,7 +1,8 @@
 # In-flight & parked work - how this directory works
 
 Shared, cross-branch working notes kept on `master`, so any branch or session can see what is open
-right now. **Not** an issue tracker and **not** a backlog.
+right now. **Not** an issue tracker and **not** a backlog. This doc owns how these notes are
+written; the root AGENTS.md routes here and keeps only what binds every session.
 
 This was one file until 2026-08-04. It became a directory because *every* PR edited it - it appeared
 in 26 of the last 30 master commits - so unrelated PRs conflicted with each other constantly, purely

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -1,5 +1,8 @@
 # Refactoring backlog
 
+This doc owns the deferred-work backlog - internal refactors, the release-gated breaking-change
+queue, and `TODO`/`FIXME`/`XXX` triage. AGENTS.md routes here and keeps only the one-line rule.
+
 Deferred internal refactors - improvements noticed while working that are too big
 or too risky to fold into the change at hand, to be picked up **when things are
 quiet**. This is a solo-maintainer backlog, not an issue tracker: entries live

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -1,7 +1,9 @@
 # Self-Hosted Runner Setup (Proxmox Linux VM)
 
 Self-hosted runners give the heavy suites real hardware **and** let them run
-concurrently. This document walks through the one-time setup on a Linux VM.
+concurrently. This doc owns setting up and operating them: the one-time setup on a Linux VM, the
+labels, and the service. AGENTS.md carries only the pointer; which lanes are pinned to the
+`highcpu` label, and why, belongs to [`ci.md`](ci.md).
 
 Workflows that use them:
 [`pr-highcpu-fast-feedback.yml`](../.github/workflows/pr-highcpu-fast-feedback.yml)


### PR DESCRIPTION
## Description

Doc-only. One commit, five files, +24/-11.

AGENTS.md is a router: it holds the rules that bind every session and points at the topic doc that owns the rest. That split only works if a reader can tell **which side is authoritative from the side they entered on** — and most pointers did not say.

It failed that way on astubbs/parallel-consumer#258. A reviewer cited AGENTS.md's *"the manifest tracks upstream PRs only"*, so that copy was read as authoritative and amended there — while `docs/upstream.md` had been stating the same rule, and claiming ownership of the topic in its own opening, the whole time. Both copies read as complete; neither said who won.

**Pointers now name the owner.** Two already did it right — `docs/ci.md` (*"stated in one place only… Do not restate the rule here; it has drifted before"*) and the refactoring pointer (*"see the table above for what it owns"*). The rest listed adjacent topics, which reads as *further detail* rather than a hand-off. Converted: testing, releasing, issue-references, copyright, citations.

**Three routed docs now state their half.** `bin/AGENTS.md`, `docs/refactoring.md` and `docs/inflight/AGENTS.md` were routed from AGENTS.md but said nothing from their side, so entering from the doc gave no signal either. Eight others already did; these match them now.

**Left alone:** pointers that already carry the signal, and plain citations, where the phrasing would be noise. The goal is that a reader can find the owner — not that a template appears everywhere.

### Deliberately not here

An earlier draft added a script to enforce the reciprocal half in CI. It was cut. A review of it found the guard silently skipped a routed doc (`bin/AGENTS.md` — fixed by hand here instead), and that its self-test could not detect the guard checking only one doc of nine. Enforcement machinery for a documentation convention was not worth its own maintenance burden, let alone its own bugs. The convention is a review call, which is what the rule now says.

## Checklist

- [x] Docs updated - this PR is entirely documentation
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - no user-facing feature; these are contributor/agent-facing conventions`
- [x] Tests added/updated - `N/A - prose only, no executable code in this PR`
- [x] Title & body reflect the final content of this PR
