### PR TITLE
test(core): anchor produceTimeout and correctOffsetVerySimple to the events they check

### DIFF
--- a/docs/inflight/ci-review-agent.md
+++ b/docs/inflight/ci-review-agent.md
@@ -24,24 +24,76 @@ How the reviewer and its gate work, and the contract for asking for a review, ar
   (an `issue_comment` command phrase would, and would restore tag mode wholesale). Weigh that
   against what the dispatch route uniquely gives - `-f focus` and the packaged procedure - before
   assuming it should be replaced.
-- **OPEN, and it is the first thing to do after this lands: the dispatched reviewer has never
-  completed an end-to-end review.** Nothing has yet observed it read a PR, post a summary comment
-  as `claude[bot]`, and turn `claude-review` green in one run - only the individual mechanisms were
-  proved on runners. It could not be verified before merging, because `claude-code-action` refuses
-  to run unless the invoking workflow file is byte-identical to the default branch's copy: `--ref
-  <your branch>` is refused and `--ref master` runs the old copy. So the very first action after
-  the merge is a `--ref master` dispatch against a live PR, and **reading the run** rather than
-  assuming. Until someone has done that and said so here, treat the reviewer as unproven. The same
-  constraint is inherited by whoever edits the reviewer next - your change will land unverified
-  too. Reviewing a PR that edits this workflow is a separate thing and does work; the mechanism is
-  in [`docs/ci.md`](../ci.md).
+- **OBSERVED 2026-08-14, and it failed: the dispatched reviewer ran a full review and posted
+  nothing.** This is the end-to-end check the previous revision of this entry asked for, now done
+  and read rather than assumed. `--ref master`, `-f pr=297`, `-f focus=<a three-point steer>`, run
+  [`31770555653`](https://github.com/astubbs/parallel-consumer/actions/runs/31770555653). The
+  `Run Claude Code Review` step ran **7m12s** and reported `conclusion=success`. On the PR
+  afterwards: no `claude[bot]` issue comment, no PR review, `No buffered inline comments` in the
+  log, and `claude-review` still red. Every step of both jobs was green, including the guard and
+  the `refresh-gate`. So the reviewer is not merely unproven - one full billed review has now been
+  spent producing nothing, and **nothing in the system noticed**. Treat a green reviewer run as
+  saying only that the action exited, until the post-condition below exists.
+
+  Not yet established: whether it reviewed and declined to post, or never got that far.
+  `Bash(gh pr comment:*)` **is** granted, and the appended system prompt makes posting mandatory
+  and non-optional ("your LAST action"), so the instruction and the capability were both present.
+  The next dispatch should be read against `claude-execution-output.json` to tell those apart.
+
+- **THE GUARD CANNOT CATCH THAT, because it tests the wrong thing.** The reviewer job's "Refuse to
+  report success for a review that did not run" step branches only on
+  `steps.claude-review.outputs.conclusion`. That detects an *abort* - the workflow-validation skip
+  it was written for - and is structurally incapable of detecting a run that reviews, concludes
+  `success`, and posts nothing. That is the same class as the `--comment` regression this repo
+  already ate ("ran green for months while never posting a single review"), so the guard added
+  afterwards does not cover the case that motivated it. **The missing piece already exists**:
+  `bin/check-review-posted.sh` answers exactly "is there a finished `claude[bot]` comment on this
+  PR", and the gate uses it - the reviewer job simply never asks it about its own output. Running
+  it as a post-condition on the reviewer job turns "billed, ran, said nothing" from green into red
+  with the reason attached. Highest-value fix in this file after the check-run entry below.
+
+- **Nothing announces a dispatched review at its start, so an in-flight billed review is
+  invisible - and so is the `-f focus` steer.** Until it posts, the only record that a review was
+  requested, by whom, and what it was steered toward, is the requester's shell history. This is
+  not an oversight but an unreplaced casualty: `track_progress: true` used to post the sticky
+  `claude[bot]` comment at the start, and it is now hard-set `false` because the action refuses
+  `track_progress` on any non-entity event and aborts the run outright (which killed the first
+  live dispatch, run 31464598166). What replaced it - the FINISH WITH A SUMMARY COMMENT
+  instruction - covers only the end, and the entry above is the case where the end never comes.
+  The fix does not depend on the action at all: a plain `gh pr comment` step before it, posting
+  the PR number, the run URL and the verbatim `focus`. The action can refuse its own sticky
+  comment; it cannot refuse a step that does not involve it.
+
+  **The steer is the part worth posting.** It is appended to the packaged procedure and materially
+  shapes where the review looks hardest, so a reader who cannot see it cannot tell a narrow review
+  from a broad one - and cannot tell whether a "no findings" result was steered away from the area
+  they care about.
+
+- **What the dispatch route buys over `@claude review this`, since the comment route otherwise
+  looks strictly better.** Exactly one thing: the **packaged procedure**. `plugins:
+  'code-review@claude-code-plugins'` plus `/code-review:code-review <repo>/pull/<n> --comment`
+  invokes a versioned multi-step review; a mention passes whatever was typed as the *entire*
+  prompt, silently substituting an improvised review that still looks like a review. Three things
+  commonly assumed to be advantages are **not** - both routes carry the same curated tool
+  allowlist, both execute the default branch's workflow copy, and both satisfy the gate, which
+  matches `.user.login == 'claude[bot]'` and nothing else. Against that one advantage the comment
+  route announces itself by construction and can open inline review threads that mechanically
+  block the merge. Worth re-deciding only alongside the trigger question in the inline-comment
+  entry above; recorded here so the next reader does not re-derive it.
+
+  The constraint that made all of this unverifiable before merge still holds: `claude-code-action`
+  refuses to run unless the invoking workflow file is byte-identical to the default branch's copy,
+  so `--ref <your branch>` is refused and `--ref master` runs the old copy. Whoever edits the
+  reviewer next lands their change unverified in exactly the same way. Reviewing a PR that edits
+  this workflow is a separate thing and does work; the mechanism is in [`docs/ci.md`](../ci.md).
 
   **The comment route is no better off, for a different reason.** It looks testable - just comment
   on a PR - but `issue_comment` workflows always run the **default branch's** copy, so a comment
   exercises master's `claude.yml`, never the one on your branch. The tool grants and the
-  `refresh-gate` added there are unverified in exactly the same way. After the merge, exercise
-  both: a `--ref master` dispatch, and an `@claude review this` comment on a live PR - checking
-  that the comment route really does open an inline thread, and that `claude-review` clears itself.
+  `refresh-gate` added there are unverified in exactly the same way. The dispatch half of that
+  exercise is now done and is the entry above; **the comment route is still unexercised** - the
+  open questions are whether it really does open an inline thread, and whether `claude-review`
+  clears itself afterwards.
 - **The duplication scanners are pointed away from where agents duplicate.** `dups: clones` and
   `dups: similarity` scan `parallel-consumer-*/src` only, and the similarity job additionally
   filters `file_extensions: 'java'` - so `docs/`, `.github/`, `bin/` and `AGENTS.md` are scanned by

--- a/docs/inflight/test-load-tightness-flakes.md
+++ b/docs/inflight/test-load-tightness-flakes.md
@@ -7,7 +7,6 @@ baseline for comparison is 15/20 runs fully clean, zero stall-class failures.
 | Test | Rate | Symptom |
 |------|------|---------|
 | `MultiInstanceMetricsTest.sameRegistryCanBeReusedAfterPcInstanceClosed` | 0/20 hunt, ~1/104 on CI | 1-2s produce/commit lock timeouts |
-| `TransactionTimeoutsTest.produceTimeout` | 1/20 + 1 highcpu (2026-07-30); **0 in all three reproducers 2026-08-07** - see below | assertion failure inside the produce-timeout test; which assertion is the open question - see below |
 | `LoadTest` | 1/20 | 60s throughput awaits |
 | `DbTest` | 2/20 | postgres container start under contention |
 | `KafkaSanityTests`, `TransactionMarkersTest` | singles | residual, uncategorised |
@@ -32,48 +31,34 @@ experiment numbers live in
 [`docs/solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md`](../solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md)**
 - do not restate them here, or the two copies will drift.
 
-## `produceTimeout`: investigated 2026-08-07, not reproduced, and the old label was wrong
+## A fourth member has left the family: `produceTimeout` is SOLVED (2026-08-13)
 
-Do **not** start from "tight assertion", and do not start from the trigger. Both were checked.
+It was neither tight nor unforceable. Its phase-2 at-most assertion waited a flat 5s while the commit
+block it was checking *also* lasted 5s, started on PC's own commit cadence, and was never tied to it -
+so the whole margin was `commit tick - assert poll latency`, **measured at ~500ms**. Fixed by anchoring
+the check to the start of the block. **The mechanism, the control arm and the refuted attempts live in
+[`docs/solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md`](../solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md)**
+- do not restate them here, or the two copies will drift.
 
-**Its trigger is properly latched** - the injected `sendOffsetsToTransaction` counts the latch down
-*while already holding the commit write lock* and then sleeps, and the worker awaits that latch before
-sleeping again and attempting the produce lock against a shorter timeout. Real margin, forced
-ordering. So `produceTimeout` is **not** the unforceable-trigger class, whatever its sibling turned out
-to be.
+Three corrections this leaves behind, because each of them sent an earlier look the wrong way:
 
-**The suspect, if it flakes again, is phase 2's `assertConsumedAtMostOffset`.** That helper waits, then
-checks **once**, and it needs *no* transaction to commit new output records in the whole window. The
-injected sleep only fires when the commit's base offset is exactly `OFFSET_TO_PRODUCE_SLOWLY` - which
-requires the two records below it complete and it not (`PartitionState#getOffsetToCommit` is "one below
-the highest sequentially succeeded offset"). A commit tick landing after the first completes but before
-the second does has a lower base, injects no sleep, commits for real, and the at-most assertion loses.
-Nothing in the test prevents that interleaving.
-
-**Not reproduced, at these N** - report the rate, not a verdict:
-
-| Reproducer | Result |
-|---|---|
-| single test + CPU burners, `SOAK_FREE_CORES=1` | 0/20 |
-| full forked IT suite, `rerunFailingTestsCount=0` | 0/3 |
-| CI surefire flake markers, 45 runs | 0 sightings |
-
-The mechanism is unchanged since the 1/20 was measured - no main-code commit has touched
-`ProducerManager`, `PartitionState` or `AbstractParallelEoSStreamProcessor` since - so this is **not**
-"fixed by something else". Three suite runs is a small N against 1-in-20; treat it as "not flaking at a
-detectable rate today", nothing stronger.
-
-**Use the right reproducer.** A single-test CPU soak is the wrong shape for this one: the interleaving
-above needs the gap between two records completing to stretch, which is broker latency, not CPU. The
-original rate came from the whole suite forked per core. Disable `rerunFailingTestsCount` when hunting,
-or CI's own retry will hide the failure you are trying to catch (see
-[`../solutions/workflow-issues/ci-retries-hid-flakes-from-the-ledger-2026-08-07.md`](../solutions/workflow-issues/ci-retries-hid-flakes-from-the-ledger-2026-08-07.md)).
+1. **The suspect recorded here was wrong.** A lower-base commit splitting offsets 5 and 6 was never
+   observed - zero such commits across 9 instrumented runs, and in baseline runs those two records
+   completed in the *same millisecond*. That hole is real but unobserved, and is still open by
+   construction; it is noted at the trigger site in the test.
+2. **"Not reproduced" was a property of the reproducer.** A single-test CPU soak cannot find this:
+   burners dilate the commit tick and the poll latency together, leaving their difference intact. The
+   margin held at 504-522ms under `SOAK_FREE_CORES=1`. That is why 0/20, 0/3 and 0/45 all came back
+   clean while the flake was still live.
+3. **A 0-failure soak still told you nothing.** As its own closing line says. What settled this was a
+   control arm, not a repetition count.
 
 **What this means for the members still listed above:** before filing any
 of them as a tight assertion, check whether the thing being awaited can be *triggered at all* in every
 interleaving. A test that waits on a consequence it cannot force is not tight - it is unsound, and
