### PR TITLE
feat(core) astubbs#242: let work return to scheduling with no verdict, without consuming a retry

### DIFF
--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ProcessingShard.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ProcessingShard.java
@@ -203,6 +203,22 @@ public class ProcessingShard<K, V> {
         includeInSelection(failedWork);
     }
 
+    /**
+     * Work returned without a verdict. It never failed, so no retry is scheduled and no attempt is consumed - but
+     * it must become selectable again, so it re-joins the selection population exactly as a failure would.
+     * <p>
+     * Deliberately its own entry point rather than a call to {@link #onFailure}: the two say different things
+     * about the record, and it is {@link ShardManager} that acts on the difference by skipping the retry queue.
+     * Naming the shard-level step after the failure it is not would put the one seam that distinguishes them
+     * behind a method whose name denies it.
+     * <p>
+     * Idempotent for the same reason {@link #onFailure} is - the claim is a compare-and-set, so calling this twice
+     * for the same container includes it once.
+     */
+    public void onAbandoned(WorkContainer<?, ?> abandonedWork) {
+        includeInSelection(abandonedWork);
+    }
+
 
     public boolean isEmpty() {
         return workMap.isEmpty();

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ShardManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ShardManager.java
@@ -410,6 +410,21 @@ public class ShardManager<K, V> {
     }
 
     /**
+     * Work returned without a verdict - restores shard availability but, unlike {@link #onFailure}, does
+     * <em>not</em> insert into the retry queue. There is nothing to retry: the record was never attempted to a
+     * conclusion, so it becomes immediately selectable rather than waiting out a retry delay it never earned.
+     * <p>
+     * Idempotent in the same sense as {@link #onFailure} - work may or may not have been removed already, and the
+     * shard's selection claim is a compare-and-set, so a repeat call counts the container once.
+     */
+    public void onAbandoned(WorkContainer<?, ?> wc) {
+        log.debug("Work ABANDONED without verdict");
+
+        var key = computeShardKey(wc);
+        getShard(key).ifPresent(shard -> shard.onAbandoned(wc));
+    }
+
+    /**
      * @return none if there are no messages to retry
      */
     public Optional<Duration> getLowestRetryTime() {

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkContainer.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkContainer.java
@@ -335,6 +335,31 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
     private final AtomicBoolean selectionClaimed = new AtomicBoolean(false);
 
     /**
+     * Set when this delivery is handed back to scheduling without any verdict at all - the record was neither
+     * processed successfully nor seen to fail. An external engine whose worker disconnects mid-record has no
+     * verdict to report, but the record must not be treated as a failure either: a dropped connection is not a
+     * processing attempt and must not consume a retry.
+     * <p>
+     * <b>Why this is not an {@link ExecutionState}</b>, given that {@link #state} exists precisely so that two
+     * fields cannot contradict each other. The hazard that collapsing fixed was a claim decision <em>reading</em>
+     * one field and being contradicted by the other; nothing reads this one to decide a claim. It is not a
+     * lifecycle position but a note left by the returner for {@link WorkManager#handleFutureResult} - "there is
+     * no verdict coming, and that is expected" - which is the same reason {@link #selectionClaimed} is its own
+     * field: the state at an instant records what the container is, never who acted on it. An abandoned record
+     * that has left flight is {@link ExecutionState#AVAILABLE}, which is exactly what it is, and is claimable on
+     * that basis alone.
+     * <p>
+     * Atomic rather than a plain field because the marker is written by whichever thread noticed the worker was
+     * gone and read by the controller, with no lock between them.
+     * <p>
+     * Deliberately distinct from the verdict: an empty verdict with this marker unset is still the bug
+     * {@link WorkManager#handleFutureResult} throws on.
+     *
+     * @see #markAbandoned()
+     */
+    private final AtomicBoolean abandoned = new AtomicBoolean(false);
+
+    /**
      * How many times this record has been handed to a worker. Incremented only by a WON claim, so a refused
      * claim leaves it untouched - which is one of the properties {@code WorkClaimStateMachineTest} pins.
      * <p>
@@ -550,6 +575,26 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
         return !isInFlight();
     }
 
+    /**
+     * Marks this delivery as returned without a verdict, so {@link WorkManager#handleFutureResult} returns it to
+     * scheduling rather than throwing. Does not touch the failure count or the retry delay - the record is
+     * redelivered as the same attempt it already was.
+     *
+     * @see #abandoned
+     */
+    public void markAbandoned() {
+        log.trace("Abandoning without verdict {}", this);
+        abandoned.set(true);
+    }
+
+    /**
+     * @return true if this delivery was handed back with no verdict, and has not since been claimed again
+     * @see #abandoned
+     */
+    public boolean isAbandoned() {
+        return abandoned.get();
+    }
+
     public boolean isInFlight() {
         return state.get().state().isInFlight();
     }
@@ -663,6 +708,12 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
             return false;
         }
         log.trace("Queueing for execution: {}", this);
+        // A redelivery is a fresh attempt and carries no note from the last one. The verdict clears itself - the
+        // transition above lands on IN_FLIGHT, which has none - but this marker is not part of that state, so it
+        // is cleared here, by the claim WINNER and only after the compare-and-set has been won. A record that
+        // failed, was redelivered and was then abandoned would otherwise still be carrying the previous
+        // delivery's marker.
+        abandoned.set(false);
         deliveryCount.incrementAndGet();
         timeTakenAsWorkMs = of(System.currentTimeMillis());
         return true;

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkManager.java
@@ -276,6 +276,31 @@ public class WorkManager<K, V> implements ConsumerRebalanceListener {
         numberRecordsOutForProcessing--;
     }
 
+    /**
+     * Work returned with no verdict at all - neither succeeded nor failed. Used by external engines when the
+     * process holding a record goes away before reporting on it: the record has to go back into scheduling
+     * without the return counting as a processing attempt.
+     * <p>
+     * Deliberately not {@link #onFailureResult}: that increments the failure counter, records failure history
+     * against the partition, and queues a retry the record never earned. The only thing shared is the in-flight
+     * bookkeeping, which must net out exactly - {@link #numberRecordsOutForProcessing} gates the broker poller,
+     * and drift in it stalls the consumer silently while it still looks alive.
+     */
+    public void onAbandonedResult(WorkContainer<K, V> wc) {
+        if (wc.isNotInFlight()) {
+            // A disconnect detected while a report was already in flight can return the same record twice.
+            // Decrementing again would drift the counter downwards and eventually stall the poller.
+            log.warn("Abandoned work returned more than once, ignoring the duplicate return {}", wc);
+            return;
+        }
+
+        log.debug("Work returned without a verdict, returning to scheduling {}", wc);
+
+        wc.endFlight();
+        sm.onAbandoned(wc);
+        numberRecordsOutForProcessing--;
+    }
+
     public long getNumberOfIncompleteOffsets() {
         return pm.getNumberOfIncompleteOffsets();
     }
@@ -434,6 +459,8 @@ public class WorkManager<K, V> implements ConsumerRebalanceListener {
                 } else {
                     onFailureResult(wc, partitionState);
                 }
+            } else if (wc.isAbandoned()) {
+                onAbandonedResult(wc);
             } else {
                 throw new IllegalStateException("Work returned, but without a success flag - report a bug");
             }

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/WorkManagerTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/WorkManagerTest.java
@@ -47,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.*;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static pl.tlinkowski.unij.api.UniLists.of;
 
