### PR TITLE
fix(core) #209: harden work submission against an already-closed worker pool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,7 +288,7 @@ chaos suite, the ambient probe - and wins where the two disagree. Four rules bin
   test an uncontended broker: passes → contention; still fails → investigate the code, do not mask
   it. Say in the commit/PR which cause you established and how. Loosening deadlines to go green
   hides exactly the bugs this library exists to prevent. **When a broker integration test fails,
-  read its `=== AMBIENT PROBE AUTOPSY ===` block before diagnosing by hand** - and check the
+  read its `AMBIENT PROBE AUTOPSY` block before diagnosing by hand** - and check the
   probe's thresholds before believing a clean one.
 - **A flake fails the build - there is no retry, deliberately.** The CI scripts no longer pass
   `-Dsurefire.rerunFailingTestsCount=2`: it retried failures into green runs and hid three flakes no

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -18,7 +18,7 @@ gh api "repos/astubbs/parallel-consumer/actions/jobs/$jid/logs" > /tmp/job.log
 ```
 
 Then grep it: `Tests run:`, `<<< FAILURE`, and for broker integration tests the
-`=== AMBIENT PROBE AUTOPSY ===` block, which classifies contention-vs-bug before you start reading
+`AMBIENT PROBE AUTOPSY` block, which classifies contention-vs-bug before you start reading
 stack traces (see [`docs/testing.md`](testing.md)).
 
 ## Workflows

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -152,7 +152,7 @@ branches passing the same day only means their seeds did not draw this interleav
 
 **Retrieval note - the autopsy was NOT in the CI log.** GitHub truncated the job's log stream partway
 through the run, so neither `gh run view --log` nor `--log-failed` contained the
-`=== AMBIENT PROBE AUTOPSY ===` block, and the check-run annotations carried only
+`AMBIENT PROBE AUTOPSY` block, and the check-run annotations carried only
 `Process completed with exit code 1`. The autopsy and all three seeds came from the **uploaded test
 report artifact** (`highcpu-fast-feedback-reports-Chaos Pain Suite-*`), inside the failsafe XML for
 the failing class, where the block is embedded in the captured system-out. Go there first for a

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -127,6 +127,22 @@ family's original deadlock (astubbs#29) is still open. **Do not read this entry 
 either.** It records a signature and a replayable seed; which defect it belongs to, if any, is what
 the replay is for.
 
+**Answered, 2026-08-13: this one was the test harness, not the product.** astubbs#292 (squash
+`40575362`) read this exact job log and found instance 34 drawing
+`STOP_NO_DRAIN -> RESTART -> STOP_NO_DRAIN -> RESTART` in ~4s, then running **twice** 138ms apart on
+two pool workers, each building its own consumer:
+
+```
+05:00:42.192  Runner-34 [worker-10]  Running consumer instance 34   -> KafkaConsumer@60186851
+05:00:42.330  Runner-34 [worker-5]   WARN previous PC did not close within 10s, proceeding anyway
+05:00:42.330  Runner-34 [worker-5]   Running consumer instance 34   -> KafkaConsumer@5b669f02
+```
+
+Both joined `group-1-1929174831`; the probe fired four seconds later. Two PCs for one logical
+instance, one of them orphaned and closed by nobody - a group member that answers no rebalance. That
+is the double-start race astubbs#292 fixed, so this sighting is **retired from the family**: it was
+never evidence about astubbs#29 or astubbs#80. The replay above is no longer worth spending.
+
 **Branch context: astubbs#289 is not a suspect, and here is why rather than an assertion.** It
 changes documentation, logback *test* configuration, `<repositories>` blocks in three poms,
 `CODEOWNERS`, deleted upstream CI files, one added unit test, and exactly one line of main source -
@@ -145,8 +161,204 @@ exist. This generalises beyond the entry - it belongs in the ambient-probe secti
 `docs/testing.md`, which currently states that every broker integration test failure *log* includes
 the block, and that file was owned by another branch when this was written.
 
-**Fifth sighting, 2026-08-18 - the fleet-level `NO_PROGRESS` arm, twice in one night (this entry
-and the sixth below share a signature).** `ChaosChurnStormIT.churnStormMeetsSlosAndBalancesLedger`
+**Fifth sighting, 2026-08-13 - the same `ZOMBIE_MEMBER` signature, with astubbs#292 present and no
+double-start anywhere in the log.** This is the one that matters, because it is what the fourth
+sighting's attribution does *not* cover.
+`ChaosChurnStormIT` on [job 94333179847](https://github.com/astubbs/parallel-consumer/actions/runs/31663523870/job/94333179847),
+at head `8fc2a244`. **Replay seed `8724638006462097730`**:
+
+    ./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true \
+      -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=8724638006462097730
+
+The harness was ruled out by counting, not by assertion - **0** concurrent double-runs across 41
+`run()` invocations over 16 instances, **0** guard engagements (so the race window was never even
+entered), and **0** teardown indicators: no drain exceeded its 60s join budget, no `settleFleet`
+close error, no `ConcurrentModificationException`. The chaos timeline around the violation is
+healthy - every `STOP_DRAIN` paired with a `DRAIN_COMPLETE`, restarts proceeding, PCs logging
+"Close complete". A member simply stopped answering the rebalance with no orphaned PC involved.
+
+**The triage rule this changes.** The third sighting says nothing distinguishes a product stall from
+"an ordinary chaos `STOP_NO_DRAIN` racing a slow shutdown". That is now half answered - one cause
+identified and removed, at least one remaining - and the check is cheap:
+
+> A `ZOMBIE_MEMBER` violation is no longer evidence of the harness double-start; that is fixed and
+> guarded. Grep the log for two `Running consumer instance N` lines on different pool workers within
+> ~2s. Present, it is the harness and astubbs#292's guards regressed. **Absent, it is the other
+> cause, and this file is where it belongs.**
+
+astubbs#29 and confluentinc#857 remain open, and none of this attributes anything to either.
+
+**Corroboration that the guards do engage.** The chaos lane on astubbs#296 at head `347ceae90`
+(`ChaosRevokeUnderWorkCooperativeIT`, `ChaosRevokeUnderWorkIT`) came back with **14** guard
+engagements - `start aborted - stopped while this start was queued` / `async stop skipped - close
+already in progress` - and zero double-runs, zero `ZOMBIE_MEMBER`, zero
+`ConcurrentModificationException`. So on that run the window was entered fourteen times and closed
+every time. Absence of the signature there is weak evidence on its own (it is drawn per seed); the
+engagement count is the part worth keeping.
+
+**Also open, recorded here so it is not lost.** A `CLASS2_STALL`/`LAG_STAGNATION` fired locally on
+the merged tree - `ChaosRevokeUnderWorkCooperativeIT`, lag stagnant 154s against a 150s bound, group
+STABLE with heartbeats flowing - and did **not** reproduce on a re-run of the same scenario. That is
+the second sighting's signature rather than the zombie arm, still intermittent, still open. It also
+weakens the second sighting's "whatever remains is eager-protocol-specific" reading further, on the
+cooperative side, without settling it.
+
+**Sixth sighting, 2026-08-13 - the eager `CLASS2_STALL` again, and the first time both arms fired in
+one run.** `ChaosRevokeUnderWorkIT.revokeUnderWorkStaysProtocolHonest` (the **eager** variant) was
+killed by `ProgressProbe` on
+[job 94355941379](https://github.com/astubbs/parallel-consumer/actions/runs/31671178444/job/94355941379),
+on astubbs#296 at head `e7956798c`. **Replay seed `4317404402494426241`**:
+
+    ./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true \
+      -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=4317404402494426241
+
+The autopsy in full - **9 violations**, one zombie and eight stalls, all on topic
+`ChaosRevokeUnderWorkIT-w4-255551928`:
+
+```
+=== AMBIENT PROBE AUTOPSY (test failed): revokeUnderWorkStaysProtocolHonest() ===
+failure: TerminalFailureException: probe violation
+violations (9):
+  - ZOMBIE_MEMBER/REBALANCE_BLOCKED: group 'group-1-1258752376' dwelling in PreparingRebalance
+    for 15s (bound 15s) - a member is not answering the rebalance (protocol-unresponsive)
+  - CLASS2_STALL/LAG_STAGNATION: partition -43 lag=2438 committed stagnant at 669  for 154s (bound 150s)
+  - CLASS2_STALL/LAG_STAGNATION: partition -10 lag=2255 committed stagnant at 818  for 154s
+  - CLASS2_STALL/LAG_STAGNATION: partition -14 lag=2414 committed stagnant at 740  for 154s
+  - CLASS2_STALL/LAG_STAGNATION: partition -47 lag=1885 committed stagnant at 1273 for 154s
+  - CLASS2_STALL/LAG_STAGNATION: partition  -8 lag=2197 committed stagnant at 937  for 154s
+  - CLASS2_STALL/LAG_STAGNATION: partition -41 lag=591  committed stagnant at 2435 for 154s
+  - CLASS2_STALL/LAG_STAGNATION: partition -12 lag=2320 committed stagnant at 749  for 154s
+  - CLASS2_STALL/LAG_STAGNATION: partition -16 lag=496  committed stagnant at 2688 for 154s
+peaks: rebalanceDwell=15444ms lagStagnation=154099ms
+frozen partitions (committed stagnant >= 10s with lag >= 1):
+  - -10: committed=818  end=3073 lag=2255 stagnant=17s
+  - -12: committed=749  end=3069 lag=2320 stagnant=17s
+  - -14: committed=740  end=3154 lag=2414 stagnant=17s
+  - -16: committed=2688 end=3184 lag=496  stagnant=17s
+  - -27: committed=2846 end=3132 lag=286  stagnant=12s
+  - -29: committed=2465 end=3045 lag=580  stagnant=12s
+```
+
+**Read the two numbers together.** Every stall violation reports 154s of stagnation, but the frozen
+list reports 12-17s. They are different clocks, not a contradiction: the violation's 154s is the
+probe's stagnation timer against its 150s bound, while `stagnant=` is how long that partition had
+been frozen at the moment the autopsy was taken. Six partitions were still frozen at the end; eight
+had breached the bound during the run.
+
+**Also worth noting: partitions -41 and -16 stalled with committed offsets *ahead* of the others**
+(2435 and 2688 against 669-937) and correspondingly small lag. So this is not one wedged consumer
+falling behind from the start - partitions that had progressed furthest froze too.
+
+**This is the second sighting's signature, reproduced.** Same scenario, same eager variant, same
+154s-against-150s stagnation, same "group STABLE + heartbeats flowing" framing. The second sighting
+stood alone for two days; it no longer does.
+
+**The control arm holds, and strengthens the eager-specific reading.** `ChaosRevokeUnderWorkCooperativeIT`
+and `ChaosChurnStormIT` both **passed in this same run** - same runner, same broker image, same
+minute. That is exactly the pattern the second sighting reported (cooperative green while eager
+died), now seen twice, which is the strongest evidence yet that whatever remains is
+eager-protocol-specific - where astubbs#29's `onPartitionsRevoked` / `commitOffsetsThatAreReady`
+contention lives.
+
+**Both arms in one run is new.** Previous entries treat `CLASS2_STALL` and `ZOMBIE_MEMBER` as
+separate arms seen in separate runs. Here the zombie violation fired alongside eight stall
+violations in the same autopsy. Whether that makes them one defect or two coincident ones is not
+settled by this entry - but "these are unrelated signatures" can no longer be assumed for free. The
+ordering is the thread to pull: a member that stops answering the rebalance and partitions whose
+committed offsets stop moving are exactly what one wedged commit path would produce at both ends.
+
+**Not quarantined, deliberately.** `Chaos Pain Suite` is **not** in master's required-checks ruleset
+- it is the advisory highcpu lane - so this red blocks no merge, and quarantine exists to move a red
+out of the *gating* suites. Quarantining would also block the 0.6.0.0 release under registry rule 5
+in order to silence something that is not gating, and it would switch off the detector that is
+producing this file's evidence. Each red here is a sighting plus a seed that dies with its artifact;
+that is the asset, not the noise. Re-read this if the reds get tiresome enough to reconsider.
+
+**The harness is excluded by the fifth sighting's own rule, applied and counted.** Across 38 `run()`
+invocations over 14 instances there were **0** concurrent double-runs (two `Running consumer instance
+N` lines on different pool workers within 2s), with 10 guard engagements showing the guards
+themselves active. Not the astubbs#292 double-start.
+
+**Branch context: astubbs#296 is not a suspect, and this run proves it unusually cleanly** - the
+commit under test is **documentation-only** (this very file), and the same branch's *previous* head
+ran the same suite green. Its product change is a shutdown-path guard; the log contains zero
+`rejected from ThreadPoolExecutor` and zero of that guard's `Worker pool is shut down` warnings, so
+it never even engaged.
+
+**Retrieval note, again, and it caught a careful reader out.** The console log for this job was
+**truncated mid-run** - grepping it returned zero for every probe signature, which reads exactly like
+a clean run. All twelve stall violations, the zombie violation, the autopsy and the seed came from
+the **uploaded artifact** (`highcpu-fast-feedback-reports-Chaos Pain Suite-*`), inside the failsafe
+XML's captured system-out. The fourth sighting already recorded this; it is repeated here because
+the trap was walked into anyway, one screen after reading the warning. **A zero from the console is
+not a zero.**
+
+**Gated on astubbs#29: proving thread-parallel integration tests are safe again.** astubbs#68 made the integration
+suite reliable by *forking* per broker (`forkCount=4`), which sidesteps the deadlock rather than
+proving it gone - the contended `RebalanceEoSDeadlockTest.noDeadlockOnRevoke` failure it was hiding is
+the real confluentinc#857 bug. The deferred "Step 2" is to re-run with `-Dparallel-tests=true` on a
+shared broker **after astubbs#29 lands** and see whether it stays green. One probe on the highcpu runner
+hinted it might (forked unit suite green with threads enabled; the integration red was the separate
+`PartitionStateCommittedOffsetIT` flake, since fixed by astubbs#80), but one green run is not proof. Forking
+stays the default regardless: fork×threads measured no faster than fork alone, because forking already
+saturates the cores.
+
+---
+
+**Seventh sighting, 2026-08-14 - local, not CI, and the first one bisected against a clean
+baseline.** `PCMetricsTest.metricsRegisterBinding` failed a full multi-module unit run with
+`expected: 205.0 but was: 203.0 within 2 minutes` - two records that never completed. That is the
+family's signature, not a new one, and it appeared while landing astubbs#296's work-return path -
+since removed - whose whole subject was work being taken and not accounted for. So it had to be either the strongest evidence yet or a flake, and
+guessing was not acceptable.
+
+**Bisected, not reasoned about.** A detached worktree at the branch's last documentation-only commit
+gave a genuine pre-change baseline:
+
+| Run | Result |
+|---|---|
+| `PCMetricsTest` isolated, with the change | pass x2, 10s |
+| `PCMetricsTest` isolated, baseline | pass, 10s |
+| All modules, baseline | BUILD SUCCESS |
+| All modules, with the change | **FAILURE** (137s), then BUILD SUCCESS on re-run |
+
+**This is evidence the un-quarantine was premature, and the first write-up of it said otherwise.**
+`PCMetricsTest` was un-quarantined by astubbs#265 on 2026-08-13; this failure is from the day after,
+and astubbs#304 has since removed its row from `test-untracked-ci-flakes.md` on the grounds that the
+ledger named a quarantine no longer in force.
+
+The first version of this entry dismissed the sighting as "load, not the test". That is the exact
+move [`AGENTS.md`](../../AGENTS.md) warns against - *"a test failing under concurrent load may be
+exposing a real main-code bug that only manifests under stress"* - and it is self-serving here,
+because the load was partly self-inflicted by concurrent Maven runs. **"Only fails under load" is
+what a flaky test is.** The suite runs under load in CI too.
+
+What the bisect does establish is narrower than the dismissal claimed: the failure is not attributable
+to astubbs#296, because it reproduces on a clean baseline worktree and the branch's changes cannot
+reach a running instance. It says nothing about whether the test is fit for the gating lane.
+
+**What would settle it**: a full-suite run on a CI runner, not a developer box, repeated enough times
+to put a number on the rate. Until someone does that, treat the test as un-quarantined on the strength
+of astubbs#265's fix and one contrary observation, rather than as proven stable.
+
+**Flake.** The failing run took 137s where the passing ones take 10s, which is load, not logic. Two
+other timing-sensitive tests each failed exactly once across the same session's ~10 heavy runs and
+passed on repeat: `ParallelEoSStreamProcessorTest.processInKeyOrder` and
+`ParallelEoSStreamProcessorTest.executorThreadsInterruptedOnShutdownTimeout`. Three different tests,
+one failure each, none reproducible - that is a saturated box, not three regressions.
+
+**What this adds to the family.** The signature reproduces *locally*, off the chaos suite, on an
+ordinary unit run. Every prior sighting came from CI, which made the seed-randomised chaos harness
+the natural suspect. This one had no chaos harness involved at all, which weakens any reading that
+ties the family specifically to that suite.
+
+**The method is the reusable part.** Neither "it passed on retry" nor "it failed once" is evidence
+on its own. A worktree at the pre-change commit, the same command on both, is cheap and it is what
+turns "probably a flake" into an answer. Do that before attributing - or dismissing - anything with
+this signature, especially on a branch whose subject matter would explain it.
+
+**Eighth sighting, 2026-08-18 - the fleet-level `NO_PROGRESS` arm, twice in one night (this entry
+and the ninth below share a signature).** `ChaosChurnStormIT.churnStormMeetsSlosAndBalancesLedger`
 was killed fail-fast by `ProgressProbe` on
 [job 95579861648](https://github.com/astubbs/parallel-consumer/actions/runs/32093367999/job/95579861648),
 2026-08-18T02:52Z, on the astubbs#310 branch (docs+hooks only; since merged, branch deleted - the
@@ -179,7 +391,7 @@ log came from the run-logs archive
 attempt) - a second retrieval route alongside the fourth sighting's report-artifact note, and the
 console-log truncation trap is the same one recorded there.
 
-**Sixth sighting, 2026-08-18 - same test, same arm, four hours earlier, different branch.**
+**Ninth sighting, 2026-08-18 - same test, same arm, four hours earlier, different branch.**
 `ChaosChurnStormIT.churnStormMeetsSlosAndBalancesLedger`, killed by the same fleet detector on
 [job 95584026682's run, attempt at head d96375053](https://github.com/astubbs/parallel-consumer/actions/runs/32078875110)
 (2026-08-17T23:04Z), on astubbs#308 - a docs-only branch (ideation/strategy/ledger files, zero
@@ -208,13 +420,3 @@ consumed count freezes outright with the group ostensibly live, under churn-stor
 productive trap. Two replayable seeds with the same signature within four hours is the strongest
 single-arm evidence the ledger holds; whichever defect they belong to, the replays are now the
 cheapest next experiment the family has.
-
-**Gated on astubbs#29: proving thread-parallel integration tests are safe again.** astubbs#68 made the integration
-suite reliable by *forking* per broker (`forkCount=4`), which sidesteps the deadlock rather than
-proving it gone - the contended `RebalanceEoSDeadlockTest.noDeadlockOnRevoke` failure it was hiding is
-the real confluentinc#857 bug. The deferred "Step 2" is to re-run with `-Dparallel-tests=true` on a
-shared broker **after astubbs#29 lands** and see whether it stays green. One probe on the highcpu runner
-hinted it might (forked unit suite green with threads enabled; the integration red was the separate
-`PartitionStateCommittedOffsetIT` flake, since fixed by astubbs#80), but one green run is not proof. Forking
-stays the default regardless: fork×threads measured no faster than fork alone, because forking already
-saturates the cores.

--- a/docs/inflight/ci-mutation-lane-skip-reads-as-a-pass.md
+++ b/docs/inflight/ci-mutation-lane-skip-reads-as-a-pass.md
@@ -1,0 +1,97 @@
+# The mutation lane's skip renders as a green tick - decision pending
+
+**Open decision, not a bug.** The lane behaves exactly as designed and says so in its job summary.
+What is undecided is whether *the checks list* should keep showing a pass when the lane graded
+nothing. Raised off astubbs#296, whose only main-code file is
+`internal/AbstractParallelEoSStreamProcessor.java`: the lane went green in ~10s having asserted
+nothing about it.
+
+The scope decision itself - why `offsets.` only, and the order in which to re-widen - is owned by
+[`ci-mutation-testing.md`](ci-mutation-testing.md) and
+[`docs/plans/2026-08-03-002-mutation-testing-plan.md`](../plans/2026-08-03-002-mutation-testing-plan.md).
+This file owns only the visibility question.
+
+## Recommendation
+
+**Make the skip render as a *skipped* (grey) check rather than a green one; leave
+`PIT_DECIDABLE_PACKAGES` alone.** It is the only option that puts the truth where the reader already
+looks, and on this repo's shape it is cheaper than the status quo, not dearer.
+
+## What actually fires, and how often
+
+Three exit paths in `bin/ci-mutation-test.sh`; two of them are skips and both exit 0.
+
+| Path | Log line | Last 100 merged PRs | Since the lane landed (astubbs#111) |
+|---|---|---|---|
+| Nothing to mutate | `no core main-source classes changed` | 86 | 49 |
+| Nothing **decidable** to mutate | `changed classes are all outside the decidable packages` | 8 | 5 |
+| Actually scored mutants | - | 6 | 4 |
+
+So a green tick means "did no work" on **94 of 100** PRs. The path that prompted this - changed core
+main code, declined as undecidable - is **8 of the 14** PRs that touched core main code at all, i.e.
+when the lane had something it *could* have looked at, it declined more often than not.
+
+Method (re-run it rather than trusting the table): `gh pr list -R astubbs/parallel-consumer --state
+merged --limit 100 --json number,files`, then classify each PR by whether any path matches
+`^parallel-consumer-core/src/main/java/.*\.java$` and, of those, whether any matches
+`/parallelconsumer/offsets/`. Path-based, so it spans the `io.confluent` -> `bz.stub` rename;
+deletions are not filtered out, where the script's `--diff-filter=d` would.
+
+**Red is honest, green is not.** A genuine failure surfaces as a red check row - the job-level
+`continue-on-error: true      # advisory - never gates merge` in `.github/workflows/maven.yml` stops
+the *workflow run* failing, but the check run's conclusion is still `failure` (confirmed against a
+run where the mutation step failed). Only the green side is ambiguous.
+
+## Why the scope is right, and should not move
+
+Every declined class across those 8 PRs was in `internal.` (12) or `state.` (2) - precisely the
+argument in the plan's `is close to the worst possible target`: mutants to locks, loop conditions and
+timeouts hang rather than dying, and the covering tests are timing-based, so a survivor cannot be
+told from a race that did not happen. astubbs#296 is the textbook case, a shutdown race in the
+concurrency core. **Widening to `state.` would convert honest silence into unfalsifiable survivors**,
+and the plan already fixes the price of admission: a completed `state.` sweep, measured, not argued.
+
+One nuance the package filter cannot express: `internal/Documentation.java` (astubbs#289) is pure
+constants, where mutants *would* be decidable and also worthless. The filter is a proxy for
+"hang-prone concurrency" and errs toward silence on a couple of harmless classes. Not worth fixing.
+
+## Options considered
+
+- **Leave as-is.** Defensible: the lane never gates, the job summary already says
+  `This green tick is not evidence about test quality`, and the public limitation is disclosed in
+  `docs/data/testing-evidence.yaml` (`a skipped or narrow run is not a project-wide coverage claim`).
+  Rejected because the repo's recurring failure mode is false-green, and a row that is green 94% of
+  the time while meaning nothing is the purest instance of it on the board.
+- **Widen the decidable set.** Rejected above - it trades a truthful skip for noise.
+- **Post a second check run with `conclusion: neutral`.** Rejected: needs `checks: write` plumbing,
+  and the plan already established (in removing the duplicate PIT lanes) that an extra tick trains
+  people to skim the list, which is how a real red gets missed.
+- **Skip the job instead of passing it.** Split the decision into a cheap `mutation-scope` job that
+  calls the existing script in a scope-only mode, then guard the real job with `if:` so the row
+  renders grey. The check name can carry the reason via `${{ needs... }}` interpolation - the pattern
+  `.github/workflows/pr-highcpu-fast-feedback.yml` already uses for
+  `format('{0} (optional)', matrix.suite-name)`.
+
+## Why the recommended option is cost-negative
+
+On the 94% skip path the job today pays `actions/setup-java` **and** a Maven cache restore before the
+script gets to decide there is nothing to do. Moving the decision in front of those steps deletes
+that work from almost every PR. The scope job still needs the `fetch-depth: 0` checkout the diff
+depends on; deriving the changed-file list from the PR API instead would drop even that, but would
+fork the decidable regex away from `bin/ci-mutation-test.sh`, which must stay its sole owner.
+
+Both skips collapse to one grey row, which is correct - "we graded nothing" is the reader's answer
+either way, and the summary still distinguishes them.
+
+## Do this first, regardless of the decision above
+
+The only always-loaded agent-facing warning -
+`Confirm the mutation lane scored mutants rather than trusting its tick` in `AGENTS.md` - is the last
+bullet of the temporary `IN FLIGHT: rename your branch BEFORE you merge master` section, which that
+same file instructs to **delete** once no open branch predates the rename. Deleting the section
+deletes the warning. Its wording is rename-specific too ("when its package regex is stale"), which is
+narrower than the case that actually fires. Re-home it, or the visibility gap widens on its own.
+
+## Who decides
+
+Antony. The measurement and the reasoning are here; nothing is blocked on further investigation.

--- a/docs/inflight/ci-review-agent.md
+++ b/docs/inflight/ci-review-agent.md
@@ -13,7 +13,9 @@ How the reviewer and its gate work, and the contract for asking for a review, ar
   PR. That is the same boundary the previous gate drew -
   it guards against the action failing quietly, not against the author - but it is worth re-reading
   if the review ever stops feeling load-bearing.
-- **The DISPATCHED reviewer cannot open inline review comments; the comment route can.** The
+- **The DISPATCHED reviewer cannot open inline review comments; the comment route can** - read off
+  the action's entity-event handling below, not off an observed thread; see the measured note linked
+  further down for what has and has not actually been seen. The
   action installs the inline-comment MCP server only for an *entity* event. `workflow_dispatch` is
   not one, so on a dispatch the tool does not exist and the grant was removed rather than left
   inert - blocking findings arrive as a marked section in the summary comment, and
@@ -90,10 +92,14 @@ How the reviewer and its gate work, and the contract for asking for a review, ar
   **The comment route is no better off, for a different reason.** It looks testable - just comment
   on a PR - but `issue_comment` workflows always run the **default branch's** copy, so a comment
   exercises master's `claude.yml`, never the one on your branch. The tool grants and the
-  `refresh-gate` added there are unverified in exactly the same way. The dispatch half of that
-  exercise is now done and is the entry above; **the comment route is still unexercised** - the
-  open questions are whether it really does open an inline thread, and whether `claude-review`
-  clears itself afterwards.
+  `refresh-gate` added there are unverified in exactly the same way.
+
+  **Both routes have since been exercised and measured**, and the result is closed, so it lives in
+  [`docs/solutions/workflow-issues/the-two-review-routes-measured-2026-08-17.md`](../solutions/workflow-issues/the-two-review-routes-measured-2026-08-17.md)
+  rather than here. The short version: the comment route posts, at both ends; the dispatch route can
+  run for nine minutes, conclude success, and post nothing, leaving `claude-review` green on an older
+  comment. **What is still open is only the inline thread** - neither run had a blocking finding, so
+  neither had occasion to open one, and deciding it needs a PR that does.
 - **The duplication scanners are pointed away from where agents duplicate.** `dups: clones` and
   `dups: similarity` scan `parallel-consumer-*/src` only, and the similarity job additionally
   filters `file_extensions: 'java'` - so `docs/`, `.github/`, `bin/` and `AGENTS.md` are scanned by

--- a/docs/inflight/next-actor-revival.md
+++ b/docs/inflight/next-actor-revival.md
@@ -23,7 +23,11 @@ Survivors, one line each (the doc carries the substance - read it before picking
 5. Skeleton-first strangler - land the six thread-ownership interfaces as a pure refactor; the
    mailbox becomes a per-seam swap
 6. Concurrency mass budget - ArchUnit ratchet on primitive counts; conversions graded on locks
-   removed
+   removed. **One reading already taken**, if a starting instrument is wanted: the control thread's
+   interrupt flag carries four unrelated meanings and has accrued four hand-clears, one of which does
+   not clear and only warns that it cannot tell which meaning it got -
+   [`waking-a-thread-by-interrupting-it-2026-08-17.md`](../solutions/workflow-issues/waking-a-thread-by-interrupting-it-2026-08-17.md)
+   has the count, the failure it caused in astubbs#296, and why a local clear can never hold
 
 Key facts the ideation verified (so nobody re-derives them): the framework proper is 537 lines in
 4 files coupled to PC by one 16-line marker interface; the two 2022 actor bases were never unified

--- a/docs/inflight/next-archunit-main-code-rules.md
+++ b/docs/inflight/next-archunit-main-code-rules.md
@@ -1,0 +1,71 @@
+# ArchUnit is wired up and barely used
+
+Nothing is switched off. There is no `archunit.properties`, no `FreezingArchRule`, no `@Disabled`,
+no `allowEmptyShould` suppression anywhere in the repo. Every rule that exists runs on every PR at
+ArchUnit's defaults, and they pass because the codebase complies.
+
+The reason no findings are ever seen is simply that **there are four rules, and three of them are
+about test hygiene**:
+
+| Rule | Where | Polices |
+|---|---|---|
+| Integration tests live in an `integrationTest` package | `TestConventionRules` | test hygiene |
+| Tests must not use shaded libraries | `TestConventionRules` | test hygiene |
+| Test classes named so surefire collects them | `TestConventionRules` | test hygiene |
+| `WorkContainer#getFuture()` has no production readers | `WorkContainerFutureIsWriteOnlyArchTest` | one main-code invariant |
+
+The harness is in good shape and the hard part is already done: `TestConventionRules` is a shared
+rule library shipped in the core test-jar, and each module has a thin `TestConventionsArchTest` that
+points `@AnalyzeClasses` at its own packages. Core, vertx, reactor and mutiny all wire it up. Adding
+a rule is a few lines in one place and it applies everywhere.
+
+**No main-code architecture is policed.** Not layering, not package boundaries, not the dependency
+direction between `internal` and `state`, not the God-class boundaries `docs/refactoring.md` wants
+to decompose.
+
+## Why this is worth picking up
+
+`docs/refactoring.md` carries **"Decompose the God class - `AbstractParallelEoSStreamProcessor`
+(1533 lines)"**, marked high risk, plus a thread-model rework and a list of SpotBugs findings for
+non-atomic and stale-thread state. Every one of those is a structural constraint that is currently
+enforced by review attention alone. A decomposition with no rule holding the new boundaries will
+drift back, and the drift is invisible until someone reads the whole class again.
+
+The precedent for the value is on this branch: `WorkContainerFutureIsWriteOnlyArchTest` was written
+because a comment saying "nothing reads this" is not enforcement, and mutation-checking it proved it
+fires. That is one invariant. The class it guards has several more that nothing checks.
+
+## Candidate rules, cheapest first
+
+Each needs its own judgement about whether it is true today; a rule that fails on arrival needs the
+code fixed or the rule narrowed, not a suppression.
+
+- **Dependency direction** between `internal`, `state`, `offsets` and the public API package - state
+  should not reach back into the controller.
+- **No raw `Thread` / executor construction outside the places that own lifecycle**, so the
+  thread-model rework has a boundary to hold.
+- **Non-volatile shared-state guard** for fields written by one thread and read by another - the
+  SpotBugs findings in `docs/refactoring.md` (`lastWorkRequestWasFulfilled`,
+  `ConsumerManager.commitRequested`, `RetryQueue.closed`) name the current offenders, and `state` in
+  `AbstractParallelEoSStreamProcessor` is the one that makes the astubbs#209 race window
+  unpredictable.
+- **Public API surface** - what may be `public` outside the documented API packages, which would have
+  caught the `// todo make private` in `WorkManager` before it became a `todo`.
+
+## When
+
+**After 0.6.0.0.** Adding architecture rules during a release cut turns the build red for reasons
+that have nothing to do with the release, and the God-class decomposition these rules would guard is
+itself post-v6 work. The `next-` prefix on this file is that decision.
+
+**One exception, and it is already in use:** a rule that pins an invariant created by work landing
+now. `WorkContainerFutureIsWriteOnlyArchTest` was added mid-branch for exactly that reason - a
+comment saying "nothing reads this" is not enforcement. Keep doing that per-invariant; it is not the
+programme this file describes, and it does not wait for v6.
+
+## The trap to avoid
+
+Do not add rules in bulk and freeze the failures. `FreezingArchRule` exists and would let a wide net
+land green on day one, but a frozen violation is a documented invariant nobody enforces - the exact
+pattern this repo already rejects for quarantined tests, where the registry is "enforced, not
+advisory". Add one rule at a time, green on arrival, each with a mutation check proving it can fail.

--- a/docs/inflight/next-candidates.md
+++ b/docs/inflight/next-candidates.md
@@ -18,5 +18,8 @@ Collisions are in `pr-blockers-and-collisions.md`. The ranked backlog and full v
   classes (test-only; the duplication bot keeps flagging them).
 - **`confluentinc#915` batch construction strategy** - cherry-pick, closes the 4-year-old
   `confluentinc#266`. Medium effort.
+- **Point ArchUnit at main code** (`next-archunit-main-code-rules.md`) - the harness is already
+  wired into all four modules with a shared rule library, but polices only three test conventions.
+  Post-v6: it is what would hold the boundaries the God-class decomposition creates.
 - **DLQ** (`confluentinc#310`, or revive `confluentinc#366`) - the most-demanded missing feature. Large, and
   spec-stage only.

--- a/docs/inflight/next-control-thread-contract-debts.md
+++ b/docs/inflight/next-control-thread-contract-debts.md
@@ -1,0 +1,145 @@
+# Control-thread and worker-pool contract debts
+
+Four things astubbs#296 surfaced and did not fix. Kept because each is a contract that is currently
+enforced by a reader's attention, and all four live in the same class.
+
+Ranked by how likely the next person is to trip over them.
+
+## 1. The control thread's interrupt flag is a shared channel with four meanings
+
+`AbstractParallelEoSStreamProcessor` signals its control thread by **interrupting it**, and that one
+JVM bit is the transport for at least four unrelated messages:
+
+| Meaning | Where |
+|---|---|
+| "you have mail, wake up" | `notifySomethingToDo` -> `interruptControlThread`, from five call sites |
+| "stop blocking on the mailbox" | `processWorkCompleteMailBox`'s poll, and the 1 ms spin-avoidance sleep, both catch `InterruptedException` and treat it as *woke up* |
+| "shut down" | `supervisorLoop`'s `catch (InterruptedException)` -> `doClose` |
+| "the next commit-lock acquisition will throw" | not a message anyone sends - a side effect of the other three |
+
+**The tell is that the class has accumulated defensive clears rather than a fix.** Four sites now
+handle the collision by hand:
+
+- `Thread.interrupted(); //clear interrupted flag as during close need to acquire commit locks and
+  interrupted flag will cause it to throw another interrupted exception.`
+- `if (Thread.interrupted()) { //clear interrupted flag` in the supervisor's error path
+- `log.warn("control thread interrupted - may lead to issues with transactional commit lock
+  acquisition")` in `innerDoClose` - which does not clear it, and does not know whether the interrupt
+  meant *wake up* or *shut down*. The code is admitting it cannot tell.
+- one added by astubbs#296 itself, after `transitionToClosing` interrupted the very thread that was
+  about to run `doClose`
+
+A signalling channel that every consumer must manually clear is not a channel; it is a shared mutable
+global with no owner. Each clear is correct in isolation and none of them can be checked, so the next
+person to send a wakeup near a close reintroduces the same defect - as astubbs#296 did.
+
+## The fix, designed but deliberately not built
+
+Sketched with the author 2026-08-17 and parked with the decomposition (item 2). Recorded at this
+depth because the design turns on details that are expensive to rediscover.
+
+**Read [`next-actor-revival.md`](next-actor-revival.md) before building any of it.** The 2022
+micro-actor family (`sweep-2023-actor-ipc`) already carries a framework - 537 lines, 4 files, one
+16-line marker interface - and a ranked set of six directions for reviving it. What follows is a
+concrete first slice, not a greenfield design, and survivor 5 (skeleton-first strangler) is the shape
+it should land in.
+
+**The rule: an interrupt carries no meaning. Messages carry all of it.**
+
+An interrupt is a wakeup primitive, not an instruction - it has no payload, no sender and no reason,
+so anything inferred from it is a guess. Today "shut down" is inferred from it, which is the same
+category error as the wakeup, only less obvious. Under the rule, a thread that is interrupted learns
+nothing from the interrupt itself: it wakes and reads its mailbox.
+
+**1. The mailbox already exists, and one message bypasses it.** `ControllerEventMessage` is an actor
+message in all but name - its own javadoc calls it *"an Either type class"* - and the control loop
+already blocks on `workMailBox.poll(timeToBlockFor)`. Add a payload-free `NUDGE` variant and have
+`notifySomethingToDo` enqueue it. The poll returns immediately, which is exactly what a wakeup should
+do.
+
+The confirming detail: `blockableControlThread`'s javadoc says it is *"used for waking up a blocking
+poll against a collection sooner"*. **That field exists only because the wakeup has no message.**
+
+**2. Shutdown becomes a message too.** Then nothing is inferred from the interrupt at all. This also
+takes a bite out of item 2 below: today shutdown is conveyed by the *non-volatile* `state` field plus
+an interrupt, and a message is both the signal and the memory barrier.
+
+**3. Coalescing is the answer to flooding, and it is not a compromise.** Five call sites into an
+unbounded queue would pile up nudges. Gate the send on an `AtomicBoolean`:
+
+```
+if (nudgePending.compareAndSet(false, true)) workMailBox.add(NUDGE);
+```
+
+N nudges mean exactly what one means - *there is something to look at* - so collapsing them is the
+correct semantics, not a lossy optimisation. The same edge-trigger already used for the pool-gone
+diagnosis.
+
+**The ordering is the part that will be got wrong: clear the flag BEFORE draining, never after.**
+Clearing after processing loses any nudge that arrived during it, and that loss is a silent stall -
+the failure mode this whole area keeps producing.
+
+**4. The interrupt cannot go away entirely, and that is fine.** The control thread blocks in five
+places, and a queue element only reaches the first:
+
+| Blocks in | Reachable by a message? |
+|---|---|
+| `workMailBox.poll(timeToBlockFor)` | yes - the main idle wait |
+| `Thread.sleep(1)` spin avoidance | no, and irrelevant at 1 ms |
+| `Thread.sleep(100)` waiting for a transaction to commit | no |
+| `awaitTermination` during close | no - already excluded by `notifySomethingToDo`'s guard |
+| commit-lock acquisition | no |
+
+So the interrupt survives as the mechanism for unparking a thread the mailbox cannot reach - carrying
+no meaning, saying only *wake up and read your mailbox*. **`currentlyPollingWorkCompleteMailBox`
+already tracks which case applies**, so the send site can tell whether a message alone suffices.
+
+Hand-clears of the flag may still be wanted as hygiene before operations that dislike it, but they
+stop being disambiguation guesses, which is the actual defect.
+
+## 2. This class is already queued for decomposition, and this work grew it
+
+`docs/refactoring.md` carries **"Decompose the God class - `AbstractParallelEoSStreamProcessor`"**,
+marked high risk, plus SpotBugs findings in the same class
+(`AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE`, `AT_STALE_THREAD_WRITE_OF_PRIMITIVE` on
+`lastWorkRequestWasFulfilled`), and warns *"Fixing piecemeal now may conflict"* with the thread-model
+rework.
+
+astubbs#296 added to it anyway - deliberately, because the alternative was shipping a silent
+work-drop. Worth deciding explicitly whether further hardening here waits for the decomposition.
+
+Directly relevant to item 1: the `state` field these paths read is **non-volatile**, written by one
+thread and read by another.
+
+## 3. `RejectedExecutionException` does not mean "pool shut down"
+
+The JDK throws it for **two** conditions - the executor is shut down, **and** the pool is saturated
+(bounded queue at capacity, max threads busy). The name says neither, so every reader re-derives the
+distinction, and `submitWorkToPoolInner` has to call `isShutdown()` to tell them apart.
+
+Raised: translate it at the boundary into a domain exception whose name states the condition. Not
+designed. Note the library does not control the throw - this would be catch-inspect-rethrow at the
+point of use, not a replacement.
+
+## 4. Bounding the worker queue changes what a rejection means
+
+`setupWorkerPool` uses an unbounded `LinkedBlockingQueue`, so with `AbortPolicy` a rejection can only
+mean *shut down*. **Bound it and it also means *saturated***, and any code branching on a rejection
+must then distinguish the two or silently drop live work under healthy load. astubbs#296's catch is
+written for that, and `requireRejectionIsVisible` refuses a handler that would swallow it - but the
+constraint itself is unenforced.
+
+**Do not read "unbounded" as "never rejects".** `ThreadPoolExecutor#execute` rejects a task submitted
+to a *shut down* pool before it ever offers it to the queue, so the handler is reachable on the default
+pool. Measured: unbounded queue plus `DiscardPolicy`, shut down, and `submit` returns without throwing
+and hands back a `Future` that never completes. An unbounded queue removes *saturation*, not
+*rejection* - a distinction a review of astubbs#296 got wrong in the direction of weakening the guard,
+now pinned by `anUnboundedQueueDoesNotMakeALosingHandlerHarmless`.
+
+Recorded on astubbs#216 ("Metrics: expose the buffers that have no upper bound"), which astubbs#116
+names as the mitigation for buffers that cannot be bounded. That queue is unbounded by *type* but
+self-limited by the control loop's in-flight target, so it is not the JStream failure mode - its bound
+is emergent from `numberRecordsOutForProcessing` bookkeeping rather than structural.
+
+There is no general "bound our queues" initiative to attach to: astubbs#116 settled that the JStream
+deque is unbounded by design, and observability is the answer instead.

--- a/docs/inflight/parked-ci-path-filters-for-docs-only-prs.md
+++ b/docs/inflight/parked-ci-path-filters-for-docs-only-prs.md
@@ -1,0 +1,57 @@
+# Skipping CI on docs-only PRs - investigated, parked
+
+**Recommendation: do not do it.** Investigated 2026-08-16/17 and answered, with nothing changed.
+Parked here rather than dropped so the next person asking "why does a markdown-only PR run the whole
+suite?" gets the answer instead of re-deriving it.
+
+## The prize is smaller than it looks
+
+Measured on astubbs/parallel-consumer#282, a docs-only PR: Integration 7 min, Unit 6 min, Performance
+3 min, everything else about a minute each, plus the self-hosted `highcpu` lane at about 6 min.
+Roughly **16 parallel hosted-runner minutes, about 8 minutes wall clock**. The 60-minute job timeouts
+suggest a far bigger saving than actually exists.
+
+## The trap that makes the obvious approach fatal
+
+Master is protected by a ruleset carrying **21 required checks**, ten of them from `maven.yml` alone.
+
+**A workflow skipped by `paths-ignore` never reports its checks.** They sit at *"Expected, waiting for
+status to be reported"* indefinitely, and the PR can never merge. There are no path filters anywhere
+in `.github/workflows/` today, so this is not a pattern the repo has already solved somewhere.
+
+## The mechanism that would work, and is unproven
+
+A `changes` gate job plus job-level `if:` on each dependent job. A job skipped by `if:` **does** report
+as skipped, which satisfies a required check where `paths-ignore` does not.
+
+**That claim was not verified.** Prove it on a throwaway PR against a protected branch before trusting
+it. The test matrix is not an obstacle - all three suites are one `test` job with
+`name: "${{ matrix.name }}"`.
+
+## The hard part is the filter, not the YAML
+
+It has to be an allowlist, because several "docs" paths are load-bearing:
+
+- [`docs/quarantined-tests.md`](../quarantined-tests.md) is validated against Java annotations by the
+  `quarantine: audit` check.
+- [`docs/todo-index.md`](../todo-index.md) is generated, and `--check` fails when it is stale.
+- `AGENTS.md`, `.github/` and `bin/` are neither code nor docs, and changing them can change what CI
+  itself does.
+
+## Why it is parked rather than queued
+
+It manufactures green checks whose meaning is *"we did not look"* - across ten required checks at
+once. That is the same class of defect
+[a check that reports success without having run](../solutions/workflow-issues/a-check-that-reports-success-without-having-run.md)
+documents, and that `AGENTS.md` already warns about for `bin/ci-mutation-test.sh`'s
+"nothing to mutate, skipping". Trading that for eight minutes of wall clock is a bad exchange on a
+repo whose recurring failure mode is exactly false-green.
+
+The two places it might pay are the self-hosted `highcpu` lane and the billed `claude-review` - and
+the latter is a policy question about when review is worth paying for, not a path filter.
+
+## Restarting this
+
+If someone wants it anyway: prove the `if:`-skip-satisfies-required-check claim first, build the
+allowlist from the three exceptions above, and start with the `highcpu` lane alone, where the cost is
+real and the check is not one of the 21 required.

--- a/docs/inflight/release-0.6.0.0.md
+++ b/docs/inflight/release-0.6.0.0.md
@@ -36,6 +36,53 @@ None of these has an issue of its own - they were found by reading code to diagn
   that way. Fixed in `CoreApp.java`, since the README embeds that snippet by asciidoc include, and
   `README.adoc` regenerated.
 
+## Breaking changes that have already landed
+
+Two, both from astubbs#296 (`fix(core) astubbs#209`, commit `79a7b6c62`, whose body carries the full
+reasoning). They are written down here because `CHANGELOG.adoc`'s `=== Breaking` section is
+regenerated from the commit log when the tag is cut - until then the log is the only record, and a
+release note is not something to discover by reading commits.
+
+These are **not** items from [`docs/refactoring.md`](../refactoring.md)'s *Breaking changes queued for
+next major version*. That section is the queue of removals still to be done; these two are done. What
+they share is the gate: that section explains why it is currently OPEN, which is what let them land
+now rather than wait.
+
+Both narrow a `protected`/subclass surface on `internal/AbstractParallelEoSStreamProcessor.java`. **A
+user of `ParallelStreamProcessor` is not affected, and neither is a subclass that leaves both alone** -
+the population is people extending the internal controller. Say that plainly in the notes: an
+unqualified "breaking" on a stability release will cost more upgrade hesitancy than these two are
+worth.
+
+- **A subclass overriding `setupWorkerPool` must now return a pool whose `RejectedExecutionHandler` is
+  a `ThreadPoolExecutor.AbortPolicy`** (a subclass of `AbortPolicy` counts - the requirement is the
+  throw). Anything else, and construction throws `IllegalArgumentException` with a message naming the
+  handler it got. Previously such a pool was accepted and **silently lost records**: with a
+  non-throwing handler `submit()` returns a `Future` that never completes, so the containers stay in
+  flight, `numberRecordsOutForProcessing` is inflated for the life of the instance, and their offsets
+  are never committed - no exception, nothing in the logs. **What to do:** build the pool with
+  `AbortPolicy`, or delegate to `super.setupWorkerPool` and adjust the pool it returns; if the pool
+  then rejects work, its queue is too small for the configured `maxConcurrency`, which is now visible
+  rather than absorbed. In-repo subclasses are unaffected - `VertxParallelEoSStreamProcessor` and
+  `ExternalEngine` both `return super.setupWorkerPool(1)`. The named guard this release's condition
+  asks for is `requireRejectionIsVisible`, pinned by `AbstractParallelEoSStreamProcessorConfigurationTest`
+  (`aPoolThatSilentlyDiscardsRejectedWorkIsRefusedAtSetup` and its three siblings, plus
+  `theDefaultPoolIsAcceptedUnchanged` against over-reach).
+
+- **`setState` is no longer callable from outside its own package.** The `private State state` field
+  carried a bare Lombok `@Setter`, so `setState` was public and reachable from any subclass - including
+  the cross-module `VertxParallelEoSStreamProcessor`, `MutinyProcessor` and `ReactorProcessor`. It is
+  now `@Setter(AccessLevel.PACKAGE)`, because this is the controller's own state machine and a subclass
+  driving it arbitrarily is the shape of bug astubbs#296 exists to prevent. **Who is affected: only
+  code that actually called it**, and nothing outside this package's own tests did, on either side of
+  the fork. There is deliberately no replacement for the write. A `protected getState` arrives in the
+  same change - new, not narrowed, since the field had no getter at all before - so a subclass that
+  only wanted to know whether it is still running is better off than it was.
+
+At release, when the changelog section is regenerated, check both survived into `=== Breaking`:
+generation reads the commit log, so they are only as findable as those commit bodies. The rename side
+of that same check is in [`release-0600-blockers.md`](release-0600-blockers.md).
+
 ## Release gate: no disabled tests
 
 **0.6.0.0 does not ship while any test is disabled.** Tests currently carrying `@Disabled`:

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -156,6 +156,18 @@ Do not start one casually.
   lambda-actor-bus's `Actor`/`ActorImpl`; its commit d391398f1 records the unification as unfinished).
   Only meaningful as part of the [confluentinc#200](https://github.com/confluentinc/parallel-consumer/issues/200) (mirror astubbs#142) rework.
   Registered in the manifest as `sweep-2023-actor-ipc` (this doc stays the editorial owner).
+- **A concrete, already-costed first slice: stop signalling the control thread by interrupting it.**
+  `Thread#interrupt` has no payload, so the one bit currently carries four meanings - wake up, stop
+  blocking, shut down, and "your next commit-lock acquisition will throw". Receivers cannot tell
+  which, so the class has accumulated four hand-clears instead of a fix, one of which does not clear
+  and merely warns that it cannot tell. astubbs#296 hit it by adding an ordinary state transition and
+  inheriting a shutdown hazard from a wakeup.
+  `ControllerEventMessage` is already an actor message in all but name and the loop already blocks on
+  its mailbox, so the first slice is small: a payload-free nudge variant, shutdown as a message, and
+  coalescing on an `AtomicBoolean` (clear **before** draining, or a nudge arriving mid-processing is
+  lost). Full design, including which of the five blocking sites a message cannot reach, in
+  [`docs/solutions/workflow-issues/waking-a-thread-by-interrupting-it-2026-08-17.md`](solutions/workflow-issues/waking-a-thread-by-interrupting-it-2026-08-17.md).
+  Belongs with the God-class decomposition above, not before it.
 
 ### Remove static state (unblocks parallel test execution)
 *Mirror: [#131](https://github.com/astubbs/parallel-consumer/issues/131).*

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -59,11 +59,19 @@ at as of the seed date (` @abcdef12`); re-resolve if a branch has since moved.
 
 ## Breaking changes queued for next major version
 
-API/behaviour changes that are ready in principle but must wait for a major-version
-bump (current line is 0.6.x). Unlike the internal refactors below - which are
-non-breaking and can land any time - these change the public, user-visible surface,
-so they are **release-gated**: do not fold them into a minor/patch. Collected here
-so a major-release prep can action them in one pass.
+**The gate is currently OPEN: `0.6.0.0` is that major, it is unreleased, and it is the release being
+cut right now.** It already carries a `=== Breaking` section in `CHANGELOG.adoc` (the `bz.stub`
+package rename), so the items below are **not** waiting for some future bump - this is the pass they
+were collected for, and work that lands now lands in the right release.
+
+Do not read "queued for next major" as "not yet". Check
+[`CHANGELOG.adoc`](../CHANGELOG.adoc) for whether the top section is still marked `(unreleased)`
+before deciding a breaking change must wait: while it is, the gate is open. It closes when 0.6.0.0
+ships, and then this section starts accruing for the release after it.
+
+These change the public, user-visible surface, so they still may not be folded into a **minor or
+patch** - that is what release-gating means, and it is the only thing it means. Unlike the internal
+refactors below, which are non-breaking and can land at any point in any line.
 
 - **Remove the deprecated `commitInterval` options** - `public void setTimeBetweenCommits` /
   `public Duration getTimeBetweenCommits` in `internal/AbstractParallelEoSStreamProcessor.java`.

--- a/docs/solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md
+++ b/docs/solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md
@@ -13,7 +13,7 @@ root_cause: assertion_window_raced_the_artificial_block_it_asserted_against
 resolution_type: test_fix_anchor_assertion_to_the_blocked_window
 severity: low
 status: "SOLVED - test-side fix. PC is healthy; no product defect. The ledger's previously-recorded suspect (a lower-base commit splitting offsets 5 and 6) was NOT the mechanism and was never observed in 9 instrumented runs; it remains open by construction and is noted at the trigger site."
-last_updated: 2026-08-13
+last_updated: 2026-08-17
 related_prs:
   - "astubbs#220 - fixed the sibling commitTimeout in this same file, and is where this flake was left on the ledger as unfinished business"
 related:
@@ -69,6 +69,14 @@ The same 700 ms of latency, in two positions, everything else identical:
 Same magnitude, different position, outcome flips - which is what rules out "it is just slower under
 load". CPU contention alone does *not* reproduce it: under `SOAK_FREE_CORES=1` the margin stayed at
 504-522 ms across runs, because burners slow both terms together.
+
+**One term the arms do not isolate**, stated so the table is not read as a complete decomposition.
+Both arms place their latency around the *send*; neither places any between the latch firing and the
+`pollDelay` clock starting. That gap is real: `assertConsumedAtMostOffset` calls `setup(topic, atMost)`
+- `subscribe` plus `seekToBeginning` - **before** `await().pollDelay(delay)`, so its cost lands inside
+the window being measured. It is left un-decomposed rather than measured because `subscribe` is lazy
+and `seekToBeginning` on an empty set defers, making the term realistically sub-millisecond against
+the post-fix ~4 s margin. Recorded for honesty about what was measured, not as a suspected defect.
 
 ## The fix
 

--- a/docs/solutions/test-flakiness/vacuous-counting-assertion-loop-changed-its-own-precondition-2026-08-18.md
+++ b/docs/solutions/test-flakiness/vacuous-counting-assertion-loop-changed-its-own-precondition-2026-08-18.md
@@ -1,0 +1,153 @@
+---
+title: "A counting assertion is vacuous when the loop body changes the precondition it counts under"
+date: 2026-08-18
+category: test-flakiness
+module: parallel-consumer-core
+problem_type: test_design_bug
+component: testing
+severity: medium
+root_cause: assertion_counted_a_path_the_loop_stopped_reaching_after_its_first_pass
+resolution_type: test_fix_re_arm_the_precondition_each_iteration
+status: "SOLVED - test-side fix on astubbs#296 (branch `fix/209-submit-to-terminated-executor`, commit 79a7b6c62), OPEN at the time of writing. Nothing enforces the rule; it is the mutation check plus this write-up."
+applies_when:
+  - "Writing any assertion that counts occurrences - `hasSize(n)`, `verify(times(n))`, 'logged once', 'called once'"
+  - "Pinning an edge-trigger, a CAS-guarded one-shot, a rate limiter, or any 'say it once' diagnostic"
+  - "Driving a state machine repeatedly from a test loop, where the code under test also writes that state"
+  - "Deciding which of a change's new assertions are worth mutation-checking"
+symptoms:
+  - "The assertion passes, reads as strong, and survives review by reading"
+  - "Deleting the guard the assertion claims to pin leaves the test green"
+  - "The expected count happens to equal the number of times the path was actually reached, for an unrelated reason"
+  - "A loop of N calls, but the code under test reached the interesting branch on pass 1 only"
+tags:
+  - vacuous-assertion
+  - counting-assertion
+  - mutation-testing
+  - edge-trigger
+  - state-machine
+  - assertion-design
+  - test-review
+related_prs:
+  - "astubbs#296 - hardening work submission against an already-closed worker pool; where all three vacuous assertions were written and found"
+  - "astubbs#292 - removed the harness double-start that produced the original chaos failure astubbs#296 hardens against"
+related:
+  - "vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md - the await-side sibling: a condition satisfied before the system reaches its initial state. Same failure (the assertion cannot fail), different mechanism (timing window, not a state transition)"
+  - "at-most-assertion-raced-the-block-it-checked-2026-08-13.md - an assertion whose window was the same length as the thing it asserted against"
+  - "../workflow-issues/red-proof-old-code-new-tests-2026-08-18.md - the git traps that make a red-proof vacuously green, i.e. how the mutation check itself gets faked"
+---
+
+# A counting assertion is vacuous when the loop body changes the precondition it counts under
+
+## Problem
+
+Three assertions written during astubbs#296 turned out to be **vacuous** - each passed against the
+very guard it claimed to pin, so deleting the guard left the test green. Two were caught by the
+author while mutation-checking (one repaired, one deleted). The third survived two review rounds and
+was caught by a third.
+
+This is a finding about method, not about three careless moments: the author *was* mutation-checking
+guards, and still shipped a vacuous assertion, because the check was applied selectively - to the
+assertions that felt load-bearing.
+
+## The instructive one
+
+astubbs#296 adds an edge trigger so that a specific ERROR diagnosis is logged **once** per instance
+rather than once per control-loop pass. The condition it reports is sticky - a shut-down worker pool
+never comes back - so repeating the line every pass would bury the one line worth reading. The
+trigger is a CAS on an `AtomicBoolean`
+(`handledPoolGoneWhileStateAllowsWork` in
+`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java`,
+`compareAndSet(false, true)` inside `onPoolGoneWhileStateAllowsWork`).
+
+The test called `retrieveAndDistributeNewWork` three times against a shut-down pool, captured the
+class logger with a Logback `ListAppender`, filtered to the pool-gone ERROR line, and asserted:
+
+```java
+.that(skipWarnings).hasSize(1);
+```
+
+It reads as airtight: three chances to log, exactly one line, therefore the edge trigger suppressed
+the repeats.
+
+**It did not test the trigger at all.** The guarded block sits behind the state gate in
+`retrieveAndDistributeNewWork` -
+
+```java
+if (state == RUNNING || state == DRAINING) {
+```
+
+\- and the first call's own reaction to the dead pool is `transitionToClosing()`. So call 1 detected,
+logged, and moved the instance to `CLOSING`; calls 2 and 3 failed the state gate and never reached
+the guarded block. One log line was the only possible outcome **whether or not the CAS existed**.
+Confirmed by deleting the CAS: still green.
+
+The shape, stated plainly: **the loop body destroyed the precondition the loop was counting under**,
+and the count came out right for a reason unrelated to the guard.
+
+## Why review by reading could not find it
+
+All three vacuous assertions read as strong assertions. Nothing about `hasSize(1)` over three calls
+looks weak; the weakness is a two-hop inference - the code under test writes the state, and the state
+gates the branch being counted - and neither hop is visible at the assertion. Two review rounds went
+past this one.
+
+**The only thing that finds it is deleting the guard and watching the test fail.**
+
+## The repair
+
+Re-arm the state on every iteration, and say why at the site:
+
+```java
+pc.setState(loop == 0 ? State.RUNNING : State.DRAINING);
+pc.retrieveAndDistributeNewWork(userFunction, callback);
+```
+
+`DRAINING` rather than `RUNNING` after the first pass because it is the *real* re-entry route the
+trigger exists for: a `close(DRAIN)` arriving after the self-close puts the state back to `DRAINING`,
+which is what the guard's own comment describes. Re-arming with a state the production system could
+never present would make the test pass for a reason production does not have.
+
+With the CAS deleted, the repaired test now reports 3 log lines and fails. That was verified by
+actually deleting the guard and running it, not reasoned about.
+
+Test: `aPoolGoneUnderARunningInstanceClosesItOnceAndSaysWhy` in
+`parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/SubmitWorkToPoolShutdownRaceTest.java`
+(the filter it counts is keyed on `POOL_GONE_MESSAGE`). Both files are on
+`fix/209-submit-to-terminated-executor` at 79a7b6c62; `retrieveAndDistributeNewWork` and the
+`state == RUNNING || state == DRAINING` gate are already on master.
+
+## The transferable shape
+
+- **A counting assertion is only meaningful if the path under test is actually *reached* the expected
+  number of times.** `hasSize(1)`, `verify(..., times(1))`, "logged once", "called once" all assert a
+  count; none of them assert *arrival*. A state transition, an early return, an exception, or a
+  short-circuit inside the loop can make the count correct for a reason that has nothing to do with
+  the guard.
+- **Sharpest single heuristic**: if an assertion counts occurrences of something inside a loop, check
+  what the loop body does to the precondition on its first pass. If pass 1 changes the state that
+  gates the counted branch, passes 2..n are decoration.
+- **Suppression assertions are the high-risk family**, because "it happened once" and "it was only
+  reachable once" produce identical evidence. Anything that pins an edge trigger, a one-shot CAS, a
+  rate limiter, a memoisation, or a de-duplicating log is asserting a *negative* - that the extra
+  occurrences did not happen - and a negative is satisfied just as well by never getting there.
+- **Assert arrival separately when you can.** Counting the log line proves nothing about how often
+  the branch ran; a second assertion on an observable that increments per *reached* pass turns an
+  unreachable path into a failure rather than a pass.
+
+## Prevention: mutation-check every new assertion, not just the risky-looking ones
+
+The rule this incident produces is not "be careful with counts" - it is a change to *coverage of the
+check*:
+
+- **Delete the guard, run the test, confirm it fails, restore.** Per guard, individually, confirming
+  that *exactly* its own test went red. A guard whose removal breaks three tests and a guard whose
+  removal breaks none are both findings.
+- **Apply it to every new assertion in the change.** Three vacuous assertions in one change is the
+  evidence for this. Selectivity is what failed: the author's judgement about which assertions were
+  load-bearing was itself the thing that was wrong, so it cannot be the filter that decides what gets
+  checked.
+- **An assertion that cannot fail is worse than none**, because it is counted as coverage - by the
+  next reader, by the PR description, and by whoever later decides the area is well tested.
+- Beware faking the check itself: a stash/checkout round-trip can run the *old* tests against the
+  *old* code and report a comfortable green - see
+  [`../workflow-issues/red-proof-old-code-new-tests-2026-08-18.md`](../workflow-issues/red-proof-old-code-new-tests-2026-08-18.md).

--- a/docs/solutions/workflow-issues/a-repair-to-a-review-finding-is-unreviewed-code-2026-08-18.md
+++ b/docs/solutions/workflow-issues/a-repair-to-a-review-finding-is-unreviewed-code-2026-08-18.md
@@ -1,0 +1,123 @@
+---
+title: "A repair to a review finding is unreviewed code - three rounds to fix one sentence, and the enumeration that could not be fixed"
+date: 2026-08-18
+category: workflow-issues
+module: parallel-consumer-core
+problem_type: workflow_issue
+component: code_review
+severity: medium
+root_cause: process_gap
+resolution_type: workflow_improvement
+applies_when:
+  - "Fixing a finding raised by a code review, human or automated"
+  - "A claim in a comment or document enumerates the callers, senders or subclasses of something"
+  - "A second review round finds the previous round's fix was itself wrong"
+  - "Deciding whether to correct a list or replace it with the rule that generates it"
+symptoms:
+  - "The same paragraph is corrected in consecutive review rounds and is still wrong"
+  - "A repair makes a vague claim more precise, and the precision is what is false"
+  - "A fix ships with less scrutiny than the code it fixes, because the reviewer 'already checked that area'"
+  - "Each correction adds a missing item to a list rather than asking why the list keeps being incomplete"
+tags:
+  - code-review
+  - review-findings
+  - enumeration
+  - invariants
+  - documentation-accuracy
+  - process
+related_components:
+  - development_workflow
+---
+
+# A repair to a review finding is unreviewed code
+
+Reviews of astubbs#296 found a false claim in a code comment and in a solutions write-up. The claim
+was repaired three times. **The first two repairs were themselves wrong, and each took another full
+review round to catch.** After the original defect, every subsequent defect in that paragraph was
+introduced by a fix, not by the author's first draft.
+
+The mechanism the paragraph is about - one interrupt bit carrying four meanings, and why its senders
+are not an enumerable set - is owned by
+[`waking-a-thread-by-interrupting-it-2026-08-17.md`](waking-a-thread-by-interrupting-it-2026-08-17.md). **That document owns the concurrency defect; this one owns the repair
+sequence** - the three superseded wordings, which round produced each, and what the sequence says
+about how fixes to review findings get scrutinised. Read that one for why the set is open; nothing
+about the interrupt design is restated here.
+
+## The three rounds, verbatim
+
+**The original claim**, in a code comment and in the document:
+
+> any worker finishing work re-arms the flag through `notifySomethingToDo` in that gap
+
+Review found it false. Worker threads do not re-arm the flag: `addToMailbox` only enqueues
+(`workMailBox.add(ControllerEventMessage.of(wc))` in
+`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java`),
+and nothing on the completion path interrupts.
+
+**Repair 1** replaced the wrong sender with a list of the right ones:
+
+> The re-armers are the rebalance listener in `onPartitionsAssigned` and two public API methods,
+> `requestCommitAsap` and `resumeIfPaused`, called from whatever thread the embedding application
+> uses.
+
+Next review round: `transitionToDraining` - reached by `close(DRAIN)` - was missing.
+
+**Repair 2** added the missing route and conceded the shape of the problem without acting on it:
+
+> The re-armers are the rebalance listener in `onPartitionsAssigned`, `transitionToDraining` by way
+> of a `close(DRAIN)` arriving after the self-close, and two public API methods, `requestCommitAsap`
+> and `resumeIfPaused` - all called from whatever thread the embedding application uses.
+> `notifySomethingToDo` is itself `public`, so the list is open-ended by API rather than closed by
+> this enumeration.
+
+Next review round found two things. Plain `close()` was still missing - `public void close()` calls
+`closeDontDrainFirst()`, which reaches `case DONT_DRAIN ->` and `transitionToClosing`. That is the
+**likeliest** route of the lot: the class is `implements ParallelConsumer<K, V>,
+ConsumerRebalanceListener, Closeable`, so try-with-resources, a container teardown and a JVM shutdown
+hook all call the no-arg `close()`, never `close(DRAIN)`.
+
+**Repair 3** stopped enumerating and stated the rule: anything that reaches `public void
+notifySomethingToDo()` re-arms the flag; every state transition and both forms of `close()` do; the
+method is public, so the senders are not an enumerable set.
+
+## Why the repairs were the weak point
+
+**A fix for a review finding arrives with borrowed confidence.** The reviewer found the bug, so the
+repair feels validated by association - it is the answer to a question someone else already
+verified. It is nothing of the sort: it is fresh, unreviewed prose or code, written under time
+pressure, by the one person just shown to be wrong about this exact area. The original claim had a
+draft, a self-check and a review; repairs 1 and 2 had none of the three. Reviewers compound it from
+the other side - having already read that region closely, the next pass skims the delta.
+
+**An enumeration is the failure-prone form.** Three people, each having just read the class, each
+produced an incomplete list of the same set. The lists were not careless; the misses were a
+`ConsumerRebalanceListener` callback, a drain-mode branch and the plainest `close()` in the API - all
+one grep away, and all missed anyway. **When a list has been wrong twice, the fix is not a more
+careful list.** Wrong three times is evidence about the *shape*, not the effort: state the invariant
+that generates the list, and let the reader derive the members. Repair 2 is the instructive one - it
+noticed the set was open-ended by API and still shipped the enumeration, adding the caveat next to
+the list instead of replacing it.
+
+**The precision trap: making a vague claim more definite can make it false, and it reads as an
+improvement.** Repair 2 asserted the re-armers were "all called from whatever thread the embedding
+application uses". `onPartitionsAssigned` is not - it is the `ConsumerRebalanceListener` callback
+(`usersConsumerRebalanceListener.ifPresent(x -> x.onPartitionsAssigned(partitions))`) and runs on the
+broker poll thread. The pre-repair wording said nothing about threads and was merely vague; the
+repair made it specific and wrong. Reviewers reward added specificity, so this class of regression
+passes review more easily than the vagueness it replaced.
+
+## What to do
+
+- **Treat a repair to a review finding as new code.** Same scrutiny, same verification, same
+  red-proof. Do not let "the reviewer already looked here" stand in for having checked.
+- **Re-derive the claim from source; do not patch the previous wording.** Repairs 1 and 2 both edited
+  the sentence in place, inheriting its structure - a list - which is what kept being wrong. Repair 3
+  went back to `notifySomethingToDo` and asked what reaches it.
+- **On the second wrong list, replace the list with its invariant.** If you cannot state the
+  invariant, say the set is open and name why (here: the method is `public`); an honest "not
+  enumerable" beats an enumeration that will be silently invalidated by the next caller.
+- **Verify a repair's *added* precision hardest.** The claim the repair makes that the original did
+  not make is the one nobody has checked - here, which thread each caller runs on.
+- Say in the PR which round each fix belongs to. Two consecutive rounds finding a defect in the
+  previous round's fix is the signal that the *form* is wrong, and it is only visible if the rounds
+  are distinguishable afterwards.

--- a/docs/solutions/workflow-issues/gh-run-view-log-truncation.md
+++ b/docs/solutions/workflow-issues/gh-run-view-log-truncation.md
@@ -47,7 +47,7 @@ without running the greps `AGENTS.md` requires before investigating anything.
 
 This is a sibling of an earlier trap in the same file's fourth sighting: there, GitHub truncated the
 log **stream** itself server-side, so neither `--log` nor `--log-failed` contained the
-`=== AMBIENT PROBE AUTOPSY ===`  block at all, and the autopsy had to be recovered from the uploaded
+`AMBIENT PROBE AUTOPSY`  block at all, and the autopsy had to be recovered from the uploaded
 test-report artifact (see that entry's `**Retrieval note`). Two different truncation mechanisms,
 same failure mode: a log that looks complete but isn't, feeding a diagnosis that inherits the gap.
 
@@ -118,7 +118,7 @@ wrong.
 - When a job was re-run and you need the failing attempt's log, not the latest (successful) attempt.
 - When `docs/testing.md`'s ambient-probe section is the next thing you'd check for a broker
   integration-test failure. It used to state that every such failure **log** includes the
-  `=== AMBIENT PROBE AUTOPSY ===` block; both truncation incidents in this repo (fourth and fifth sightings
+  `AMBIENT PROBE AUTOPSY` block; both truncation incidents in this repo (fourth and fifth sightings
   of `docs/inflight/bug-857-family.md`) showed that needed a scope correction rather than a
   retraction - the autopsy is reliably **emitted** on failure, but the console **log** you fetch it
   from is not a reliable place to find it; the artifact and archive routes above are. **That
@@ -168,7 +168,7 @@ implicated.
 - [`docs/inflight/bug-857-family.md`](../../inflight/bug-857-family.md) - fourth sighting
   (`**Retrieval note`, server-side stream truncation, artifact recovery) and fifth sighting
   (`**Correction worth recording`, this incident, archive-zip recovery, both seeds).
-- [`docs/testing.md`](../../testing.md) - ambient-probe section (`=== AMBIENT PROBE AUTOPSY ===`), which
+- [`docs/testing.md`](../../testing.md) - ambient-probe section (`AMBIENT PROBE AUTOPSY`), which
   now carries the corrected "emits" wording and points here for the retrieval routes rather than
   restating them.
 - [`docs/ci.md`](../../ci.md) - "Reading a failed job's log", the topic doc for CI log retrieval;

--- a/docs/solutions/workflow-issues/gh-run-view-log-truncation.md
+++ b/docs/solutions/workflow-issues/gh-run-view-log-truncation.md
@@ -34,9 +34,20 @@ run link, is recorded as the fifth sighting in
 [`docs/inflight/bug-857-family.md`](../../inflight/bug-857-family.md), under the heading
 **"Correction worth recording: a truncated log misattributed this sighting before it was written."**
 
+**It happened again the same day, to someone who had this document available and did not read it**,
+which is the most useful thing recorded here. Diagnosing a `Chaos Pain Suite` failure on astubbs#296
+([run 32104058992](https://github.com/astubbs/parallel-consumer/actions/runs/32104058992)), the
+job-log route returned 2207 lines of a 6266-line log; the tail carried the verdict, the autopsy and
+all three scenario seeds. The conclusion written from it - "the seed is lost, this sighting can never
+be replayed" - was published to a ledger entry on astubbs#29 and had to be corrected an hour later.
+The seed, `4709156528562690268`, had never been anywhere but the part of the log that was cut. Same
+command, same failure mode, same class of wrong claim, two days after this file was written to
+prevent exactly it. **Prior-art checks are the fix, not more documentation** - the entry was written
+without running the greps `AGENTS.md` requires before investigating anything.
+
 This is a sibling of an earlier trap in the same file's fourth sighting: there, GitHub truncated the
 log **stream** itself server-side, so neither `--log` nor `--log-failed` contained the
-`=== AMBIENT PROBE AUTOPSY === ` block at all, and the autopsy had to be recovered from the uploaded
+`=== AMBIENT PROBE AUTOPSY ===`  block at all, and the autopsy had to be recovered from the uploaded
 test-report artifact (see that entry's `**Retrieval note`). Two different truncation mechanisms,
 same failure mode: a log that looks complete but isn't, feeding a diagnosis that inherits the gap.
 
@@ -63,7 +74,13 @@ Three retrieval routes exist for this repo's CI logs, in order of completeness:
    ```
    Unzip and read the per-job `.txt` files. These downloads can be slow and large for a long
    job - use a generous timeout or background the fetch rather than letting it appear to hang.
-3. **`gh run view --job <id> --log`** - convenience only. It is fine for a short job or a quick
+3. **`gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs`** - the job-level route
+   [`docs/ci.md`](../../ci.md) recommends. It can exit **1 having written zero bytes to stdout**,
+   with `the response contains terminal escape sequences; pass --allow-escape-sequences to output it
+   anyway` on **stderr**. Redirect stdout to a file and you get an empty file and a job that appears
+   to have no log at all. It is the only route here that does signal - and it signals into the one
+   stream a `>` redirect does not capture.
+4. **`gh run view --job <id> --log`** - convenience only. It is fine for a short job or a quick
    skim, but it is **not diagnostic-grade for a long job**: it silently returned 1654 of 5948 lines
    in this incident, with no indication anything was cut.
 
@@ -73,6 +90,13 @@ ends with the job's real terminal lines - a surefire/failsafe summary (`Tests ru
 with no closing marker, is truncated, and any diagnosis built on it inherits the cut. A suspiciously
 round or repeated line count across two independent fetches (as happened here - two sessions both
 got exactly 1654 lines) is another tell that the cut is systematic, not incidental.
+
+**Corollary: never parse test totals out of console text.** When the tail is missing, no `Tests run:`
+line survives, so every parser downstream reports zero tests and zero failures - which is the shape
+of a suite that was *skipped*, not one that failed. A grep for a failure signature returning **0** on
+a truncated log is a false negative, and it reads exactly like a clean run; the more systematically
+you grep, the more confident the wrong answer gets. Parse the failsafe/surefire XML from the uploaded
+artifact instead, where the counts are attributes and the autopsy is captured inside `system-out`.
 
 ## Why This Matters
 
@@ -93,12 +117,13 @@ wrong.
   or attributes a CI failure to a specific phase of a job.
 - When a job was re-run and you need the failing attempt's log, not the latest (successful) attempt.
 - When `docs/testing.md`'s ambient-probe section is the next thing you'd check for a broker
-  integration-test failure: its current wording states that every such failure **log** includes the
-  `=== AMBIENT PROBE AUTOPSY === ` block. Both truncation incidents in this repo (fourth and fifth
-  sightings of `docs/inflight/bug-857-family.md`) show that claim needs a scope correction, not a
+  integration-test failure. It used to state that every such failure **log** includes the
+  `=== AMBIENT PROBE AUTOPSY ===` block; both truncation incidents in this repo (fourth and fifth sightings
+  of `docs/inflight/bug-857-family.md`) showed that needed a scope correction rather than a
   retraction - the autopsy is reliably **emitted** on failure, but the console **log** you fetch it
-  from is not a reliable place to find it; the artifact and archive routes above are. This is a gap
-  to fix in that doc's wording, not something already corrected there.
+  from is not a reliable place to find it; the artifact and archive routes above are. **That
+  correction has landed**: the section now says "emits" and defers the retrieval routes to this
+  document. What remains is to keep the two consistent if either moves.
 
 ## Examples
 
@@ -143,8 +168,9 @@ implicated.
 - [`docs/inflight/bug-857-family.md`](../../inflight/bug-857-family.md) - fourth sighting
   (`**Retrieval note`, server-side stream truncation, artifact recovery) and fifth sighting
   (`**Correction worth recording`, this incident, archive-zip recovery, both seeds).
-- [`docs/testing.md`](../../testing.md) - ambient-probe section (`=== AMBIENT PROBE AUTOPSY ===`)
-  whose "every failure log includes" wording needs the scope correction described above.
+- [`docs/testing.md`](../../testing.md) - ambient-probe section (`=== AMBIENT PROBE AUTOPSY ===`), which
+  now carries the corrected "emits" wording and points here for the retrieval routes rather than
+  restating them.
 - [`docs/ci.md`](../../ci.md) - "Reading a failed job's log", the topic doc for CI log retrieval;
   currently documents the job-level `actions/jobs/$jid/logs` API route only, not the run-level
   archive-zip endpoints or the terminal-marker completeness check this incident established.

--- a/docs/solutions/workflow-issues/the-two-review-routes-measured-2026-08-17.md
+++ b/docs/solutions/workflow-issues/the-two-review-routes-measured-2026-08-17.md
@@ -1,0 +1,84 @@
+---
+title: "Two routes to the same reviewer, measured - the mention route posts, the dispatch route can finish and post nothing"
+date: 2026-08-17
+category: workflow-issues
+module: tooling
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+root_cause: config_error
+resolution_type: documentation
+status: "Measured, not fixed. The dispatch route's silent no-post has no guard; `claude-review` stays green on whatever comment was posted last, however stale."
+applies_when:
+  - Choosing how to request the automated reviewer on a PR
+  - A review run reports success and no review appears on the PR
+  - Reading a green `claude-review` check and treating it as evidence this head was reviewed
+  - Deciding whether to build a progress announce for the dispatch route
+symptoms:
+  - A review workflow runs for minutes, concludes success, and posts no comment
+  - The required review check is green while the only review comment predates the current head
+  - Two review entry points behave differently and the difference is undocumented
+tags:
+  - ci
+  - review-automation
+  - silent-failure
+  - claude-review
+  - false-negative
+---
+
+# Two routes to the same reviewer, measured
+
+There are two ways to ask the automated reviewer for a review, and they are not equivalent. Both were
+exercised on astubbs/parallel-consumer#296 on 2026-08-14. This records what each actually did, because
+the difference decides which one to use and the reviewer-notes file previously said the comment route
+was untested.
+
+## What was measured
+
+| | Dispatch route | Mention route |
+|---|---|---|
+| Trigger | `workflow_dispatch` on `claude-code-review-dispatch.yml` | `@claude` in a PR comment, `claude.yml` |
+| Runs | [`31771994565`](https://github.com/astubbs/parallel-consumer/actions/runs/31771994565), [`31774560811`](https://github.com/astubbs/parallel-consumer/actions/runs/31774560811) | [`31773366411`](https://github.com/astubbs/parallel-consumer/actions/runs/31773366411), [`31775979614`](https://github.com/astubbs/parallel-consumer/actions/runs/31775979614) |
+| Posted a comment | **First run yes, second run no** | **Yes, both** |
+| Progress announce | none - `track_progress` is hard-set `false` | posts a sticky comment at start, rewrites it at the end |
+
+**The dispatch route can finish successfully and post nothing.** Run `31774560811` ran for
+**8 minutes 42 seconds**, its `Run Claude Code Review` step concluded `success`, and the workflow's own
+`Refuse to report success for a review that did not run` guard passed - yet no comment appeared on the
+PR. Its prompt is explicit that this must not happen: *"your LAST action must be to post exactly one
+comment... A review that finds problems and posts no comment leaves the PR unmergeable and is
+indistinguishable from no review at all."* It happened anyway, on the run that had the most to say.
+
+**The mention route posts at both ends.** The `claude[bot]` comment on astubbs/parallel-consumer#297
+was `created_at` 9 seconds into the run and `updated_at` at the end - so the sticky comment *is* the
+progress announce, posted first and rewritten into the finished review. That is exactly the announce
+the dispatch route lost when `track_progress` had to be hard-set `false`.
+
+## Why it matters more than "one route is nicer"
+
+`claude-review` is a required check satisfied by an issue comment from the reviewer **and by nothing
+else**. It does not know which head that comment reviewed. So a dispatch run that finishes and posts
+nothing leaves the check green on an **older** comment - and on astubbs#296 that stale comment was
+headed **Blocking**, describing a defect in code that had since been deleted. A reader arriving at the
+PR sees an unresolved blocker against code that is not there, and the gate says everything is fine.
+
+This is [a check that reports success without having run](a-check-that-reports-success-without-having-run.md)
+in its review-automation form: the failure is not that the check goes red, it is that it stays green
+while nothing looked at this head.
+
+## What to do
+
+- **Prefer the mention route** for requesting a review. It posts, and it announces.
+- **After a dispatch run, check a comment actually appeared**, and that its head SHA matches the PR's.
+  Do not read the green check as the answer.
+- If the dispatch route is kept, the announce work `docs/inflight/ci-review-agent.md` proposes
+  (a `gh pr comment` step) is largely what the mention route already does for free.
+
+## Still unexercised
+
+Whether either route can open an **inline review thread** is untested. Both measured runs found
+nothing blocking on the head they reviewed, so neither had occasion to open one; that says nothing
+either way. The dispatch route's prompt states outright it cannot ("YOU CANNOT OPEN INLINE REVIEW
+THREADS ON THIS RUN"), and the claim that the mention route can is read off the action's
+entity-event handling, not off an observed thread. Deciding it needs a PR with a real blocking
+finding.

--- a/docs/solutions/workflow-issues/waking-a-thread-by-interrupting-it-2026-08-17.md
+++ b/docs/solutions/workflow-issues/waking-a-thread-by-interrupting-it-2026-08-17.md
@@ -1,0 +1,176 @@
+---
+title: "One bit, four meanings - waking a thread by interrupting it, and the defensive clears that accumulate"
+date: 2026-08-17
+category: workflow-issues
+module: parallel-consumer-core
+problem_type: design_issue
+component: concurrency
+severity: medium
+root_cause: design_limitation
+resolution_type: documentation
+status: "Not fixed. Recorded because the defect recurs on every new close path, and the only thing stopping it is a reader noticing."
+applies_when:
+  - Adding a state transition, wakeup, or close path to a thread that is signalled by interruption
+  - Reviewing code that calls Thread.interrupt() on a long-lived worker
+  - A close, commit, or lock acquisition throws InterruptedException for no apparent reason
+  - Deciding whether a defensive Thread.interrupted() is a fix or a symptom
+symptoms:
+  - The same class clears the interrupt flag by hand in several unrelated places
+  - A comment explains that the flag must be cleared "or the commit lock will throw"
+  - Code logs a warning that a thread was interrupted and carries on, because it cannot tell why
+  - A new wakeup near a shutdown path causes an unrelated operation to fail
+tags:
+  - concurrency
+  - interrupt
+  - signalling
+  - shared-mutable-state
+  - shutdown
+  - design-smell
+---
+
+# One bit, four meanings
+
+`AbstractParallelEoSStreamProcessor` wakes its control thread by **interrupting** it
+(`notifySomethingToDo` -> `interruptControlThread` -> `Thread#interrupt`). That is a normal idiom for
+unblocking a thread parked on a queue. The problem is that the same bit is also the shutdown signal,
+and the JDK gives it a third meaning nobody chose.
+
+Four messages, one bit:
+
+| Meaning | Sent by |
+|---|---|
+| "you have mail, wake up" | `notifySomethingToDo`, from five call sites |
+| "stop blocking on the mailbox" | the mailbox poll and the spin-avoidance sleep, which catch `InterruptedException` and treat it as *woke up* |
+| "shut down" | `supervisorLoop`'s `catch (InterruptedException)` -> `doClose` |
+| "your next commit-lock acquisition will throw" | nobody - a side effect of the other three |
+
+**A receiver cannot tell which message it got.** They are the same bit.
+
+## The symptom to recognise: defensive clears accumulate
+
+The failure does not present as a bug in the signalling. It presents as unrelated operations
+throwing, and it gets fixed locally each time - so the tell is a **population of hand-clears** rather
+than any one of them:
+
+```java
+Thread.interrupted(); // clear interrupted flag as during close need to acquire commit locks and
+                      // interrupted flag will cause it to throw another interrupted exception.
+```
+
+```java
+if (Thread.interrupted()) { // clear interrupted flag
+```
+
+```java
+log.warn("control thread interrupted - may lead to issues with transactional commit lock acquisition");
+```
+
+That third one is the most informative: it does not clear the flag, and it does not know whether the
+interrupt meant *wake up* or *shut down*. **The code is admitting it cannot tell.** A signalling
+channel every consumer must manually reset is not a channel - it is a shared mutable global with no
+owner, and every clear is correct in isolation while none of them can be checked.
+
+## How it recurred, which is the point
+
+astubbs#296 added a path where a running instance whose worker pool had been destroyed closes itself:
+
+```java
+transitionToClosing();   // -> notifySomethingToDo -> interruptControlThread
+```
+
+That call runs **on the control thread**, one step before `controlLoop`'s switch reaches
+`doClose`. So the thread interrupted itself and then ran the entire close sequence with the flag set -
+exactly the condition the existing comment above warns about. Code review caught it; no test could,
+because the unit tests drive the method directly without starting `supervisorLoop`, so
+`blockableControlThread` is null and `interruptControlThread` no-ops. An assertion written for it
+**passed under mutation** and had to be deleted as vacuous.
+
+Nothing was violated. The author added a state transition - the most ordinary thing in the class - and
+inherited a shutdown hazard from a wakeup.
+
+## The clear cannot hold, which is the thesis rather than an exception to it
+
+Review of astubbs#296 found the follow-on, and it is worth more than the original defect as evidence.
+
+The first fix for the self-interrupt put `Thread.interrupted()` immediately after the transition -
+at the point of **cause**. That left two log statements, the loop-end hooks and the state switch
+between the clear and `doClose` - the hooks are a test seam and empty in production, so the real gap
+was smaller than the list suggests - and another thread can re-arm the flag through
+`notifySomethingToDo` in that gap. **Not a worker thread**, which is worth stating because it is the
+first guess and it is wrong: `addToMailbox` only enqueues. Nearly everything else is a re-armer:
+every state transition calls `notifySomethingToDo`, **both** forms of `close()` reach it through
+`transitionToClosing` or `transitionToDraining`, the rebalance listener reaches it from the broker
+poll thread, and the method is `public`, so an embedding application can call it directly.
+
+**This section enumerated that set three times and was wrong three times** - first naming worker
+threads, which never call it; then omitting `close(DRAIN)`; then omitting plain `close()`, the
+likeliest route of all, since a shutdown hook calls `close()` and not `close(DRAIN)`. Each correction
+was made carefully, by someone who had just read the code, and each was still incomplete.
+
+That is worth more than the enumeration it replaces, because it is the thesis restated as a fact
+about this document: **a channel with no owner has no enumerable set of senders.** Any list is a
+snapshot that the next transition invalidates silently, exactly as the defensive clears are local
+fixes that the next wakeup invalidates. State the rule instead - anything that reaches
+`notifySomethingToDo` re-arms the flag - and do not maintain a list. The guard that would suppress those
+calls, `awaitingInflightProcessingCompletionOnShutdown`, is not set until `innerDoClose`, later
+still.
+
+**Moving the clear to the point of need fixes most of it** - one statement before `doClose`, in the
+state switch, covering every route into `CLOSING` rather than each site that might cause an interrupt.
+That is what the pre-existing clears already do, and it takes the window from *arbitrary user code*
+down to *one statement*.
+
+**What it cannot do is close the window**, because clear-then-call is not atomic: a worker can still
+interrupt between the two. That residue is irreducible while the channel is shared.
+
+**It is not new and it is not worse.** Both pre-existing clears have the same shape - clear, then
+call `doClose` - and clear-then-call is never atomic. The second of them is the path this codebase
+already used for exactly this scenario. What the third clear adds is a slightly wider gap, not a new
+hazard.
+
+**The consequence is bounded and inside the delivery contract**, which is why it is recorded rather
+than fixed: the flag surviving into `doClose` risks the final commit, which is caught
+(`log.warn("failed to commit during close sequence", e)`), so those offsets are redelivered on the
+next assignment. At-least-once already permits that.
+
+**The point is what it says about the mechanism.** A defensive clear is a *local* fix to a *shared*
+channel, so it can only ever hold for the instant between the clear and the next reader - and anyone
+may re-arm it in that instant, legitimately, for an unrelated reason. That is why the count of clears
+grows rather than the problem shrinking: each one is correct, each one is temporary, and none of them
+can be made permanent while the channel carries more than one meaning. Four clears is not four
+oversights; it is the same unfixable thing four times.
+
+## What to do
+
+**Now, when touching one of these paths:** if you call anything that reaches `notifySomethingToDo`
+from the control thread itself, clear the flag afterwards, and say which of the four meanings you
+intended. Grep the class for `Thread.interrupted()` before adding a fifth.
+
+**Properly:** move *every* meaning into messages, including shutdown - not just the wakeup. Leaving
+"shut down" on the interrupt is the same category error one step quieter: an interrupt has no payload,
+no sender and no reason, so anything read from it is a guess. Under the rule *an interrupt carries no
+meaning*, a woken thread learns nothing from the wakeup itself; it reads its mailbox. The interrupt
+survives only as the mechanism for unparking a thread the mailbox cannot reach.
+
+**Do not start this from scratch.** A 2022 micro-actor branch family already exists - manifest entry
+`sweep-2023-actor-ipc`, editorially owned by `docs/refactoring.md`'s *Actor / IPC message bus*
+section - and it went through a ranked ideation pass on 2026-08-17:
+[`docs/inflight/next-actor-revival.md`](../../inflight/next-actor-revival.md). The framework proper is
+537 lines in 4 files, coupled to PC by one 16-line marker interface.
+
+Two of its six survivors bear directly on this write-up. **Survivor 6, the concurrency mass budget**
+(an ArchUnit ratchet on primitive counts, conversions graded on locks removed), is the generalisation
+of what is measured here - four clears for one bit is a mass reading, and the counting rule below is
+the instrument. **Survivor 5, the skeleton-first strangler**, is where a payload-free nudge would
+land as a per-seam swap rather than a rewrite.
+
+The narrow contract debts this sits among are in
+[`docs/inflight/next-control-thread-contract-debts.md`](../../inflight/next-control-thread-contract-debts.md).
+
+## The transferable shape
+
+**When one primitive carries several meanings, the cost is not confusion at the send site - it is that
+every receiver must guess, and each guess is written as a local defensive fix.** Count the defensive
+fixes. If the same clear, reset or re-check appears three or more times for one piece of state, the
+state is overloaded, and the next feature will add a fourth. The clears are not the bug being fixed;
+they are the bug being paid for, repeatedly.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ you have read this file.
 
 ## The ambient probe: contention artifact, or genuine bug?
 
-Every broker integration test failure **emits** an `=== AMBIENT PROBE AUTOPSY ===` block (grep for
+Every broker integration test failure **emits** an `AMBIENT PROBE AUTOPSY` block (grep for
 it) with rebalance-dwell and lag-stagnation violations plus per-partition frozen-committed detail.
 It answers the contention-versus-bug question before you start manual diagnosis. Disable it with
 `-Dambient.probe=off` or `@NoAmbientProbe` only when the probe itself is the problem (see

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,11 +18,26 @@ you have read this file.
 
 ## The ambient probe: contention artifact, or genuine bug?
 
-Every broker integration test failure log includes an `=== AMBIENT PROBE AUTOPSY ===` block (grep
-for it) with rebalance-dwell and lag-stagnation violations plus per-partition frozen-committed
-detail. It answers the contention-versus-bug question before you start manual diagnosis. Disable it
-with `-Dambient.probe=off` or `@NoAmbientProbe` only when the probe itself is the problem (see
+Every broker integration test failure **emits** an `=== AMBIENT PROBE AUTOPSY ===` block (grep for
+it) with rebalance-dwell and lag-stagnation violations plus per-partition frozen-committed detail.
+It answers the contention-versus-bug question before you start manual diagnosis. Disable it with
+`-Dambient.probe=off` or `@NoAmbientProbe` only when the probe itself is the problem (see
 `AmbientProbeExtension`'s javadoc).
+
+**Emitted reliably; found reliably only off the console.** The block is captured into the failsafe
+XML that CI uploads, so it survives a truncated console log - and a fetched CI log here has been
+cut mid-job twice, silently, with the autopsy past the cut. Fetch it from a route that cannot
+truncate, and check the log you did fetch is complete before diagnosing from it:
+[`docs/solutions/workflow-issues/gh-run-view-log-truncation.md`](solutions/workflow-issues/gh-run-view-log-truncation.md)
+**owns those routes** and the completeness check.
+
+**A failing chaos test's autopsy carries its own replay.** `chaos seed:` and `chaos replay:` sit
+directly under the failure line, the replay command complete - the `chaos` tag is excluded by
+default, so the seed alone does not select the test. **First move on a chaos failure is to run that
+command, not to reason from the log**: the replay is the deciding experiment, and every sighting in
+the confluentinc#857 ledger was settled by one. How the seed reaches the block, and why it lives
+there rather than only in the run-start log line: `ChaosSeed` and `AmbientProbeExtension`'s
+`captureChaosSeed`.
 
 **`probe clean` is only informative when the probe's detectors could have fired.** Lag stagnation
 needs `LAG_STAGNATION_MIN_LAG` (50) of real lag sustained past `LAG_STAGNATION_BOUND` (150s), and
@@ -82,7 +97,8 @@ Tagged `@Tag("chaos")` and excluded from all default and gating suites via `pom.
 
 - **Run locally** (requires Docker; ~5-6 min):
   `./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true -Dincluded.groups=chaos -Dexcluded.groups=`
-- **Replay a schedule**: every run logs its seed and the full replay command; add
+- **Replay a schedule**: every run logs its seed and the full replay command, and a failure repeats
+  both inside its autopsy block (above, where truncation cannot reach them); add
   `-Dchaos.seed=<seed>`.
 - **CI**: per same-repo PR commit via the highcpu fast-feedback lane (check `highcpu / Chaos Pain
   Suite` - not optional: a chaos RED shows red); on-demand seeded hunts via `chaos-pain.yml`, e.g.
@@ -98,6 +114,16 @@ Tagged `@Tag("chaos")` and excluded from all default and gating suites via `pom.
 - **A RED run is investigation food, not flake noise.** The probes are calibrated against the real
   historical drain-zombie defect (RED on pre-fix compositions, GREEN on fixed; thresholds sit in
   measured gaps). **Never loosen a probe to go green** - tune the workload or conductor instead.
+
+## Mutation-check every new assertion, not just the risky-looking ones
+
+Delete the guard an assertion claims to pin, run the test, confirm it fails, restore. An assertion
+that cannot fail is worse than none, because everyone after you counts it as coverage - and reading
+does not find one: three assertions written on astubbs#296 all read as strong, and all passed
+against a deleted guard, the last of them surviving two review rounds. The mechanism (a loop whose
+first pass moved the state out of the branch it was counting), the repair, and the
+counting-assertion heuristics:
+[`docs/solutions/test-flakiness/vacuous-counting-assertion-loop-changed-its-own-precondition-2026-08-18.md`](solutions/test-flakiness/vacuous-counting-assertion-loop-changed-its-own-precondition-2026-08-18.md).
 
 ## Reusing test utilities
 

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -190,6 +190,17 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      */
     private final AtomicBoolean awaitingInflightProcessingCompletionOnShutdown = new AtomicBoolean();
 
+    /**
+     * Edge trigger for {@link #onPoolGoneWhileStateAllowsWork()}. The condition is sticky - a shut down pool
+     * never comes back, so the disagreement lasts for the rest of this instance's life - and
+     * {@link #retrieveAndDistributeNewWork} is on the
+     * control loop, so an un-gated warn would repeat once per commit check interval forever and bury the signal it
+     * exists to give. The moment the two first disagree is the whole diagnostic; every line after it says the same
+     * thing. Deliberately not a {@link RateLimiter}: that would still repeat a message which can never change. The
+     * {@code queueStatsLimiter} precedent is a periodic debug stat, which this is not.
+     */
+    private final AtomicBoolean handledPoolGoneWhileStateAllowsWork = new AtomicBoolean(false);
+
     private final OffsetCommitter committer;
 
     /**
@@ -206,7 +217,9 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     /**
      * If the system failed with an exception, it is referenced here.
      */
-    private Exception failureReason;
+    // volatile: the self-close path writes it on the control thread and getFailureCause is read by callers
+    // and by the chaos harness's canary sweep from theirs
+    private volatile Exception failureReason;
 
     /**
      * Time of last successful commit
@@ -236,7 +249,12 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      *
      * @see State
      */
-    @Setter
+    // Neither half is public. Writing is package-only because this is the controller's own state machine: the
+    // transitions are driven from inside this class, and a subclass setting it arbitrarily is the shape of bug this
+    // class has spent astubbs#296 hardening against. Reading is protected because a subclass may legitimately want
+    // to know whether it is still running. Both are used only by this package's tests today.
+    @Setter(AccessLevel.PACKAGE)
+    @Getter(PROTECTED)
     private State state = State.UNUSED;
 
     /**
@@ -299,7 +317,14 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
 
         this.dynamicExtraLoadFactor = module.dynamicExtraLoadFactor();
 
-        workerThreadPool = SupplierUtils.memoize(() -> setupWorkerPool(newOptions.getMaxConcurrency()));
+        workerThreadPool = SupplierUtils.memoize(() -> requireRejectionIsVisible(setupWorkerPool(newOptions.getMaxConcurrency())));
+        // Resolved here, not left to the first dispatch. The supplier is memoized and therefore lazy, but
+        // #requireRejectionIsVisible is a precondition on a subclass's #setupWorkerPool, and a precondition that only
+        // fires when the first batch is submitted is one a subclass can ship without ever meeting. Construction built
+        // the pool anyway - #initMetrics binds meters to it a few lines below - so this changes no startup behaviour,
+        // it only stops the precondition's timing from depending on that, and moves the failure ahead of the poller
+        // and producer manager, so nothing half built has to be unwound.
+        workerThreadPool.get();
 
         this.wm = module.workManager();
 
@@ -366,6 +391,72 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         LinkedBlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>();
         return new ThreadPoolExecutor(poolSize, poolSize, 0L, MILLISECONDS, workQueue,
                 namingThreadFactory, rejectionHandler);
+    }
+
+    /**
+     * A worker pool must announce a rejection by throwing, so any pool whose {@link RejectedExecutionHandler} is not an
+     * {@link java.util.concurrent.ThreadPoolExecutor.AbortPolicy} is refused here, where it is built.
+     * <p>
+     * Refused at setup rather than detected later because there is nothing to detect. {@code submit} wraps the task in
+     * a {@code FutureTask}, calls {@code execute}, and hands back that future whatever the handler then does with the
+     * task. {@code DiscardPolicy}'s body is empty, so a discarded batch produces no exception, no log line and a
+     * {@link Future} that simply never completes - at the call site in {@link #submitWorkToPoolInner} that is
+     * indistinguishable from a batch a worker is still running. The pool's configuration is only visible here.
+     * <p>
+     * What each of the JDK's handlers would do to this subsystem:
+     * <ul>
+     *     <li>{@code AbortPolicy} - throws {@link RejectedExecutionException}, which {@code submitWorkToPoolInner}
+     *         catches, hands the batch back for, and either rethrows or logs. Supported.</li>
+     *     <li>{@code CallerRunsPolicy} - loses nothing, but runs the user's function on the caller, which is the
+     *         control thread: polling, committing and work distribution all stop for its duration.</li>
+     *     <li>{@code DiscardPolicy} - the submitted batch is lost, silently.</li>
+     *     <li>{@code DiscardOldestPolicy} - a <em>different</em>, already queued batch is lost, silently.</li>
+     *     <li>a custom handler - unknowable, so not supported.</li>
+     * </ul>
+     * Barring {@code CallerRunsPolicy}, every one of those leaves work that {@link WorkManager#getWorkIfAvailable(int)}
+     * marked in flight and counted with no event that could ever clear it.
+     * <p>
+     * Reachable on this codebase's own default pool, which is why this check is not conditional on the queue.
+     * {@code ThreadPoolExecutor#execute} rejects a task submitted to a **shut down** pool before it ever offers it to
+     * the queue, so an unbounded queue does not make the handler unreachable - it only makes saturation unreachable.
+     * Measured: an unbounded pool with {@code DiscardPolicy}, shut down, accepts {@code submit} without throwing and
+     * returns a {@link Future} that never completes. That is precisely the close-race path
+     * {@link #submitWorkToPoolInner} exists to survive, so narrowing this check to bounded queues would reopen the
+     * hole on the one path that is definitely reached.
+     * <p>
+     * A subclass of {@code AbortPolicy} passes: the requirement is the throw, not the exact class, and a subclass that
+     * logs or counts before calling {@code super} still throws.
+     * <p>
+     * This is a construction-time snapshot, not a lifetime guarantee - {@code setRejectedExecutionHandler} is public,
+     * so a subclass holding the pool can swap the handler afterwards and this would not see it. It narrows
+     * {@code submitWorkToPoolInner}'s catch of {@link RejectedExecutionException} alone from unsound to
+     * unsound-only-under-deliberate-misuse; it does not make it total.
+     *
+     * @return the pool, unaltered - this is a precondition on what {@link #setupWorkerPool} returned, not a chance to
+     *         substitute something else
+     * @throws IllegalArgumentException if the pool would swallow a rejection
+     */
+    private ThreadPoolExecutor requireRejectionIsVisible(ThreadPoolExecutor pool) {
+        RejectedExecutionHandler handler = pool.getRejectedExecutionHandler();
+        if (!(handler instanceof ThreadPoolExecutor.AbortPolicy)) {
+            throw new IllegalArgumentException(msg(
+                    "Unsupported worker pool returned by {}#setupWorkerPool: its rejected execution handler is {}, " +
+                            "but only {} (or a subclass of it) is supported. Rejection is only visible to this " +
+                            "subsystem as a RejectedExecutionException. A handler that does not throw either drops the " +
+                            "batch silently ({}, {}) - submit() still returns a Future, but that Future never " +
+                            "completes, so those records stay in flight, numberRecordsOutForProcessing stays inflated " +
+                            "for the life of this instance, and their offsets are never committed - or runs the user's " +
+                            "function on the calling thread ({}), which is the control thread, stalling polling and " +
+                            "committing while it runs. Return a pool built with AbortPolicy; if that pool then rejects " +
+                            "work, its queue is too small for the configured maxConcurrency.",
+                    getClass().getName(),
+                    handler.getClass().getName(),
+                    ThreadPoolExecutor.AbortPolicy.class.getName(),
+                    ThreadPoolExecutor.DiscardPolicy.class.getSimpleName(),
+                    ThreadPoolExecutor.DiscardOldestPolicy.class.getSimpleName(),
+                    ThreadPoolExecutor.CallerRunsPolicy.class.getSimpleName()));
+        }
+        return pool;
     }
 
     private void checkNotSubscribed(org.apache.kafka.clients.consumer.Consumer<K, V> consumerToCheck) {
@@ -903,6 +994,18 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                 drain();
             }
             case CLOSING -> {
+                // Clear immediately before the close, never earlier. doClose acquires commit locks and an interrupted
+                // flag makes that throw, skipping the final commit - so those offsets go uncommitted and their records
+                // are redelivered. Every route into CLOSING can arrive with the flag set: transitionToClosing wakes
+                // this loop by interrupting it, and so does every other path through notifySomethingToDo. Do not
+                // try to list them: this comment enumerated that set three times and was wrong three times. Every
+                // state transition calls it, BOTH forms of close() reach it via transitionToClosing or
+                // transitionToDraining, the rebalance listener reaches it on the broker poll thread, and the method
+                // is public, so an embedding application can call it directly. The one notable non-source is the
+                // worker threads, worth saying only because they are the first guess: addToMailbox enqueues, it
+                // does not interrupt. Clearing here rather than at each of those sites keeps the window to one
+                // statement, which is the same guarantee supervisorLoop's own pre-doClose clear gives.
+                Thread.interrupted();
                 doClose(shutdownTimeout);
             }
         }
@@ -965,7 +1068,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         return shouldTryCommitNow;
     }
 
-    private <R> int retrieveAndDistributeNewWork(final Function<PollContextInternal<K, V>, List<R>> userFunction, final Consumer<R> callback) {
+    <R> int retrieveAndDistributeNewWork(final Function<PollContextInternal<K, V>, List<R>> userFunction, final Consumer<R> callback) {
         // check queue pressure first before addressing it
         checkPipelinePressure();
 
@@ -973,14 +1076,20 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
 
         //
         if (state == RUNNING || state == DRAINING) {
-            int delta = calculateQuantityToRequest();
-            var records = wm.getWorkIfAvailable(delta);
+            if (isWorkerPoolShutDown()) {
+                // don't take work there is nowhere to run - taking it would only get it dropped at the submit,
+                // uncommitted, for redelivery after rebalance
+                onPoolGoneWhileStateAllowsWork();
+            } else {
+                int delta = calculateQuantityToRequest();
+                var records = wm.getWorkIfAvailable(delta);
 
-            gotWorkCount = records.size();
-            lastWorkRequestWasFulfilled = gotWorkCount >= delta;
+                gotWorkCount = records.size();
+                lastWorkRequestWasFulfilled = gotWorkCount >= delta;
 
-            log.trace("Loop: Submit to pool");
-            submitWorkToPool(userFunction, callback, records);
+                log.trace("Loop: Submit to pool");
+                submitWorkToPool(userFunction, callback, records);
+            }
         }
 
         //
@@ -993,8 +1102,70 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         return gotWorkCount;
     }
 
+
+    /**
+     * Whether the worker pool can no longer run anything handed to it. Two places ask - before taking work, and when
+     * a submission is rejected - and both mean the same thing by it: nothing this pool is given from now on will ever
+     * run.
+     */
+    private boolean isWorkerPoolShutDown() {
+        return workerThreadPool.get().isShutdown();
+    }
+
+    /**
+     * The state says work may be submitted, but the pool it would be submitted to is shut down.
+     * <p>
+     * A single control thread cannot produce that on its own: {@link #innerDoClose} is the only caller of
+     * {@code workerThreadPool.shutdown()}, it is only reached from {@link #doClose}, {@code doClose} is only called
+     * from inside the control task, and its {@code finally} sets the state to {@link State#CLOSED} before the loop
+     * guard re-reads it - one thread writes both. So this is defence against the subsystem being misused from
+     * outside: a pool supplied through {@link #setupWorkerPool} and shut down by whoever owns it, or a driver that
+     * gives one instance two control threads.
+     * <p>
+     * It narrows the window, it does not close it - the pool can be shut down just after this check passes - so
+     * {@link #submitWorkToPoolInner} still has to tolerate a rejection for work already taken.
+     */
+    private void onPoolGoneWhileStateAllowsWork() {
+        if (handledPoolGoneWhileStateAllowsWork.compareAndSet(false, true)) {
+            // The condition is sticky - a shut down pool never comes back - so the diagnosis is said once. Only the
+            // log is gated: transitioning is idempotent, and gating that too would spend the trigger on the first
+            // detection and leave a later close(DRAIN) with no way out of DRAINING.
+            log.error("Worker pool is shut down while the state is {}, so this instance can never process another " +
+                        "record. It only shuts its own pool down as part of closing, which also moves the state, so " +
+                        "this pool was shut down from outside. Closing, rather than looping with nothing to run. " +
+                        "Records already taken are not committed, so they are redelivered after rebalance. " +
+                        "Pool stats: {}",
+                    state, workerThreadPool.get());
+        }
+
+        // Record why, even though nothing is thrown. On master a dead pool reached the supervisor catch, which set
+        // this, so a caller could ask getFailureCause() what happened. Closing quietly without it would make a
+        // destroyed pool indistinguishable from an ordinary close - to a user health check, and to the chaos
+        // harness's canary sweep, which reads exactly this field.
+        if (failureReason == null) {
+            failureReason = new IllegalStateException(msg(
+                    "Worker pool is shut down while the state is {} - this instance can never process another record, "
+                            + "so it is closing itself", state));
+        }
+
+        // Closing rather than throwing. The instance is unusable either way, but an orderly close still commits
+        // what completed, releases the group membership and lets close() return normally, where an exception out
+        // of the control thread leaves the caller to discover the corpse. Loud in the log, calm in the shutdown.
+        // The interrupt this causes is cleared where it matters, immediately before doClose in controlLoop's state
+        // switch, not here. Clearing at the point of cause leaves the hooks callback and two log statements between
+        // the clear and the close, and any thread reaching notifySomethingToDo can re-arm the flag in that gap.
+        // Every state transition and both forms of close() reach it, and it is public - so the senders are not an
+        // enumerable set. Worker threads are the exception: addToMailbox only enqueues.
+        transitionToClosing();
+    }
+
     /**
      * Submit a piece of work to the processing pool.
+     * <p>
+     * A batch this method declines to dispatch is dropped. Its containers stay marked in flight and counted against
+     * {@link WorkManager#getNumberRecordsOutForProcessing()}, which would matter on an instance that kept running -
+     * but every path that declines is a closing instance or one whose pool is already dead, and its
+     * {@link WorkManager} does not outlive it. The offsets are not committed, so the records are redelivered.
      *
      * @param workToProcess the polled records to process
      */
@@ -1003,6 +1174,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                                         List<WorkContainer<K, V>> workToProcess) {
         if (state.equals(CLOSING) || state.equals(CLOSED)) {
             log.debug("Not submitting new work as Parallel Consumer is in {} state, incoming work: {}, Pool stats: {}", state, workToProcess.size(), workerThreadPool.get());
+            return;
         }
         if (!workToProcess.isEmpty()) {
             log.debug("New work incoming: {}, Pool stats: {}", workToProcess.size(), workerThreadPool.get());
@@ -1022,24 +1194,57 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
 
             // submit
             for (var batch : batches) {
-                submitWorkToPoolInner(usersFunction, callback, batch);
+                if (!submitWorkToPoolInner(usersFunction, callback, batch)) {
+                    // the pool is gone, so every remaining batch would reject too - and each would log its own
+                    // stack trace. One warning per poll is the useful signal; N of them is noise.
+                    break;
+                }
             }
         }
     }
 
-    private <R> void submitWorkToPoolInner(final Function<PollContextInternal<K, V>, List<R>> usersFunction,
-                                           final Consumer<R> callback,
-                                           final List<WorkContainer<K, V>> batch) {
+    /**
+     * @return false if the pool rejected the batch because it is shut down, in which case the batch is dropped -
+     *         uncommitted, so redelivered after rebalance - and no further batch can be submitted either.
+     * @throws RejectedExecutionException if a live pool rejected the batch, which means saturation rather than
+     *                                    shutdown and is not something this class can absorb
+     */
+    private <R> boolean submitWorkToPoolInner(final Function<PollContextInternal<K, V>, List<R>> usersFunction,
+                                              final Consumer<R> callback,
+                                              final List<WorkContainer<K, V>> batch) {
         // for each record, construct dispatch to the executor and capture a Future
         log.trace("Sending work ({}) to pool", batch);
-        Future outputRecordFuture = workerThreadPool.get().submit(() -> {
-            addInstanceMDC();
-            return runUserFunction(usersFunction, callback, batch);
-        });
+        Future outputRecordFuture;
+        try {
+            outputRecordFuture = workerThreadPool.get().submit(() -> {
+                addInstanceMDC();
+                return runUserFunction(usersFunction, callback, batch);
+            });
+        } catch (RejectedExecutionException e) {
+            // Narrow on purpose, and safe to be: #requireRejectionIsVisible refuses any pool whose handler is not an
+            // AbortPolicy, so RejectedExecutionException is the only thing a rejection here can throw.
+            if (!isWorkerPoolShutDown()) {
+                // A live pool rejected, which means saturation rather than shutdown - #setupWorkerPool's queue is
+                // unbounded, so this takes a subclass that bounds it. Absorbing that would drop work under healthy
+                // load, which is the one thing this catch must never do, so it stays loud.
+                throw e;
+            }
+            // The pool is shut down, so this is the close racing work distribution. The batch is dropped: a closing
+            // instance does not commit these offsets, so the records are redelivered after rebalance.
+            // Warn rather than debug: the state guard above absorbs the ordinary closing case, so reaching
+            // here means the pool died while the state still said otherwise - rare, and worth noticing.
+            // Count and a locator, not the batch itself: rendering the records makes this line grow with batch size
+            // until log tooling truncates it, which is astubbs#169 and astubbs#170's complaint in a third place.
+            var first = batch.get(0);
+            log.warn("Worker pool is shut down, not submitting work ({} record(s), first {}:{}). Records will be redelivered.",
+                    batch.size(), first.getTopicPartition(), first.offset(), e);
+            return false;
+        }
         // for a batch, each message in the batch shares the same result
         for (final WorkContainer<K, V> workContainer : batch) {
             workContainer.setFuture(outputRecordFuture);
         }
+        return true;
     }
 
     private List<List<WorkContainer<K, V>>> makeBatches(List<WorkContainer<K, V>> workToProcess) {

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/AmbientProbeExtension.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/AmbientProbeExtension.java
@@ -4,6 +4,7 @@ package bz.stub.parallelconsumer.integrationTests;
  * Copyright (C) 2026 Antony Stubbs and contributors
  */
 
+import bz.stub.parallelconsumer.integrationTests.chaostests.ChaosSeed;
 import bz.stub.parallelconsumer.integrationTests.chaostests.ProgressProbe;
 import bz.stub.parallelconsumer.integrationTests.utils.KafkaClientUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +73,7 @@ public class AmbientProbeExtension implements BeforeEachCallback, AfterTestExecu
     private static final ExtensionContext.Namespace NAMESPACE =
             ExtensionContext.Namespace.create(AmbientProbeExtension.class);
     private static final String PROBE_KEY = "ambientProbe";
+    private static final String CHAOS_SEED_KEY = "chaosSeed";
 
     @Override
     public void beforeEach(ExtensionContext context) {
@@ -104,7 +106,33 @@ public class AmbientProbeExtension implements BeforeEachCallback, AfterTestExecu
      */
     @Override
     public void afterTestExecution(ExtensionContext context) {
+        captureChaosSeed(context);
         stopProbe(context);
+    }
+
+    /**
+     * Copy a chaos run's seed into the per-test store, so {@link #buildAutopsy} can print it.
+     * <p>
+     * The seed is the only handle that replays a chaos failure, and the scenario otherwise announces it
+     * on a single console line at run start - which is exactly what a truncated CI log costs you
+     * ({@code docs/solutions/workflow-issues/gh-run-view-log-truncation.md}, whose retrieval note
+     * records the autopsy surviving in the uploaded failsafe XML after the console stream was cut).
+     * The autopsy is captured as {@code system-out} inside that XML, so the seed rides out with it.
+     * <p>
+     * Captured HERE rather than in {@link #testFailed}: an {@code AfterTestExecutionCallback} still has
+     * the live test instance, and the store is the same channel the probe already survives teardown on.
+     * The seed is read off per-test instance state, so nothing is shared between the chaos classes
+     * JUnit may be running concurrently.
+     */
+    private static void captureChaosSeed(ExtensionContext context) {
+        try {
+            context.getTestInstance()
+                    .filter(ChaosSeed.Holder.class::isInstance)
+                    .map(instance -> ((ChaosSeed.Holder) instance).getChaosSeed()) // null before the test resolved one
+                    .ifPresent(seed -> context.getStore(NAMESPACE).put(CHAOS_SEED_KEY, seed));
+        } catch (Exception e) {
+            log.debug("[ambient-probe] could not capture the chaos seed: {}", e.getMessage());
+        }
     }
 
     /**
@@ -172,6 +200,11 @@ public class AmbientProbeExtension implements BeforeEachCallback, AfterTestExecu
         return context.getStore(NAMESPACE).get(PROBE_KEY, ProgressProbe.class);
     }
 
+    /** {@code null} for every test that is not a seeded chaos scenario - see {@link #captureChaosSeed}. */
+    private static ChaosSeed chaosSeedOf(ExtensionContext context) {
+        return context.getStore(NAMESPACE).get(CHAOS_SEED_KEY, ChaosSeed.class);
+    }
+
     /** Public for unit testing only - see {@link #isDisabled(ExtensionContext)}. */
     public static String buildAutopsy(ExtensionContext context, ProgressProbe probe, Throwable cause) {
         List<String> violations = new ArrayList<>(probe.getViolations());
@@ -180,6 +213,13 @@ public class AmbientProbeExtension implements BeforeEachCallback, AfterTestExecu
         var sb = new StringBuilder(512);
         sb.append("\n=== AMBIENT PROBE AUTOPSY (test failed): ").append(context.getDisplayName()).append(" ===\n");
         sb.append("failure: ").append(describe(cause)).append('\n');
+        // ready to paste: a truncated console log takes the run-start seed line with it, so the only
+        // surviving copy has to be self-sufficient - see captureChaosSeed()
+        ChaosSeed chaosSeed = chaosSeedOf(context);
+        if (chaosSeed != null) {
+            sb.append("chaos seed: ").append(chaosSeed.getValue()).append('\n');
+            sb.append("chaos replay: ").append(chaosSeed.replayCommand()).append('\n');
+        }
         boolean nothingObserved = violations.isEmpty() && frozen.isEmpty()
                 && probe.getPeakRebalanceDwellMs() == 0 && probe.getPeakLagStagnationMs() == 0;
         if (nothingObserved) {

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/AbstractRevokeUnderWorkScenario.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/AbstractRevokeUnderWorkScenario.java
@@ -77,10 +77,9 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
     protected abstract String scenarioLabel();
 
     protected void runRevokeUnderWorkScenario() throws Exception {
-        long seed = resolveSeed();
-        String replayCmd = replayCommand(seed);
+        ChaosSeed seed = resolveSeed();
         log.info("=== CHAOS {} revoke-under-work (cooperative={}): seed={} (replay: {}) ===",
-                scenarioLabel(), useCooperativeAssignor(), seed, replayCmd);
+                scenarioLabel(), useCooperativeAssignor(), seed.getValue(), seed.replayCommand());
 
         String topic = getClass().getSimpleName() + "-" + scenarioLabel() + "-" + RandomUtils.nextInt();
         ensureTopic(topic, PARTITIONS);
@@ -112,7 +111,7 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
                 .withNoProgressWindow(Duration.ofSeconds(60));
 
         ChaosConductor conductor = conductorFor(fleet, pcConfig, HEAVY_EVERY, HEAVY_SLEEP, MAX_FLEET)
-                .seed(seed)
+                .seed(seed.getValue())
                 // faster ticks than W1: more rebalances per run = more revoke-under-work collisions
                 .minTick(Duration.ofMillis(300))
                 .maxTick(Duration.ofMillis(1000))
@@ -144,6 +143,6 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
             settleRun(conductor, probe, fleet.getProducerThread(), fleet.getPcExecutor(), totalConsumed);
         }
 
-        assertScenarioSlos(probe, conductor, replayCmd, expectedKeys, allConsumed);
+        assertScenarioSlos(probe, conductor, seed.replayCommand(), expectedKeys, allConsumed);
     }
 }

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosChurnStormIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosChurnStormIT.java
@@ -78,9 +78,8 @@ class ChaosChurnStormIT extends ChaosScenarioBase {
 
     @Test
     void churnStormMeetsSlosAndBalancesLedger() throws Exception {
-        long seed = resolveSeed();
-        String replayCmd = replayCommand(seed);
-        log.info("=== CHAOS W1 churn storm: seed={} (replay: {}) ===", seed, replayCmd);
+        ChaosSeed seed = resolveSeed();
+        log.info("=== CHAOS W1 churn storm: seed={} (replay: {}) ===", seed.getValue(), seed.replayCommand());
 
         String topic = getClass().getSimpleName() + "-w1-" + RandomUtils.nextInt();
         ensureTopic(topic, PARTITIONS); // explicit partition count (base numPartitions is package-private)
@@ -101,7 +100,7 @@ class ChaosChurnStormIT extends ChaosScenarioBase {
         ProgressProbe probe = fleet.getProbe();
 
         ChaosConductor conductor = conductorFor(fleet, pcConfig, HEAVY_EVERY, HEAVY_SLEEP, MAX_FLEET)
-                .seed(seed)
+                .seed(seed.getValue())
                 .minTick(Duration.ofMillis(500))
                 .maxTick(Duration.ofMillis(1500))
                 .joinAfterDrainBias(0.9)
@@ -121,6 +120,6 @@ class ChaosChurnStormIT extends ChaosScenarioBase {
             settleRun(conductor, probe, fleet.getProducerThread(), fleet.getPcExecutor(), totalConsumed);
         }
 
-        assertScenarioSlos(probe, conductor, replayCmd, expectedKeys, allConsumed);
+        assertScenarioSlos(probe, conductor, seed.replayCommand(), expectedKeys, allConsumed);
     }
 }

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosScenarioBase.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosScenarioBase.java
@@ -6,9 +6,9 @@ package bz.stub.parallelconsumer.integrationTests.chaostests;
 
 import bz.stub.parallelconsumer.integrationTests.BrokerIntegrationTest;
 import bz.stub.parallelconsumer.integrationTests.utils.ManagedPCInstance;
+import lombok.Getter;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.RandomUtils;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -37,7 +37,7 @@ import static org.awaitility.Awaitility.await;
  * owns the mechanics every scenario shares, so scenarios can't drift apart on them.
  */
 @Slf4j
-abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> {
+abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> implements ChaosSeed.Holder {
 
     /**
      * A processing function with a heavy tail: every {@code heavyEvery}-th record dwells
@@ -118,18 +118,21 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> {
         }
     }
 
-    /** Resolve the run's schedule seed: {@code -Dchaos.seed=<long>} replays a schedule; unset = random
-     * seed (always logged via {@link #replayCommand}). */
-    protected static long resolveSeed() {
-        String seedProp = System.getProperty("chaos.seed");
-        return seedProp == null ? RandomUtils.nextLong() : Long.parseLong(seedProp);
-    }
+    /**
+     * The seed this run is replayable from - {@code null} until {@link #resolveSeed()} runs inside the
+     * test method. Held on the instance, not just logged, so {@code AmbientProbeExtension} can lift it
+     * into the failure autopsy: the run-start console line carrying it does not survive a truncated CI
+     * log, and the autopsy travels in the uploaded failsafe XML instead
+     * ({@code docs/solutions/workflow-issues/gh-run-view-log-truncation.md}).
+     */
+    @Getter
+    private ChaosSeed chaosSeed;
 
-    /** The FULL replay invocation, not just the seed - a raw CI log must be self-sufficient to
-     * reproduce (the chaos tag is excluded by default, so the seed alone is not enough). */
-    protected static String replayCommand(long seed) {
-        return "./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true"
-                + " -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=" + seed;
+    /** Resolve AND record the run's schedule seed - see {@link #getChaosSeed()} for why recording it
+     * matters. {@code -Dchaos.seed=<long>} replays a schedule; unset = random. */
+    protected ChaosSeed resolveSeed() {
+        this.chaosSeed = ChaosSeed.resolve();
+        return chaosSeed;
     }
 
     /**

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosSeed.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosSeed.java
@@ -1,0 +1,53 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.Value;
+import org.apache.commons.lang3.RandomUtils;
+
+/**
+ * A chaos run's schedule seed, and the full invocation that replays it. Every sighting in the
+ * confluentinc#857 family ledger ({@code docs/inflight/bug-857-family.md}) names the seed replay as
+ * its deciding experiment, so this is the one value a chaos failure cannot be diagnosed without.
+ * <p>
+ * Split out of {@code ChaosScenarioBase} so it is reachable without loading it: that class extends
+ * {@code BrokerIntegrationTest}, whose static initialiser starts a Kafka Testcontainer, which puts
+ * seed resolution and replay-command formatting out of reach of the unit suite. Here they are plain
+ * surefire-testable functions ({@code AmbientProbeExtensionTest}).
+ */
+@Value
+public class ChaosSeed {
+
+    /** {@code -Dchaos.seed=<long>} replays a schedule; unset = a fresh random seed. */
+    public static final String SEED_PROPERTY = "chaos.seed";
+
+    long value;
+
+    public static ChaosSeed resolve() {
+        String seedProp = System.getProperty(SEED_PROPERTY);
+        return new ChaosSeed(seedProp == null ? RandomUtils.nextLong() : Long.parseLong(seedProp));
+    }
+
+    /**
+     * The FULL replay invocation, not just the seed - a raw CI log must be self-sufficient to
+     * reproduce (the chaos tag is excluded by default, so the seed alone is not enough).
+     */
+    public String replayCommand() {
+        return "./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true"
+                + " -Dincluded.groups=chaos -Dexcluded.groups= -D" + SEED_PROPERTY + "=" + value;
+    }
+
+    /**
+     * How a chaos scenario hands its seed to {@code AmbientProbeExtension}, which lifts it into the
+     * failure autopsy block. Implemented by {@code ChaosScenarioBase}; the extension cannot name that
+     * class (it is package-private here), and reading a per-test instance field is what keeps the
+     * hand-off free of state shared between chaos classes JUnit may run concurrently.
+     */
+    public interface Holder {
+
+        /** {@code null} until the scenario resolves a seed - it does so inside the test method. */
+        ChaosSeed getChaosSeed();
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
@@ -25,9 +25,18 @@ import pl.tlinkowski.unij.api.UniLists;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests to verify the protected and internal methods of
@@ -123,5 +132,209 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
             Assertions.assertEquals(testInstance.getMailBoxSuccessCnt(), 2);
             Assertions.assertEquals(testInstance.getMailBoxFailedCnt(), 0);
         }
+    }
+
+    /**
+     * {@code setupWorkerPool} is a {@code protected} extension point, so a subclass chooses the pool's queue bounds and
+     * its {@link RejectedExecutionHandler}. Only a handler that throws is supported, and the pool is checked when it is
+     * built rather than when it first rejects something - by then the work is already gone.
+     * <p>
+     * These construct the processor and assert on construction itself, which is the point: a precondition that only
+     * fired on the first dispatch would let a subclass ship a work-losing pool and only discover it in production,
+     * under the load that makes a bounded queue reject in the first place.
+     */
+    @Test
+    void aPoolThatSilentlyDiscardsRejectedWorkIsRefusedAtSetup() {
+        var discarding = boundedPoolWith(new ThreadPoolExecutor.DiscardPolicy());
+        try {
+            assertThatThrownBy(() -> processorBackedBy(discarding))
+                    .as("a pool whose rejection handler drops the batch without a sound must not be accepted, and the " +
+                            "refusal must happen at construction, not at the first dispatch")
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(ThreadPoolExecutor.DiscardPolicy.class.getName())
+                    .hasMessageContaining(ThreadPoolExecutor.AbortPolicy.class.getName())
+                    // the consequence, not just the rule: a message that only says "unsupported" leaves the reader to
+                    // guess whether this is a style preference or a data loss
+                    .hasMessageContaining("never completes")
+                    .hasMessageContaining("numberRecordsOutForProcessing");
+        } finally {
+            discarding.shutdownNow();
+        }
+    }
+
+    /**
+     * {@link ThreadPoolExecutor.DiscardOldestPolicy} loses a <em>different</em> batch than the one being submitted - it
+     * evicts the head of the queue and retries - so the submit appears to succeed while some earlier batch is gone.
+     */
+    @Test
+    void aPoolThatEvictsTheOldestQueuedWorkIsRefusedAtSetup() {
+        var evicting = boundedPoolWith(new ThreadPoolExecutor.DiscardOldestPolicy());
+        try {
+            assertThatThrownBy(() -> processorBackedBy(evicting))
+                    .as("evicting a queued batch loses work just as surely as discarding the submitted one")
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(ThreadPoolExecutor.DiscardOldestPolicy.class.getName());
+        } finally {
+            evicting.shutdownNow();
+        }
+    }
+
+    /**
+     * {@link ThreadPoolExecutor.CallerRunsPolicy} loses nothing, but it runs the user's function on whichever thread
+     * called {@code submit} - the control thread - so the control loop stops polling, committing and distributing work
+     * for as long as that function takes. Refused for that, not for loss.
+     */
+    @Test
+    void aPoolThatRunsRejectedWorkOnTheControlThreadIsRefusedAtSetup() {
+        var callerRuns = boundedPoolWith(new ThreadPoolExecutor.CallerRunsPolicy());
+        try {
+            assertThatThrownBy(() -> processorBackedBy(callerRuns))
+                    .as("running the user's function on the control thread stalls the control loop")
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(ThreadPoolExecutor.CallerRunsPolicy.class.getName());
+        } finally {
+            callerRuns.shutdownNow();
+        }
+    }
+
+    /**
+     * Guards against the check over-reaching: the pool this class builds for itself must sail through unaltered.
+     * <p>
+     * Asserted on the instance {@code setupWorkerPool} returned, so this fails if the check ever starts substituting a
+     * pool or a handler of its own rather than refusing one.
+     */
+    @Test
+    void theDefaultPoolIsAcceptedUnchanged() {
+        var built = new AtomicReference<ThreadPoolExecutor>();
+        try (var testInstance = new TestParallelEoSStreamProcessor<String, String>(testOptions) {
+            @Override
+            protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+                var pool = super.setupWorkerPool(poolSize);
+                built.set(pool);
+                return pool;
+            }
+        }) {
+            assertThat(built.get())
+                    .as("the default pool must be built during construction - the check cannot be deferred to first use")
+                    .isNotNull();
+            assertThat(built.get().getRejectedExecutionHandler())
+                    .as("the pool must be handed on exactly as setupWorkerPool built it")
+                    .isInstanceOf(ThreadPoolExecutor.AbortPolicy.class);
+        }
+    }
+
+    /**
+     * The pool supplier is memoized, so nothing about its type stops the pool - and therefore the check on it - from
+     * being deferred to the first dispatch. It is not: the constructor resolves it immediately.
+     * <p>
+     * Pinned through a landmark rather than a clock, because "when" is a position in the constructor: {@code wm} is
+     * assigned on the statement after the pool is resolved, so a pool built at that point sees a null one, and a pool
+     * built any later - by the metrics binding at the end of the constructor, or by the first dispatch - does not. The
+     * distinction matters beyond timing: a refusal here happens before the broker poller and producer manager exist,
+     * so there is no half built subsystem to unwind.
+     */
+    @Test
+    void theWorkerPoolIsResolvedBeforeTheRestOfTheSubsystemIsBuilt() {
+        var landmarkWhenPoolWasBuilt = new AtomicReference<Object>("the pool was never built");
+        try (var testInstance = new TestParallelEoSStreamProcessor<String, String>(testOptions) {
+            @Override
+            protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+                landmarkWhenPoolWasBuilt.set(getWm());
+                return super.setupWorkerPool(poolSize);
+            }
+        }) {
+            assertThat(landmarkWhenPoolWasBuilt.get())
+                    .as("the pool - and the precondition on it - must be resolved before the WorkManager is assigned, " +
+                            "not left for the first dispatch, which a subclass could ship without ever reaching")
+                    .isNull();
+        }
+    }
+
+    /**
+     * The requirement is behavioural - reject by throwing {@link java.util.concurrent.RejectedExecutionException} - so
+     * an {@link ThreadPoolExecutor.AbortPolicy} subclass that adds logging or a metric still satisfies it. Checking for
+     * the exact class would ban that for no reason.
+     */
+    @Test
+    void aSubclassOfAbortPolicyIsAccepted() {
+        var custom = boundedPoolWith(new CountingAbortPolicy());
+        var accepted = new AtomicReference<TestParallelEoSStreamProcessor<String, String>>();
+        try {
+            assertThatCode(() -> accepted.set(processorBackedBy(custom)))
+                    .as("an AbortPolicy subclass still throws on rejection, which is all the submission path needs")
+                    .doesNotThrowAnyException();
+            assertThat(((CountingAbortPolicy) custom.getRejectedExecutionHandler()).rejections)
+                    .as("the check must read the pool's configuration, not probe it by pushing a task through")
+                    .hasValue(0);
+        } finally {
+            if (accepted.get() != null) {
+                accepted.get().close();
+            }
+            custom.shutdownNow();
+        }
+    }
+
+    /**
+     * Still an {@link ThreadPoolExecutor.AbortPolicy} - it throws - it just counts first. Stands in for the wrapping a
+     * real subclass would do.
+     */
+    static class CountingAbortPolicy extends ThreadPoolExecutor.AbortPolicy {
+        final AtomicInteger rejections = new AtomicInteger();
+
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor e) {
+            rejections.incrementAndGet();
+            super.rejectedExecution(r, e);
+        }
+    }
+
+    /**
+     * The check is deliberately NOT conditional on the queue being bounded, and this is the test that says why.
+     * <p>
+     * It is tempting to argue that an unbounded queue never rejects, so a losing handler on one is harmless. That is
+     * wrong: {@code ThreadPoolExecutor#execute} rejects a task submitted to a <em>shut down</em> pool before it ever
+     * offers it to the queue. Measured on this exact configuration - unbounded queue, {@code DiscardPolicy}, pool shut
+     * down - {@code submit} returns without throwing and hands back a {@code Future} that never completes.
+     * <p>
+     * That is precisely the close-race {@code submitWorkToPoolInner} exists to survive, so narrowing this refusal to
+     * bounded queues would reopen the hole on the one path that is definitely reached. An unbounded queue removes
+     * saturation, not rejection.
+     */
+    @Test
+    void anUnboundedQueueDoesNotMakeALosingHandlerHarmless() {
+        var unboundedDiscarding = new ThreadPoolExecutor(1, 1, 0L, MILLISECONDS,
+                new LinkedBlockingQueue<>(), new ThreadPoolExecutor.DiscardPolicy());
+        try {
+            assertThatThrownBy(() -> processorBackedBy(unboundedDiscarding))
+                    .as("an unbounded queue only removes saturation - a shut down pool still routes through the "
+                            + "handler, so a discarding one still loses the batch silently")
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(ThreadPoolExecutor.DiscardPolicy.class.getName());
+        } finally {
+            unboundedDiscarding.shutdownNow();
+        }
+    }
+
+    /**
+     * A pool that can actually reject under load: one thread, one queue slot. The bound is what makes the
+     * handler reachable by SATURATION - an unbounded queue never saturates - which is why these tests bound it.
+     * Note this is not the only way to reach the handler: a shut down pool rejects before it ever offers to the
+     * queue, bounded or not, which is what {@code anUnboundedQueueDoesNotMakeALosingHandlerHarmless} measures and
+     * why the refusal is on the handler rather than on the bound.
+     */
+    private ThreadPoolExecutor boundedPoolWith(RejectedExecutionHandler handler) {
+        return new ThreadPoolExecutor(1, 1, 0L, MILLISECONDS, new LinkedBlockingQueue<>(1), handler);
+    }
+
+    /**
+     * A processor whose worker pool is the given one, exactly as a user's subclass would supply it.
+     */
+    private TestParallelEoSStreamProcessor<String, String> processorBackedBy(ThreadPoolExecutor pool) {
+        return new TestParallelEoSStreamProcessor<String, String>(testOptions) {
+            @Override
+            protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+                return pool;
+            }
+        };
     }
 }

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/AmbientProbeExtensionTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/AmbientProbeExtensionTest.java
@@ -10,6 +10,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import bz.stub.parallelconsumer.integrationTests.AmbientProbeExtension;
 import bz.stub.parallelconsumer.integrationTests.NoAmbientProbe;
+import bz.stub.parallelconsumer.integrationTests.chaostests.ChaosSeed;
 import bz.stub.parallelconsumer.integrationTests.chaostests.ProgressProbe;
 import bz.stub.parallelconsumer.integrationTests.utils.KafkaClientUtils;
 import org.apache.kafka.common.TopicPartition;
@@ -280,6 +281,83 @@ class AmbientProbeExtensionTest {
         assertThat(AmbientProbeExtension.frozenPartitionLines(probe)).isEmpty();
     }
 
+    // --- chaos seed replay handle ---
+
+    /**
+     * The seed is the only handle that replays a chaos failure, and the run-start console line carrying
+     * it is precisely what a truncated CI log eats - so it has to be in the autopsy, which travels as
+     * {@code system-out} inside the uploaded failsafe XML. Resolved here the way a scenario resolves it,
+     * so this covers the real {@code -Dchaos.seed} path and not a hand-built value.
+     */
+    @Test
+    @ResourceLock(ENVIRONMENT_DUMP_LOCK)
+    @SetSystemProperty(key = ChaosSeed.SEED_PROPERTY, value = "4734674029169027864")
+    void autopsyCarriesTheChaosSeedAndItsReplayCommand() {
+        ChaosSeed seed = ChaosSeed.resolve();
+        assertThat(seed.getValue()).isEqualTo(4734674029169027864L);
+
+        var context = contextFor(PlainFixture.class, "plainMethod");
+        doReturn(Optional.of(new SeededFixture(seed))).when(context).getTestInstance();
+        // the capture point: the live test instance is only guaranteed to be there this early
+        new AmbientProbeExtension().afterTestExecution(context);
+
+        String autopsy = AmbientProbeExtension.buildAutopsy(context, observerProbe(), new AssertionError("stalled"));
+
+        assertThat(autopsy).contains("chaos seed: 4734674029169027864");
+        assertThat(autopsy).contains("chaos replay: ./mvnw -Pci -pl parallel-consumer-core -am verify"
+                + " -DskipUTs=true -Dincluded.groups=chaos -Dexcluded.groups="
+                + " -Dchaos.seed=4734674029169027864");
+    }
+
+    /** Every other broker IT is unseeded - it must not grow two lines of empty chaos boilerplate. */
+    @Test
+    @ResourceLock(ENVIRONMENT_DUMP_LOCK)
+    void autopsyOmitsTheSeedLinesForTestsThatHaveNone() {
+        var context = contextFor(PlainFixture.class, "plainMethod");
+        doReturn(Optional.of(new PlainFixture())).when(context).getTestInstance();
+        new AmbientProbeExtension().afterTestExecution(context);
+
+        String autopsy = AmbientProbeExtension.buildAutopsy(context, observerProbe(), new AssertionError("stalled"));
+
+        assertThat(autopsy).doesNotContain("chaos seed:");
+        assertThat(autopsy).doesNotContain("chaos replay:");
+    }
+
+    /** A scenario that failed before resolving a seed holds null - the capture must not publish it. */
+    @Test
+    @ResourceLock(ENVIRONMENT_DUMP_LOCK)
+    void autopsyOmitsTheSeedLinesWhenTheScenarioNeverResolvedOne() {
+        var context = contextFor(PlainFixture.class, "plainMethod");
+        doReturn(Optional.of(new SeededFixture(null))).when(context).getTestInstance();
+        new AmbientProbeExtension().afterTestExecution(context);
+
+        String autopsy = AmbientProbeExtension.buildAutopsy(context, observerProbe(), new AssertionError("stalled"));
+
+        assertThat(autopsy).doesNotContain("chaos seed:");
+    }
+
+    /** Unset means a fresh schedule every run - a resolve() that returned a constant would be silent. */
+    @Test
+    @ClearSystemProperty(key = ChaosSeed.SEED_PROPERTY)
+    void chaosSeedIsRandomisedWhenTheReplayPropertyIsUnset() {
+        assertThat(ChaosSeed.resolve().getValue()).isNotEqualTo(ChaosSeed.resolve().getValue());
+    }
+
+    /** Stands in for {@code ChaosScenarioBase}, which cannot be loaded here - it extends
+     * {@code BrokerIntegrationTest}, whose static initialiser starts a Kafka Testcontainer. */
+    static class SeededFixture implements ChaosSeed.Holder {
+        private final ChaosSeed seed;
+
+        SeededFixture(ChaosSeed seed) {
+            this.seed = seed;
+        }
+
+        @Override
+        public ChaosSeed getChaosSeed() {
+            return seed;
+        }
+    }
+
     // --- beforeEach fallback paths + callback no-ops ---
 
     @Test
@@ -393,6 +471,10 @@ class AmbientProbeExtensionTest {
         });
         when(context.getTestMethod()).thenReturn(method);
         when(context.getDisplayName()).thenReturn("mockedTest()");
+        // one real store per context: the extension hands state from its callbacks to buildAutopsy
+        // through it, so a null (unstubbed) store would only ever exercise half the path
+        var store = new StubStore();
+        doReturn(store).when(context).getStore(any(ExtensionContext.Namespace.class));
         return context;
     }
 

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/SubmitWorkToPoolShutdownRaceTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/SubmitWorkToPoolShutdownRaceTest.java
@@ -1,0 +1,501 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import bz.stub.parallelconsumer.PollContextInternal;
+import bz.stub.parallelconsumer.state.WorkContainer;
+import bz.stub.parallelconsumer.state.WorkManager;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import pl.tlinkowski.unij.api.UniLists;
+import pl.tlinkowski.unij.api.UniMaps;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static bz.stub.parallelconsumer.internal.DrainingCloseable.DrainingMode;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Submitting work must not blow up the control thread when the worker pool is already gone.
+ * <p>
+ * Reproduces astubbs/parallel-consumer#209, where {@code submitWorkToPoolInner} submitted to a
+ * {@code ThreadPoolExecutor[Terminated]} and the resulting {@link java.util.concurrent.RejectedExecutionException}
+ * escaped {@code controlLoop} to be reported as an unclassified "Error from poll control thread".
+ * <p>
+ * There are two independent defences, and one test each, because neither subsumes the other:
+ * <ol>
+ *     <li>{@code submitWorkToPool} returns when the state is already {@code CLOSING}/{@code CLOSED}.</li>
+ *     <li>{@code submitWorkToPoolInner} tolerates a rejected submit, which is the only defence that
+ *         covers the window where the state still reads {@code RUNNING} but the pool has gone.</li>
+ * </ol>
+ * Both paths drop the batch, and each is asserted not to have dispatched it. Dropping leaves the containers in
+ * flight and counted against {@code numberRecordsOutForProcessing}, which is safe only because every caller that
+ * declines to dispatch is a closing instance or one whose pool is already dead - the offsets are not committed, so
+ * the records are redelivered, and the leaked accounting does not outlive the instance that leaked it.
+ * <p>
+ * These drive {@code submitWorkToPool} directly rather than starting the control loop, so no broker
+ * and no {@code supervisorLoop} are involved. The work, though, is taken exactly as the control loop takes it - through
+ * {@link WorkManager#getWorkIfAvailable(int)} - because a hand built {@link WorkContainer} is not in flight and was
+ * never counted, so it could not show a leak of either.
+ */
+@Slf4j
+class SubmitWorkToPoolShutdownRaceTest {
+
+    static final String TOPIC = "topic";
+    static final int PARTITION = 0;
+
+    /**
+     * The stable part of the pool-gone line. Asserted on rather than the whole line so wording can move, but the line
+     * cannot vanish.
+     */
+    static final String POOL_GONE_MESSAGE = "Worker pool is shut down while the state is";
+
+    /**
+     * The stable part of the per-submission rejection warning, counted to prove the batch loop stops rather than
+     * offering every remaining batch to a pool that will refuse each one.
+     */
+    static final String REJECTED_SUBMISSION_MESSAGE = "Worker pool is shut down, not submitting work";
+
+    final TopicPartition tp = new TopicPartition(TOPIC, PARTITION);
+    final PCModuleTestEnv module = new PCModuleTestEnv();
+
+    final Function<PollContextInternal<String, String>, List<String>> userFunction = context -> new ArrayList<>();
+    final Consumer<String> callback = result -> {
+    };
+
+    TestParallelEoSStreamProcessor<String, String> pc;
+    ThreadPoolExecutor pool;
+    WorkManager<String, String> wm;
+
+    /**
+     * Offsets are never reused across a test, so a container returned in one assertion cannot be confused with a fresh
+     * take in the next.
+     */
+    long nextOffset = 0;
+
+    @BeforeEach
+    void setup() {
+        var options = ParallelConsumerOptions.<String, String>builder()
+                .consumer(new MockConsumer<String, String>(OffsetResetStrategy.LATEST))
+                .build();
+        pc = new TestParallelEoSStreamProcessor<>(options);
+
+        wm = module.workManager();
+        wm.onPartitionsAssigned(UniLists.of(tp));
+        pc.setWm(wm);
+
+        // the pool is a lazy supplier - resolve it up front so each test acts on the same instance
+        pool = pc.workerThreadPool.get();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // these tests never start the control loop, so the normal close handshake - which blocks on the
+        // control thread's future - does not apply. Mark it closed and release the pool directly.
+        pc.setState(State.CLOSED);
+        pc.close();
+        pool.shutdownNow();
+    }
+
+    /**
+     * The state guard must actually stop the submission. Before the fix it logged "Not submitting new
+     * work..." and then fell through and submitted anyway.
+     */
+    @Test
+    void closingStateStopsSubmission() {
+        var work = takeWork(1);
+        pc.setState(State.CLOSING);
+
+        pc.submitWorkToPool(userFunction, callback, work);
+
+        // asserted on the container, not pool.getTaskCount(): that counter is documented approximate - a
+        // worker's first task goes uncounted until runWorker takes its lock - so it can read 0 even when the
+        // submit happened, which would let this test pass with the guard's return removed. setFuture is
+        // synchronous inside submitWorkToPoolInner, so the future is exact.
+        assertWithMessage("no work may be submitted once closing has begun")
+                .that(work.get(0).getFuture()).isNull();
+        assertNotDispatched(work);
+    }
+
+    /**
+     * The window that actually produced astubbs/parallel-consumer#209: the pool has been terminated, but the state has not caught
+     * up, so the guard above cannot help. The submit must fail soft rather than escape to the control loop.
+     * <p>
+     * This is also what keeps the return path proven live code now that {@code retrieveAndDistributeNewWork} checks
+     * pool liveness before it takes anything. The check narrows the window; it cannot close it, because the pool can
+     * be shut down in the instant after the check passes. What this test shows is that the path still works when
+     * driven - not that {@code retrieveAndDistributeNewWork} can reach it. That reachability rests on an externally
+     * shut-down pool or a second control thread, which no unit test can force from inside one instance.
+     */
+    @Test
+    void terminatedPoolDoesNotEscapeToTheControlThread() throws InterruptedException {
+        pool.shutdown();
+        assertThat(pool.awaitTermination(5, SECONDS)).isTrue();
+
+        var work = takeWork(1);
+        // the state deliberately still reads RUNNING - this is the race, not a tidy shutdown
+        pc.setState(State.RUNNING);
+
+        assertThatCode(() -> pc.submitWorkToPool(userFunction, callback, work))
+                .as("a terminated pool must not throw out of the control loop")
+                .doesNotThrowAnyException();
+        // pins the narrow behaviour: swallowing alone would also satisfy the assertion above, including from a
+        // blanket catch. The batch must be undispatched whole, never left half-submitted.
+        assertWithMessage("the rejected batch must not be dispatched")
+                .that(work.get(0).getFuture()).isNull();
+        assertNotDispatched(work);
+    }
+
+    /**
+     * One batch is rejected, but the whole take is at stake: the {@code break} that stops the pointless resubmits
+     * leaves every later batch taken and never dispatched, so those must come back too.
+     */
+    @Test
+    void aShutdownRejectionStopsTheWholeSubmission() throws InterruptedException {
+        pool.shutdown();
+        assertThat(pool.awaitTermination(5, SECONDS)).isTrue();
+
+        // batchSize is 1 by default, so three records are three batches - only the first is ever offered to the pool
+        var work = takeWork(3);
+        pc.setState(State.RUNNING);
+
+        var processorLogger = (Logger) LoggerFactory.getLogger(AbstractParallelEoSStreamProcessor.class);
+        var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        processorLogger.addAppender(appender);
+        try {
+            pc.submitWorkToPool(userFunction, callback, work);
+        } finally {
+            processorLogger.detachAppender(appender);
+        }
+
+        assertNotDispatched(work);
+
+        // The count is the whole point. Without the break, every remaining batch is offered to a pool that refuses
+        // each one, and each refusal logs its own warning with a stack trace - so asserting only that nothing was
+        // dispatched passes whether the loop stops or not. Scoped to this test's own pool by identity, because the
+        // appender is on the class logger and surefire runs these concurrently.
+        var ownPool = "@" + Integer.toHexString(System.identityHashCode(pool));
+        var rejections = appender.list.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .filter(event -> event.getFormattedMessage().contains(REJECTED_SUBMISSION_MESSAGE))
+                .filter(event -> event.getThrowableProxy() != null
+                        && event.getThrowableProxy().getMessage() != null
+                        && event.getThrowableProxy().getMessage().contains(ownPool))
+                .collect(Collectors.toList());
+        assertWithMessage("the batch loop must stop at the first rejection - three batches offered to a dead pool "
+                + "would log three warnings, each with its own stack trace")
+                .that(rejections).hasSize(1);
+    }
+
+    /**
+     * Guards against the fix over-reaching: a healthy, running instance must still submit, and must not hand the work
+     * back while a worker is holding it.
+     */
+
+    @Test
+    void runningStateStillSubmits() {
+        var work = takeWork(1);
+        pc.setState(State.RUNNING);
+
+        pc.submitWorkToPool(userFunction, callback, work);
+
+        assertWithMessage("normal operation must be unaffected")
+                .that(work.get(0).getFuture()).isNotNull();
+        assertWithMessage("dispatched work stays in flight")
+                .that(work.get(0).isInFlight()).isTrue();
+        assertWithMessage("dispatched work stays counted as out for processing")
+                .that(wm.getNumberRecordsOutForProcessing()).isEqualTo(1);
+    }
+
+    /**
+     * The discard must be reachable ONLY by shutdown. A live pool that rejects is saturated, and swallowing
+     * that would drop work under load - invisibly, which is the one outcome the catch must never produce.
+     * <p>
+     * {@code setupWorkerPool} is {@code protected}, so a subclass really can hand the processor a bounded
+     * pool; this test is that subclass. It saturates a one-thread pool with a {@link SynchronousQueue} - no
+     * queue slot, no free worker, so the next submit is rejected immediately while {@code isShutdown()} is
+     * still false.
+     * <p>
+     * The throw is deliberately not absorbed: a live pool rejecting means saturation, and swallowing that would drop
+     * work under healthy load - the one thing this catch must never do. It unwinds straight out of the batch loop, so
+     * the batches queued behind the rejected one are dropped with it.
+     */
+    @Test
+    void aLivePoolThatRejectsIsNotSwallowed() throws Exception {
+        var workerRunning = new CountDownLatch(1);
+        var releaseWorker = new CountDownLatch(1);
+        var saturated = new ThreadPoolExecutor(1, 1, 0L, MILLISECONDS, new SynchronousQueue<>());
+
+        var pcOnASaturatedPool = pcBackedBy(saturated);
+        // two records is two batches: the first is rejected, the second never reaches the pool at all
+        var work = takeWork(2);
+        try {
+            // occupy the only worker, so the SynchronousQueue has nowhere to hand off
+            saturated.submit(() -> {
+                workerRunning.countDown();
+                releaseWorker.await();
+                return null;
+            });
+            assertThat(workerRunning.await(5, SECONDS)).isTrue();
+            assertWithMessage("precondition: the pool must be alive, not shut down")
+                    .that(saturated.isShutdown()).isFalse();
+
+            pcOnASaturatedPool.setState(State.RUNNING);
+
+            assertThatThrownBy(() -> pcOnASaturatedPool.submitWorkToPool(userFunction, callback, work))
+                    .as("a saturated live pool must fail loudly, never be discarded as if it were a shutdown")
+                    .isInstanceOf(RejectedExecutionException.class);
+
+            assertNotDispatched(work);
+        } finally {
+            releaseWorker.countDown();
+            saturated.shutdownNow();
+            pcOnASaturatedPool.setState(State.CLOSED);
+            pcOnASaturatedPool.close();
+        }
+    }
+
+
+
+    /**
+     * The control loop must not take work it has nowhere to run. The state and the pool can disagree - a pool handed in
+     * through {@code setupWorkerPool} and shut down by its owner, or a second control thread driving one instance -
+     * and while they do, every take is a round trip out of the {@link WorkManager} and straight back in.
+     */
+    @Test
+    void aShutDownPoolMeansNoWorkIsTakenAtAll() throws InterruptedException {
+        registerWork(2);
+        pool.shutdown();
+        assertThat(pool.awaitTermination(5, SECONDS)).isTrue();
+        // the disagreement: a live-looking state over a dead pool
+        pc.setState(State.RUNNING);
+
+        int got = pc.retrieveAndDistributeNewWork(userFunction, callback);
+
+        assertWithMessage("no work may be taken when the pool cannot run it")
+                .that(got).isEqualTo(0);
+        assertWithMessage("nothing may be counted as out for processing")
+                .that(wm.getNumberRecordsOutForProcessing()).isEqualTo(0);
+        assertWithMessage("the work must be left where it was, still selectable")
+                .that(wm.getNumberOfWorkQueuedInShardsAwaitingSelection()).isEqualTo(2);
+    }
+
+    /**
+     * The skip has to be visible, or a consumer that has silently stopped processing looks identical to one with
+     * nothing to do.
+     * <p>
+     * Once, though - not once per loop. The condition is sticky: a shut down pool never comes back, so the
+     * disagreement lasts for the life of the instance. {@code controlLoop} blocks in {@code processWorkCompleteMailBox}
+     * between passes, so this would be one line per commit-check interval rather than a spin - but repeated forever it
+     * still buries the signal it exists to give. The edge is the diagnostic: the moment the state and the pool first
+     * disagreed.
+     */
+    @Test
+    void aPoolGoneUnderARunningInstanceClosesItOnceAndSaysWhy() throws InterruptedException {
+        registerWork(3);
+        pool.shutdown();
+        assertThat(pool.awaitTermination(5, SECONDS)).isTrue();
+        var processorLogger = (Logger) LoggerFactory.getLogger(AbstractParallelEoSStreamProcessor.class);
+        var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        processorLogger.addAppender(appender);
+        try {
+            for (int loop = 0; loop < 3; loop++) {
+                // Re-arm the state every iteration, and note WHY: the first call transitions to CLOSING, and CLOSING
+                // does not pass the state gate above onPoolGoneWhileStateAllowsWork. Without this the later calls
+                // never reach the guarded block at all, so the count below would be 1 whether or not the edge
+                // trigger exists - the assertion would pass against a deleted guard. DRAINING after the first pass
+                // is the real re-entry route the trigger exists for: a close(DRAIN) arriving after the self-close
+                // puts the state back to DRAINING, which is exactly what the guard's own comment describes.
+                pc.setState(loop == 0 ? State.RUNNING : State.DRAINING);
+                pc.retrieveAndDistributeNewWork(userFunction, callback);
+            }
+        } finally {
+            processorLogger.detachAppender(appender);
+        }
+
+        // The appender is on the class logger, and surefire runs these tests concurrently, so it also catches the
+        // warning from any other instance skipping at the same moment. Narrow to this test's own pool by its identity,
+        // which the warning prints as part of the pool's toString - otherwise this passes or fails on scheduling.
+        var ownPool = "@" + Integer.toHexString(System.identityHashCode(pool));
+        var skipWarnings = appender.list.stream()
+                .filter(event -> event.getLevel() == Level.ERROR)
+                .filter(event -> event.getFormattedMessage().contains(POOL_GONE_MESSAGE))
+                .filter(event -> event.getFormattedMessage().contains(ownPool))
+                .collect(Collectors.toList());
+        assertWithMessage("the pool-gone line must be logged once for this instance across %s loops - the condition "
+                + "is sticky, so repeating it would bury the one line worth reading", 3)
+                .that(skipWarnings).hasSize(1);
+        assertWithMessage("a running instance whose pool was killed must close itself, not loop forever with work "
+                + "it can never run")
+                .that(pc.getState()).isEqualTo(State.CLOSING);
+        assertWithMessage("the close must say why - a caller asking getFailureCause() should not see a destroyed "
+                + "pool as an ordinary close, and the chaos harness's canary sweep reads exactly this")
+                .that(pc.getFailureCause()).isNotNull();
+        // Not asserted here, deliberately: transitionToClosing wakes the loop through interruptControlThread, which
+        // no-ops unless blockableControlThread is set - and that is only assigned by supervisorLoop, which these
+        // tests do not start. An interrupt assertion would pass because nothing interrupted, not because the flag was
+        // cleared. The clear is still required in production, where that field is set; it is verified by reading, and
+        // by the precedent supervisorLoop sets before its own doClose.
+    }
+
+    /**
+     * Guards against the check over-reaching: a live pool must still be given work, exactly as before.
+     */
+    @Test
+    void aLivePoolStillTakesAndDispatches() throws InterruptedException {
+        registerWork(1);
+        pc.setState(State.RUNNING);
+
+        var ranOnAWorker = new CountDownLatch(1);
+        Function<PollContextInternal<String, String>, List<String>> latchedUserFunction = context -> {
+            ranOnAWorker.countDown();
+            return new ArrayList<>();
+        };
+
+        int got = pc.retrieveAndDistributeNewWork(latchedUserFunction, callback);
+
+        assertWithMessage("a live pool must still have work taken for it")
+                .that(got).isEqualTo(1);
+        assertWithMessage("and the work must actually reach a worker")
+                .that(ranOnAWorker.await(5, SECONDS)).isTrue();
+    }
+
+    /**
+     * A drain mode close must still finish over a dead pool.
+     * <p>
+     * The drain gate would not let it. {@code drain()} only transitions to {@code CLOSING} once
+     * {@code isRecordsAwaitingProcessing()} is false, which during a live control loop reduces to the shards'
+     * awaiting-selection count - and over a dead pool nothing consumes that count, because the pre-take check
+     * declines to take work the pool can never run. Left to the gate alone, this would sit until
+     * {@link java.util.concurrent.TimeoutException} out of {@code waitForClose}.
+     * <p>
+     * It terminates because the gate is never reached. {@code retrieveAndDistributeNewWork} runs before
+     * {@code controlLoop}'s state switch, so its pool-liveness check calls {@code transitionToClosing} first, on the
+     * same reasoning that makes a dead pool terminal in {@code RUNNING}: nobody asked this instance to close, and it
+     * can never process another record. Draining is just the state it happened to be in.
+     */
+    @Test
+    void drainModeCloseStillTerminatesOverADeadPool() {
+        // work sat in the shards is what the drain gate reads, so this is the case that can hold it open
+        registerWork(2);
+
+        var draining = new TestParallelEoSStreamProcessor<String, String>(
+                ParallelConsumerOptions.<String, String>builder()
+                        .consumer(new MockConsumer<String, String>(OffsetResetStrategy.LATEST))
+                        // short, so a gate that never opens fails fast rather than sitting on the 30s default
+                        .drainTimeout(Duration.ofSeconds(2))
+                        .shutdownTimeout(Duration.ofSeconds(1))
+                        .commitInterval(Duration.ofMillis(50))
+                        .build());
+        draining.setWm(wm);
+        // shut down by something other than this instance's close - the only way the state can still read live
+        var deadPool = draining.workerThreadPool.get();
+        deadPool.shutdown();
+
+        try {
+            draining.supervisorLoop(userFunction, callback);
+
+            assertThatCode(() -> draining.close(DrainingMode.DRAIN))
+                    .as("a drain mode close must reach CLOSED even when the pool it is draining into is gone")
+                    .doesNotThrowAnyException();
+            assertWithMessage("the instance must actually be closed, not merely un-thrown")
+                    .that(draining.isClosedOrFailed()).isTrue();
+        } finally {
+            deadPool.shutdownNow();
+        }
+    }
+
+    /**
+     * None of this work reached the pool. It is dropped rather than handed back, which is only safe because every
+     * caller that declines to dispatch is a closing instance or one whose pool is already dead: the offsets are not
+     * committed, so the records are redelivered, and the in flight accounting it leaves behind does not outlive the
+     * instance that leaked it.
+     */
+    private void assertNotDispatched(List<WorkContainer<String, String>> work) {
+        for (var wc : work) {
+            assertWithMessage("this work must not have reached the pool: %s", wc)
+                    .that(wc.getFuture()).isNull();
+        }
+    }
+
+    /**
+     * A processor whose worker pool is the given one. {@code setupWorkerPool} is {@code protected} precisely so a
+     * subclass can do this, which is also how a user could hand the real thing a bounded pool.
+     */
+    private TestParallelEoSStreamProcessor<String, String> pcBackedBy(ThreadPoolExecutor boundedPool) {
+        var processor = new TestParallelEoSStreamProcessor<String, String>(
+                ParallelConsumerOptions.<String, String>builder()
+                        .consumer(new MockConsumer<String, String>(OffsetResetStrategy.LATEST))
+                        .build()) {
+            @Override
+            protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+                return boundedPool;
+            }
+        };
+        processor.setWm(wm);
+        return processor;
+    }
+
+    /**
+     * Registers {@code count} records and takes them as work the way the control loop does, so every container really
+     * is in flight and really is counted against {@code numberRecordsOutForProcessing}.
+     * <p>
+     * A key per record: the default ordering is KEY, so sharing one would serialise them and only the first would ever
+     * be selectable.
+     */
+    private List<WorkContainer<String, String>> takeWork(int count) {
+        registerWork(count);
+
+        var taken = wm.getWorkIfAvailable(count);
+        assertWithMessage("fixture: all %s records must be taken as work", count)
+                .that(taken).hasSize(count);
+        assertWithMessage("fixture: the take must be counted as out for processing")
+                .that(wm.getNumberRecordsOutForProcessing()).isEqualTo(count);
+        return taken;
+    }
+
+    /**
+     * As {@link #takeWork(int)}, but stops at registration - the records are left sitting in the shards, selectable but
+     * not taken. That is the starting state {@code retrieveAndDistributeNewWork} is given: it does its own take.
+     */
+    private void registerWork(int count) {
+        var records = new ArrayList<ConsumerRecord<String, String>>();
+        for (int i = 0; i < count; i++) {
+            long offset = nextOffset++;
+            records.add(new ConsumerRecord<>(TOPIC, PARTITION, offset, "key-" + offset, "value"));
+        }
+        wm.registerWork(new EpochAndRecordsMap<>(new ConsumerRecords<>(UniMaps.of(tp, records)), wm.getPm()));
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/WorkContainerFutureIsWriteOnlyArchTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/WorkContainerFutureIsWriteOnlyArchTest.java
@@ -1,0 +1,52 @@
+package bz.stub.parallelconsumer.state;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * {@link WorkContainer#getFuture()} must have no production callers.
+ * <p>
+ * This is not a style preference. The future is set only when a batch is dispatched to the worker pool, so
+ * it is null for every container that has not been dispatched - including every batch
+ * {@code AbstractParallelEoSStreamProcessor#submitWorkToPool} declines to dispatch and drops. A production
+ * reader would see null on those paths and have no way to tell "never ran" from "finished".
+ * <p>
+ * The precondition used to live in a comment beside the discard. A comment does not fail a build, so it
+ * would have gone stale the first time somebody added a caller and nothing would have said so. This rule is
+ * the enforcement. If it fails, do not delete it: drop the new caller, or ask the question through a named
+ * predicate on {@link WorkContainer} that reads the field, rather than through this getter.
+ * <p>
+ * Tests may read it - {@code SubmitWorkToPoolShutdownRaceTest} asserts on it precisely to pin that a dropped
+ * batch was never dispatched - so this analyses main classes only.
+ */
+@AnalyzeClasses(packages = "bz.stub.parallelconsumer", importOptions = ImportOption.DoNotIncludeTests.class)
+class WorkContainerFutureIsWriteOnlyArchTest {
+
+    @ArchTest
+    static final ArchRule work_container_future_has_no_production_readers =
+            noClasses()
+                    .should().callMethod(WorkContainer.class, "getFuture")
+                    .because("the future is set only by dispatch, so a production reader would observe null for "
+                            + "any container that has not been dispatched - including every batch dropped "
+                            + "undispatched - and could not tell that from completion.");
+
+    /**
+     * The rule above names {@code getFuture} as a string, and ArchUnit does not check that the target exists: rename
+     * or delete the getter and the rule matches nothing and passes, having asserted nothing. That is the silent
+     * false-green this repo keeps finding, so pin the name the rule depends on.
+     */
+    @Test
+    void theMethodTheRuleNamesStillExists() throws NoSuchMethodException {
+        assertThat(WorkContainer.class.getDeclaredMethod("getFuture")).isNotNull();
+    }
+}


### PR DESCRIPTION
Closes astubbs/parallel-consumer#209 — see *What this does not do* for the one part of that issue it leaves open.

Built on astubbs/parallel-consumer#292, which fixed the actual cause of the recorded failure (a harness
double-start) and is merged. This is the other side of the same condition: the submission path should not
be killable by a pool that is already gone, whatever put it in that state.

## What it does

**1. The state guard did not guard.** `submitWorkToPool` checked for `CLOSING`/`CLOSED`, logged *"Not
submitting new work as Parallel Consumer is in {} state"*, and then fell through and submitted anyway. It
has never had a `return` — `git log -L` dates it to upstream `8815ae1d8`, *"PL-176 handle close dont drain
mode gracefully"*. It was born inert, in the commit whose stated purpose was closing gracefully.

**2. A rejected submit no longer escapes the control thread.** The state can flip after the guard and
before the submit, so the guard alone cannot close the window. `submitWorkToPoolInner` now tolerates a
rejection from a pool that is shut down. A rejection from a *live* pool still escapes loudly — that means
saturation, not shutdown, and absorbing it would drop work under healthy load.

**3. An instance whose pool was destroyed closes, instead of spinning.**
`retrieveAndDistributeNewWork` checks pool liveness alongside the state before taking. When the state
still permits work but the pool is gone, that is terminal — nobody asked this instance to close, and it can
never process another record — so it logs once at ERROR and transitions to `CLOSING`.

Closing rather than throwing is deliberate. The instance is unusable either way, but an orderly close still
commits what completed, releases group membership, and lets `close()` return normally, where an exception
out of the control thread leaves the caller to find the corpse.

This is the half of the tolerance in (2) that must **not** be tolerant. `CLOSING`/`CLOSED` means we are
racing our own close, which is what this PR is for. `RUNNING`/`DRAINING` means the pool was destroyed
underneath a healthy instance — a pool supplied through the protected `setupWorkerPool` and shut down by
its owner, or a driver giving one instance two control threads (the astubbs/parallel-consumer#292 class of
fault). Master dies loudly in that case, because it has no catch at all; without this, absorbing the
rejection would have left the instance looping forever with leaked in-flight accounting. That would be the
opposite of this PR's purpose — trading a loud, diagnosable failure for an undiagnosable one.

A drain over a dead pool therefore terminates too, through the same path and before `drain()` is reached.

**4. A worker pool that would swallow work is refused at construction.** `setupWorkerPool` is protected, so
a subclass chooses the rejection handler. `DiscardPolicy` has an empty body: `submit()` still returns a
`Future`, but it never completes, so the records stay in flight and `numberRecordsOutForProcessing` is
inflated for the life of the instance, with no exception and nothing in the logs. `DiscardOldestPolicy`
does that to a different batch; `CallerRunsPolicy` runs the user's function on the control thread. Only
`AbortPolicy` (or a subclass) is accepted, and the message says why.

## Why dropping the batch is safe

A batch that is declined is dropped, and its in-flight accounting is left inconsistent. That would matter
on an instance that kept running — `WorkManager#isSufficientlyLoaded` gates the broker poller on
`awaitingSelection + outForProcessing`, and its own comment names an inflated `outForProcessing` as the
counter-drift signature of the `confluentinc#857` stall.

It does not matter here, because every path that declines is a closing instance or one whose pool is
already dead, and the `WorkManager` does not outlive either. The offsets are not committed, so the records
are redelivered after rebalance — the correct outcome for work a dying instance never ran.

## What was tried and removed

An earlier revision of this branch handed the batch back instead of dropping it, so the accounting stayed
true for a hypothetical future caller. That was removed, because it was the more dangerous option.

Returning a never-dispatched container through `onFailureResult` schedules it for retry, and it has no
retry time. `getRetryDueAt()` falls back to `Instant.MIN`, which becomes the retry queue's sort key, so the
entry pins to the front — and `ProcessingShard#getWorkIfAvailable` only evicts entries whose container has
previously failed, so nothing ever clears it. The control loop reads the head entry's delay as how long to
block for, and `Duration.between(now, Instant.MIN).toMillis()` overflows a `long` and throws. Measured:
`-31557015953904934` seconds, `ArithmeticException`. That kills the control thread on an instance that is
otherwise still running — strictly worse than the leak it was fixing.

Avoiding it meant gating `ShardManager`'s retry scheduling: changing shared state internals to support a
path that only ever serves an instance on its way out. Not worth it. The history keeps that revision.

## What this does not do

astubbs/parallel-consumer#209 asks for two things. This is the first. The second — giving the chaos probe
its own violation class for a shutdown race, so the next occurrence is legible without reading the raw
failsafe report — is a harness change and is not in this PR. Nothing here classifies it, and the issue is
being closed on the product fix alone.

It also does not claim to fix `confluentinc#857`. The counter-drift link is inference.

An earlier revision of this body said "neither discard site is reachable on a running instance". That was
wrong, and this branch's own tests contradict it - two of them kill the pool and then set `RUNNING`
deliberately. The accurate statement is the one the code comments already make: the sites are unreachable
from a *single control thread driving an instance that closes itself*, because `innerDoClose` is the only
caller of `shutdown()` and `doClose` sets `CLOSED` before the loop guard re-reads it. They are reachable
when a subclass supplies a pool through the protected `setupWorkerPool` and shuts it down behind the
consumer's back, or when a driver gives one instance two control threads.

Dropping is still safe there, because the instance can no longer process anything either way — and it does
not keep running with the leak: (3) closes it. That the spin was a regression this branch introduced, and
how it was closed, is recorded in the `fix(core)` commit body; the contract debts it leaves behind are in
`docs/inflight/next-control-thread-contract-debts.md`.

## Breaking changes

Both land in `0.6.0.0`, which is unreleased and already carries a `=== Breaking` section.

**1. `setupWorkerPool` overriders must return a pool whose `RejectedExecutionHandler` is an
`AbortPolicy`**, or construction throws `IllegalArgumentException`. Previously such a pool was
accepted and silently lost records: with a non-throwing handler `submit()` returns a `Future` that
never completes, so containers stay in flight, `numberRecordsOutForProcessing` is inflated for the
life of the instance, and their offsets are never committed — no exception, nothing in the logs.
In-repo subclasses are unaffected; `VertxParallelEoSStreamProcessor` and `ExternalEngine` both
delegate to `super.setupWorkerPool`.

**2. `setState` is no longer callable from outside the package.** The field carried a bare Lombok
`@Setter`, so `setState` was public and reachable from any subclass, including the cross-module
`VertxParallelEoSStreamProcessor`, `MutinyProcessor` and `ReactorProcessor`. It is now
package-private: this is the controller's own state machine, and a subclass driving it arbitrarily
is the shape of bug this PR exists to prevent. Nothing outside this package's own tests called it.
A `protected getState` arrives in the same change — new rather than narrowed, since the field had no
getter before.

## What else rides with this

Reviewing this PR produced findings about the process that found them, and a diagnosability gap that
got in the way while reviewing it. Those land here rather than as a follow-up, because they are
lessons about this PR's own test suite and their cross-references only resolve on this branch.

**One code change.** The chaos replay seed now travels inside the `AMBIENT PROBE AUTOPSY` block
rather than only on a console line. A truncated CI log during this PR's own review made a real
confluentinc#857 sighting look unreplayable; the autopsy is captured into the failsafe XML and
uploaded as an artifact, so a console truncation can no longer take the seed with it.

**Four write-ups**, each from something that went wrong here:

- Three assertions on this branch were vacuous - they passed against the guard they claimed to pin.
  The rule that follows is to mutation-check every new assertion, not the ones that look risky.
- A repair to a review finding is unreviewed code. One sentence took three rounds, and rounds two and
  three were fixing the previous *fix*. An enumeration wrong twice needs a rule, not a better list.
- The same truncated-log trap, hit two days after the document describing it was written - folded into
  that document rather than duplicated, since the fix is the prior-art greps, not more documentation.
- The PR-scoped mutation lane reports green when it mutates nothing, which is 94 of the last 100
  merged PRs. Recommendation recorded; no change made here.

## Scope

One file, `AbstractParallelEoSStreamProcessor`. `WorkManager`, `ShardManager`, `ProcessingShard` and
`WorkContainer` are byte-identical to master.

## Verification

Core unit suite green. Every guard is covered by a test in `SubmitWorkToPoolShutdownRaceTest`,
`AbstractParallelEoSStreamProcessorConfigurationTest` and `WorkContainerFutureIsWriteOnlyArchTest`,
each mutation-checked — removed in turn, confirmed exactly its own test fails, restored.

Three assertions written during this work turned out to be **vacuous** — they passed against the
guard they claimed to pin. Two were caught here and one deleted; the third was caught by review and
now re-arms the state each iteration, so deleting the edge trigger fails it. Recorded because three
in one change is a finding about the method, not about the assertions.

The PR-scoped mutation lane does **not** cover this change: it mutates only `offsets.*`, so it
reports "outside the decidable packages" and skips the file. The per-guard mutation checks above
were run by hand.

The chaos suite is not a gate here: it is advisory and seed-randomised, so a green run proves nothing about
this change.


The shutdown-rejection warning logs the batch's size and the first record's topic-partition and offset rather
than the batch itself, so the line stays bounded. That is only the line this branch touches;
astubbs/parallel-consumer#169, astubbs/parallel-consumer#170 and astubbs/parallel-consumer#238 report the same
shape elsewhere and are not addressed here.

## Checklist

- [x] Docs updated - `docs/inflight/next-control-thread-contract-debts.md` (the contract debts this left,
      including the work-return path that was tried and removed) and `docs/inflight/bug-857-family.md`. No
      user-facing documentation changes beyond the breaking notes above.
- [ ] N/A - user-facing feature documentation data. `docs/features/README.md` excludes "a bug fix that restores
      an existing contract" from feature records, which is what this is. It does add one constraint on the
      `setupWorkerPool` extension point - the pool's rejection handler must be an `AbortPolicy` - but that
      extension point has no feature record today, and the nearest neighbour, `managed-thread-factory.yaml`,
      covers the thread factory rather than the handler. The default pool is unaffected. Worth a constraint line
      whenever that extension point is documented.
- [x] Tests added/updated - `SubmitWorkToPoolShutdownRaceTest`,
      `AbstractParallelEoSStreamProcessorConfigurationTest` and `WorkContainerFutureIsWriteOnlyArchTest`. Every
      guard is mutation-checked: removed in turn, confirmed exactly its own test failed, restored.
- [x] Title & body reflect the final content of this PR