-raising its timeout will never fix it. (`produceTimeout` already latches its own trigger, so it is the
-worked example of doing this right.)
+raising its timeout will never fix it. And before trusting a clean soak, check that the reproducer can
+move the term you believe is responsible - `produceTimeout` is now the worked example of one that
+could not.
 
 **Classify before touching any of them** (the astubbs#68 lesson): this family is exactly where the upstream
 confluentinc#857 deadlock and the drain zombie were hiding, and both looked like tightness first. Two members have

--- a/docs/solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md
+++ b/docs/solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md
@@ -20,6 +20,8 @@ related:
   - "docs/inflight/test-load-tightness-flakes.md - the family this belonged to; entry shrunk to point here"
   - "unforceable-trigger-commit-lock-timeout-2026-08-07.md - the sibling in the same file. Its 'Explicitly NOT an instance' section is correct that this test latches its TRIGGER, but its conclusion that the 'tight assertion' label stands is only accidentally right - the tightness is nowhere near the assertion's threshold"
   - "docs/investigating.md - the control-arm method this was settled with"
+  - "assert-the-commit-frontier-not-the-tick-path.md (astubbs#264) - the residual left open below is an instance of its class: the injected sleep is keyed on the commit tick that carries an exact base offset, not on the frontier having advanced"
+  - "vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md - the sibling failure mode, and the one the CloseAndOpenOffsetTest sweep below turned up"
 ---
 
 # The assertion and the thing it was asserting against were both 5 seconds long
@@ -109,3 +111,46 @@ even when anchored. **This was never observed** - zero such commits across 9 ins
 the baseline runs those two records completed in the same millisecond - so it is left as-is, noted at
 the trigger site. Closing it would mean firing the slow commit on the first commit carrying any phase-2
 progress rather than on an exact base offset.
+
+That residual is an instance of the class in
+[`assert-the-commit-frontier-not-the-tick-path.md`](assert-the-commit-frontier-not-the-tick-path.md):
+it keys on *which tick* carried the progress rather than on the frontier having reached it, and every
+such key is hostage to a scheduler that is free to split the work across two ticks instead of one.
+Naming the class is also the fix shape - "the first commit carrying any phase-2 progress" **is** the
+frontier reading.
+
+## Other instances of this shape - a sweep, with one hit and one miss
+
+Both `pollDelay` sites in `CloseAndOpenOffsetTest` were checked, and they are not the same defect as
+each other. Fixed here, because the class is the point:
+
+**`correctOffsetVerySimple` - a real instance, of the vacuity variety.** It asserted that a freshly
+opened PC reads nothing back, having waited a flat 1s, with nothing establishing that PC had joined the
+group. Control arm, subscribing that PC to a topic that is not the one under test:
+
+| Arm | Result |
+|---|---|
+| original assertion, consumer pointed at a decoy topic | **passes** - it was asserting nothing |
+| anchored assertion, same decoy topic | **fails** at the assignment await |
+
+Now anchored on `PartitionStateManager#getPartitionState` being non-null (a `ConcurrentHashMap`, so
+unlike `Consumer#assignment` it is safe to read from the test thread), and followed by a record
+produced *after* the window that must be read - assignment proves it joined, the trailing record proves
+its poller actually reached the topic. Same rule as
+[`TransactionalPartialResultSetIT#proveVerifierIsActuallyReading`](../../../parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/TransactionalPartialResultSetIT.java):
+prove the detector works before trusting what it did not detect.
+
+**`largeNumberOfMessagesSmallOffsetBitmap` - not an instance.** Its assertion retries, so a slow start
+costs time rather than correctness. Two smaller things were true of it, and only the measured ones were
+acted on:
+
+- `atLeast(500ms)` behind `pollDelay(1000ms)` can never fire. Measured: with the `atLeast` raised to
+  1500ms the condition is reported "evaluated in 1 seconds 6 milliseconds", so at 500ms it was dead.
+  Removed.
+- The trailing `assertThat(...).hasSize(...)` was commented "double check after closing" while sitting
+  *inside* the try-with-resources, so it ran before close. **Moving it out does not earn the claim**:
+  produce an extra record after the await and flush it to the broker before close, and PC never
+  delivers it - it stops fetching at close - so both positions still pass. The assertion stays where it
+  is with a comment that says what it is (a restatement), rather than being relocated on a theory the
+  control refuted. Catching a genuinely late delivery needs a quiet window or a settle anchor while PC
+  is still running, and nothing has been seen that needs it.

--- a/docs/solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md
+++ b/docs/solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md
@@ -1,0 +1,111 @@
+---
+title: "An at-most assertion that raced the block it was checking: TransactionTimeoutsTest.produceTimeout waited a flat 5s against a 5s commit hold"
+date: 2026-08-13
+category: test-flakiness
+module: parallel-consumer-core
+problem_type: flaky_test
+component: testing
+symptoms:
+  - "TransactionTimeoutsTest.produceTimeout: ConditionTimeoutException from BrokerCommitAsserter, `headOffset expected to be at most: 4, but was: 8`"
+  - "Passes in isolation and on rerun; measured 1/20 plus one high-CPU sighting (2026-07-30), then 0/20, 0/3 and 0/45 across three reproducers (2026-08-07)"
+  - "Nothing wrong in PC in the failing window - the records it committed had genuinely succeeded"
+root_cause: assertion_window_raced_the_artificial_block_it_asserted_against
+resolution_type: test_fix_anchor_assertion_to_the_blocked_window
+severity: low
+status: "SOLVED - test-side fix. PC is healthy; no product defect. The ledger's previously-recorded suspect (a lower-base commit splitting offsets 5 and 6) was NOT the mechanism and was never observed in 9 instrumented runs; it remains open by construction and is noted at the trigger site."
+last_updated: 2026-08-13
+related_prs:
+  - "astubbs#220 - fixed the sibling commitTimeout in this same file, and is where this flake was left on the ledger as unfinished business"
+related:
+  - "docs/inflight/test-load-tightness-flakes.md - the family this belonged to; entry shrunk to point here"
+  - "unforceable-trigger-commit-lock-timeout-2026-08-07.md - the sibling in the same file. Its 'Explicitly NOT an instance' section is correct that this test latches its TRIGGER, but its conclusion that the 'tight assertion' label stands is only accidentally right - the tightness is nowhere near the assertion's threshold"
+  - "docs/investigating.md - the control-arm method this was settled with"
+---
+
+# The assertion and the thing it was asserting against were both 5 seconds long
+
+`produceTimeout`'s phase 2 asserts that while a commit is artificially blocked, no new output records
+become visible to a `READ_COMMITTED` consumer. Both halves of that were five seconds, and nothing tied
+them together.
+
+- The block: the injected `sendOffsetsToTransaction` holds the commit write lock and sleeps **5s**.
+- The check: `BrokerCommitAsserter#assertConsumedAtMostOffset` waited a flat **5s**, then polled once.
+
+The two windows started at different moments and only overlapped by luck. The block starts when PC's
+own commit cadence reaches a commit whose base offset is `OFFSET_TO_PRODUCE_SLOWLY`; the check starts
+whenever the test thread arrives. So the entire margin was
+
+```
+margin = (commit tick, relative to the check starting) - (the assert consumer's poll latency)
+```
+
+## Measured, not inferred
+
+Instrumented run on an idle box, times relative to the at-most check starting:
+
+| Event | t |
+|---|---|
+| offsets 5, 6, 8 all finish processing | +0 (same millisecond) |
+| commit tick, `base=7`, 5s block begins | +1016 ms |
+| at-most check polls and passes | +5512 ms |
+| blocked transaction actually commits | **+6016 ms** |
+
+**Margin: ~500 ms.** Both terms in it are wall-clock latencies - `produceMessages(4)` plus the assert
+consumer's `subscribe`/group-join/first `poll` - so a contended runner or a slow broker erodes them
+directly. When the margin goes negative the transaction commits *inside* the assertion's own poll
+window, and the failure reads like an EOS violation while PC is behaving correctly.
+
+## Control arm
+
+The same 700 ms of latency, in two positions, everything else identical:
+
+| Arm | 700 ms placed | block begins at | check completes | margin | Result |
+|---|---|---|---|---|---|
+| force | after the send, before the check | +320 ms | +5515 ms | **-180 ms** | **3/3 fail** |
+| control | before the send | +1016 ms | +5514 ms | +502 ms | **3/3 pass** |
+
+Same magnitude, different position, outcome flips - which is what rules out "it is just slower under
+load". CPU contention alone does *not* reproduce it: under `SOAK_FREE_CORES=1` the margin stayed at
+504-522 ms across runs, because burners slow both terms together.
+
+## The fix
+
+Anchor the check to the **start** of the block instead of hoping to overlap it. The test already has a
+latch counted down as the injected commit begins its hold, while the write lock is held; phase 2 now
+awaits that latch and checks with a delay sized against the hold (1s inside a 5s block). Margin goes
+from ~0.5s to ~4s, and - the real point - the assertion now runs while the property it asserts is
+actually claimed to hold.
+
+`assertConsumedAtMostOffset` takes the delay as a parameter rather than hard-coding 5s. It has exactly
+one caller, and the delay is a property of whatever is blocking the records, which only the caller
+knows.
+
+Verified:
+
+| Arm | Result |
+|---|---|
+| fixed, stock settings | 3/3 pass |
+| fixed, plus the 700 ms that failed the old assertion 3/3 | 3/3 pass |
+| fixed, check delay moved back outside the block (7s vs 5s hold) | **2/2 fail** |
+| whole `TransactionTimeoutsTest` class, fixed | see PR |
+
+## What didn't work, and one refuted prediction
+
+- **A single-test CPU soak.** 2 runs at `SOAK_FREE_CORES=1` before it was stopped as redundant; the
+  ledger had already recorded 0/20 for this shape. The margin is not CPU-sensitive - burners dilate the
+  commit tick and the poll latency together, leaving the difference intact. This is why three earlier
+  reproducers all came back clean.
+- **A guard asserting the block was still held when the check finished.** Written, then removed. The
+  negative control showed the at-most assertion fails *first* (`headOffset ... but was: 10`), so the
+  guard was never reached - an assertion nobody has seen fail is decoration
+  (`docs/investigating.md`). The negative control was kept, because it verifies the anchor itself.
+
+## What this does NOT fix
+
+The ledger's previously-recorded suspect: the injected sleep is keyed on the commit base offset being
+*exactly* `OFFSET_TO_PRODUCE_SLOWLY`, which assumes offsets 5 and 6 both complete between two commit
+ticks. A tick landing between them commits for real with a lower base, and the at-most check would lose
+even when anchored. **This was never observed** - zero such commits across 9 instrumented runs, and in
+the baseline runs those two records completed in the same millisecond - so it is left as-is, noted at
+the trigger site. Closing it would mean firing the slow commit on the first commit carrying any phase-2
+progress rather than on an exact base offset.

--- a/docs/solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md
+++ b/docs/solutions/test-flakiness/unforceable-trigger-commit-lock-timeout-2026-08-07.md
@@ -248,12 +248,18 @@ find candidates: *sleep-as-synchronisation* in integration tests, and *awaits on
 `isClosedOrFailed` uses in this repo are guards).
 
 **Explicitly NOT an instance - `TransactionTimeoutsTest.produceTimeout`.** This is the most important