@@ -845,8 +846,11 @@ public class WorkManagerTest {
      * with no clamp to catch it - so this drives all of them through {@link WorkManager} in one sequence:
      * success, failure into retry back-off, retry redelivery, a stale sweep triggered by a partition being
      * re-assigned underneath live work, a partition revocation that takes both a parked record and one still
-     * out at a worker, and the stale result that worker later hands back. (The branch developing external
-     * engines adds a further departure - a verdict-free abandonment - and extends this walk with it there.)
+     * out at a worker, and the stale result that worker later hands back.
+     * <p>
+     * The verdict-free return the external engines needed has since landed, and it turned out <em>not</em> to be
+     * a further departure - the record stays resident - so it extends this coverage rather than this walk:
+     * {@link #abandonmentLeavesTheConservationFigureUnmoved()}.
      */
     @Test
     void theConservationFigureMatchesTheShardsThroughEveryKindOfDeparture() {
@@ -975,6 +979,236 @@ public class WorkManagerTest {
                 .collect(Collectors.toList());
         assertThat(onPartition).hasSize(3);
         return onPartition;
+    }
+
+
+    // -----------------------------------------------------------------------------------------------------
+    // Verdict-free work return (astubbs#242) - a record can go back to scheduling with no verdict at all,
+    // without the return counting as a processing attempt. Used by external engines when the process holding
+    // a record disappears before reporting on it.
+    // -----------------------------------------------------------------------------------------------------
+
+    /**
+     * Returns work through the real dispatch path rather than calling the result handler directly, so the
+     * branch selection in {@link WorkManager#handleFutureResult} is what is under test.
+     */
+    private void abandon(WorkContainer<String, String> wc) {
+        wc.markAbandoned();
+        wm.handleFutureResult(wc);
+    }
+
+    @Test
+    void abandonedWorkBecomesSelectableAgain() {
+        setupUnordered();
+        registerSomeWork();
+
+        var taken = wm.getWorkIfAvailable(1);
+        assertThat(taken).hasSize(1);
+        var wc = taken.get(0);
+
+        abandon(wc);
+
+        var retaken = wm.getWorkIfAvailable(1);
+        assertThat(retaken)
+                .as("work returned without a verdict is immediately selectable again - it earned no retry delay")
+                .hasSize(1);
+        assertThat(retaken.get(0).offset()).isEqualTo(wc.offset());
+    }
+
+    @Test
+    void abandoningDoesNotConsumeARetryAttempt() {
+        setupUnordered();
+        registerSomeWork();
+
+        var wc = wm.getWorkIfAvailable(1).get(0);
+        assertThat(wc.getNumberOfFailedAttempts()).isEqualTo(0);
+
+        abandon(wc);
+
+        assertThat(wc.getNumberOfFailedAttempts())
+                .as("a dropped connection is not a processing attempt")
+                .isEqualTo(0);
+        assertThat(wc.getLastFailedAt()).isEmpty();
+    }
+
+    /**
+     * Covers AE9: a worker killed while holding a record on its second attempt must see that record redelivered
+     * still reporting one prior failure, not two.
+     */
+    @Test
+    void abandonAfterAPriorFailureKeepsTheAttemptCount() {
+        setupUnordered();
+        registerSomeWork();
+
+        var wc = wm.getWorkIfAvailable(1).get(0);
+        fail(wc);
+        assertThat(wc.getNumberOfFailedAttempts()).isEqualTo(1);
+
+        advanceClockByDelay();
+        var retaken = wm.getWorkIfAvailable(1);
+        assertThat(retaken).hasSize(1);
+        var second = retaken.get(0);
+        assertThat(second.offset()).isEqualTo(wc.offset());
+
+        abandon(second);
+
+        assertThat(second.getNumberOfFailedAttempts())
+                .as("attempt count is unchanged by a verdict-free return")
+                .isEqualTo(1);
+
+        // Without clearing the stale verdict on redelivery, this record still carries
+        // maybeUserFunctionSucceeded == false from its earlier failure, takes the failure path, and lands in the
+        // retry queue behind a delay it never earned - so it would NOT be selectable here.
+        var third = wm.getWorkIfAvailable(1);
+        assertThat(third)
+                .as("selectable immediately - an abandoned record earns no retry delay, even after a prior failure")
+                .hasSize(1);
+        assertThat(third.get(0).getNumberOfFailedAttempts())
+                .as("redelivered still reporting one prior failure, not two")
+                .isEqualTo(1);
+    }
+
+    /**
+     * The in-flight counter gates the broker poller. Drift in it stalls the consumer silently while it still
+     * looks alive, so this asserts the exact number rather than merely that work keeps flowing.
+     */
+    @Test
+    void abandonReturnsTheInFlightCounterToItsPreviousValue() {
+        setupUnordered();
+        registerSomeWork();
+
+        long baseline = wm.getNumberRecordsOutForProcessing();
+        assertThat(baseline).isEqualTo(0);
+
+        var taken = wm.getWorkIfAvailable(2);
+        assertThat(taken).hasSize(2);
+        assertThat(wm.getNumberRecordsOutForProcessing()).isEqualTo(2);
+
+        abandon(taken.get(0));
+        assertThat(wm.getNumberRecordsOutForProcessing())
+                .as("exactly one decrement per abandoned record")
+                .isEqualTo(1);
+
+        abandon(taken.get(1));
+        assertThat(wm.getNumberRecordsOutForProcessing())
+                .as("counter is back to where it started, with no work lost")
+                .isEqualTo(baseline);
+    }
+
+    @Test
+    void abandoningTwiceDoesNotDoubleDecrementTheCounter() {
+        setupUnordered();
+        registerSomeWork();
+
+        var wc = wm.getWorkIfAvailable(1).get(0);
+        assertThat(wm.getNumberRecordsOutForProcessing()).isEqualTo(1);
+
+        abandon(wc);
+        assertThat(wm.getNumberRecordsOutForProcessing()).isEqualTo(0);
+
+        // a disconnect detected while a report is already in flight can return the same record twice
+        wm.handleFutureResult(wc);
+
+        assertThat(wm.getNumberRecordsOutForProcessing())
+                .as("the duplicate return is ignored rather than driving the counter negative")
+                .isEqualTo(0);
+    }
+
+    /**
+     * The extension the conservation walk's javadoc reserved for the external-engine work
+     * ({@link #theConservationFigureMatchesTheShardsThroughEveryKindOfDeparture()}). Abandonment is the one
+     * return path that retires nothing - the record stays resident in its shard - so the conservation figure
+     * behind the broker-poller load gate must be unmoved by it, in both directions.
+     */
+    @Test
+    void abandonmentLeavesTheConservationFigureUnmoved() {
+        setupUnordered();
+        registerSomeWork();
+
+        var taken = wm.getWorkIfAvailable(3);
+        assertThat(taken).hasSize(3);
+        assertConservationHolds("with every record out at a worker");
+        assertThat(wm.getNumberOfRecordsInShards()).isEqualTo(3);
+
+        taken.forEach(this::abandon);
+
+        assertConservationHolds("after every record was returned without a verdict");
+        assertThat(wm.getNumberOfRecordsInShards())
+                .as("a verdict-free return is not a departure - the record is still the system's responsibility")
+                .isEqualTo(3);
+        assertThat(wm.getSm().getRecordPopulation().getRetiredTotal())
+                .as("abandonment retires nothing, so nothing may be deducted from the population")
+                .isZero();
+    }
+
+    @Test
+    void workWithNeitherVerdictNorAbandonMarkerStillThrows() {
+        setupUnordered();
+        registerSomeWork();
+
+        var wc = wm.getWorkIfAvailable(1).get(0);
+
+        assertThatThrownBy(() -> wm.handleFutureResult(wc))
+                .as("an empty verdict with no abandon marker is still the bug it always was")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("without a success flag");
+    }
+
+    /**
+     * The marker is a note about ONE delivery, so winning a fresh claim has to clear it. Left set, the next
+     * verdict-free return of the same record would be silently forgiven instead of reported - the bug guard above
+     * would stop working for every record that had ever been abandoned, and nothing else would notice.
+     * <p>
+     * The verdict half of this used to need clearing too, and no longer does: astubbs/parallel-consumer#335 made
+     * the verdict a function of the execution state, and a won claim lands on {@code IN_FLIGHT}, which has none.
+     */
+    @Test
+    void aFreshClaimClearsThePreviousDeliverysAbandonMarker() {
+        setupUnordered();
+        registerSomeWork();
+
+        var wc = wm.getWorkIfAvailable(1).get(0);
+        abandon(wc);
+        assertThat(wc.isAbandoned()).isTrue();
+
+        var retaken = wm.getWorkIfAvailable(1);
+        assertThat(retaken).hasSize(1);
+        var second = retaken.get(0);
+        assertThat(second.isAbandoned())
+                .as("a redelivery is a fresh attempt, carrying no note from the previous one")
+                .isFalse();
+
+        assertThatThrownBy(() -> wm.handleFutureResult(second))
+                .as("so a genuinely verdict-free return is still reported, even on a record abandoned before")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("without a success flag");
+    }
+
+    /**
+     * Covers AE15: every worker disconnecting is not an end-of-life signal. The returned records stay in
+     * scheduling rather than being dropped or retried.
+     */
+    @Test
+    void everyWorkerDisconnectingLeavesAllWorkInScheduling() {
+        setupUnordered();
+        registerSomeWork();
+
+        var taken = wm.getWorkIfAvailable(3);
+        assertThat(taken).hasSize(3);
+        assertThat(wm.getNumberOfWorkQueuedInShardsAwaitingSelection()).isEqualTo(0);
+
+        // the whole fleet goes away without reporting on anything
+        taken.forEach(this::abandon);
+
+        assertThat(wm.getNumberRecordsOutForProcessing()).isEqualTo(0);
+        assertThat(wm.getNumberOfWorkQueuedInShardsAwaitingSelection())
+                .as("all three records are back awaiting selection, none discarded")
+                .isEqualTo(3);
+
+        var retaken = wm.getWorkIfAvailable(3);
+        assertThat(retaken)
+                .as("and all three are handed out again once a worker reconnects")
+                .hasSize(3);
     }
 
 }


### PR DESCRIPTION
Core has two ways for work to come back and neither fits a worker that vanished. `onSuccessResult` commits the offset. `onFailureResult` records a failure, queues a retry and bills the record an attempt. But an external engine whose worker process dies mid-record has **no verdict to report**: nothing failed, so charging a retry attempt is wrong, and a record that reliably outlives its worker would burn through its retry budget without ever being processed.

Today `handleFutureResult` throws `IllegalStateException` on a verdict-free return, so the engine cannot hand the record back at all. This adds the third path.

## What changed

An `abandoned` marker on `WorkContainer`, deliberately distinct from the user function's verdict, selects a branch that does what the stale-work branch does — `endFlight()` and exactly one decrement — then restores shard availability **without** a retry-queue insert, so the record is immediately selectable rather than waiting out a delay it never earned. An empty verdict with the marker unset still throws; that is the bug it always was.

## Two things worth reviewer attention

**The in-flight counter is the danger.** `numberRecordsOutForProcessing` gates the broker poller through `isSufficientlyLoaded`, and drift in it stalls the consumer silently while it still looks alive — this repo already has that failure documented in `docs/solutions/test-flakiness/`. So `onAbandonedResult` ignores a repeat return rather than decrementing twice, which is a real case rather than a hypothetical: a disconnect detected while a report is already in flight returns the same record twice. The tests assert the exact counter value, not merely that work keeps flowing.

**Redelivery has to clear the previous delivery's state.** A redelivery is a fresh attempt, so nothing the last one left behind may decide its outcome. The marker is cleared in `actOnClaim`, after the compare-and-set — by the claim *winner* and only then. Left set, every later verdict-free return of a record that had ever been abandoned would be silently forgiven instead of reported, which is what `aFreshClaimClearsThePreviousDeliverysAbandonMarker` pins.

## Resurrected from its own closure, rebased onto current master

This PR was closed as folded into astubbs/parallel-consumer#293 while that PR was the only home for it. It is landing on its own again because a core scheduling primitive should not first arrive inside a remote-runtime PR; astubbs/parallel-consumer#293 and its stack depend on this one. The change is the same. Three things moved to fit master, and in each case master's design won:

- **The verdict no longer needs clearing on redelivery.** astubbs/parallel-consumer#335 collapsed `inFlight` and `maybeUserFunctionSucceeded` into one atomic `ExecutionState`, so the verdict is derived from the state and a won claim lands on `IN_FLIGHT`, which has none. The original reset that field explicitly; the field is gone and the reset with it. Only the abandon marker is cleared now.
- **The marker stays its own field rather than becoming a seventh `ExecutionState`,** and is an `AtomicBoolean` rather than a plain boolean. "One field, because two were the bug" is about a claim *decision* reading one field and being contradicted by the other — and nothing reads this one to decide a claim. It is a note left by the returner for `handleFutureResult`, which is why `selectionClaimed` is also its own field. The field javadoc carries that argument in place.
- **The shard-level restore goes through the selection claim,** not a raw counter increment: astubbs/parallel-consumer#336 replaced `availableWorkContainerCnt` with a compare-and-set-owned claim, so idempotence is now structural instead of argued.

Master's conservation walk reserved a slot for this in its own javadoc — "the branch developing external engines adds a further departure". On contact it is **not** a departure: abandonment retires nothing, because the record stays resident in its shard. The reservation is answered with a test asserting the conservation figure is unmoved, and the javadoc corrected to say so.

## Verification

- `bin/build.sh` — full reactor unit build green.
- Teeth checked twice, each with a control arm. Removing the `handleFutureResult` branch fails all seven behavioural tests, and leaves `workWithNeitherVerdictNorAbandonMarkerStillThrows` correctly green since that one guards the pre-existing behaviour. Removing the marker clear in `actOnClaim` fails exactly `aFreshClaimClearsThePreviousDeliverysAbandonMarker` and nothing else.

## Context

This is unit U4 of the language proxy plan (`docs/plans/2026-08-12-001-feat-language-proxy-plan.md`, on astubbs/parallel-consumer#293). It is deliberately dependency-free and lands on its own so core owners can review it without the proxy module in the way. Nothing else in that plan is needed for this to be correct or useful.

## Checklist

- [x] Docs updated — the field and method javadoc this change touches, including the argument for why the marker is its own field, and the correction to the conservation walk's reservation.
- [ ] User-facing feature documentation data added under `docs/features/` — N/A - no user-facing feature. The new path is reachable only from an engine that calls `markAbandoned()`, and no shipped engine does yet.
- [x] Tests added/updated — eight behavioural tests in `WorkManagerTest`, each proven able to fail by a control arm that removes the one line it guards.
- [x] Title & body reflect the final content of this PR
- [ ] Ran `ce-simplify` and `ce-code-review` locally — N/A - neither was run. The diff was instead validated by two control arms (above), and the automated review is the intended next step on this PR.