-line in the section, because it is the nearest sibling: same file, same lock, and still listed as an
-open flake in `docs/inflight/test-load-tightness-flakes.md`. It **latches its trigger and keeps a real
-margin** - the injected `sendOffsetsToTransaction` counts its latch down while already holding the
-commit write lock and then sleeps 5s, and the worker attempts the produce read lock at `latch + 1s`
-against a 2s deadline. Its "tight assertion" classification stands. **Do not "fix" it the way
-`commitTimeout` was fixed** - it does not have this defect.
+line in the section, because it is the nearest sibling: same file, same lock. It **latches its trigger
+and keeps a real margin** - the injected `sendOffsetsToTransaction` counts its latch down while already
+holding the commit write lock and then sleeps 5s, and the worker attempts the produce read lock at
+`latch + 1s` against a 2s deadline. **Do not "fix" it the way `commitTimeout` was fixed** - it does not
+have this defect.
+
+> **Correction, 2026-08-13.** Two claims above have since been falsified. `produceTimeout` is no longer
+> an open flake - it was solved, and the sentence "its 'tight assertion' classification stands" was
+> right only by accident. The tightness was not in the assertion's threshold: its phase-2 at-most check
+> waited a flat 5s while the commit block it was checking also lasted 5s, leaving a ~500ms margin that
+> nobody had measured. Ruling it out of *this* defect class was correct, and that is what stands.
+> See [`at-most-assertion-raced-the-block-it-checked-2026-08-13.md`](at-most-assertion-raced-the-block-it-checked-2026-08-13.md).
 
 Relatives found, neither the same defect:
 

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/CloseAndOpenOffsetTest.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/CloseAndOpenOffsetTest.java
@@ -296,24 +296,48 @@ class CloseAndOpenOffsetTest extends BrokerIntegrationTest<String, String> {
         try (var asyncThree = new ParallelEoSStreamProcessor<String, String>(optionsThree)) {
             asyncThree.subscribe(UniLists.of(topic));
 
-            // read what we're given
-            var readByThree = new ArrayList<ConsumerRecord<String, String>>();
+            // read what we're given - concurrent, as the assertions below read it from the test thread while
+            // PC's worker thread may be adding to it
+            var readByThree = new ConcurrentLinkedQueue<ConsumerRecord<String, String>>();
             asyncThree.poll(x -> {
                 log.info("Three read: {}", x.value());
                 readByThree.add(x.getSingleConsumerRecord());
             });
 
-            // for at least normalTimeout, nothing should be read back (will be long enough to be sure it never is)
-            await().alias("nothing should be read back (will be long enough to be sure it never is)")
+            // Asserting an ABSENCE proves nothing unless the consumer that saw nothing was actually listening,
+            // so anchor the window to the assignment first. PartitionStateManager only holds a state for a
+            // partition it has been assigned (onPartitionsAssigned populates the map), and that map is a
+            // ConcurrentHashMap - so unlike Consumer#assignment, this is safe to read from the test thread
+            // while PC's poll thread is running.
+            var partition = new TopicPartition(topic, 0);
+            await().alias("PC three has been assigned the partition - without this, 'nothing was read' is equally "
+                            + "true of a consumer that never finished joining the group")
+                    .atMost(timeoutToUse)
+                    .until(() -> asyncThree.getWm().getPm().getPartitionState(partition) != null);
+
+            // nothing should be read back: asyncOne processed and committed the only record there was.
+            // No atLeast() here - pollDelay already puts the single evaluation at >= 1s, so an atLeast at or
+            // below that can never fail, and an assertion that cannot fail is decoration.
+            await().alias("nothing should be read back")
                     .pollDelay(ofSeconds(1))
                     .atMost(ofSeconds(2))
-                    .atLeast(ofSeconds(1))
                     .untilAsserted(() -> {
                                 assertThat(readByThree).as("Nothing should be read into the collection")
                                         .extracting(ConsumerRecord::value)
                                         .isEmpty();
                             }
                     );
+
+            // Prove the detector works. Assignment says three joined; it does not say three's poller ever
+            // reached the topic. A record produced now must come through - if it does not, the emptiness above
+            // was measuring a consumer that could not have reported a re-read even if one had happened.
+            String afterCommitPayload = "1";
+            getKcu().getProducer().send(new ProducerRecord<>(topic, afterCommitPayload, afterCommitPayload));
+            await().alias("a record produced after the absence window IS read - proves three was live throughout it")
+                    .atMost(timeoutToUse)
+                    .untilAsserted(() -> assertThat(readByThree)
+                            .extracting(ConsumerRecord::value)
+                            .containsExactly(afterCommitPayload));
         }
     }
 
@@ -390,9 +414,10 @@ class CloseAndOpenOffsetTest extends BrokerIntegrationTest<String, String> {
                     readByThree.add(x.value());
                 });
 
+                // No atLeast() - pollDelay already puts the single evaluation at >= 1s, so an atLeast at or
+                // below that can never fail, and an assertion that cannot fail is decoration
                 await().alias("Only the one remaining failing message should be submitted for processing")
                         .pollDelay(ofMillis(1000))
-                        .atLeast(ofMillis(500))
                         .untilAsserted(() -> {
                                     assertThat(readByThree)
                                             .as("Contains only previously failed messages")
@@ -400,8 +425,13 @@ class CloseAndOpenOffsetTest extends BrokerIntegrationTest<String, String> {
                                 }
                         );
 
-                //
-                assertThat(readByThree).hasSize(numberOfFailingMessages); // double check after closing
+                // A restatement, not an independent check - it cannot fail unless the await above passed.
+                // Its previous comment claimed it was a "double check after closing", which it never was: it
+                // sits inside the try, so it runs before close. Moving it out does not earn the claim either -
+                // measured, by producing an extra record here and letting it reach the broker before close:
+                // PC stops fetching at close, so the record is never delivered and BOTH positions still pass.
+                // Catching a late delivery would need a quiet window or a settle anchor while PC still runs.
+                assertThat(readByThree).hasSize(numberOfFailingMessages);
             }
         }
     }

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/TransactionTimeoutsTest.java
@@ -77,6 +77,18 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
      */
     private static final int OFFSET_TO_MARK_DIRTY = OFFSET_TO_GO_SLOW + 1;
 
+    /**
+     * How long {@link #produceTimeout()}'s injected commit holds the transaction open, and how long after
+     * that block begins the output topic is checked.
+     * <p>
+     * The check must finish well inside the hold. It asserts that nothing new becomes visible <em>while the
+     * commit is blocked</em>, so a check that outlives the block is asserting nothing - and worse, it fails,
+     * because by then PC is entitled to have committed.
+     */
+    private static final Duration SLOW_COMMIT_HOLD = ofSeconds(5);
+
+    private static final Duration BLOCKED_WINDOW_CHECK_DELAY = ofSeconds(1);
+
 
     private ParallelEoSStreamProcessor<String, String> pc;
 
@@ -278,6 +290,8 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
     void produceTimeout() {
         final int OFFSET_TO_PRODUCE_SLOWLY = NUMBER_TO_SEND + 2;
 
+        // Counted down as the slow commit STARTS holding the transaction open - which is what phase 2's
+        // at-most check anchors to, so that it runs while the block is in force rather than racing its end.
         CountDownLatch produceLock = new CountDownLatch(1);
 
         // inject system that causes commit to take too long
@@ -308,10 +322,13 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
                 long offset = offsetAndMetadata.offset();
 
                 boolean firstCycle = produceLock.getCount() > 0;
+                // Keyed on the exact base offset, which assumes offsets 5 and 6 both complete between two
+                // commit ticks. Nothing enforces that: a tick landing between them commits for real with a
+                // lower base. Never observed in 9 instrumented runs, and left as-is - see the ledger entry.
                 if (offset == OFFSET_TO_PRODUCE_SLOWLY && firstCycle) {
                     log.debug("Causing commit to take too long which will trigger produce lock timeout");
                     produceLock.countDown();
-                    ThreadUtils.sleepQuietly(5000); // sleep for some time to simulate timeout
+                    ThreadUtils.sleepQuietly(SLOW_COMMIT_HOLD.toMillis()); // sleep for some time to simulate timeout
                     log.debug("Causing commit to take too long COMPLETE");
                 }
 
@@ -353,7 +370,21 @@ class TransactionTimeoutsTest extends BrokerIntegrationTest<String, String> {
         getKcu().produceMessages(getTopic(), EXTRA_TO_SEND);
 
         // assert output topic - still has ONLY got the new records due to commit being blocked
-        assertConsumer.assertConsumedAtMostOffset(OUTPUT_TOPIC, NUMBER_TO_SEND - 1); // only base records committed ok to output topic
+        //
+        // Anchored to the START of the block, rather than run in the hope of overlapping it. This used to
+        // wait a flat 5s from wherever the test happened to reach it, while the block it checks also lasts
+        // 5s and starts on PC's own commit cadence - so two 5s windows raced, and the whole margin was
+        // `commit tick - assert poll latency`, measured at ~500ms on an idle box. Broker or runner latency
+        // ate it, the transaction committed inside the assertion's own poll window, and it surfaced as
+        // "headOffset expected to be at most 4, but was 8" - a genuine EOS-looking failure with nothing
+        // wrong in PC.
+        //
+        // The anchor is load-bearing, by negative control: move the check back outside the block (set
+        // BLOCKED_WINDOW_CHECK_DELAY past SLOW_COMMIT_HOLD) and this fails 2/2 on the at-most assertion.
+        // The original margin was reproduced the same way - 700ms of added latency here failed 3/3, while
+        // the same 700ms added before the send passed 3/3, and the fixed test passes 3/3 with it.
+        LatchTestUtils.awaitLatch(produceLock);
+        assertConsumer.assertConsumedAtMostOffset(OUTPUT_TOPIC, NUMBER_TO_SEND - 1, BLOCKED_WINDOW_CHECK_DELAY); // only base records committed ok to output topic
 
         // wait for eventually retry on the blocked / slow sending offset
         await().untilAsserted(() -> Truth.assertThat(retryCount.get()).isAtLeast(1));

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/utils/BrokerCommitAsserter.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/utils/BrokerCommitAsserter.java
@@ -65,12 +65,17 @@ public class BrokerCommitAsserter {
     }
 
     /**
-     * Checks only once, with an assertion delay of 5 second
+     * Checks only once, after the given delay.
+     * <p>
+     * The delay is the window in which the records must NOT appear, so it belongs to the caller: it has to
+     * be sized against whatever is holding them back, and must expire while that thing is still holding.
+     * A delay that outlives the block turns this into an assertion about nothing - which is how
+     * {@code TransactionTimeoutsTest#produceTimeout} flaked, when this method's own flat 5s raced the 5s
+     * block it was checking.
      */
-    public void assertConsumedAtMostOffset(String topic, int atMost) {
+    public void assertConsumedAtMostOffset(String topic, int atMost, Duration delay) {
         setup(topic, atMost);
 
-        Duration delay = ofSeconds(5);
         log.debug("Delaying by {} to check consumption from topic {} by at most {}", delay, topic, atMost);
         await()
                 .pollDelay(delay)


### PR DESCRIPTION
<!-- What does this PR change, and why? Keep it in sync with the actual content as the PR evolves. -->

## Description

Two flaky-by-construction assertions were checking a window they were never tied to, plus one CI defect found while reviewing this PR and recorded rather than fixed. **Test and docs only - no product code changes**, and nothing under any `src/main`.

1. **`TransactionTimeoutsTest#produceTimeout`** - the original subject of this PR.
2. **`CloseAndOpenOffsetTest#correctOffsetVerySimple`** - found by sweeping the other `pollDelay` sites for the same class.
3. **`docs/inflight/ci-review-agent.md`** - the dispatched reviewer ran a full review of this PR and posted nothing while reporting success.

---

## 1. `produceTimeout` - the assertion raced the block it was checking

`TransactionTimeoutsTest#produceTimeout` was the last open member of the load-tightness flake family - 1/20 plus a high-CPU sighting, then three reproducers that all came back clean. It failed as `headOffset expected to be at most: 4, but was: 8`, which reads like an EOS violation. **PC was healthy every time.**

Phase 2's at-most assertion and the artificial commit block it checks were **both 5 seconds**, and nothing tied them together. The block begins when PC's own commit cadence reaches a commit whose base offset is `OFFSET_TO_PRODUCE_SLOWLY`; the check began whenever the test thread arrived, then waited a flat 5s. So the entire margin was

```
(commit tick, relative to the check starting) - (assert consumer's poll latency)
```

**measured at ~500ms** on an idle box. Both terms are wall-clock latencies - `produceMessages(4)`, plus the assert consumer's subscribe, group join and first poll - so a slow broker or a contended runner erodes them directly and the transaction commits inside the assertion's own poll window.

Instrumented timeline, relative to the check starting:

| Event | t |
|---|---|
| offsets 5, 6, 8 all finish processing | +0 (same millisecond) |
| commit tick, `base=7`, 5s block begins | +1016 ms |
| at-most check polls and passes | +5512 ms |
| blocked transaction actually commits | **+6016 ms** |

### The fix

The check anchors to the **start** of the block - awaiting the latch the injected commit already counts down while holding the write lock - and checks with a delay sized against the hold: 1s inside a 5s block. `assertConsumedAtMostOffset` now takes that delay as a parameter instead of hard-coding 5s; it has exactly one caller, and the delay is a property of whatever is blocking the records, which only the caller knows.

**No assertion was weakened, and no timeout was raised.** The opposite: the check now runs *while* the property it asserts is claimed to hold, instead of at a moment when PC is entitled to have committed. It is non-vacuous by construction - the latch only fires on a commit that collected base offset 7, so offsets 5 and 6 had already succeeded and their output records were sitting in the open transaction.

### Evidence

Control arm per [`docs/investigating.md`](docs/investigating.md) - same magnitude, different position, rather than a fix that appears to work:

| Arm | Result |
|---|---|
| 700ms added after the send, before the check | **3/3 fail** |
| the same 700ms added before the send | 3/3 pass |
| fixed, stock settings | 3/3 pass |
| fixed, plus the 700ms that failed the old assertion 3/3 | 3/3 pass |
| fixed, anchor removed (check delay past the hold) | **2/2 fail** |
| whole `TransactionTimeoutsTest` class, fixed | 2/2 pass (3 tests each) |

**One term the control arms did not isolate**, raised by the review on this PR and worth recording rather than glossing: `assertConsumedAtMostOffset` runs `setup()` (`subscribe` + `seekToBeginning`) *before* the `pollDelay` clock starts, so there is a gap between the latch firing and the delay beginning that neither arm placed latency into - both added their 700ms before or after the send. Very unlikely to matter against the ~4s margin, but the margin is not fully decomposed by the table above.

### Why three earlier reproducers came back clean

A single-test CPU soak cannot find this. Burners dilate the commit tick and the poll latency **together**, leaving their difference intact - the margin held at 504-522ms under `SOAK_FREE_CORES=1`. That is why 0/20, 0/3 and 0/45 were all recorded while the flake was live, and it is the transferable lesson: before trusting a clean soak, check that the reproducer can move the term you believe is responsible.

### Two recorded claims corrected

Each one sent an earlier look the wrong way, so both are fixed where they live rather than left to mislead again:

- **The ledger's suspect was wrong.** A lower-base commit splitting offsets 5 and 6 was never the mechanism - zero such commits across 9 instrumented runs, and in baseline runs those two records completed in the *same millisecond*.
- **The sibling write-up's "its 'tight assertion' classification stands" was right only by accident.** Ruling `produceTimeout` out of the unforceable-trigger class was correct and still stands; the tightness was nowhere near the assertion's threshold.

Analysis promoted to `docs/solutions/test-flakiness/at-most-assertion-raced-the-block-it-checked-2026-08-13.md`; the ledger entry shrinks to the classification and a pointer, the way `commitTimeout`'s did, and its roster row goes with it - the fourth member to leave the family.

---

## 2. The sweep - one hit and one miss

Both `pollDelay` sites in `CloseAndOpenOffsetTest` were checked. They are **not the same defect as each other**, and saying so is half the point.

### `correctOffsetVerySimple` - a real instance, of the vacuity variety

It asserted that a freshly opened PC reads nothing back, having waited a flat 1s, with nothing establishing that PC had joined the group - so "nothing was read" was equally true of a consumer that never finished joining. Control arm, pointing that PC at a decoy topic:

| Arm | Result |
|---|---|
| original assertion, consumer pointed at a topic that is not the one under test | **passes** - it was asserting nothing |
| anchored assertion, same decoy topic | **fails** at the assignment await |

Now anchored on `PartitionStateManager#getPartitionState` being non-null - a `ConcurrentHashMap`, so unlike `Consumer#assignment` it is safe to read from the test thread - and followed by a record produced *after* the window which must be read. Assignment proves it joined; the trailing record proves its poller actually reached the topic. Same rule as `TransactionalPartialResultSetIT#proveVerifierIsActuallyReading`: prove the detector works before trusting what it did not detect. `readByThree` becomes a `ConcurrentLinkedQueue`, since the test thread now reads it while a worker writes.

### `largeNumberOfMessagesSmallOffsetBitmap` - not an instance

Its assertion retries, so a slow start costs time rather than correctness. Two smaller things were true of it, and **only the measured ones were acted on**:

- `atLeast(500ms)` behind `pollDelay(1000ms)` can never fire. Measured: with the `atLeast` raised to 1500ms the condition is reported "evaluated in 1 seconds 6 milliseconds", so at 500ms it was dead. Removed.
- The trailing `hasSize` was commented "double check after closing" while sitting *inside* the try-with-resources, so it ran before close. **Moving it out does not earn the claim**: produce an extra record after the await and flush it to the broker before close, and PC never delivers it - it stops fetching at close - so both positions still pass. I wrote the relocation, the control refuted it, and I reverted it; the assertion stays where it is with a comment saying what it actually is (a restatement).

---

## 3. Recorded, not fixed: the dispatched reviewer posted nothing

Requesting a review of this PR exercised the end-to-end check `docs/inflight/ci-review-agent.md` had been asking someone to run. It failed. Run [31770555653](https://github.com/astubbs/parallel-consumer/actions/runs/31770555653) reviewed for **7m12s**, reported `conclusion=success`, and afterwards there was no `claude[bot]` comment, no PR review, and `claude-review` still red - with every step of both jobs green. One full billed review produced nothing and nothing in the system noticed.

Three findings recorded in that file, none fixed here (they are `.github/workflows/` changes unrelated to a test fix, and want their own branch):

- **The guard tests the wrong thing.** "Refuse to report success for a review that did not run" branches on `steps.claude-review.outputs.conclusion`, which detects an *abort* and cannot detect a run that reviews, succeeds and posts nothing - the same class as the `--comment` regression this repo already ate. `bin/check-review-posted.sh` already answers the right question and the gate already uses it; the reviewer job never asks it about its own output.
- **Nothing announces a dispatched review at its start**, so a billed in-flight review is invisible and so is the `-f focus` steer. An unreplaced casualty of `track_progress` being hard-set `false`, not an oversight - and the fix needs no cooperation from the action, just a `gh pr comment` step before it.
- **What the dispatch route buys over an `@claude` mention is one thing** - the packaged procedure. The tool allowlist, default-branch execution and gate satisfaction are common to both routes, so they are not reasons to prefer it.

The review that actually reviewed this PR was requested by comment instead, which posted in ~4m and cleared the gate.

---

## Not fixed, deliberately

The slow commit is still keyed on the **exact** base offset, which assumes offsets 5 and 6 both complete between two commit ticks. A tick landing between them commits for real with a lower base, and the at-most check would lose even when anchored. Never observed - zero such commits across 9 instrumented runs - so it is left as-is and noted at the trigger site. Closing it would mean firing the slow commit on the first commit carrying any phase-2 progress.

That residual is now named as an instance of the class in `docs/solutions/test-flakiness/assert-the-commit-frontier-not-the-tick-path.md` (added by astubbs/parallel-consumer#264): it keys on *which tick* carried the progress rather than on the frontier having reached it. Naming the class is also the fix shape - "the first commit carrying any phase-2 progress" **is** the frontier reading.

A guard asserting the block was still held when the check finished was written and then **removed**: the negative control showed the at-most assertion fails first, so the guard was never reached, and an assertion nobody has seen fail is decoration.

## Collision

Related: astubbs/parallel-consumer#262 also edits `TransactionTimeoutsTest.java` (adding `@ProvesClaim` to `commitTimeout` and `produceTimeout`) and the same ledger file, so it will need a rebase after this lands. The flake was left as open business by astubbs/parallel-consumer#220, which fixed the sibling `commitTimeout` in the same file.

## Checklist

- [x] Docs updated - new solution write-up, ledger entry shrunk to a pointer, two falsified claims corrected in place, the sweep recorded, and the reviewer defect recorded in `docs/inflight/`
- [x] N/A - test-only change, no user-facing feature
- [x] Tests added/updated - `produceTimeout` and `correctOffsetVerySimple` anchored, each verified by a control arm in both directions; full `CloseAndOpenOffsetTest` class green (14 run, 0 failures, 4 skipped)
- [x] Title & body reflect the final content of this PR - **this body was rewritten after merge**; the original described only strand 1, having been written before the sweep and the CI finding existed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
