### PR TITLE
tooling(agents): make the repo's conventions fire instead of hoping they are read

### DIFF
--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -3,56 +3,102 @@
 # Copyright (C) 2026 Antony Stubbs and contributors
 #
 
-# PreToolUse hook: refuse `--subject` on `gh pr merge`.
+# PreToolUse hook: refuse a `gh pr merge` whose `--subject` does not end with the PR number.
 #
-# `gh pr merge --squash` lands a subject ending `... (#265)` because GitHub appends the PR number -
-# but only when the subject is NOT overridden. Pass `--subject` and your text is used verbatim, the
-# number silently never appears, and the commit lands out of step with every neighbour on master.
-# That happened on astubbs#206 and needed a force-push to master to correct.
+# THE TRAP. `gh pr merge --squash` lands a subject ending `... (#265)` because GitHub appends the
+# number - but only when the subject is NOT overridden. Override it and your text is used verbatim,
+# the number silently never appears, and the commit lands out of step with every neighbour on
+# master. That happened on astubbs#206 and needed a force-push to master to correct, which is why
+# this is a hook and not a line in a document: the mistake is invisible at the point of failure.
 #
-# So the rule is DON'T OVERRIDE THE SUBJECT, not "override it correctly". If the PR title is wrong,
-# fix the PR title - it is what reviewers saw, and AGENTS.md already asks for it to be kept in step.
-# `--body-file` alone does not touch the subject, so a hand-written message still works.
+# THE RULE, WHOLE: if the command overrides the subject, that subject must end with `(#N)`. Ending
+# is the point - it is the slot GitHub itself uses, and the slot AGENTS.md reserves.
 #
-# The first version tried to police correct use: parse the flag, take the last one the way gh does,
-# cross-check the number against the PR being merged. It was 343 lines with a 400-line test suite,
-# and review found it wrong in both directions - allowing a wrong PR number through, and denying a
-# legitimate subject containing an escaped apostrophe. Refusing the flag needs no parser, cannot be
-# fooled by quoting, and has no false-positive class to defend against.
+# BOTH SPELLINGS. `gh pr merge --help` documents `-t, --subject text`, and `-t` is the shorter one,
+# so it is the one a hand-typed merge reaches for. A guard that knows only the long form is a guard
+# with a documented way around it.
 #
-# Fails open on anything it cannot parse: a hook that blocks on its own bug is worse than no hook.
+# TOKENS, NOT SUBSTRINGS. The value is read from the parsed argument list of the `gh pr merge`
+# command itself, so `--body "explain why --subject matters"` is not mistaken for an override, and
+# the flag is found wherever it sits.
+#
+# THE PAYLOAD GOES THROUGH A TEMP FILE, and only its NAME through argv. Passed as an argument the
+# payload itself hits E2BIG on a large command - measured with a 150 KB one - and the hook then
+# exits non-2 having printed nothing, which reads as ALLOW. A guard that fails open on big inputs
+# is worse than no guard, because it looks present. Note the program cannot simply read stdin
+# instead: stdin is where the heredoc delivers the program.
+#
+# FAILS OPEN otherwise, deliberately: unparseable JSON, unbalanced quotes, no python3. A hook that
+# blocks on its own bug jams the tool call shut, and docs/merge-checklist.md still carries the rule
+# for anyone merging by hand.
 
 set -euo pipefail
 
-payload=$(cat)
+payload_file=$(mktemp)
+trap 'rm -f "$payload_file"' EXIT
+cat > "$payload_file"
 
-python3 - "$payload" <<'PY'
-import json, re, sys
+python3 - "$payload_file" <<'PY'
+import json, re, shlex, sys
 
 try:
-    tool = json.loads(sys.argv[1])
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        tool = json.load(fh)
 except Exception:
-    sys.exit(0)                      # unparseable: never block on our own bug
+    sys.exit(0)                          # never block on our own parse failure
 
 if tool.get("tool_name") != "Bash":
     sys.exit(0)
 
 cmd = tool.get("tool_input", {}).get("command", "")
-if not re.search(r"\bgh\s+pr\s+merge\b", cmd) or not re.search(r"--subject\b", cmd):
-    sys.exit(0)
 
-print(json.dumps({
-    "hookSpecificOutput": {
-        "hookEventName": "PreToolUse",
-        "permissionDecision": "deny",
-        "permissionDecisionReason": (
-            "Don't pass --subject to gh pr merge. It suppresses the (#N) GitHub would otherwise "
-            "append, so the commit lands without its PR number and out of step with every "
-            "neighbour on master - and that is not fixable afterwards without rewriting a pushed "
-            "commit (astubbs#206). Drop the flag and the PR title is used. If the title is wrong, "
-            "fix the title: it is what reviewers saw. --body-file alone does not affect the "
-            "subject. See docs/merge-checklist.md."
-        ),
-    }
-}))
+SUBJECT_FLAGS = ("--subject", "-t")
+MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
+
+# One command line can hold more than one `gh pr merge`; each is judged on its own slice so a good
+# merge cannot vouch for a bad one.
+starts = [m.start() for m in MERGE.finditer(cmd)]
+for start, end in zip(starts, starts[1:] + [len(cmd)]):
+    try:
+        tokens = shlex.split(cmd[start:end])
+    except ValueError:
+        continue                         # our own parse limit, not the author's mistake
+
+    subject = None
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t in SUBJECT_FLAGS and i + 1 < len(tokens):
+            subject, i = tokens[i + 1], i + 2
+            continue
+        for flag in SUBJECT_FLAGS:
+            if t.startswith(flag + "="):
+                subject = t[len(flag) + 1:]
+                break
+        i += 1
+
+    if subject is None:
+        continue                         # no override - GitHub appends the number itself
+    if re.search(r"\(#\d+\)\s*$", subject):
+        continue                         # ends with the number, which is the whole rule
+
+    pr = next((t for t in tokens[tokens.index("merge") + 1:] if t.isdigit()), None) \
+        if "merge" in tokens else None
+    hint = f"(#{pr})" if pr else "(#<pr>)"
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"This --subject does not end with {hint}. Overriding the subject suppresses the "
+                "PR number GitHub would otherwise append, so the commit lands out of step with "
+                "every neighbour on master - and that is not fixable afterwards without rewriting "
+                f"a pushed commit (astubbs#206). End the subject with ' {hint}', or drop the flag "
+                "and let the PR title be used. --body/--body-file do not affect the subject. "
+                "See docs/merge-checklist.md."
+            ),
+        }
+    }))
+    break
 PY

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -131,9 +131,24 @@ EXPANSION = re.compile(r"\$[A-Za-z_{(]|`")
 # swallowed everything after `&&`/`;`/`|`, so an unrelated later command's `--subject` became "the
 # last one" - a decoy could vouch for a bad merge, and a trailing `echo --subject "no number"`
 # could condemn a good one. Both directions, from the same missing boundary.
-OPERATORS = {"&&", "||", ";", ";;", "|", "&", "(", ")"}
+OPERATORS = {"&&", "||", ";", ";;", "|", "&", ")"}
+
+# `(` is NOT in the set above, and that is the fix for a false positive rather than an oversight.
+# posix lexing strips quoting, so the `(` in `echo "(" gh pr merge ...` - an ordinary string
+# argument - was indistinguishable from a subshell and reset command position, making the text
+# after it look like an executed merge and HARD-DENYING a harmless command. Recovering the quoting
+# is not available: a second, non-posix lex does not align token-for-token with the posix one (an
+# escaped apostrophe splits differently), and mis-aligning would resurrect an older false positive.
+#
+# Instead `(` is honoured only where a command could actually begin - see OPEN_SUBSHELL below.
+# `echo "("` cannot, because `echo` has already taken the command slot.
+OPEN_SUBSHELL = "("
 
 ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# Wrappers that RUN the next word, so command position survives them. `command gh pr merge ...` is
+# a real invocation Bash's own `help command` documents, and it was walking straight past the guard.
+EXEC_PREFIXES = {"command", "builtin", "exec", "env", "nohup", "time", "sudo", "nice", "stdbuf"}
 
 
 def is_gh(token):
@@ -156,8 +171,16 @@ def merge_slices(tokens):
             at_command = True
             i += 1
             continue
+        if token == OPEN_SUBSHELL:
+            # Only a `(` where a command could start opens a subshell; anywhere else it is an
+            # argument that happened to lose its quotes to the lexer.
+            i += 1
+            continue
         if at_command and ASSIGNMENT.match(token):
             i += 1                                   # env prefix, still command position
+            continue
+        if at_command and token in EXEC_PREFIXES:
+            i += 1                                   # wrapper runs the next word: still a command
             continue
         if at_command and is_gh(token):
             j = i + 1

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -105,6 +105,11 @@ LONG_VALUE_FLAGS = {
 SHORT_VALUE_FLAGS = {"t": "--subject", "b": "--body", "F": "--body-file",
                      "A": "--author-email", "R": "--repo"}
 
+# Flags `gh` accepts BETWEEN the executable and its subcommand: `gh -R owner/repo pr merge 1299`
+# is valid, and requiring `gh pr merge` to be adjacent silently missed it.
+GLOBAL_VALUE_FLAGS = {"-R", "--repo"}
+GLOBAL_BOOL_FLAGS = {"--help", "-h", "--version"}
+
 # `gh pr merge [<number> | <url> | <branch>]`. Only the first two carry a number to cross-check.
 # ANCHORED TO A REAL URL. Searching any non-numeric selector for `/pull/<digits>` also matched a
 # perfectly legal BRANCH name - `git check-ref-format --branch fix/pull/1299` accepts it - so
@@ -112,67 +117,80 @@ SHORT_VALUE_FLAGS = {"t": "--subject", "b": "--body", "F": "--body-file",
 # DENIED. A false positive, in the class this hook weights hardest.
 PR_URL = re.compile(r"^https?://\S+/pull/(\d+)(?:[/?#]|$)")
 
-# A subject that still contains a shell variable or command substitution when we see it. `shlex`
-# does not expand either, so the text we are holding is not the text `gh` will send.
-UNEXPANDED = re.compile(r"[$`]")
-
-# SEGMENT ON TOKENS, NEVER ON THE RAW STRING. One command line can carry more than one
-# `gh pr merge` (`a && b`, `a ; b`), and each must be judged on its own slice so a good merge
-# cannot vouch for a bad one. Finding those boundaries with a regex over the raw line also finds
-# the phrase inside QUOTED BODY TEXT: `--body "text gh pr merge here"` cut the line into two
-# slices that each had unbalanced quotes, so both fail-opened and the real `--subject` was never
-# judged at all. Splitting first and matching on tokens makes the body a single token, so text
-# inside it can no longer look like a command.
-# `shlex.split` alone will not do: with default settings `a;b` is ONE token, so shell operators
-# have to be lexed as tokens in their own right for the slice to end at them. `commenters` is
-# cleared because a `#` in an unquoted subject is text here, not the start of a comment.
-try:
-    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    tokens = list(lexer)
-except ValueError:
-    sys.exit(0)                      # unbalanced quotes: our own parse limit, never block on it
+# Shell expansion the shell will resolve and we cannot. NOT a bare `$`: shlex has already stripped
+# quoting by the time we see the value, so `'reduce cost to $5'` - a literal Bash sends verbatim -
+# looked identical to `"$SUBJECT"` and was allowed through with no number at all. Requiring a name,
+# a brace, a paren or a backtick keeps the real cases (`$VAR`, `${V}`, `$(cmd)`, backticks) failing
+# open while a literal dollar is judged like any other text.
+#
+# STATED RESIDUAL: a SINGLE-quoted `'$VAR'` is a literal too, and is still read as an expansion.
+# That is the fail-open direction, and recovering the quoting would mean lexing the line twice.
+EXPANSION = re.compile(r"\$[A-Za-z_{(]|`")
 
 # Where one command ends and the next begins. A slice that ran to the next `gh pr merge` instead
 # swallowed everything after `&&`/`;`/`|`, so an unrelated later command's `--subject` became "the
 # last one" - a decoy could vouch for a bad merge, and a trailing `echo --subject "no number"`
 # could condemn a good one. Both directions, from the same missing boundary.
-OPERATORS = {"&&", "||", ";", ";;", "|", "&", "\n"}
+OPERATORS = {"&&", "||", ";", ";;", "|", "&", "(", ")"}
+
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 
 def is_gh(token):
     return token == "gh" or token.endswith("/gh")
 
 
-starts = [i for i in range(len(tokens) - 2)
-          if is_gh(tokens[i]) and tokens[i + 1] == "pr" and tokens[i + 2] == "merge"]
-if not starts:
-    sys.exit(0)
+def merge_slices(tokens):
+    """Every `gh pr merge` in COMMAND POSITION, as (first-arg-index, end-index) pairs.
 
-
-def slice_end(start):
-    """One `gh pr merge` runs until a shell operator or the next merge - whichever comes first."""
-    for j in range(start + 3, len(tokens)):
-        if tokens[j] in OPERATORS or j in starts:
-            return j
-    return len(tokens)
-
-
-bounds = [(start, slice_end(start)) for start in starts]
+    Command position matters because this hook is registered for every Bash call: without it,
+    `echo gh pr merge 1299 --subject bad` - which only prints text - was hard-denied. A token is
+    in command position at the start of the line or straight after a shell operator, skipping
+    any leading `VAR=value` assignments.
+    """
+    out = []
+    i, at_command = 0, True
+    while i < len(tokens):
+        token = tokens[i]
+        if token in OPERATORS:
+            at_command = True
+            i += 1
+            continue
+        if at_command and ASSIGNMENT.match(token):
+            i += 1                                   # env prefix, still command position
+            continue
+        if at_command and is_gh(token):
+            j = i + 1
+            while j < len(tokens):                   # global flags before the subcommand
+                if tokens[j] in GLOBAL_VALUE_FLAGS:
+                    j += 2
+                elif tokens[j] in GLOBAL_BOOL_FLAGS or tokens[j].startswith("--repo="):
+                    j += 1
+                else:
+                    break
+            if j + 1 < len(tokens) and tokens[j] == "pr" and tokens[j + 1] == "merge":
+                start = j + 2
+                end = start
+                while end < len(tokens) and tokens[end] not in OPERATORS:
+                    end += 1
+                out.append((start, end))
+                i = end
+                at_command = True
+                continue
+        at_command = False
+        i += 1
+    return out
 
 
 def subjects_and_pr(slice_tokens):
-    """The subject values and the PR number in one already-tokenised `gh pr merge ...` slice.
+    """The subject values and the PR number in one `gh pr merge` argument list.
 
     Every spelling `gh` accepts for the subject counts, because the hook is worthless against the
     one it cannot read: `--subject X`, `--subject=X`, `-t X`, `-tX`, `-t=X`, and `-t` inside a
     combined shorthand group such as `-st X`. Flags that consume a value have theirs consumed here
     too, so a value is never mistaken for the PR selector.
-
     """
     values, pr = [], None
-    seen_merge = False
     selector_seen = False
     i = 0
     while i < len(slice_tokens):
@@ -219,67 +237,84 @@ def subjects_and_pr(slice_tokens):
             i += 2 if took_next else 1
             continue
 
-        if token == "merge":
-            seen_merge = True
-        elif seen_merge and not selector_seen:
+        if not selector_seen:
             # `gh pr merge [<number> | <url> | <branch>]` - the first bare argument is the
             # selector, whatever its form, so nothing after it can be re-read as one.
             selector_seen = True
             if token.isdigit():
                 pr = token
             else:
-                match = PR_URL.search(token)
+                match = PR_URL.match(token)
                 if match:
                     pr = match.group(1)
         i += 1
     return values, pr
 
 
-for start, end in bounds:
-    subjects, pr = subjects_and_pr(tokens[start:end])
+# A NEWLINE IS A COMMAND BOUNDARY, and `#` still starts a comment. Both were lost when the whole
+# payload was lexed in one go with newlines as plain whitespace and comments disabled: a decoy on
+# the next line, or after a `#` Bash would ignore, became "the last --subject" of the merge above
+# it. Lexing line by line restores both, and a subject's own `(#N)` is safe because it is quoted.
+for line in cmd.splitlines():
+    try:
+        lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        continue                     # unbalanced quotes: our own parse limit, never block on it
 
-    if not subjects:
-        continue                     # no override, so GitHub appends the number itself - fine
+    for start, end in merge_slices(tokens):
+        subjects, pr = subjects_and_pr(tokens[start:end])
 
-    subject = subjects[-1]           # gh honours the LAST occurrence, so that is the one judged
+        if not subjects:
+            continue                 # no override, so GitHub appends the number itself - fine
 
-    # `--subject "$SUBJECT"` / `--subject "$(cat msg.txt)"`: shlex does not expand either, so what
-    # we are holding is not what gh will send, and its `(#N)` may well be in there. Denying on a
-    # string we cannot resolve is the false-positive class this hook weights hardest against - and
-    # the header promises to fail open on our own limits, which this is one of.
-    if UNEXPANDED.search(subject):
-        continue
+        subject = subjects[-1]       # gh honours the LAST occurrence, so that is the one judged
 
-    found = re.findall(r"\(#(\d+)\)", subject)
-    pr_hint = f"(#{pr})" if pr else "(#<pr>)"
+        if EXPANSION.search(subject):
+            continue                 # not the text gh will send; judging it judges the wrong text
 
-    if not found:
-        reason = (
-            "This --subject has no PR-number suffix, and passing --subject suppresses the "
-            f"{pr_hint} that GitHub would otherwise append. "
-        )
-    elif pr is not None and pr not in found:
-        reason = (
-            f"This --subject carries (#{found[-1]}) but the merge is of PR #{pr}. A number that "
-            "points at the wrong PR - or at an issue - is worse than none: it reads as correct and "
-            "links a future reader somewhere else. "
-        )
-    else:
-        continue                     # carries the right number - fine
+        found = re.findall(r"\(#(\d+)\)", subject)
+        pr_hint = f"(#{pr})" if pr else "(#<pr>)"
 
-    print(json.dumps({
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": (
-                reason
-                + "The commit would land out of step with every neighbour on master, and it is not "
-                "fixable afterwards without rewriting a pushed commit (this happened on "
-                f"astubbs#206). Either end the subject with ' {pr_hint}', or drop --subject "
-                "entirely and let the PR title be used - --body-file alone does not affect the "
-                "subject. See docs/merge-checklist.md."
-            ),
-        }
-    }))
-    break
+        if not found:
+            reason = (
+                "This --subject has no PR-number suffix, and passing --subject suppresses the "
+                f"{pr_hint} that GitHub would otherwise append. "
+            )
+        elif pr is not None and [n for n in found if n != pr]:
+            # ANY parenthesised number that is not this PR is a defect, even alongside the right
+            # one. `fix (#1206) (#1299)` recreates precisely the ambiguity AGENTS.md calls out -
+            # two bare numbers with no way to tell the issue from the squash-added PR number.
+            wrong = next(n for n in found if n != pr)
+            reason = (
+                f"This --subject carries (#{wrong}) but the merge is of PR #{pr}. A number that "
+                "points at the wrong PR - or at an issue - is worse than none: it reads as correct "
+                "and links a future reader somewhere else. AGENTS.md reserves the trailing "
+                "parenthesised slot for the PR number alone; cite an issue at the front of the "
+                "subject instead. "
+            )
+        elif pr is None and len(set(found)) > 1:
+            reason = (
+                f"This --subject carries more than one parenthesised number ({', '.join(sorted(set(found)))}), "
+                "so a future reader cannot tell which is the PR. "
+            )
+        else:
+            continue                 # carries the right number, and only that - fine
+
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    reason
+                    + "The commit would land out of step with every neighbour on master, and it is "
+                    "not fixable afterwards without rewriting a pushed commit (this happened on "
+                    f"astubbs#206). Either end the subject with ' {pr_hint}', or drop --subject "
+                    "entirely and let the PR title be used - --body-file alone does not affect the "
+                    "subject. See docs/merge-checklist.md."
+                ),
+            }
+        }))
+        sys.exit(0)
 PY

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2026 Antony Stubbs and contributors
 #
 
-# PreToolUse hook: refuse a `gh pr merge --subject` whose subject does not carry the PR number.
+# PreToolUse hook: refuse a `gh pr merge --subject` whose subject does not carry the RIGHT PR number.
 #
 # THE TRAP. `gh pr merge --squash` normally lands a subject ending `... (#265)` - GitHub appends the
 # PR number itself. It does that ONLY when the subject is not overridden. Pass `--subject "..."` and
@@ -15,19 +15,44 @@
 # its neighbours in `git log`. That is what happened on astubbs#206, and rewriting a commit already
 # on master is not a fix anyone should need.
 #
-# PRECISE, NOT NAGGY. It fires only when `--subject` is present AND the subject lacks a `(#N)`
-# suffix - i.e. only when the mistake is actually being made. A subject that already carries the
-# number passes silently, and so does a merge that does not override the subject at all.
+# WHY THE PARSER IS SHLEX AND NOT A REGEX. The first version read the FIRST `--subject` with a
+# regex over the whole command line. `gh` honours the LAST one, and the whole command line includes
+# text that is not part of the merge at all. Both halves of that were wrong, in both directions:
 #
-# PreToolUse cannot inject context (stdout never reaches the model), so this denies with a reason,
-# which IS fed back - see docs/agent-harness.md for what each layer can and cannot do.
+#   - `--subject "ok (#299)" --subject "bad"` was ALLOWED - the bad subject is the one that lands.
+#   - `echo --subject "x (#1)" ; gh pr merge 299 --subject "bad"` was ALLOWED - the decoy matched.
+#   - `--subject "thing (#206)"` while merging 299 was ALLOWED - any `(#N)` satisfied it, so the
+#     exact astubbs#206 shape this hook is named after walked straight through.
+#   - `--subject 'don'\''t drop it (#299)'` was DENIED - the escaped apostrophe truncated the
+#     capture before the suffix.
+#   - `--body "we discussed --subject" --subject "thing (#299)"` was DENIED - the first `--subject`
+#     is inside the body text.
+#
+# A PreToolUse deny is hard, so the last two are the more expensive class: a false positive stops a
+# legitimate merge and the agent cannot argue with it. So: slice the command at each `gh pr merge`,
+# `shlex.split` that slice so quoting is handled by something that knows shell quoting, take the
+# LAST `--subject` the way `gh` does, and cross-check the number against the PR being merged.
+#
+# FAIL OPEN, ALWAYS. Any parse failure exits 0. A hook that blocks on its own bug is worse than no
+# hook: the gate below it (docs/merge-checklist.md, and review) still catches a bad subject, but
+# nothing catches a hook that has jammed the tool call shut. `bin/test-check-agent-hooks.sh` is the
+# negative control - it asserts each shape above, in both directions.
+#
+# BOUNDARY, STATED. The `(#N)` may sit anywhere in the subject, not only at the end, so
+# `"port (#299) to master"` passes. Requiring the trailing slot would be truer to the convention
+# but turns every unusual-but-fine subject into a hard block, and the cost of the two error
+# directions is not symmetric. Likewise, a merge with no PR argument (`gh pr merge --squash`, which
+# resolves the PR from the branch) cannot be cross-checked, so any `(#N)` is accepted there.
+#
+# PreToolUse CAN feed text back to the model - a deny reason is delivered, and so is
+# `hookSpecificOutput.additionalContext`. This hook uses the deny reason. See docs/agent-harness.md.
 
 set -euo pipefail
 
 payload=$(cat)
 
 python3 - "$payload" <<'PY'
-import json, re, sys
+import json, re, shlex, sys
 
 try:
     tool = json.loads(sys.argv[1])
@@ -39,34 +64,83 @@ if tool.get("tool_name") != "Bash":
 
 cmd = tool.get("tool_input", {}).get("command", "")
 
-# Only a merge that overrides the subject can hit the trap.
-if not re.search(r"\bgh\s+pr\s+merge\b", cmd) or not re.search(r"--subject\b", cmd):
+MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
+
+# One command line can carry more than one `gh pr merge` (`a && b`, `a ; b`). Each is judged on its
+# own slice, running to the start of the next one, so a good merge cannot vouch for a bad one.
+starts = [m.start() for m in MERGE.finditer(cmd)]
+if not starts:
     sys.exit(0)
+bounds = list(zip(starts, starts[1:] + [len(cmd)]))
 
-# Pull the subject argument, tolerating single quotes, double quotes or a bare token.
-m = re.search(r"--subject(?:=|\s+)(\"(?:[^\"\\]|\\.)*\"|'[^']*'|\S+)", cmd)
-subject = m.group(1) if m else ""
-if subject[:1] in ("\"", "'"):
-    subject = subject[1:-1]
 
-if re.search(r"\(#\d+\)", subject):
-    sys.exit(0)                      # already carries the number - fine
+def subjects_and_pr(slice_):
+    """The `--subject` values and the PR number in one `gh pr merge ...` slice.
 
-pr = re.search(r"\bgh\s+pr\s+merge\s+(\d+)", cmd)
-pr_hint = f"(#{pr.group(1)})" if pr else "(#<pr>)"
+    Raises ValueError from shlex on unbalanced quotes, which the caller turns into an allow.
+    """
+    tokens = shlex.split(slice_)
+    values, pr = [], None
+    seen_merge = False
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == "--subject" and i + 1 < len(tokens):
+            values.append(tokens[i + 1])
+            i += 2
+            continue
+        if token.startswith("--subject="):
+            values.append(token[len("--subject="):])
+            i += 1
+            continue
+        if token == "merge":
+            seen_merge = True
+        elif seen_merge and pr is None and token.isdigit():
+            pr = token
+        i += 1
+    return values, pr
 
-print(json.dumps({
-    "hookSpecificOutput": {
-        "hookEventName": "PreToolUse",
-        "permissionDecision": "deny",
-        "permissionDecisionReason": (
+
+for start, end in bounds:
+    try:
+        subjects, pr = subjects_and_pr(cmd[start:end])
+    except ValueError:
+        continue                     # our own parse limit, not the author's mistake - allow
+
+    if not subjects:
+        continue                     # no override, so GitHub appends the number itself - fine
+
+    subject = subjects[-1]           # gh honours the LAST occurrence, so that is the one judged
+    found = re.findall(r"\(#(\d+)\)", subject)
+    pr_hint = f"(#{pr})" if pr else "(#<pr>)"
+
+    if not found:
+        reason = (
             "This --subject has no PR-number suffix, and passing --subject suppresses the "
-            f"{pr_hint} that GitHub would otherwise append. The commit would land out of step with "
-            "every neighbour on master, and it is not fixable afterwards without rewriting a "
-            "pushed commit (this happened on astubbs#206). Either append "
-            f"' {pr_hint}' to the subject, or drop --subject entirely and let the PR title be used "
-            "- --body-file alone does not affect the subject. See docs/merge-checklist.md."
-        ),
-    }
-}))
+            f"{pr_hint} that GitHub would otherwise append. "
+        )
+    elif pr is not None and pr not in found:
+        reason = (
+            f"This --subject carries (#{found[-1]}) but the merge is of PR #{pr}. A number that "
+            "points at the wrong PR - or at an issue - is worse than none: it reads as correct and "
+            "links a future reader somewhere else. "
+        )
+    else:
+        continue                     # carries the right number - fine
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                reason
+                + "The commit would land out of step with every neighbour on master, and it is not "
+                "fixable afterwards without rewriting a pushed commit (this happened on "
+                f"astubbs#206). Either end the subject with ' {pr_hint}', or drop --subject "
+                "entirely and let the PR title be used - --body-file alone does not affect the "
+                "subject. See docs/merge-checklist.md."
+            ),
+        }
+    }))
+    break
 PY

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -29,9 +29,10 @@
 #     is inside the body text.
 #
 # A PreToolUse deny is hard, so the last two are the more expensive class: a false positive stops a
-# legitimate merge and the agent cannot argue with it. So: slice the command at each `gh pr merge`,
-# `shlex.split` that slice so quoting is handled by something that knows shell quoting, take the
-# LAST `--subject` the way `gh` does, and cross-check the number against the PR being merged.
+# legitimate merge and the agent cannot argue with it. So: `shlex.split` the whole line, so quoting
+# is handled by something that knows shell quoting; find each `gh pr merge` in the TOKEN stream and
+# judge its slice on its own; take the LAST `--subject` the way `gh` does; and cross-check the
+# number against the PR being merged.
 #
 # FAIL OPEN, ALWAYS. Any parse failure exits 0. A hook that blocks on its own bug is worse than no
 # hook: the gate below it (docs/merge-checklist.md, and review) still catches a bad subject, but
@@ -78,8 +79,6 @@ if tool.get("tool_name") != "Bash":
 
 cmd = tool.get("tool_input", {}).get("command", "")
 
-MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
-
 # `gh pr merge` flags that CONSUME the next argument. The set matters twice over: `-t` is the
 # short spelling of `--subject`, and reading only the long one let `-t "no number"` through the
 # hook entirely; and a flag's VALUE must never be mistaken for the PR selector.
@@ -96,31 +95,45 @@ PR_URL = re.compile(r"/pull/(\d+)")
 # does not expand either, so the text we are holding is not the text `gh` will send.
 UNEXPANDED = re.compile(r"[$`]")
 
-# One command line can carry more than one `gh pr merge` (`a && b`, `a ; b`). Each is judged on its
-# own slice, running to the start of the next one, so a good merge cannot vouch for a bad one.
-starts = [m.start() for m in MERGE.finditer(cmd)]
+# SEGMENT ON TOKENS, NEVER ON THE RAW STRING. One command line can carry more than one
+# `gh pr merge` (`a && b`, `a ; b`), and each must be judged on its own slice so a good merge
+# cannot vouch for a bad one. Finding those boundaries with a regex over the raw line also finds
+# the phrase inside QUOTED BODY TEXT: `--body "text gh pr merge here"` cut the line into two
+# slices that each had unbalanced quotes, so both fail-opened and the real `--subject` was never
+# judged at all. Splitting first and matching on tokens makes the body a single token, so text
+# inside it can no longer look like a command.
+try:
+    tokens = shlex.split(cmd)
+except ValueError:
+    sys.exit(0)                      # unbalanced quotes: our own parse limit, never block on it
+
+
+def is_gh(token):
+    return token == "gh" or token.endswith("/gh")
+
+
+starts = [i for i in range(len(tokens) - 2)
+          if is_gh(tokens[i]) and tokens[i + 1] == "pr" and tokens[i + 2] == "merge"]
 if not starts:
     sys.exit(0)
-bounds = list(zip(starts, starts[1:] + [len(cmd)]))
+bounds = list(zip(starts, starts[1:] + [len(tokens)]))
 
 
-def subjects_and_pr(slice_):
-    """The subject values and the PR number in one `gh pr merge ...` slice.
+def subjects_and_pr(slice_tokens):
+    """The subject values and the PR number in one already-tokenised `gh pr merge ...` slice.
 
     Every spelling `gh` accepts for the subject counts, because the hook is worthless against the
     one it cannot read: `--subject X`, `--subject=X`, `-t X`, `-tX`, `-t=X`, and `-t` inside a
     combined shorthand group such as `-st X`. Flags that consume a value have theirs consumed here
     too, so a value is never mistaken for the PR selector.
 
-    Raises ValueError from shlex on unbalanced quotes, which the caller turns into an allow.
     """
-    tokens = shlex.split(slice_)
     values, pr = [], None
     seen_merge = False
     selector_seen = False
     i = 0
-    while i < len(tokens):
-        token = tokens[i]
+    while i < len(slice_tokens):
+        token = slice_tokens[i]
 
         if token.startswith("--"):
             name, sep, inline = token.partition("=")
@@ -129,9 +142,9 @@ def subjects_and_pr(slice_):
                     values.append(inline)
                 i += 1
                 continue
-            if name in LONG_VALUE_FLAGS and i + 1 < len(tokens):
+            if name in LONG_VALUE_FLAGS and i + 1 < len(slice_tokens):
                 if name == "--subject":
-                    values.append(tokens[i + 1])
+                    values.append(slice_tokens[i + 1])
                 i += 2
                 continue
             i += 1
@@ -152,8 +165,8 @@ def subjects_and_pr(slice_):
                     value = rest[1:]
                 elif rest:
                     value = rest
-                elif i + 1 < len(tokens):
-                    value = tokens[i + 1]
+                elif i + 1 < len(slice_tokens):
+                    value = slice_tokens[i + 1]
                     took_next = True
                 else:
                     value = None
@@ -180,10 +193,7 @@ def subjects_and_pr(slice_):
 
 
 for start, end in bounds:
-    try:
-        subjects, pr = subjects_and_pr(cmd[start:end])
-    except ValueError:
-        continue                     # our own parse limit, not the author's mistake - allow
+    subjects, pr = subjects_and_pr(tokens[start:end])
 
     if not subjects:
         continue                     # no override, so GitHub appends the number itself - fine

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -38,11 +38,25 @@
 # nothing catches a hook that has jammed the tool call shut. `bin/test-check-agent-hooks.sh` is the
 # negative control - it asserts each shape above, in both directions.
 #
+# EVERY SPELLING OF THE FLAG, OR NONE. A third review round found `-t` - `gh`'s documented short
+# form of `--subject` - was not read at all, so `-t "no number"` sailed through the "no override,
+# GitHub appends it" branch while `gh` used the text verbatim. That is the astubbs#206 shape again,
+# reached through an unhandled spelling: a parser that reads one spelling of a flag protects
+# against one spelling of the mistake. `--subject`, `--subject=X`, `-t X`, `-tX`, `-t=X` and `-t`
+# inside a shorthand group (`-st X`) are now all read, and every value-taking flag has its value
+# consumed so it cannot be misread as the PR selector.
+#
 # BOUNDARY, STATED. The `(#N)` may sit anywhere in the subject, not only at the end, so
 # `"port (#299) to master"` passes. Requiring the trailing slot would be truer to the convention
 # but turns every unusual-but-fine subject into a hard block, and the cost of the two error
-# directions is not symmetric. Likewise, a merge with no PR argument (`gh pr merge --squash`, which
-# resolves the PR from the branch) cannot be cross-checked, so any `(#N)` is accepted there.
+# directions is not symmetric.
+#
+# WHAT CANNOT BE CROSS-CHECKED, AND WHY THAT IS AN ALLOW. The number is compared against the PR
+# selector when the selector carries one - a bare `299` or a `.../pull/299` URL. It cannot when the
+# selector is a BRANCH NAME, or absent (`gh pr merge --squash`, resolving from the branch), because
+# both need a network round trip this hook has no business making; any `(#N)` is accepted there.
+# Same reasoning for a subject still holding `$VAR` or `$(...)`: shlex does not expand them, so the
+# string is not the one gh will send, and judging it would be judging the wrong text.
 #
 # PreToolUse CAN feed text back to the model - a deny reason is delivered, and so is
 # `hookSpecificOutput.additionalContext`. This hook uses the deny reason. See docs/agent-harness.md.
@@ -66,6 +80,22 @@ cmd = tool.get("tool_input", {}).get("command", "")
 
 MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
 
+# `gh pr merge` flags that CONSUME the next argument. The set matters twice over: `-t` is the
+# short spelling of `--subject`, and reading only the long one let `-t "no number"` through the
+# hook entirely; and a flag's VALUE must never be mistaken for the PR selector.
+LONG_VALUE_FLAGS = {
+    "--subject", "--body", "--body-file", "--author-email", "--repo", "--match-head-commit",
+}
+SHORT_VALUE_FLAGS = {"t": "--subject", "b": "--body", "F": "--body-file",
+                     "A": "--author-email", "R": "--repo"}
+
+# `gh pr merge [<number> | <url> | <branch>]`. Only the first two carry a number to cross-check.
+PR_URL = re.compile(r"/pull/(\d+)")
+
+# A subject that still contains a shell variable or command substitution when we see it. `shlex`
+# does not expand either, so the text we are holding is not the text `gh` will send.
+UNEXPANDED = re.compile(r"[$`]")
+
 # One command line can carry more than one `gh pr merge` (`a && b`, `a ; b`). Each is judged on its
 # own slice, running to the start of the next one, so a good merge cannot vouch for a bad one.
 starts = [m.start() for m in MERGE.finditer(cmd)]
@@ -75,28 +105,76 @@ bounds = list(zip(starts, starts[1:] + [len(cmd)]))
 
 
 def subjects_and_pr(slice_):
-    """The `--subject` values and the PR number in one `gh pr merge ...` slice.
+    """The subject values and the PR number in one `gh pr merge ...` slice.
+
+    Every spelling `gh` accepts for the subject counts, because the hook is worthless against the
+    one it cannot read: `--subject X`, `--subject=X`, `-t X`, `-tX`, `-t=X`, and `-t` inside a
+    combined shorthand group such as `-st X`. Flags that consume a value have theirs consumed here
+    too, so a value is never mistaken for the PR selector.
 
     Raises ValueError from shlex on unbalanced quotes, which the caller turns into an allow.
     """
     tokens = shlex.split(slice_)
     values, pr = [], None
     seen_merge = False
+    selector_seen = False
     i = 0
     while i < len(tokens):
         token = tokens[i]
-        if token == "--subject" and i + 1 < len(tokens):
-            values.append(tokens[i + 1])
-            i += 2
-            continue
-        if token.startswith("--subject="):
-            values.append(token[len("--subject="):])
+
+        if token.startswith("--"):
+            name, sep, inline = token.partition("=")
+            if sep:
+                if name == "--subject":
+                    values.append(inline)
+                i += 1
+                continue
+            if name in LONG_VALUE_FLAGS and i + 1 < len(tokens):
+                if name == "--subject":
+                    values.append(tokens[i + 1])
+                i += 2
+                continue
             i += 1
             continue
+
+        # A shorthand group, per pflag: scan left to right, and the FIRST value-taking letter
+        # takes the rest of the group as its value - or the next token when it ends the group.
+        # Stopping at that letter is what keeps `-bt` from being read as a subject: there, `t` is
+        # part of `-b`'s value, not a flag.
+        if len(token) > 1 and token[0] == "-" and token[1] != "-":
+            group = token[1:]
+            took_next = False
+            for j, ch in enumerate(group):
+                if ch not in SHORT_VALUE_FLAGS:
+                    continue
+                rest = group[j + 1:]
+                if rest.startswith("="):
+                    value = rest[1:]
+                elif rest:
+                    value = rest
+                elif i + 1 < len(tokens):
+                    value = tokens[i + 1]
+                    took_next = True
+                else:
+                    value = None
+                if ch == "t" and value is not None:
+                    values.append(value)
+                break
+            i += 2 if took_next else 1
+            continue
+
         if token == "merge":
             seen_merge = True
-        elif seen_merge and pr is None and token.isdigit():
-            pr = token
+        elif seen_merge and not selector_seen:
+            # `gh pr merge [<number> | <url> | <branch>]` - the first bare argument is the
+            # selector, whatever its form, so nothing after it can be re-read as one.
+            selector_seen = True
+            if token.isdigit():
+                pr = token
+            else:
+                match = PR_URL.search(token)
+                if match:
+                    pr = match.group(1)
         i += 1
     return values, pr
 
@@ -111,6 +189,14 @@ for start, end in bounds:
         continue                     # no override, so GitHub appends the number itself - fine
 
     subject = subjects[-1]           # gh honours the LAST occurrence, so that is the one judged
+
+    # `--subject "$SUBJECT"` / `--subject "$(cat msg.txt)"`: shlex does not expand either, so what
+    # we are holding is not what gh will send, and its `(#N)` may well be in there. Denying on a
+    # string we cannot resolve is the false-positive class this hook weights hardest against - and
+    # the header promises to fail open on our own limits, which this is one of.
+    if UNEXPANDED.search(subject):
+        continue
+
     found = re.findall(r"\(#(\d+)\)", subject)
     pr_hint = f"(#{pr})" if pr else "(#<pr>)"
 

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -64,13 +64,30 @@
 
 set -euo pipefail
 
-payload=$(cat)
+# THE PAYLOAD ARRIVES BY FILE, NOT BY ARGV. Linux caps a single argv string at ~128 KiB
+# (MAX_ARG_STRLEN), and a hook payload carries the whole prompt or command - a pasted diff or log
+# clears that easily. Passing it as an argument then fails with "Argument list too long" BEFORE
+# python starts, and since these hooks are built to fail open, the failure is silent: the hook
+# simply stops doing its job on exactly the large inputs a human is most likely to be mid-decision
+# on. A temp file has no such limit. mktemp is 0600 and the trap removes it.
+payload_file=$(mktemp)
+trap 'rm -f "$payload_file"' EXIT
+cat > "$payload_file"
 
-python3 - "$payload" <<'PY'
+# The matcher in .claude/settings.json can only match a command PREFIX, which misses every shape
+# this hook is built for - `/usr/local/bin/gh pr merge ...`, `echo x && gh pr merge ...`. So the
+# hook is registered for every Bash call and does its own filtering, and this is the cheap first
+# cut: no `merge` anywhere in the payload means no `gh pr merge`, decided without starting python.
+if ! grep -q merge "$payload_file"; then
+    exit 0
+fi
+
+python3 - "$payload_file" <<'PY'
 import json, re, shlex, sys
 
 try:
-    tool = json.loads(sys.argv[1])
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        tool = json.load(fh)
 except Exception:
     sys.exit(0)                      # unparseable: never block on our own bug
 
@@ -89,7 +106,11 @@ SHORT_VALUE_FLAGS = {"t": "--subject", "b": "--body", "F": "--body-file",
                      "A": "--author-email", "R": "--repo"}
 
 # `gh pr merge [<number> | <url> | <branch>]`. Only the first two carry a number to cross-check.
-PR_URL = re.compile(r"/pull/(\d+)")
+# ANCHORED TO A REAL URL. Searching any non-numeric selector for `/pull/<digits>` also matched a
+# perfectly legal BRANCH name - `git check-ref-format --branch fix/pull/1299` accepts it - so
+# merging that branch was cross-checked against 1299 and a correct subject naming the real PR was
+# DENIED. A false positive, in the class this hook weights hardest.
+PR_URL = re.compile(r"^https?://\S+/pull/(\d+)(?:[/?#]|$)")
 
 # A subject that still contains a shell variable or command substitution when we see it. `shlex`
 # does not expand either, so the text we are holding is not the text `gh` will send.
@@ -102,10 +123,22 @@ UNEXPANDED = re.compile(r"[$`]")
 # slices that each had unbalanced quotes, so both fail-opened and the real `--subject` was never
 # judged at all. Splitting first and matching on tokens makes the body a single token, so text
 # inside it can no longer look like a command.
+# `shlex.split` alone will not do: with default settings `a;b` is ONE token, so shell operators
+# have to be lexed as tokens in their own right for the slice to end at them. `commenters` is
+# cleared because a `#` in an unquoted subject is text here, not the start of a comment.
 try:
-    tokens = shlex.split(cmd)
+    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    tokens = list(lexer)
 except ValueError:
     sys.exit(0)                      # unbalanced quotes: our own parse limit, never block on it
+
+# Where one command ends and the next begins. A slice that ran to the next `gh pr merge` instead
+# swallowed everything after `&&`/`;`/`|`, so an unrelated later command's `--subject` became "the
+# last one" - a decoy could vouch for a bad merge, and a trailing `echo --subject "no number"`
+# could condemn a good one. Both directions, from the same missing boundary.
+OPERATORS = {"&&", "||", ";", ";;", "|", "&", "\n"}
 
 
 def is_gh(token):
@@ -116,7 +149,17 @@ starts = [i for i in range(len(tokens) - 2)
           if is_gh(tokens[i]) and tokens[i + 1] == "pr" and tokens[i + 2] == "merge"]
 if not starts:
     sys.exit(0)
-bounds = list(zip(starts, starts[1:] + [len(tokens)]))
+
+
+def slice_end(start):
+    """One `gh pr merge` runs until a shell operator or the next merge - whichever comes first."""
+    for j in range(start + 3, len(tokens)):
+        if tokens[j] in OPERATORS or j in starts:
+            return j
+    return len(tokens)
+
+
+bounds = [(start, slice_end(start)) for start in starts]
 
 
 def subjects_and_pr(slice_tokens):

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -3,91 +3,34 @@
 # Copyright (C) 2026 Antony Stubbs and contributors
 #
 
-# PreToolUse hook: refuse a `gh pr merge --subject` whose subject does not carry the RIGHT PR number.
+# PreToolUse hook: refuse `--subject` on `gh pr merge`.
 #
-# THE TRAP. `gh pr merge --squash` normally lands a subject ending `... (#265)` - GitHub appends the
-# PR number itself. It does that ONLY when the subject is not overridden. Pass `--subject "..."` and
-# your text is used verbatim, so the number silently never appears. AGENTS.md reserves that trailing
-# slot for exactly this, and every neighbouring commit on master has it.
+# `gh pr merge --squash` lands a subject ending `... (#265)` because GitHub appends the PR number -
+# but only when the subject is NOT overridden. Pass `--subject` and your text is used verbatim, the
+# number silently never appears, and the commit lands out of step with every neighbour on master.
+# That happened on astubbs#206 and needed a force-push to master to correct.
 #
-# It is a good candidate for a hook rather than a rule because it is invisible at the point of
-# failure: the merge succeeds, the message reads fine, and the omission only shows up later next to
-# its neighbours in `git log`. That is what happened on astubbs#206, and rewriting a commit already
-# on master is not a fix anyone should need.
+# So the rule is DON'T OVERRIDE THE SUBJECT, not "override it correctly". If the PR title is wrong,
+# fix the PR title - it is what reviewers saw, and AGENTS.md already asks for it to be kept in step.
+# `--body-file` alone does not touch the subject, so a hand-written message still works.
 #
-# WHY THE PARSER IS SHLEX AND NOT A REGEX. The first version read the FIRST `--subject` with a
-# regex over the whole command line. `gh` honours the LAST one, and the whole command line includes
-# text that is not part of the merge at all. Both halves of that were wrong, in both directions:
+# The first version tried to police correct use: parse the flag, take the last one the way gh does,
+# cross-check the number against the PR being merged. It was 343 lines with a 400-line test suite,
+# and review found it wrong in both directions - allowing a wrong PR number through, and denying a
+# legitimate subject containing an escaped apostrophe. Refusing the flag needs no parser, cannot be
+# fooled by quoting, and has no false-positive class to defend against.
 #
-#   - `--subject "ok (#299)" --subject "bad"` was ALLOWED - the bad subject is the one that lands.
-#   - `echo --subject "x (#1)" ; gh pr merge 299 --subject "bad"` was ALLOWED - the decoy matched.
-#   - `--subject "thing (#206)"` while merging 299 was ALLOWED - any `(#N)` satisfied it, so the
-#     exact astubbs#206 shape this hook is named after walked straight through.
-#   - `--subject 'don'\''t drop it (#299)'` was DENIED - the escaped apostrophe truncated the
-#     capture before the suffix.
-#   - `--body "we discussed --subject" --subject "thing (#299)"` was DENIED - the first `--subject`
-#     is inside the body text.
-#
-# A PreToolUse deny is hard, so the last two are the more expensive class: a false positive stops a
-# legitimate merge and the agent cannot argue with it. So: `shlex.split` the whole line, so quoting
-# is handled by something that knows shell quoting; find each `gh pr merge` in the TOKEN stream and
-# judge its slice on its own; take the LAST `--subject` the way `gh` does; and cross-check the
-# number against the PR being merged.
-#
-# FAIL OPEN, ALWAYS. Any parse failure exits 0. A hook that blocks on its own bug is worse than no
-# hook: the gate below it (docs/merge-checklist.md, and review) still catches a bad subject, but
-# nothing catches a hook that has jammed the tool call shut. `bin/test-check-agent-hooks.sh` is the
-# negative control - it asserts each shape above, in both directions.
-#
-# EVERY SPELLING OF THE FLAG, OR NONE. A third review round found `-t` - `gh`'s documented short
-# form of `--subject` - was not read at all, so `-t "no number"` sailed through the "no override,
-# GitHub appends it" branch while `gh` used the text verbatim. That is the astubbs#206 shape again,
-# reached through an unhandled spelling: a parser that reads one spelling of a flag protects
-# against one spelling of the mistake. `--subject`, `--subject=X`, `-t X`, `-tX`, `-t=X` and `-t`
-# inside a shorthand group (`-st X`) are now all read, and every value-taking flag has its value
-# consumed so it cannot be misread as the PR selector.
-#
-# BOUNDARY, STATED. The `(#N)` may sit anywhere in the subject, not only at the end, so
-# `"port (#299) to master"` passes. Requiring the trailing slot would be truer to the convention
-# but turns every unusual-but-fine subject into a hard block, and the cost of the two error
-# directions is not symmetric.
-#
-# WHAT CANNOT BE CROSS-CHECKED, AND WHY THAT IS AN ALLOW. The number is compared against the PR
-# selector when the selector carries one - a bare `299` or a `.../pull/299` URL. It cannot when the
-# selector is a BRANCH NAME, or absent (`gh pr merge --squash`, resolving from the branch), because
-# both need a network round trip this hook has no business making; any `(#N)` is accepted there.
-# Same reasoning for a subject still holding `$VAR` or `$(...)`: shlex does not expand them, so the
-# string is not the one gh will send, and judging it would be judging the wrong text.
-#
-# PreToolUse CAN feed text back to the model - a deny reason is delivered, and so is
-# `hookSpecificOutput.additionalContext`. This hook uses the deny reason. See docs/agent-harness.md.
+# Fails open on anything it cannot parse: a hook that blocks on its own bug is worse than no hook.
 
 set -euo pipefail
 
-# THE PAYLOAD ARRIVES BY FILE, NOT BY ARGV. Linux caps a single argv string at ~128 KiB
-# (MAX_ARG_STRLEN), and a hook payload carries the whole prompt or command - a pasted diff or log
-# clears that easily. Passing it as an argument then fails with "Argument list too long" BEFORE
-# python starts, and since these hooks are built to fail open, the failure is silent: the hook
-# simply stops doing its job on exactly the large inputs a human is most likely to be mid-decision
-# on. A temp file has no such limit. mktemp is 0600 and the trap removes it.
-payload_file=$(mktemp)
-trap 'rm -f "$payload_file"' EXIT
-cat > "$payload_file"
+payload=$(cat)
 
-# The matcher in .claude/settings.json can only match a command PREFIX, which misses every shape
-# this hook is built for - `/usr/local/bin/gh pr merge ...`, `echo x && gh pr merge ...`. So the
-# hook is registered for every Bash call and does its own filtering, and this is the cheap first
-# cut: no `merge` anywhere in the payload means no `gh pr merge`, decided without starting python.
-if ! grep -q merge "$payload_file"; then
-    exit 0
-fi
-
-python3 - "$payload_file" <<'PY'
-import json, re, shlex, sys
+python3 - "$payload" <<'PY'
+import json, re, sys
 
 try:
-    with open(sys.argv[1], encoding="utf-8") as fh:
-        tool = json.load(fh)
+    tool = json.loads(sys.argv[1])
 except Exception:
     sys.exit(0)                      # unparseable: never block on our own bug
 
@@ -95,249 +38,21 @@ if tool.get("tool_name") != "Bash":
     sys.exit(0)
 
 cmd = tool.get("tool_input", {}).get("command", "")
+if not re.search(r"\bgh\s+pr\s+merge\b", cmd) or not re.search(r"--subject\b", cmd):
+    sys.exit(0)
 
-# `gh pr merge` flags that CONSUME the next argument. The set matters twice over: `-t` is the
-# short spelling of `--subject`, and reading only the long one let `-t "no number"` through the
-# hook entirely; and a flag's VALUE must never be mistaken for the PR selector.
-LONG_VALUE_FLAGS = {
-    "--subject", "--body", "--body-file", "--author-email", "--repo", "--match-head-commit",
-}
-SHORT_VALUE_FLAGS = {"t": "--subject", "b": "--body", "F": "--body-file",
-                     "A": "--author-email", "R": "--repo"}
-
-# Flags `gh` accepts BETWEEN the executable and its subcommand: `gh -R owner/repo pr merge 1299`
-# is valid, and requiring `gh pr merge` to be adjacent silently missed it.
-GLOBAL_VALUE_FLAGS = {"-R", "--repo"}
-GLOBAL_BOOL_FLAGS = {"--help", "-h", "--version"}
-
-# `gh pr merge [<number> | <url> | <branch>]`. Only the first two carry a number to cross-check.
-# ANCHORED TO A REAL URL. Searching any non-numeric selector for `/pull/<digits>` also matched a
-# perfectly legal BRANCH name - `git check-ref-format --branch fix/pull/1299` accepts it - so
-# merging that branch was cross-checked against 1299 and a correct subject naming the real PR was
-# DENIED. A false positive, in the class this hook weights hardest.
-PR_URL = re.compile(r"^https?://\S+/pull/(\d+)(?:[/?#]|$)")
-
-# Shell expansion the shell will resolve and we cannot. NOT a bare `$`: shlex has already stripped
-# quoting by the time we see the value, so `'reduce cost to $5'` - a literal Bash sends verbatim -
-# looked identical to `"$SUBJECT"` and was allowed through with no number at all. Requiring a name,
-# a brace, a paren or a backtick keeps the real cases (`$VAR`, `${V}`, `$(cmd)`, backticks) failing
-# open while a literal dollar is judged like any other text.
-#
-# STATED RESIDUAL: a SINGLE-quoted `'$VAR'` is a literal too, and is still read as an expansion.
-# That is the fail-open direction, and recovering the quoting would mean lexing the line twice.
-EXPANSION = re.compile(r"\$[A-Za-z_{(]|`")
-
-# Where one command ends and the next begins. A slice that ran to the next `gh pr merge` instead
-# swallowed everything after `&&`/`;`/`|`, so an unrelated later command's `--subject` became "the
-# last one" - a decoy could vouch for a bad merge, and a trailing `echo --subject "no number"`
-# could condemn a good one. Both directions, from the same missing boundary.
-OPERATORS = {"&&", "||", ";", ";;", "|", "&", ")"}
-
-# `(` is NOT in the set above, and that is the fix for a false positive rather than an oversight.
-# posix lexing strips quoting, so the `(` in `echo "(" gh pr merge ...` - an ordinary string
-# argument - was indistinguishable from a subshell and reset command position, making the text
-# after it look like an executed merge and HARD-DENYING a harmless command. Recovering the quoting
-# is not available: a second, non-posix lex does not align token-for-token with the posix one (an
-# escaped apostrophe splits differently), and mis-aligning would resurrect an older false positive.
-#
-# Instead `(` is honoured only where a command could actually begin - see OPEN_SUBSHELL below.
-# `echo "("` cannot, because `echo` has already taken the command slot.
-OPEN_SUBSHELL = "("
-
-ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
-
-# Wrappers that RUN the next word, so command position survives them. `command gh pr merge ...` is
-# a real invocation Bash's own `help command` documents, and it was walking straight past the guard.
-EXEC_PREFIXES = {"command", "builtin", "exec", "env", "nohup", "time", "sudo", "nice", "stdbuf"}
-
-
-def is_gh(token):
-    return token == "gh" or token.endswith("/gh")
-
-
-def merge_slices(tokens):
-    """Every `gh pr merge` in COMMAND POSITION, as (first-arg-index, end-index) pairs.
-
-    Command position matters because this hook is registered for every Bash call: without it,
-    `echo gh pr merge 1299 --subject bad` - which only prints text - was hard-denied. A token is
-    in command position at the start of the line or straight after a shell operator, skipping
-    any leading `VAR=value` assignments.
-    """
-    out = []
-    i, at_command = 0, True
-    while i < len(tokens):
-        token = tokens[i]
-        if token in OPERATORS:
-            at_command = True
-            i += 1
-            continue
-        if token == OPEN_SUBSHELL:
-            # Only a `(` where a command could start opens a subshell; anywhere else it is an
-            # argument that happened to lose its quotes to the lexer.
-            i += 1
-            continue
-        if at_command and ASSIGNMENT.match(token):
-            i += 1                                   # env prefix, still command position
-            continue
-        if at_command and token in EXEC_PREFIXES:
-            i += 1                                   # wrapper runs the next word: still a command
-            continue
-        if at_command and is_gh(token):
-            j = i + 1
-            while j < len(tokens):                   # global flags before the subcommand
-                if tokens[j] in GLOBAL_VALUE_FLAGS:
-                    j += 2
-                elif tokens[j] in GLOBAL_BOOL_FLAGS or tokens[j].startswith("--repo="):
-                    j += 1
-                else:
-                    break
-            if j + 1 < len(tokens) and tokens[j] == "pr" and tokens[j + 1] == "merge":
-                start = j + 2
-                end = start
-                while end < len(tokens) and tokens[end] not in OPERATORS:
-                    end += 1
-                out.append((start, end))
-                i = end
-                at_command = True
-                continue
-        at_command = False
-        i += 1
-    return out
-
-
-def subjects_and_pr(slice_tokens):
-    """The subject values and the PR number in one `gh pr merge` argument list.
-
-    Every spelling `gh` accepts for the subject counts, because the hook is worthless against the
-    one it cannot read: `--subject X`, `--subject=X`, `-t X`, `-tX`, `-t=X`, and `-t` inside a
-    combined shorthand group such as `-st X`. Flags that consume a value have theirs consumed here
-    too, so a value is never mistaken for the PR selector.
-    """
-    values, pr = [], None
-    selector_seen = False
-    i = 0
-    while i < len(slice_tokens):
-        token = slice_tokens[i]
-
-        if token.startswith("--"):
-            name, sep, inline = token.partition("=")
-            if sep:
-                if name == "--subject":
-                    values.append(inline)
-                i += 1
-                continue
-            if name in LONG_VALUE_FLAGS and i + 1 < len(slice_tokens):
-                if name == "--subject":
-                    values.append(slice_tokens[i + 1])
-                i += 2
-                continue
-            i += 1
-            continue
-
-        # A shorthand group, per pflag: scan left to right, and the FIRST value-taking letter
-        # takes the rest of the group as its value - or the next token when it ends the group.
-        # Stopping at that letter is what keeps `-bt` from being read as a subject: there, `t` is
-        # part of `-b`'s value, not a flag.
-        if len(token) > 1 and token[0] == "-" and token[1] != "-":
-            group = token[1:]
-            took_next = False
-            for j, ch in enumerate(group):
-                if ch not in SHORT_VALUE_FLAGS:
-                    continue
-                rest = group[j + 1:]
-                if rest.startswith("="):
-                    value = rest[1:]
-                elif rest:
-                    value = rest
-                elif i + 1 < len(slice_tokens):
-                    value = slice_tokens[i + 1]
-                    took_next = True
-                else:
-                    value = None
-                if ch == "t" and value is not None:
-                    values.append(value)
-                break
-            i += 2 if took_next else 1
-            continue
-
-        if not selector_seen:
-            # `gh pr merge [<number> | <url> | <branch>]` - the first bare argument is the
-            # selector, whatever its form, so nothing after it can be re-read as one.
-            selector_seen = True
-            if token.isdigit():
-                pr = token
-            else:
-                match = PR_URL.match(token)
-                if match:
-                    pr = match.group(1)
-        i += 1
-    return values, pr
-
-
-# A NEWLINE IS A COMMAND BOUNDARY, and `#` still starts a comment. Both were lost when the whole
-# payload was lexed in one go with newlines as plain whitespace and comments disabled: a decoy on
-# the next line, or after a `#` Bash would ignore, became "the last --subject" of the merge above
-# it. Lexing line by line restores both, and a subject's own `(#N)` is safe because it is quoted.
-for line in cmd.splitlines():
-    try:
-        lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
-        lexer.whitespace_split = True
-        tokens = list(lexer)
-    except ValueError:
-        continue                     # unbalanced quotes: our own parse limit, never block on it
-
-    for start, end in merge_slices(tokens):
-        subjects, pr = subjects_and_pr(tokens[start:end])
-
-        if not subjects:
-            continue                 # no override, so GitHub appends the number itself - fine
-
-        subject = subjects[-1]       # gh honours the LAST occurrence, so that is the one judged
-
-        if EXPANSION.search(subject):
-            continue                 # not the text gh will send; judging it judges the wrong text
-
-        found = re.findall(r"\(#(\d+)\)", subject)
-        pr_hint = f"(#{pr})" if pr else "(#<pr>)"
-
-        if not found:
-            reason = (
-                "This --subject has no PR-number suffix, and passing --subject suppresses the "
-                f"{pr_hint} that GitHub would otherwise append. "
-            )
-        elif pr is not None and [n for n in found if n != pr]:
-            # ANY parenthesised number that is not this PR is a defect, even alongside the right
-            # one. `fix (#1206) (#1299)` recreates precisely the ambiguity AGENTS.md calls out -
-            # two bare numbers with no way to tell the issue from the squash-added PR number.
-            wrong = next(n for n in found if n != pr)
-            reason = (
-                f"This --subject carries (#{wrong}) but the merge is of PR #{pr}. A number that "
-                "points at the wrong PR - or at an issue - is worse than none: it reads as correct "
-                "and links a future reader somewhere else. AGENTS.md reserves the trailing "
-                "parenthesised slot for the PR number alone; cite an issue at the front of the "
-                "subject instead. "
-            )
-        elif pr is None and len(set(found)) > 1:
-            reason = (
-                f"This --subject carries more than one parenthesised number ({', '.join(sorted(set(found)))}), "
-                "so a future reader cannot tell which is the PR. "
-            )
-        else:
-            continue                 # carries the right number, and only that - fine
-
-        print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": (
-                    reason
-                    + "The commit would land out of step with every neighbour on master, and it is "
-                    "not fixable afterwards without rewriting a pushed commit (this happened on "
-                    f"astubbs#206). Either end the subject with ' {pr_hint}', or drop --subject "
-                    "entirely and let the PR title be used - --body-file alone does not affect the "
-                    "subject. See docs/merge-checklist.md."
-                ),
-            }
-        }))
-        sys.exit(0)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": (
+            "Don't pass --subject to gh pr merge. It suppresses the (#N) GitHub would otherwise "
+            "append, so the commit lands without its PR number and out of step with every "
+            "neighbour on master - and that is not fixable afterwards without rewriting a pushed "
+            "commit (astubbs#206). Drop the flag and the PR title is used. If the title is wrong, "
+            "fix the title: it is what reviewers saw. --body-file alone does not affect the "
+            "subject. See docs/merge-checklist.md."
+        ),
+    }
+}))
 PY

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -75,6 +75,10 @@ for start, end in zip(starts, starts[1:] + [len(cmd)]):
             if t.startswith(flag + "="):
                 subject = t[len(flag) + 1:]
                 break
+            # A SHORT flag may carry its value attached: -tbad == -t bad. Long flags do not.
+            if len(flag) == 2 and t.startswith(flag) and len(t) > 2:
+                subject = t[2:]
+                break
         i += 1
 
     if subject is None:

--- a/.claude/hooks/check-squash-subject.sh
+++ b/.claude/hooks/check-squash-subject.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# PreToolUse hook: refuse a `gh pr merge --subject` whose subject does not carry the PR number.
+#
+# THE TRAP. `gh pr merge --squash` normally lands a subject ending `... (#265)` - GitHub appends the
+# PR number itself. It does that ONLY when the subject is not overridden. Pass `--subject "..."` and
+# your text is used verbatim, so the number silently never appears. AGENTS.md reserves that trailing
+# slot for exactly this, and every neighbouring commit on master has it.
+#
+# It is a good candidate for a hook rather than a rule because it is invisible at the point of
+# failure: the merge succeeds, the message reads fine, and the omission only shows up later next to
+# its neighbours in `git log`. That is what happened on astubbs#206, and rewriting a commit already
+# on master is not a fix anyone should need.
+#
+# PRECISE, NOT NAGGY. It fires only when `--subject` is present AND the subject lacks a `(#N)`
+# suffix - i.e. only when the mistake is actually being made. A subject that already carries the
+# number passes silently, and so does a merge that does not override the subject at all.
+#
+# PreToolUse cannot inject context (stdout never reaches the model), so this denies with a reason,
+# which IS fed back - see docs/agent-harness.md for what each layer can and cannot do.
+
+set -euo pipefail
+
+payload=$(cat)
+
+python3 - "$payload" <<'PY'
+import json, re, sys
+
+try:
+    tool = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)                      # unparseable: never block on our own bug
+
+if tool.get("tool_name") != "Bash":
+    sys.exit(0)
+
+cmd = tool.get("tool_input", {}).get("command", "")
+
+# Only a merge that overrides the subject can hit the trap.
+if not re.search(r"\bgh\s+pr\s+merge\b", cmd) or not re.search(r"--subject\b", cmd):
+    sys.exit(0)
+
+# Pull the subject argument, tolerating single quotes, double quotes or a bare token.
+m = re.search(r"--subject(?:=|\s+)(\"(?:[^\"\\]|\\.)*\"|'[^']*'|\S+)", cmd)
+subject = m.group(1) if m else ""
+if subject[:1] in ("\"", "'"):
+    subject = subject[1:-1]
+
+if re.search(r"\(#\d+\)", subject):
+    sys.exit(0)                      # already carries the number - fine
+
+pr = re.search(r"\bgh\s+pr\s+merge\s+(\d+)", cmd)
+pr_hint = f"(#{pr.group(1)})" if pr else "(#<pr>)"
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": (
+            "This --subject has no PR-number suffix, and passing --subject suppresses the "
+            f"{pr_hint} that GitHub would otherwise append. The commit would land out of step with "
+            "every neighbour on master, and it is not fixable afterwards without rewriting a "
+            "pushed commit (this happened on astubbs#206). Either append "
+            f"' {pr_hint}' to the subject, or drop --subject entirely and let the PR title be used "
+            "- --body-file alone does not affect the subject. See docs/merge-checklist.md."
+        ),
+    }
+}))
+PY

--- a/.claude/hooks/inject-merge-checklist.sh
+++ b/.claude/hooks/inject-merge-checklist.sh
@@ -6,13 +6,19 @@
 # UserPromptSubmit hook: when a prompt looks like merge preparation, put docs/merge-checklist.md in
 # front of the agent - at the moment it is deciding, not in a document it might read afterwards.
 #
-# WHY THIS EVENT. PreToolUse cannot inject context (its stdout never reaches the model; it can only
-# allow, deny or ask), so it cannot be used to remind an agent of anything. UserPromptSubmit can,
-# via hookSpecificOutput.additionalContext. See docs/agent-harness.md for the full layer map.
+# WHY THIS EVENT. Not because PreToolUse cannot inject context - it can, via
+# hookSpecificOutput.additionalContext (verified live against 2.1.223; only its *stdout* is
+# discarded). The reason is timing. PreToolUse fires per tool call, so the checklist would arrive
+# attached to whichever command happened to run next, repeatedly, and never at the moment the
+# strategy is actually being chosen. UserPromptSubmit fires when the human states the intent, which
+# is the decision point. See docs/agent-harness.md for the full layer map.
 #
 # NEUTRALITY. This script holds no advice of its own - it prints docs/merge-checklist.md, which is
 # tool-neutral and routed from AGENTS.md. Codex and anything else reading AGENTS.md gets the same
-# words from the same file; only the delivery differs.
+# words from the same file; only the delivery differs. That claim is load-bearing, so the injected
+# preamble below says only where the text came from: an earlier version also summarised the
+# checklist's two standing asks, which is precisely the second copy this design exists to avoid -
+# the summary drifts from the doc, and the doc is what everything else reads.
 #
 # It never blocks. The point is to inject a thought at the right time, not to gate anything.
 
@@ -51,10 +57,8 @@ print(json.dumps({
     "hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",
         "additionalContext": (
-            "This prompt looks like merge preparation. The repo's merge checklist "
-            "(docs/merge-checklist.md) follows. Its two standing asks are to OFFER to write the "
-            "squash message, and to OFFER to reorganise the commits into cohesive units - offer "
-            "both, do not silently do either.\n\n" + body
+            "This prompt looks like merge preparation, so the repo's merge checklist follows "
+            "verbatim from docs/merge-checklist.md, which owns it.\n\n" + body
         ),
     }
 }))

--- a/.claude/hooks/inject-merge-checklist.sh
+++ b/.claude/hooks/inject-merge-checklist.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# UserPromptSubmit hook: when a prompt looks like merge preparation, put docs/merge-checklist.md in
+# front of the agent - at the moment it is deciding, not in a document it might read afterwards.
+#
+# WHY THIS EVENT. PreToolUse cannot inject context (its stdout never reaches the model; it can only
+# allow, deny or ask), so it cannot be used to remind an agent of anything. UserPromptSubmit can,
+# via hookSpecificOutput.additionalContext. See docs/agent-harness.md for the full layer map.
+#
+# NEUTRALITY. This script holds no advice of its own - it prints docs/merge-checklist.md, which is
+# tool-neutral and routed from AGENTS.md. Codex and anything else reading AGENTS.md gets the same
+# words from the same file; only the delivery differs.
+#
+# It never blocks. The point is to inject a thought at the right time, not to gate anything.
+
+set -euo pipefail
+
+payload=$(cat)
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+checklist="$project_dir/docs/merge-checklist.md"
+[ -r "$checklist" ] || exit 0
+
+# Match merge-prep intent. Deliberately broad on the verbs and narrow on the nouns: a false positive
+# costs a few hundred tokens of checklist, a false negative costs the thing this exists to prevent.
+if ! python3 - "$payload" <<'PY'
+import json, re, sys
+try:
+    prompt = json.loads(sys.argv[1]).get("prompt", "")
+except Exception:
+    sys.exit(1)
+pattern = re.compile(
+    r"\b(squash|rebase|merge|mergeable|land(ing)?\s+(it|this|the\s+pr)|ready\s+to\s+merge|"
+    r"good\s+to\s+merge|ship\s+it|tidy\s+(up\s+)?the\s+commits|commit\s+history|"
+    r"reorganis|reorganiz|fixup|autosquash)\b",
+    re.IGNORECASE,
+)
+sys.exit(0 if pattern.search(prompt) else 1)
+PY
+then
+    exit 0
+fi
+
+python3 - "$checklist" <<'PY'
+import json, sys
+body = open(sys.argv[1], encoding="utf-8").read()
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": (
+            "This prompt looks like merge preparation. The repo's merge checklist "
+            "(docs/merge-checklist.md) follows. Its two standing asks are to OFFER to write the "
+            "squash message, and to OFFER to reorganise the commits into cohesive units - offer "
+            "both, do not silently do either.\n\n" + body
+        ),
+    }
+}))
+PY

--- a/.claude/hooks/inject-merge-checklist.sh
+++ b/.claude/hooks/inject-merge-checklist.sh
@@ -24,7 +24,15 @@
 
 set -euo pipefail
 
-payload=$(cat)
+# THE PAYLOAD ARRIVES BY FILE, NOT BY ARGV. Linux caps a single argv string at ~128 KiB
+# (MAX_ARG_STRLEN), and a hook payload carries the whole prompt or command - a pasted diff or log
+# clears that easily. Passing it as an argument then fails with "Argument list too long" BEFORE
+# python starts, and since these hooks are built to fail open, the failure is silent: the hook
+# simply stops doing its job on exactly the large inputs a human is most likely to be mid-decision
+# on. A temp file has no such limit. mktemp is 0600 and the trap removes it.
+payload_file=$(mktemp)
+trap 'rm -f "$payload_file"' EXIT
+cat > "$payload_file"
 
 project_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 checklist="$project_dir/docs/merge-checklist.md"
@@ -32,10 +40,11 @@ checklist="$project_dir/docs/merge-checklist.md"
 
 # Match merge-prep intent. Deliberately broad on the verbs and narrow on the nouns: a false positive
 # costs a few hundred tokens of checklist, a false negative costs the thing this exists to prevent.
-if ! python3 - "$payload" <<'PY'
+if ! python3 - "$payload_file" <<'PY'
 import json, re, sys
 try:
-    prompt = json.loads(sys.argv[1]).get("prompt", "")
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        prompt = json.load(fh).get("prompt", "")
 except Exception:
     sys.exit(1)
 pattern = re.compile(

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -55,28 +55,81 @@ project_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null |
 gate="$project_dir/.githooks/pre-commit"
 [ -x "$gate" ] || exit 0
 
-# Does this command carry a real `--no-verify` argument? `shlex` so that a commit MESSAGE mentioning
-# the flag (`git commit -m "document --no-verify"`) is not mistaken for the flag itself; a word-
-# boundary search only as the fallback when shlex cannot parse the line, because refusing to decide
-# would mean gating a commit the author explicitly asked not to gate.
+# NO PYTHON, NO GATE. The bypass below cannot be detected without parsing the payload, and the
+# repo's documented build requirements are JDK 17, Docker and the Maven wrapper - python is not
+# among them. Falling through on a missing interpreter meant `git commit --no-verify` ran the gates
+# and was blocked at exit 2 with no way to argue: the escape hatch the header calls load-bearing,
+# absent on exactly the machine that has no other way out. Fail open, like every other limit here;
+# `.githooks/pre-commit` and CI still gate the same commit.
+command -v python3 >/dev/null 2>&1 || exit 0
+
+# Does THIS COMMIT carry a real `--no-verify` argument? Three things are load-bearing:
+#
+#   - `shlex`, so a commit MESSAGE mentioning the flag (`git commit -m "document --no-verify"`) is
+#     not mistaken for the flag itself;
+#   - the search is scoped to the `git commit` command, not the whole payload. It used to scan the
+#     entire line, so `git commit -m x && echo --no-verify` bypassed a red gate for a commit that
+#     never asked - the violation lands, and the later command is what "requested" it;
+#   - a word-boundary search over the line only as the fallback when the line cannot be lexed,
+#     because refusing to decide would mean gating a commit the author explicitly asked not to gate.
 #
 # Only the long spelling counts. `git commit -n` means the same thing to git, but `-n` is a common
 # token in a command line that merely CONTAINS a commit (`echo -n`, an unquoted `$(...)`), and a
 # bypass triggered by accident is a gate that silently stopped running. The long form is what the
 # hook headers and docs tell people to type, and it is unambiguous.
-if python3 - "$payload_file" <<'PY'
+if python3 - "$payload_file" <<'PYGATE'
 import json, re, shlex, sys
+
+OPERATORS = {"&&", "||", ";", ";;", "|", "&", "(", ")"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+GIT_VALUE_FLAGS = {"-C", "-c", "--git-dir", "--work-tree"}
+
 try:
     with open(sys.argv[1], encoding="utf-8") as fh:
         cmd = json.load(fh).get("tool_input", {}).get("command", "")
 except Exception:
     sys.exit(0)                      # unparseable payload: treat as bypass, never block on our bug
+
+
+def commit_requests_bypass(line):
+    """True when a `git commit` in COMMAND POSITION on this line carries --no-verify itself."""
+    lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    tokens = list(lexer)
+    i, at_command = 0, True
+    while i < len(tokens):
+        token = tokens[i]
+        if token in OPERATORS:
+            at_command = True
+            i += 1
+            continue
+        if at_command and ASSIGNMENT.match(token):
+            i += 1
+            continue
+        if at_command and (token == "git" or token.endswith("/git")):
+            j = i + 1
+            while j < len(tokens) and tokens[j] in GIT_VALUE_FLAGS:
+                j += 2               # git global flags that consume a value
+            if j < len(tokens) and tokens[j] == "commit":
+                end = j
+                while end < len(tokens) and tokens[end] not in OPERATORS:
+                    end += 1
+                if "--no-verify" in tokens[j:end]:
+                    return True
+                i = end
+                at_command = True
+                continue
+        at_command = False
+        i += 1
+    return False
+
+
 try:
-    bypass = "--no-verify" in shlex.split(cmd)
+    bypass = any(commit_requests_bypass(line) for line in cmd.splitlines())
 except ValueError:
     bypass = re.search(r"(?<!\S)--no-verify(?!\S)", cmd) is not None
 sys.exit(0 if bypass else 1)
-PY
+PYGATE
 then
     exit 0
 fi

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -133,13 +133,17 @@ def commit_bypass_counts(line):
 
 
 try:
-    counts = [commit_bypass_counts(line) for line in cmd.splitlines()]
-    commits = sum(c for c, _ in counts)
-    bypassing = sum(b for _, b in counts)
+    # The WHOLE command is lexed at once. Splitting into lines first breaks a quoted multiline
+    # message down the middle, so the first line raises ValueError and the fallback below finds
+    # `--no-verify` in the MESSAGE TEXT - which meant `git commit -m "...\n--no-verify\n..."`
+    # skipped the gate entirely. shlex handles the newlines; the line split never needed to.
+    commits, bypassing = commit_bypass_counts(cmd)
     # EVERY commit in the payload must ask for it. One that did not is gated, so the gate runs.
     bypass = commits > 0 and commits == bypassing
 except ValueError:
-    bypass = re.search(r"(?<!\S)--no-verify(?!\S)", cmd) is not None
+    # Genuinely unbalanced quoting. Fail OPEN so a hook bug cannot jam the tool call shut, but do
+    # not try to read the flag out of text we could not lex.
+    bypass = True
 sys.exit(0 if bypass else 1)
 PYGATE
 then

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -41,7 +41,15 @@
 
 set -euo pipefail
 
-payload=$(cat)
+# THE PAYLOAD ARRIVES BY FILE, NOT BY ARGV. Linux caps a single argv string at ~128 KiB
+# (MAX_ARG_STRLEN), and a hook payload carries the whole prompt or command - a pasted diff or log
+# clears that easily. Passing it as an argument then fails with "Argument list too long" BEFORE
+# python starts, and since these hooks are built to fail open, the failure is silent: the hook
+# simply stops doing its job on exactly the large inputs a human is most likely to be mid-decision
+# on. A temp file has no such limit. mktemp is 0600 and the trap removes it.
+payload_file=$(mktemp)
+trap 'rm -f "$payload_file"' EXIT
+cat > "$payload_file"
 
 project_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 gate="$project_dir/.githooks/pre-commit"
@@ -56,10 +64,11 @@ gate="$project_dir/.githooks/pre-commit"
 # token in a command line that merely CONTAINS a commit (`echo -n`, an unquoted `$(...)`), and a
 # bypass triggered by accident is a gate that silently stopped running. The long form is what the
 # hook headers and docs tell people to type, and it is unambiguous.
-if python3 - "$payload" <<'PY'
+if python3 - "$payload_file" <<'PY'
 import json, re, shlex, sys
 try:
-    cmd = json.loads(sys.argv[1]).get("tool_input", {}).get("command", "")
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        cmd = json.load(fh).get("tool_input", {}).get("command", "")
 except Exception:
     sys.exit(0)                      # unparseable payload: treat as bypass, never block on our bug
 try:

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -23,6 +23,17 @@
 # on stderr produces "hook error: No stderr output", which tells the agent it was blocked and
 # nothing about why; that was the observed behaviour of the inline form.
 #
+# WHICH REPOSITORY IT GATES - THE SESSION'S, NOT THE COMMAND'S. Both the gate path below and the
+# gate's own `git rev-parse --show-toplevel` resolve from this hook process, so what gets checked is
+# the checkout the SESSION is rooted in. Raised in review as a worktree hazard: a session in the
+# primary checkout running `cd .claude/worktrees/task && git commit` would be gated against the
+# wrong tree. It cannot reach here - `if: Bash(git commit *)` matches the command as WRITTEN, so
+# that command does not fire this hook at all (docs/agent-harness.md, "Known gaps"). Every command
+# that does fire it is a bare `git commit ...` in the session's own cwd, where session repo and
+# commit repo are the same one. The residual case - a `cd`'d or `git -C` commit into another
+# worktree - is covered by `.githooks/pre-commit`, which git runs inside the target repository. That
+# is why the git hook is the primary mechanism and this is belt-and-braces.
+#
 # FAIL OPEN ON OUR OWN BUG. If the payload does not parse, or the gate script is missing, this exits
 # 0. The git hook and CI both still gate the same commit.
 #

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# PreToolUse hook: run `.githooks/pre-commit` before the agent's `git commit`, and honour
+# `--no-verify` the way git itself does.
+#
+# WHY THIS EXISTS AT ALL. `core.hooksPath` cannot be committed, so a fresh clone has no git hooks
+# until someone runs the config command once. This covers Claude Code in that window. It is
+# belt-and-braces, not the primary mechanism - the git hook binds every process that runs `git`,
+# including humans and other agents; this binds one tool.
+#
+# WHY IT IS A SCRIPT AND NOT `... || exit 2` INLINE. The inline form never reads the hook payload,
+# so it could not see the command it was gating - which meant `git commit --no-verify` ran the
+# gates anyway and blocked. That directly contradicts the pre-commit hook's own header: "a gate
+# people cannot skip when they have a reason is a gate they disable permanently". An agent facing a
+# red gate it cannot bypass has exactly one move left, which is to stop working; a human in that
+# spot deletes the hook. The escape hatch is the thing that keeps the gate installed.
+#
+# WHY EXIT 2 AND NOT A JSON DENY. Exit 2 is PreToolUse's documented block, and it forwards stderr to
+# the model - so the failing gate's own output becomes the explanation. A bare `exit 2` with nothing
+# on stderr produces "hook error: No stderr output", which tells the agent it was blocked and
+# nothing about why; that was the observed behaviour of the inline form.
+#
+# FAIL OPEN ON OUR OWN BUG. If the payload does not parse, or the gate script is missing, this exits
+# 0. The git hook and CI both still gate the same commit.
+#
+# Negative control: bin/test-check-agent-hooks.sh.
+
+set -euo pipefail
+
+payload=$(cat)
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+gate="$project_dir/.githooks/pre-commit"
+[ -x "$gate" ] || exit 0
+
+# Does this command carry a real `--no-verify` argument? `shlex` so that a commit MESSAGE mentioning
+# the flag (`git commit -m "document --no-verify"`) is not mistaken for the flag itself; a word-
+# boundary search only as the fallback when shlex cannot parse the line, because refusing to decide
+# would mean gating a commit the author explicitly asked not to gate.
+#
+# Only the long spelling counts. `git commit -n` means the same thing to git, but `-n` is a common
+# token in a command line that merely CONTAINS a commit (`echo -n`, an unquoted `$(...)`), and a
+# bypass triggered by accident is a gate that silently stopped running. The long form is what the
+# hook headers and docs tell people to type, and it is unambiguous.
+if python3 - "$payload" <<'PY'
+import json, re, shlex, sys
+try:
+    cmd = json.loads(sys.argv[1]).get("tool_input", {}).get("command", "")
+except Exception:
+    sys.exit(0)                      # unparseable payload: treat as bypass, never block on our bug
+try:
+    bypass = "--no-verify" in shlex.split(cmd)
+except ValueError:
+    bypass = re.search(r"(?<!\S)--no-verify(?!\S)", cmd) is not None
+sys.exit(0 if bypass else 1)
+PY
+then
+    exit 0
+fi
+
+if ! output=$("$gate" 2>&1); then
+    printf '%s\n' "$output" >&2
+    printf '\nBlocked by the repo pre-commit gate (.githooks/pre-commit). Fix the gate(s) above, or\n' >&2
+    printf 'commit with --no-verify if you have a reason - the bypass is deliberate, not an oversight.\n' >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -91,11 +91,18 @@ except Exception:
     sys.exit(0)                      # unparseable payload: treat as bypass, never block on our bug
 
 
-def commit_requests_bypass(line):
-    """True when a `git commit` in COMMAND POSITION on this line carries --no-verify itself."""
+def commit_bypass_counts(line):
+    """(commits, bypassing) for `git commit` in COMMAND POSITION on this line.
+
+    Counted rather than short-circuited because ONE command line can hold SEVERAL commits, and a
+    later one asking for a bypass must not exempt an earlier one that did not:
+    `git commit -m first; git commit --no-verify -m second` used to exit 0 for both, so in a clone
+    with no core.hooksPath the first commit landed with no gate run at all.
+    """
     lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
     lexer.whitespace_split = True
     tokens = list(lexer)
+    commits = bypassing = 0
     i, at_command = 0, True
     while i < len(tokens):
         token = tokens[i]
@@ -114,18 +121,23 @@ def commit_requests_bypass(line):
                 end = j
                 while end < len(tokens) and tokens[end] not in OPERATORS:
                     end += 1
+                commits += 1
                 if "--no-verify" in tokens[j:end]:
-                    return True
+                    bypassing += 1
                 i = end
                 at_command = True
                 continue
         at_command = False
         i += 1
-    return False
+    return commits, bypassing
 
 
 try:
-    bypass = any(commit_requests_bypass(line) for line in cmd.splitlines())
+    counts = [commit_bypass_counts(line) for line in cmd.splitlines()]
+    commits = sum(c for c, _ in counts)
+    bypassing = sum(b for _, b in counts)
+    # EVERY commit in the payload must ask for it. One that did not is gated, so the gate runs.
+    bypass = commits > 0 and commits == bypassing
 except ValueError:
     bypass = re.search(r"(?<!\S)--no-verify(?!\S)", cmd) is not None
 sys.exit(0 if bypass else 1)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./bin/check-copyright-headers.sh)",
+      "Bash(./bin/check-docs-data.sh)",
+      "Bash(git merge-tree *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git commit *)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.githooks/pre-commit\" || exit 2"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/inject-merge-checklist.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,6 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(gh pr merge *)",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-squash-subject.sh\""
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,20 +10,20 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "if": "Bash(git commit *)",
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.githooks/pre-commit\" || exit 2"
+            "if": "Bash(git commit *)",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-gate.sh\""
           }
         ]
       },
       {
         "matcher": "Bash",
-        "if": "Bash(gh pr merge *)",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(gh pr merge *)",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-squash-subject.sh\""
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,16 @@
             "command": "\"$CLAUDE_PROJECT_DIR/.githooks/pre-commit\" || exit 2"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "if": "Bash(gh pr merge *)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-squash-subject.sh\""
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -75,6 +75,21 @@ GATES=(
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
+# Make the copyright gate's shallow-clone case REACH the soft-skip above instead of hiding.
+#
+# Left alone, `check-copyright-headers.sh` prints "WARNING: ... Skipping copyright header check."
+# and exits **0** when the fork-point commit is not in history. This loop discards the output of
+# any gate that exits 0, so the gate skipped itself and said nothing - and the `:2` soft code
+# configured for it was unreachable in the one situation it was configured for. A gate that stops
+# running with nobody told is the exact silent miss the NOT-EXECUTABLE branch below exists to
+# prevent, arriving by a different door.
+#
+# Asking it to hard-fail routes that case through the soft-code machinery: exit 2, classified
+# soft, reported as `pre-commit: skipped check-copyright-headers.sh (exit 2 - could not run)`.
+# The commit is not blocked either way - only the silence changes. Scoped to this hook; CI sets
+# the same flag for its own reason (there, full history is fetched, so it must be an error).
+export COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1
+
 failed=()
 skipped=()
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Repo pre-commit gate. Runs the fast, read-only checks that CI runs anyway, so a violation is
+# caught in the second before the commit rather than the ten minutes after the push.
+#
+# WHY THIS EXISTS RATHER THAN A DOCUMENTED RULE. Every check below is already written down, and
+# every one has still been missed - by humans and by agents - because a document only fires if
+# somebody chooses to read it. A hook fires because git runs it. That is the whole point: this file
+# is the enforcement layer for things that must not depend on anyone remembering. See
+# docs/agent-harness.md for the layer map and for how to add to it.
+#
+# ENABLE IT (per clone, once - hooks cannot be committed into .git/hooks):
+#     git config core.hooksPath .githooks
+# One clone's config covers every worktree of that clone.
+#
+# BYPASS: `git commit --no-verify`. Deliberately easy - a gate people cannot skip when they have a
+# reason is a gate they disable permanently. CI is the authority; this is the fast mirror of it.
+#
+# COST BUDGET: the whole run is ~1.5s. Keep it that way. A pre-commit hook that takes ten seconds
+# gets --no-verify'd by habit, and then it protects nothing. Anything slower belongs in CI only.
+
+set -euo pipefail
+
+# Each entry: <script>:<soft-exit-codes>
+# A "soft" code means the gate COULD NOT RUN (a missing interpreter, no merge base) as opposed to
+# finding a violation. That distinction is load-bearing: blocking a commit because node is absent
+# teaches people to bypass the hook, and the next real violation goes with it. Soft results warn.
+GATES=(
+    "check-copyright-headers.sh:"
+    "check-issue-refs.sh:2"
+    "check-docs-data.sh:"
+    "check-shell-sigpipe.sh:"
+    "check-quarantine-registry.sh:"
+    "check-action-versions.sh:"
+)
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+failed=()
+skipped=()
+
+for entry in "${GATES[@]}"; do
+    script="bin/${entry%%:*}"
+    soft_codes="${entry#*:}"
+
+    # A branch older than a gate simply does not have it. Not an error.
+    [ -x "$script" ] || continue
+
+    set +e
+    output=$("$script" 2>&1)
+    rc=$?
+    set -e
+
+    if [ "$rc" -eq 0 ]; then
+        continue
+    fi
+
+    # Compare against the soft list without a pipeline - see bin/AGENTS.md on `| grep -q` under
+    # `set -o pipefail`, where the reader closing the pipe turns a MATCH into a failure.
+    if [ -n "$soft_codes" ] && grep -qx "$rc" <<<"$(tr ',' '\n' <<<"$soft_codes")"; then
+        skipped+=("${entry%%:*} (exit $rc - could not run)")
+        continue
+    fi
+
+    failed+=("${entry%%:*}")
+    printf '\n--- %s failed (exit %s) ---\n%s\n' "$script" "$rc" "$output" >&2
+done
+
+for s in "${skipped[@]:-}"; do
+    [ -n "$s" ] && printf 'pre-commit: skipped %s\n' "$s" >&2
+done
+
+if [ ${#failed[@]} -gt 0 ]; then
+    printf '\npre-commit: %d gate(s) failed: %s\n' "${#failed[@]}" "${failed[*]}" >&2
+    printf 'Fix them, or commit with --no-verify if you have a reason.\n' >&2
+    exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,6 +18,22 @@
 #
 # BYPASS: `git commit --no-verify`. Deliberately easy - a gate people cannot skip when they have a
 # reason is a gate they disable permanently. CI is the authority; this is the fast mirror of it.
+# `.claude/hooks/pre-commit-gate.sh`, which runs this same script for Claude Code, honours the same
+# flag for the same reason.
+#
+# SCOPE - AND IT IS NOT THE COMMIT. Every gate below reads the WORKING TREE. The commit records the
+# INDEX. Those differ whenever anything is staged selectively, and the gap goes both ways:
+#
+#   - stage a clean hunk, leave an unrelated dirty one -> blocked for content that is not being
+#     committed;
+#   - stage a violation, then fix it in the working tree without staging the fix -> the violation
+#     is gated green and lands.
+#
+# This is DOCUMENTED rather than fixed, deliberately. The usual fix, `git stash push --keep-index`
+# around the run, can destroy uncommitted work if the hook dies between the stash and the pop, and
+# a pre-commit hook that can eat your changes is worse than one with a known blind spot. CI reads
+# the pushed commit and has no such gap, so nothing escapes permanently; the second case above
+# costs one CI round trip. Open decision - see docs/agent-harness.md, "Known gaps".
 #
 # COST BUDGET: the whole run is ~1.5s. Keep it that way. A pre-commit hook that takes ten seconds
 # gets --no-verify'd by habit, and then it protects nothing. Anything slower belongs in CI only.
@@ -28,10 +44,29 @@ set -euo pipefail
 # A "soft" code means the gate COULD NOT RUN (a missing interpreter, no merge base) as opposed to
 # finding a violation. That distinction is load-bearing: blocking a commit because node is absent
 # teaches people to bypass the hook, and the next real violation goes with it. Soft results warn.
+#
+# Keeping this list right means READING each gate's exit codes, not guessing them - this list was
+# written by guessing, and two of the three gates that need a soft code were missing one. Each of
+# the three below reserves 1 for a real finding and 2 for "I could not run", so no violation can be
+# reclassified as soft by these entries:
+#   - check-issue-refs.sh        - 2 when `node` is absent
+#   - check-docs-data.sh         - 2 for "no working Python 3 on PATH" and for "PyYAML is not
+#                                  installed"; 1 for structural violations
+#   - check-copyright-headers.sh - 2 when the fork-point commit is not in history (a shallow clone,
+#                                  and only when COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1); 1 for
+#                                  violations. Its own header states this contract on line "Exit
+#                                  codes:"; copyright.yml is the authoritative gate and fetches
+#                                  full history.
+# check-docs-data.sh was the expensive omission: PyYAML is a dependency nothing in this repo
+# installs, so a contributor without it was hard-blocked from committing ANYTHING, with
+# "check-docs-data.sh failed (exit 2)" as the only explanation - the precise outcome the paragraph
+# above exists to prevent. The remaining three gates exit 0 or 1 only, so they need no soft code:
+# check-shell-sigpipe.sh and check-action-versions.sh exit 1 on a finding, and
+# check-quarantine-registry.sh exits its own drift flag.
 GATES=(
-    "check-copyright-headers.sh:"
+    "check-copyright-headers.sh:2"
     "check-issue-refs.sh:2"
-    "check-docs-data.sh:"
+    "check-docs-data.sh:2"
     "check-shell-sigpipe.sh:"
     "check-quarantine-registry.sh:"
     "check-action-versions.sh:"
@@ -47,8 +82,19 @@ for entry in "${GATES[@]}"; do
     script="bin/${entry%%:*}"
     soft_codes="${entry#*:}"
 
-    # A branch older than a gate simply does not have it. Not an error.
-    [ -x "$script" ] || continue
+    # A branch older than a gate simply does not have it. Not an error - say nothing.
+    #
+    # A gate that is PRESENT but not executable is a different thing entirely, and the two used to
+    # share this one test. That is a silent miss in a tool whose whole job is to stop silent
+    # misses: a lost exec bit (a `cp` without -p, a checkout on a filesystem with no exec bit, a
+    # patch applied by hand) reads as "this branch predates the gate", and the gate simply stops
+    # running with nobody told. Report it.
+    if [ ! -e "$script" ]; then
+        continue
+    elif [ ! -x "$script" ]; then
+        skipped+=("${entry%%:*} (present but NOT EXECUTABLE - run: chmod +x $script)")
+        continue
+    fi
 
     set +e
     output=$("$script" 2>&1)

--- a/.github/workflows/quarantine-lane.yml
+++ b/.github/workflows/quarantine-lane.yml
@@ -41,6 +41,12 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
+      # The scan the two checks below read their file list from, before the checks themselves -
+      # bin/AGENTS.md: a self-test runs ahead of the gate it protects, and carries its own negative
+      # control. It pins the .claude/.git exclusions that keep a sibling worktree's annotations out
+      # of this branch's registry check, which shipped once without a test to hold them.
+      - name: Self-test the quarantine scan
+        run: bash bin/test-check-quarantine-registry.sh
       # Fail fast on rule violations BEFORE spending a test run - same checks as quarantine-audit,
       # here validating master's state.
       - name: Enforce registry (docs/quarantined-tests.md matches @Quarantined annotations)

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -47,6 +47,21 @@ jobs:
       - name: No SIGPIPE-prone pipes in bin/
         run: bash bin/check-shell-sigpipe.sh
 
+  agent-hooks:
+    name: "agents: hook self-tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Reads .claude/hooks/* and docs/merge-checklist.md from the working tree; no history needed.
+      - uses: actions/checkout@v6
+
+      # The hooks in .claude/hooks/ enforce repo conventions on every agent session, and they are
+      # the one layer with no CI behind it - a broken hook either blocks work or silently stops
+      # checking, and both look like nothing happening. docs/agent-harness.md rule 3 ("give it a
+      # negative control") applies to the harness itself; this is that control.
+      - name: Self-test the agent hooks
+        run: bash bin/test-check-agent-hooks.sh
+
   rename:
     name: "tooling: package rename"
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ CLAUDE.md
 # that shared config can be un-ignored later with a negation, e.g.
 # `!/.claude/settings.json`; git will not descend into a fully-excluded directory.
 /.claude/*
+# ...which is now done: the shared harness config is tracked, personal overrides are not.
+# settings.local.json stays ignored - it is where per-machine permission grants accumulate.
+# See docs/agent-harness.md.
+!/.claude/settings.json
+!/.claude/hooks/
+!/.claude/hooks/**
 /.codebuddy/
 /.context/
 /.compound-engineering/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,15 @@ CLAUDE.md
 /.claude/*
 # ...which is now done: the shared harness config is tracked, personal overrides are not.
 # settings.local.json stays ignored - it is where per-machine permission grants accumulate.
+#
+# ONE-TIME MIGRATION HAZARD, and it is silent. Git refuses to overwrite an untracked file, but it
+# will overwrite an IGNORED one without a word. So an existing clone that already has a local
+# `.claude/settings.json` - which every clone did, because it was ignored until this commit - has it
+# REPLACED by the tracked version on the first pull, with no conflict, no warning, and no copy left
+# anywhere: the file was never in git, so there is nothing to recover from. Verified, not assumed.
+# Nothing inside the repo can prevent it; git resolves the checkout before any hook of ours runs.
+# Copy anything local out of `.claude/settings.json` into `.claude/settings.local.json` BEFORE
+# pulling this commit - that is where it belonged anyway, and it survives every later pull.
 # See docs/agent-harness.md.
 !/.claude/settings.json
 !/.claude/hooks/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,24 @@
 /mk-include
 /.mk-include-timestamp
 .DS_Store
+
+# A `CLAUDE.md` is ignored BY DEFAULT, at any depth: historically these were personal scratch files,
+# and the default should stay "yours, not the repo's" so nobody's local notes land by accident.
 CLAUDE.md
+# ...except the harness bridges, which are the opposite of personal - they are the ONLY reason
+# Claude Code sees this repo's AGENTS.md rules at all (it never reads AGENTS.md; verified against
+# 2.1.223). Ignored, they exist on the author's machine and nowhere else, which is exactly how they
+# were nearly shipped as a no-op: everything looked wired up locally.
+#
+# ENUMERATED, NOT BLANKET (`!CLAUDE.md`), for two reasons. The default above is worth keeping for
+# any other CLAUDE.md, and a blanket negation would also invite the drifting second copy of the
+# rules that docs/agent-harness.md argues against - the stubs are pure `@AGENTS.md` imports on
+# purpose. And adding a nested AGENTS.md then requires a deliberate line here, which is one more
+# place the "did you add the bridge?" question gets asked; until the gate under "Worth adding" in
+# docs/agent-harness.md exists, that is the only place it gets asked at all.
+!/CLAUDE.md
+!/bin/CLAUDE.md
+!/docs/inflight/CLAUDE.md
 
 # Local per-worktree ownership markers (see AGENTS.md "Worktree ownership")
 .worktree-owner

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ is untracked (a whole triage doc was once written duplicating `docs/refactoring.
 | [`docs/upstream.md`](docs/upstream.md) | Work that maps to upstream: the manifest, commit trailers, issue mirrors, the sweep |
 | [`docs/self-hosted-runner.md`](docs/self-hosted-runner.md) | Setting up or operating the self-hosted highcpu runner |
 | [`bin/AGENTS.md`](bin/AGENTS.md) | Writing or changing a script in `bin/` - the shell conventions, including the ones no check enforces |
+| [`docs/agent-harness.md`](docs/agent-harness.md) | Adding a rule you need agents to follow *reliably* - which layers fire on their own, and which are merely available |
 
 **Where work and knowledge are recorded:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,10 +385,12 @@ Nothing lints commit messages, so all of this is on you.
   worked example). Do this at merge prep, once the class is understood; doing it mid-diagnosis just
   widens the investigation.
 - **Before merging, recommend a merge strategy - and say why**, and **offer** to write the squash
-  message and to re-cut the commits into atomic units rather than doing either silently. Release
-  notes are generated from the commit log, so the choice decides what a future changelog has to work
-  with. [`docs/merge-checklist.md`](docs/merge-checklist.md) **owns this** - the three strategies,
-  when each applies, and the reset-to-merge-base trap that silently reverts master.
+  message and to re-cut the commits into atomic units rather than doing either silently. Keep the
+  recommendation to a line or two: write the squash message where it is used, not into the
+  conversation, unless asked for it. Release notes are generated from the commit log, so the choice
+  decides what a future changelog has to work with.
+  [`docs/merge-checklist.md`](docs/merge-checklist.md) **owns this** - the three strategies, when
+  each applies, and the reset-to-merge-base trap that silently reverts master.
 - **Closing something as superseded: link both directions, and link a durable anchor.** Name the
   successor from the closed PR *and* the predecessor from the successor - a reader arrives from
   whichever side they know about, and a one-way link strands the other half. If the successor does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,10 +387,10 @@ Nothing lints commit messages, so all of this is on you.
 - **Before merging, recommend a merge strategy - and say why**, and **offer** to write the squash
   message and to re-cut the commits into atomic units rather than doing either silently. Keep the
   recommendation to a line or two: write the squash message where it is used, not into the
-  conversation, unless asked for it. Release notes are generated from the commit log, so the choice
-  decides what a future changelog has to work with.
-  [`docs/merge-checklist.md`](docs/merge-checklist.md) **owns this** - the three strategies, when
-  each applies, and the reset-to-merge-base trap that silently reverts master.
+  conversation, unless asked for it.
+  [`docs/merge-checklist.md`](docs/merge-checklist.md) **owns this** - why the choice matters to the
+  generated release notes, the three strategies and when each applies, and the reset-to-merge-base
+  trap that silently reverts master.
 - **Closing something as superseded: link both directions, and link a durable anchor.** Name the
   successor from the closed PR *and* the predecessor from the successor - a reader arrives from
   whichever side they know about, and a one-way link strands the other half. If the successor does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ is untracked (a whole triage doc was once written duplicating `docs/refactoring.
 | [`docs/self-hosted-runner.md`](docs/self-hosted-runner.md) | Setting up or operating the self-hosted highcpu runner |
 | [`bin/AGENTS.md`](bin/AGENTS.md) | Writing or changing a script in `bin/` - the shell conventions, including the ones no check enforces |
 | [`docs/agent-harness.md`](docs/agent-harness.md) | Adding a rule you need agents to follow *reliably* - which layers fire on their own, and which are merely available |
+| [`docs/merge-checklist.md`](docs/merge-checklist.md) | Getting a PR ready to merge - what to offer the author, including the squash message and reorganising the commits |
 
 **Where work and knowledge are recorded:**
 
@@ -383,24 +384,11 @@ Nothing lints commit messages, so all of this is on you.
   reading if it says where you looked, and ruling one out is a real result (astubbs#220 is the
   worked example). Do this at merge prep, once the class is understood; doing it mid-diagnosis just
   widens the investigation.
-- **Before merging, recommend a merge strategy - and say why.** A long-lived PR accumulates fix-ups
-  nobody wants in the permanent log, but usually also two or three genuinely separate pieces of
-  work. Do not default; look at the actual commits:
-  - **Re-cut the commits** - `git reset --mixed <merge-base>`, restage into a handful of atomic
-    commits, rebase-merge - when the branch holds distinct workstreams someone will later want to
-    bisect to or revert independently. The test for "atomic" is whether the message needs an "and
-    also". **`git fetch origin master` first, every time**, and reset to the **merge-base**, not to
-    `origin/master`: a stale ref or the wrong base silently reverts whatever master gained
-    meanwhile, and the tell is files appearing in the staged set that the branch never touched.
-    Verify with `git diff <old-tip> HEAD` - it must be empty, proving history changed and content
-    did not.
-  - **Squash-merge** when the branch is one idea and the intermediate commits are noise. If you
-    recommend this, **write the suggested squash message out in full** - it becomes the permanent
-    record, and the default concatenation of every subject is unreadable.
-  - **Rebase-merge as-is** only when the existing commits are already clean and atomic.
-
-  Release notes are generated from the commit log, so this choice decides what a future changelog
-  has to work with.
+- **Before merging, recommend a merge strategy - and say why**, and **offer** to write the squash
+  message and to re-cut the commits into atomic units rather than doing either silently. Release
+  notes are generated from the commit log, so the choice decides what a future changelog has to work
+  with. [`docs/merge-checklist.md`](docs/merge-checklist.md) **owns this** - the three strategies,
+  when each applies, and the reset-to-merge-base trap that silently reverts master.
 - **Closing something as superseded: link both directions, and link a durable anchor.** Name the
   successor from the closed PR *and* the predecessor from the successor - a reader arrives from
   whichever side they know about, and a one-way link strands the other half. If the successor does

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+Claude Code reads **`CLAUDE.md`** and never reads `AGENTS.md` (verified against 2.1.223). This file
+exists only to bridge that gap, so the repo's conventions are loaded rather than merely available.
+
+@AGENTS.md
+
+It is deliberately a pure import with no rules of its own. Anything written here instead of in
+`AGENTS.md` would be a second copy that Codex and other agents cannot see, and that drifts from the
+first. `docs/agent-harness.md` explains the layers, what each can enforce, and how to add to them.

--- a/bin/CLAUDE.md
+++ b/bin/CLAUDE.md
@@ -1,0 +1,7 @@
+# bin/CLAUDE.md
+
+Bridge only. Claude Code lazy-loads a nested `CLAUDE.md` when it reads or writes a file in that
+directory, and does not load `AGENTS.md` at all - so this arrives with the shell conventions before
+you write the script, rather than after review catches you.
+
+@AGENTS.md

--- a/bin/lib/quarantine-common.sh
+++ b/bin/lib/quarantine-common.sh
@@ -16,15 +16,18 @@ REGISTRY="${REGISTRY:-docs/quarantined-tests.md}"
 
 # All java files containing real annotation usage (repo-relative paths).
 #
-# .claude is excluded because it holds this repo's WORKTREES (.claude/worktrees/<name>), each a full
-# checkout of some other branch. Without the exclusion the scan is green in a worktree and red on a
-# clean master in the primary checkout, reporting drift from ~60 sibling branches - annotations that
-# are not on this branch at all, against a registry that is. It stayed hidden because the repo's own
-# rule is never to work in the primary checkout, so nobody ran it there; the pre-commit hook added in
-# this PR does. .git is excluded for the same shape of reason, cheaply.
+# WORKTREE ROOTS ARE EXCLUDED, BOTH OF THEM. `.claude/worktrees/<name>` and `/.worktrees/` each hold
+# a full checkout of some OTHER branch - .gitignore names both, calling the second "the other root in
+# use". Without the exclusions the scan is green inside a worktree and red on a clean master in the
+# primary checkout, reporting drift from ~60 sibling branches: annotations that are not on this
+# branch at all, judged against a registry that is. It stayed hidden because the repo's own rule is
+# never to work in the primary checkout, so nobody ran it there; the pre-commit hook added in this PR
+# does. Excluding only one root was the same bug with a smaller blast radius - review caught it, and
+# bin/test-check-quarantine-registry.sh now has a fixture for each. .git is excluded for the same
+# shape of reason, cheaply.
 quarantined_files() {
-    grep -rlE --include='*.java' --exclude-dir=target --exclude-dir=.claude --exclude-dir=.git \
-        "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null || true
+    grep -rlE --include='*.java' --exclude-dir=target --exclude-dir=.claude --exclude-dir=.worktrees \
+        --exclude-dir=.git "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null || true
 }
 
 # Count of annotation usages in one file.
@@ -38,8 +41,8 @@ quarantined_occurrences() {
 # so the worktree-pollution bug fixed there still reproduced in the audit output, listing
 # annotations from ~60 sibling branches. One pattern and one exclusion set, one place.
 quarantined_audit() {
-    grep -rnE --include='*.java' --exclude-dir=target --exclude-dir=.claude --exclude-dir=.git \
-        -A 4 "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null
+    grep -rnE --include='*.java' --exclude-dir=target --exclude-dir=.claude --exclude-dir=.worktrees \
+        --exclude-dir=.git -A 4 "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null
 }
 
 # Registry entries, one per line: `Class.method` (or `Class` for class-level quarantines).

--- a/bin/lib/quarantine-common.sh
+++ b/bin/lib/quarantine-common.sh
@@ -15,8 +15,16 @@ QUARANTINE_ANNOTATION_ERE='^[[:space:]]*(@[[:alnum:]_.]+(\([^)]*\))?[[:space:]]*
 REGISTRY="${REGISTRY:-docs/quarantined-tests.md}"
 
 # All java files containing real annotation usage (repo-relative paths).
+#
+# .claude is excluded because it holds this repo's WORKTREES (.claude/worktrees/<name>), each a full
+# checkout of some other branch. Without the exclusion the scan is green in a worktree and red on a
+# clean master in the primary checkout, reporting drift from ~60 sibling branches - annotations that
+# are not on this branch at all, against a registry that is. It stayed hidden because the repo's own
+# rule is never to work in the primary checkout, so nobody ran it there; the pre-commit hook added in
+# this PR does. .git is excluded for the same shape of reason, cheaply.
 quarantined_files() {
-    grep -rlE --include='*.java' --exclude-dir=target "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null || true
+    grep -rlE --include='*.java' --exclude-dir=target --exclude-dir=.claude --exclude-dir=.git \
+        "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null || true
 }
 
 # Count of annotation usages in one file.

--- a/bin/lib/quarantine-common.sh
+++ b/bin/lib/quarantine-common.sh
@@ -32,6 +32,16 @@ quarantined_occurrences() {
     grep -cE "$QUARANTINE_ANNOTATION_ERE" "$1" 2>/dev/null || echo 0
 }
 
+# The human-readable audit listing: every annotation usage with the following lines that carry its
+# `fixedBy`/reason. Lives here rather than in the caller because it needs the SAME exclusions as
+# quarantined_files() above - bin/quarantined-test.sh had its own copy of this grep without them,
+# so the worktree-pollution bug fixed there still reproduced in the audit output, listing
+# annotations from ~60 sibling branches. One pattern and one exclusion set, one place.
+quarantined_audit() {
+    grep -rnE --include='*.java' --exclude-dir=target --exclude-dir=.claude --exclude-dir=.git \
+        -A 4 "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null
+}
+
 # Registry entries, one per line: `Class.method` (or `Class` for class-level quarantines).
 registry_entries() {
     grep -E '^- \[ \] `' "$REGISTRY" 2>/dev/null | sed -E 's/^- \[ \] `([^`]+)`.*/\1/' || true

--- a/bin/quarantined-test.sh
+++ b/bin/quarantined-test.sh
@@ -33,7 +33,7 @@ if [ "${QUARANTINE_SKIP_CHECKS:-0}" != "1" ]; then
   fi
 fi
 echo "=== Quarantine audit (entries are diagnosed, or recorded rule-1 exceptions; empty fixedBy = unowned) ==="
-grep -rnE --include='*.java' --exclude-dir=target -A 4 "$QUARANTINE_ANNOTATION_ERE" . || echo "(no @Quarantined tests - this lane is empty)"
+quarantined_audit || echo "(no @Quarantined tests - this lane is empty)"
 echo "==================================================================================================="
 
 ./mvnw --batch-mode \

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -59,10 +59,17 @@ echo
 echo "--- check-squash-subject.sh ---"
 
 
+fails=${fails:-0}
+
 verdict() { # <bash-command> -> ALLOW | DENY
-    local payload out
-    payload=$(python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]}}))' "$1")
-    out=$(printf '%s' "$payload" | "$HOOKS/check-squash-subject.sh" 2>/dev/null)
+    # The command goes to the JSON builder on STDIN, never argv: one case here is a 150 KB command,
+    # and passing that as an argument hits the same E2BIG the case exists to detect - the harness
+    # would die and the failure would read as the hook's.
+    local out tmp
+    tmp=$(mktemp)
+    printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.stdin.read()}}))' > "$tmp"
+    out=$("$HOOKS/check-squash-subject.sh" < "$tmp" 2>/dev/null)
+    rm -f "$tmp"
     case "$out" in
         *'"deny"'*) echo DENY ;;
         *)          echo ALLOW ;;
@@ -74,13 +81,27 @@ expect() { # <expected> <name> <command>
     if [ "$got" = "$1" ]; then echo "ok:   $2"; else echo "FAIL: $2 (expected $1, got $got)"; fails=$((fails + 1)); fi
 }
 
-expect DENY  "a bare --subject"                    'gh pr merge 2999 --squash --subject "foo"'
-expect DENY  "--subject even WITH a (#N)"          'gh pr merge 2999 --squash --subject "foo (#2999)"'
+expect DENY  "--subject with no (#N)"              'gh pr merge 2999 --squash --subject "foo"'
+expect DENY  "-t, the documented SHORT form"       'gh pr merge 2999 --squash -t "foo"'
 expect DENY  "--subject= equals form"              'gh pr merge 2999 --squash --subject=foo'
+expect DENY  "-t= equals form"                     'gh pr merge 2999 --squash -t=foo'
+expect DENY  "(#N) present but not at the END"     'gh pr merge 2999 --squash --subject "port (#2999) to master"'
+expect ALLOW "--subject ending with (#N)"          'gh pr merge 2999 --squash --subject "foo (#2999)"'
+expect ALLOW "-t ending with (#N)"                 'gh pr merge 2999 --squash -t "foo (#2999)"'
+expect ALLOW "--subject mentioned inside --body"   'gh pr merge 2999 --squash --body "why --subject matters"'
+expect ALLOW "escaped apostrophe, number present"  'gh pr merge 2999 --squash --subject '"'"'don'"'"'\'"'"''"'"'t drop it (#2999)'"'"''
 expect ALLOW "--body-file does not touch subject"  'gh pr merge 2999 --squash --body-file b.txt'
 expect ALLOW "no subject override at all"          'gh pr merge 2999 --squash'
 expect ALLOW "not a merge command"                 'gh pr view 2999 --json title'
 expect ALLOW "the word --subject in other text"    'echo "we discussed --subject and why"'
+
+# A 150 KB command used to hit E2BIG and exit having printed nothing, which reads as ALLOW.
+big=$(python3 -c "print('gh pr merge 2999 --squash --subject bad # ' + 'x'*150000)")
+if [ "$(verdict "$big")" = DENY ]; then
+    echo "ok:   a 150 KB command does not fail open"
+else
+    echo "FAIL: a 150 KB command fails open"; fails=$((fails + 1))
+fi
 
 # Negative control: prove it can deny. A guard that has never fired proves nothing (bin/AGENTS.md).
 if [ "$(verdict 'gh pr merge 2999 --squash --subject "x"')" = DENY ] \
@@ -153,6 +174,13 @@ assert "--no-verify in a LATER command is not this commit's bypass" 2 \
     "$(gate_rc "$red" 'git commit -m x && echo --no-verify')"
 assert "--no-verify in an EARLIER command is not this commit's bypass" 2 \
     "$(gate_rc "$red" 'echo --no-verify && git commit -m x')"
+# TWO REAL COMMITS, one asking for a bypass and one not. The bypass used to be judged over the
+# whole payload, so the second commit's flag exempted the first - which in a clone with no
+# core.hooksPath meant that first commit landed with no gate run at all.
+assert "a later commit's --no-verify does not exempt an earlier one" 2 \
+    "$(gate_rc "$red" 'git commit -m first; git commit --no-verify -m second')"
+assert "both commits asking for a bypass is honoured" 0 \
+    "$(gate_rc "$red" 'git commit --no-verify -m a; git commit --no-verify -m b')"
 assert "git -C <path> commit --no-verify is still a bypass" 0 \
     "$(gate_rc "$red" 'git -C /some/path commit --no-verify -m x')"
 

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -238,6 +238,23 @@ assert "a literal \$5 is judged, not treated as an expansion" DENY \
 assert "a real \$VAR expansion still fails OPEN" ALLOW \
     "$(verdict 'gh pr merge 1299 --squash --subject "$SUBJECT"')"
 
+# Round seven. Both are consequences of running on every Bash call: the parser now sees commands
+# it never used to, so what it treats as a command boundary and as an executable both matter more.
+#
+# FALSE POSITIVE. posix lexing strips quoting, so the `(` in an ordinary string argument looked
+# exactly like a subshell, reset command position, and hard-denied a harmless command.
+assert "a QUOTED paren is an argument, not a subshell" ALLOW \
+    "$(verdict 'echo "(" gh pr merge 1299 --subject bad')"
+assert "...while a real subshell still is one" DENY \
+    "$(verdict '( gh pr merge 1299 --subject "bad no number" )')"
+# `command gh ...` runs gh - Bash's own `help command` says so - and cleared command position.
+assert "a merge run through the 'command' builtin is still a merge" DENY \
+    "$(verdict 'command gh pr merge 1299 --subject "bad no number"')"
+assert "...and passes with the right number" ALLOW \
+    "$(verdict 'command gh pr merge 1299 --subject "tooling: thing (#1299)"')"
+assert "other execution wrappers count too" DENY \
+    "$(verdict 'sudo gh pr merge 1299 --subject "bad no number"')"
+
 assert "a non-Bash tool is ignored" ALLOW \
     "$(printf '%s' '{"tool_name":"Read","tool_input":{"command":"gh pr merge 1299 --subject \"x\""}}' \
         | "$HOOKS/check-squash-subject.sh" 2>/dev/null | grep -c '"deny"' | sed 's/^0$/ALLOW/;s/^[1-9].*/DENY/')"

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -206,6 +206,38 @@ assert "a branch named like a URL is not read as one" ALLOW \
 assert "a real URL selector still cross-checks" DENY \
     "$(verdict 'gh pr merge https://github.com/astubbs/parallel-consumer/pull/1299 --squash --subject "w (#1206)"')"
 
+# Round six. Registering the guard for EVERY Bash call (round five) widened what it must get right,
+# and review found seven more. Each was reproduced first; all seven go red against the prior parser.
+assert "a newline ends the merge slice, like any other boundary" DENY \
+    "$(verdict 'gh pr merge 1299 --subject "bad"
+echo --subject "decoy (#1299)"')"
+assert "a decoy after # is a comment, not a subject" DENY \
+    "$(verdict 'gh pr merge 1299 --subject "bad" # decoy --subject "x (#1299)"')"
+# FALSE POSITIVE, and one the hook created for itself by dropping its `if`: printing a command is
+# not running it, and hard-denying a diagnostic echo is exactly what an agent cannot argue with.
+assert "echo'ing the command is text, not a merge" ALLOW \
+    "$(verdict 'echo gh pr merge 1299 --subject bad')"
+assert "gh in command position after && is still a merge" DENY \
+    "$(verdict 'echo ready && gh pr merge 1299 --subject "bad no number"')"
+# `gh -R owner/repo pr merge ...` is valid and the local CLI accepts it; requiring `gh pr merge`
+# to be adjacent silently missed it.
+assert "a global flag before the subcommand is still a merge" DENY \
+    "$(verdict 'gh -R astubbs/parallel-consumer pr merge 1299 --subject "bad"')"
+assert "...and the same shape with a correct subject passes" ALLOW \
+    "$(verdict 'gh -R astubbs/parallel-consumer pr merge 1299 --subject "ok (#1299)"')"
+# AGENTS.md reserves the trailing parenthesised slot for the PR number ALONE - two bare numbers
+# recreate the issue-vs-PR ambiguity the convention exists to remove, whichever order they are in.
+assert "an extra (#N) alongside the right one is rejected" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "fix (#1206) (#1299)"')"
+assert "...in either order" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "fix (#1299) (#1206)"')"
+# shlex strips quoting, so a literal dollar looked exactly like an unresolved expansion and the
+# subject failed open with no number at all. Only real expansion syntax fails open now.
+assert "a literal \$5 is judged, not treated as an expansion" DENY \
+    "$(verdict "gh pr merge 1299 --squash --subject 'reduce cost to \$5'")"
+assert "a real \$VAR expansion still fails OPEN" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --subject "$SUBJECT"')"
+
 assert "a non-Bash tool is ignored" ALLOW \
     "$(printf '%s' '{"tool_name":"Read","tool_input":{"command":"gh pr merge 1299 --subject \"x\""}}' \
         | "$HOOKS/check-squash-subject.sh" 2>/dev/null | grep -c '"deny"' | sed 's/^0$/ALLOW/;s/^[1-9].*/DENY/')"
@@ -265,6 +297,27 @@ case "$stderr_text" in
     *)                   got="swallowed: $stderr_text" ;;
 esac
 assert "the failing gate's own output reaches stderr" forwarded "$got"
+
+
+# Round six. The bypass search scanned the WHOLE payload, so a later, unrelated command could
+# request a bypass the commit never asked for - and the violation lands.
+assert "--no-verify in a LATER command is not this commit's bypass" 2 \
+    "$(gate_rc "$red" 'git commit -m x && echo --no-verify')"
+assert "--no-verify in an EARLIER command is not this commit's bypass" 2 \
+    "$(gate_rc "$red" 'echo --no-verify && git commit -m x')"
+assert "git -C <path> commit --no-verify is still a bypass" 0 \
+    "$(gate_rc "$red" 'git -C /some/path commit --no-verify -m x')"
+
+# No python, no way to read the payload - so no way to see --no-verify. Running the gate anyway
+# blocked the documented escape hatch on the one machine with no other way out. Python is not among
+# the repo's build requirements (JDK 17, Docker, the Maven wrapper), so this is a real setup.
+nopython="$TMP/nopython"; mkdir -p "$nopython"
+for b in bash cat mktemp rm sh dirname env; do
+    resolved=$(command -v "$b" 2>/dev/null) && ln -sf "$resolved" "$nopython/$b"
+done
+nopython_rc=$(printf '%s' "$(python3 -c 'import json; print(json.dumps({"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}))')" \
+    | PATH="$nopython" CLAUDE_PROJECT_DIR="$red" "$HOOKS/pre-commit-gate.sh" >/dev/null 2>&1; echo $?)
+assert "a missing python3 fails OPEN rather than blocking the bypass" 0 "$nopython_rc"
 
 # Fail open: no gate script in the project at all must not block every commit.
 empty="$TMP/empty$RANDOM"; mkdir -p "$empty"

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -49,14 +49,15 @@ assert() { # <description> <expected> <actual>
 # ---------------------------------------------------------------------------------------------
 # check-squash-subject.sh
 #
-# The subject the hook must judge is the one `gh` will actually use: the LAST `--subject`, inside
-# the `gh pr merge` command, cross-checked against the PR being merged. Cases 1-6 are the six
-# defects found in review; the rest is behaviour that already worked and must not regress.
-#
-# The fixture numbers are four digits on purpose. bin/check-issue-refs.sh flags an unqualified
-# `#NNN` below 1000 on any added line, and it is right to - these literals are indistinguishable
-# from a real citation. The cases do not depend on the values, so they sit above the threshold.
+# The rule is now "no --subject on gh pr merge at all", so there is nothing to parse and nothing
+# to get subtly wrong. The previous version policed CORRECT use of the flag - last-occurrence
+# semantics, PR-number cross-check, shell quoting - in 343 lines that review found wrong in both
+# directions. These cases exist to stop that creeping back.
 # ---------------------------------------------------------------------------------------------
+
+echo
+echo "--- check-squash-subject.sh ---"
+
 
 verdict() { # <bash-command> -> ALLOW | DENY
     local payload out
@@ -68,196 +69,26 @@ verdict() { # <bash-command> -> ALLOW | DENY
     esac
 }
 
-echo "--- check-squash-subject.sh ---"
+expect() { # <expected> <name> <command>
+    local got; got=$(verdict "$3")
+    if [ "$got" = "$1" ]; then echo "ok:   $2"; else echo "FAIL: $2 (expected $1, got $got)"; fails=$((fails + 1)); fi
+}
 
-# 1. `gh` honours the LAST --subject. Reading the first one allowed the bad subject to land while
-#    reporting the good one as proof it was fine.
-assert "two --subject flags, the LAST one is bad" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "ok (#1299)" --subject "bad no number"')"
+expect DENY  "a bare --subject"                    'gh pr merge 2999 --squash --subject "foo"'
+expect DENY  "--subject even WITH a (#N)"          'gh pr merge 2999 --squash --subject "foo (#2999)"'
+expect DENY  "--subject= equals form"              'gh pr merge 2999 --squash --subject=foo'
+expect ALLOW "--body-file does not touch subject"  'gh pr merge 2999 --squash --body-file b.txt'
+expect ALLOW "no subject override at all"          'gh pr merge 2999 --squash'
+expect ALLOW "not a merge command"                 'gh pr view 2999 --json title'
+expect ALLOW "the word --subject in other text"    'echo "we discussed --subject and why"'
 
-# 2. A `--subject` elsewhere on the command line is not part of the merge. A regex over the whole
-#    line matched the decoy and never looked at the real one.
-assert "a decoy --subject before the merge command" DENY \
-    "$(verdict 'echo --subject "x (#1001)" ; gh pr merge 1299 --squash --subject "bad no number"')"
-
-# 3. Any `(#N)` used to satisfy the check, so the astubbs#206 shape - a number pointing at a
-#    DIFFERENT PR - passed while the right number was sitting in the same command.
-assert "a (#N) naming the wrong PR" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "tooling: thing (#1206)"')"
-
-# 4. Same defect, the commoner spelling of it: an issue reference read as a PR number.
-assert "a (#N) that is an issue reference, not the PR" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "fixes the thing (#1012)"')"
-
-# 5. FALSE POSITIVE. An escaped apostrophe ends the shell string, so a regex capture stopped before
-#    the suffix and denied a correct merge. A PreToolUse deny is hard - the agent cannot argue.
-assert "escaped apostrophe inside the subject" ALLOW \
-    "$(verdict "gh pr merge 1299 --squash --subject 'don'\''t drop it (#1299)'")"
-
-# 6. FALSE POSITIVE. The words "--subject" inside --body text are body content, not a flag.
-assert "the word --subject appearing inside --body" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --body "we discussed --subject and why" --subject "tidy: thing (#1299)"')"
-
-assert "plain correct subject" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --subject "tooling: thing (#1299)"')"
-assert "plain subject with no (#N) at all" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "tooling: thing"')"
-assert "no --subject: GitHub appends the number itself" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --body-file /tmp/body.md')"
-assert "not a merge command at all" ALLOW \
-    "$(verdict 'git commit -m "hello"')"
-
-# Boundaries, pinned so a later tightening is a deliberate act rather than a surprise.
-assert "--subject=VALUE form is read too" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject="tooling: thing"')"
-assert "no PR argument, so no cross-check is possible" ALLOW \
-    "$(verdict 'gh pr merge --squash --subject "tooling: thing (#1206)"')"
-# The convention puts (#N) in the TRAILING slot, and this hook deliberately does not require it -
-# raised in review, kept on purpose. What is unfixable after a merge is a number that is MISSING or
-# points at the WRONG PR, and both of those are denied above. A number that is present and correct
-# but sits mid-subject is a visible, cosmetic deviation that review catches and that still links
-# correctly; a hard PreToolUse deny for it would block "port (#N) to master" and every other
-# unusual-but-fine subject, with no way for the agent to argue. Pinned so tightening it later is a
-# deliberate act - see the BOUNDARY note in .claude/hooks/check-squash-subject.sh.
-assert "a correct (#N) outside the trailing slot is allowed (stated boundary)" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --subject "fix(core) (#1299): detail"')"
-assert "...but the same shape with the WRONG number is still denied" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "fix(core) (#1206): detail"')"
-assert "two merges chained, the second is bad" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "a (#1299)" && gh pr merge 1300 --squash --subject "b"')"
-assert "unbalanced quotes fail OPEN, never on our own parse bug" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --subject "unterminated')"
-# Round three. All three of these were live holes, reproduced before being fixed - `-t` and the
-# URL selector let the mistake through, the unexpanded subject blocked a legitimate merge.
-#
-# 7. `-t` is gh's documented short form of --subject. Reading only the long spelling meant the
-#    parser saw NO override, took the "GitHub appends the number itself" branch, and allowed a
-#    subject that lands verbatim with no number - the astubbs#206 shape via another spelling.
-assert "-t is --subject: no number is still denied" DENY \
-    "$(verdict 'gh pr merge 1299 --squash -t "tooling: thing with no number"')"
-assert "-tVALUE attached form" DENY \
-    "$(verdict 'gh pr merge 1299 --squash -t"tooling: thing with no number"')"
-assert "-t=VALUE form" DENY \
-    "$(verdict 'gh pr merge 1299 --squash -t="tooling: thing with no number"')"
-assert "-t inside a combined shorthand group" DENY \
-    "$(verdict 'gh pr merge 1299 --squash -st "tooling: thing with no number"')"
-assert "-t carrying the right number is allowed" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash -t "tooling: thing (#1299)"')"
-assert "-t naming the WRONG PR" DENY \
-    "$(verdict 'gh pr merge 1299 --squash -t "tooling: thing (#1206)"')"
-# `t` here is part of -b's VALUE, not a flag. Reading it as a subject would deny a merge whose
-# real subject is fine - so the shorthand scan stops at the first value-taking letter.
-assert "a 't' inside another short flag's value is not a subject" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash -bt --subject "tooling: thing (#1299)"')"
-
-# 8. FALSE POSITIVE. shlex does not expand shell variables, so the hook was judging a string that
-#    is not the one gh will send - and denying it. Every other unresolvable case fails open; this
-#    one hard-blocked a legitimate merge, which the header calls the more expensive direction.
-assert "an unexpanded \$VAR subject fails OPEN" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --subject "$SUBJECT"')"
-assert "an unexpanded command substitution fails OPEN" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --subject "$(cat msg.txt)"')"
-
-# 9. The PR selector may be a number, a URL or a branch. Only `isdigit()` was read, so a URL left
-#    the cross-check switched off entirely and ANY number satisfied it - including a wrong one.
-assert "a URL selector still cross-checks the number" DENY \
-    "$(verdict 'gh pr merge https://github.com/astubbs/parallel-consumer/pull/1299 --squash --subject "thing (#1206)"')"
-assert "a URL selector with the right number is allowed" ALLOW \
-    "$(verdict 'gh pr merge https://github.com/astubbs/parallel-consumer/pull/1299 --squash --subject "thing (#1299)"')"
-# A branch name carries no number and resolving it needs the network, so any (#N) is accepted -
-# the same stated boundary as a merge with no selector at all. Pinned, not incidental.
-assert "a branch-name selector cannot be cross-checked (stated boundary)" ALLOW \
-    "$(verdict 'gh pr merge some-branch --squash --subject "thing (#1206)"')"
-assert "a branch-name selector with NO number is still denied" DENY \
-    "$(verdict 'gh pr merge some-branch --squash --subject "thing with no number"')"
-# A flag VALUE that looks like a PR number must not be read as the selector. Discriminating on
-# purpose: read 1206 as the PR and the correct (#1299) becomes a mismatch, so the old parser
-# hard-denied a perfectly good merge.
-assert "a flag value is not mistaken for the PR selector" ALLOW \
-    "$(verdict 'gh pr merge --body 1206 --squash 1299 --subject "thing (#1299)"')"
-
-# Round four. Segmenting the command with a regex over the RAW line found `gh pr merge` inside
-# quoted body text, cut the line into two slices that each had unbalanced quotes, and fail-opened
-# both - so the real --subject was never judged. Body text could switch the hook off. Segmentation
-# now runs over shlex TOKENS, where a quoted body is a single token and cannot look like a command.
-assert "the phrase 'gh pr merge' inside --body does not disable the guard" DENY \
-    "$(verdict 'gh pr merge 1299 --body "text gh pr merge here" --subject "bad no number"')"
-assert "...and the same body with a correct subject still passes" ALLOW \
-    "$(verdict 'gh pr merge 1299 --body "text gh pr merge here" --subject "tooling: thing (#1299)"')"
-assert "the phrase inside the SUBJECT does not disable the guard either" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "how to gh pr merge safely"')"
-# An absolute path to gh is still gh; a word merely ending in those letters is not a command.
-assert "an absolute path to gh is still matched" DENY \
-    "$(verdict '/usr/local/bin/gh pr merge 1299 --squash --subject "tooling: thing"')"
-
-# Round five. A slice ran to the next `gh pr merge`, so it swallowed everything after `&&`/`;`/`|`
-# and an unrelated command's --subject became "the last one" - in BOTH directions.
-assert "a decoy --subject after && cannot vouch for a bad merge" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "bad" && echo --subject "decoy (#1299)"')"
-assert "a later --subject after && cannot condemn a good merge" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --subject "good (#1299)" && echo --subject "no number"')"
-assert "a pipe also ends the merge slice" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --subject "good (#1299)" | tee --subject "x"')"
-
-# `fix/pull/1299` is a legal branch name (`git check-ref-format --branch` accepts it). Reading it
-# as a PR URL cross-checked the merge against 1299 and DENIED a correct subject - a false positive.
-assert "a branch named like a URL is not read as one" ALLOW \
-    "$(verdict 'gh pr merge fix/pull/1299 --squash --subject "tooling: thing (#1300)"')"
-assert "a real URL selector still cross-checks" DENY \
-    "$(verdict 'gh pr merge https://github.com/astubbs/parallel-consumer/pull/1299 --squash --subject "w (#1206)"')"
-
-# Round six. Registering the guard for EVERY Bash call (round five) widened what it must get right,
-# and review found seven more. Each was reproduced first; all seven go red against the prior parser.
-assert "a newline ends the merge slice, like any other boundary" DENY \
-    "$(verdict 'gh pr merge 1299 --subject "bad"
-echo --subject "decoy (#1299)"')"
-assert "a decoy after # is a comment, not a subject" DENY \
-    "$(verdict 'gh pr merge 1299 --subject "bad" # decoy --subject "x (#1299)"')"
-# FALSE POSITIVE, and one the hook created for itself by dropping its `if`: printing a command is
-# not running it, and hard-denying a diagnostic echo is exactly what an agent cannot argue with.
-assert "echo'ing the command is text, not a merge" ALLOW \
-    "$(verdict 'echo gh pr merge 1299 --subject bad')"
-assert "gh in command position after && is still a merge" DENY \
-    "$(verdict 'echo ready && gh pr merge 1299 --subject "bad no number"')"
-# `gh -R owner/repo pr merge ...` is valid and the local CLI accepts it; requiring `gh pr merge`
-# to be adjacent silently missed it.
-assert "a global flag before the subcommand is still a merge" DENY \
-    "$(verdict 'gh -R astubbs/parallel-consumer pr merge 1299 --subject "bad"')"
-assert "...and the same shape with a correct subject passes" ALLOW \
-    "$(verdict 'gh -R astubbs/parallel-consumer pr merge 1299 --subject "ok (#1299)"')"
-# AGENTS.md reserves the trailing parenthesised slot for the PR number ALONE - two bare numbers
-# recreate the issue-vs-PR ambiguity the convention exists to remove, whichever order they are in.
-assert "an extra (#N) alongside the right one is rejected" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "fix (#1206) (#1299)"')"
-assert "...in either order" DENY \
-    "$(verdict 'gh pr merge 1299 --squash --subject "fix (#1299) (#1206)"')"
-# shlex strips quoting, so a literal dollar looked exactly like an unresolved expansion and the
-# subject failed open with no number at all. Only real expansion syntax fails open now.
-assert "a literal \$5 is judged, not treated as an expansion" DENY \
-    "$(verdict "gh pr merge 1299 --squash --subject 'reduce cost to \$5'")"
-assert "a real \$VAR expansion still fails OPEN" ALLOW \
-    "$(verdict 'gh pr merge 1299 --squash --subject "$SUBJECT"')"
-
-# Round seven. Both are consequences of running on every Bash call: the parser now sees commands
-# it never used to, so what it treats as a command boundary and as an executable both matter more.
-#
-# FALSE POSITIVE. posix lexing strips quoting, so the `(` in an ordinary string argument looked
-# exactly like a subshell, reset command position, and hard-denied a harmless command.
-assert "a QUOTED paren is an argument, not a subshell" ALLOW \
-    "$(verdict 'echo "(" gh pr merge 1299 --subject bad')"
-assert "...while a real subshell still is one" DENY \
-    "$(verdict '( gh pr merge 1299 --subject "bad no number" )')"
-# `command gh ...` runs gh - Bash's own `help command` says so - and cleared command position.
-assert "a merge run through the 'command' builtin is still a merge" DENY \
-    "$(verdict 'command gh pr merge 1299 --subject "bad no number"')"
-assert "...and passes with the right number" ALLOW \
-    "$(verdict 'command gh pr merge 1299 --subject "tooling: thing (#1299)"')"
-assert "other execution wrappers count too" DENY \
-    "$(verdict 'sudo gh pr merge 1299 --subject "bad no number"')"
-
-assert "a non-Bash tool is ignored" ALLOW \
-    "$(printf '%s' '{"tool_name":"Read","tool_input":{"command":"gh pr merge 1299 --subject \"x\""}}' \
-        | "$HOOKS/check-squash-subject.sh" 2>/dev/null | grep -c '"deny"' | sed 's/^0$/ALLOW/;s/^[1-9].*/DENY/')"
+# Negative control: prove it can deny. A guard that has never fired proves nothing (bin/AGENTS.md).
+if [ "$(verdict 'gh pr merge 2999 --squash --subject "x"')" = DENY ] \
+   && [ "$(verdict 'gh pr merge 2999 --squash')" = ALLOW ]; then
+    echo "ok:   the guard distinguishes overridden from not"
+else
+    echo "FAIL: the guard does not distinguish overridden from not"; fails=$((fails + 1))
+fi
 
 # ---------------------------------------------------------------------------------------------
 # pre-commit-gate.sh

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -23,7 +23,15 @@
 
 set -uo pipefail
 
-HOOKS="$(cd "$(dirname "$0")/.." && pwd)/.claude/hooks"
+# Resolved from $0, never from the caller's cwd. inject-merge-checklist.sh finds its checklist via
+# CLAUDE_PROJECT_DIR or `git rev-parse --show-toplevel`, so running this script from a DIFFERENT
+# checkout of this repo - the primary one, a sibling worktree on another branch - silently pointed
+# the hook at that tree's docs/ instead of this branch's. On a branch without the checklist the
+# hook exits 0 and the assertions below read the absence as "not injected". That is the failure
+# this file exists to catch, in this file: pinning the root makes the test measure the branch it
+# ships with, wherever it is run from.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOKS="$REPO_ROOT/.claude/hooks"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -119,6 +127,55 @@ assert "two merges chained, the second is bad" DENY \
     "$(verdict 'gh pr merge 1299 --squash --subject "a (#1299)" && gh pr merge 1300 --squash --subject "b"')"
 assert "unbalanced quotes fail OPEN, never on our own parse bug" ALLOW \
     "$(verdict 'gh pr merge 1299 --squash --subject "unterminated')"
+# Round three. All three of these were live holes, reproduced before being fixed - `-t` and the
+# URL selector let the mistake through, the unexpanded subject blocked a legitimate merge.
+#
+# 7. `-t` is gh's documented short form of --subject. Reading only the long spelling meant the
+#    parser saw NO override, took the "GitHub appends the number itself" branch, and allowed a
+#    subject that lands verbatim with no number - the astubbs#206 shape via another spelling.
+assert "-t is --subject: no number is still denied" DENY \
+    "$(verdict 'gh pr merge 1299 --squash -t "tooling: thing with no number"')"
+assert "-tVALUE attached form" DENY \
+    "$(verdict 'gh pr merge 1299 --squash -t"tooling: thing with no number"')"
+assert "-t=VALUE form" DENY \
+    "$(verdict 'gh pr merge 1299 --squash -t="tooling: thing with no number"')"
+assert "-t inside a combined shorthand group" DENY \
+    "$(verdict 'gh pr merge 1299 --squash -st "tooling: thing with no number"')"
+assert "-t carrying the right number is allowed" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash -t "tooling: thing (#1299)"')"
+assert "-t naming the WRONG PR" DENY \
+    "$(verdict 'gh pr merge 1299 --squash -t "tooling: thing (#1206)"')"
+# `t` here is part of -b's VALUE, not a flag. Reading it as a subject would deny a merge whose
+# real subject is fine - so the shorthand scan stops at the first value-taking letter.
+assert "a 't' inside another short flag's value is not a subject" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash -bt --subject "tooling: thing (#1299)"')"
+
+# 8. FALSE POSITIVE. shlex does not expand shell variables, so the hook was judging a string that
+#    is not the one gh will send - and denying it. Every other unresolvable case fails open; this
+#    one hard-blocked a legitimate merge, which the header calls the more expensive direction.
+assert "an unexpanded \$VAR subject fails OPEN" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --subject "$SUBJECT"')"
+assert "an unexpanded command substitution fails OPEN" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --subject "$(cat msg.txt)"')"
+
+# 9. The PR selector may be a number, a URL or a branch. Only `isdigit()` was read, so a URL left
+#    the cross-check switched off entirely and ANY number satisfied it - including a wrong one.
+assert "a URL selector still cross-checks the number" DENY \
+    "$(verdict 'gh pr merge https://github.com/astubbs/parallel-consumer/pull/1299 --squash --subject "thing (#1206)"')"
+assert "a URL selector with the right number is allowed" ALLOW \
+    "$(verdict 'gh pr merge https://github.com/astubbs/parallel-consumer/pull/1299 --squash --subject "thing (#1299)"')"
+# A branch name carries no number and resolving it needs the network, so any (#N) is accepted -
+# the same stated boundary as a merge with no selector at all. Pinned, not incidental.
+assert "a branch-name selector cannot be cross-checked (stated boundary)" ALLOW \
+    "$(verdict 'gh pr merge some-branch --squash --subject "thing (#1206)"')"
+assert "a branch-name selector with NO number is still denied" DENY \
+    "$(verdict 'gh pr merge some-branch --squash --subject "thing with no number"')"
+# A flag VALUE that looks like a PR number must not be read as the selector. Discriminating on
+# purpose: read 1206 as the PR and the correct (#1299) becomes a mismatch, so the old parser
+# hard-denied a perfectly good merge.
+assert "a flag value is not mistaken for the PR selector" ALLOW \
+    "$(verdict 'gh pr merge --body 1206 --squash 1299 --subject "thing (#1299)"')"
+
 assert "a non-Bash tool is ignored" ALLOW \
     "$(printf '%s' '{"tool_name":"Read","tool_input":{"command":"gh pr merge 1299 --subject \"x\""}}' \
         | "$HOOKS/check-squash-subject.sh" 2>/dev/null | grep -c '"deny"' | sed 's/^0$/ALLOW/;s/^[1-9].*/DENY/')"
@@ -194,7 +251,7 @@ echo "--- inject-merge-checklist.sh ---"
 injected() { # <prompt> -> YES | NO
     local out
     out=$(python3 -c 'import json,sys; print(json.dumps({"prompt":sys.argv[1]}))' "$1" \
-        | "$HOOKS/inject-merge-checklist.sh" 2>/dev/null)
+        | CLAUDE_PROJECT_DIR="$REPO_ROOT" "$HOOKS/inject-merge-checklist.sh" 2>/dev/null)
     [ -n "$out" ] && echo YES || echo NO
 }
 
@@ -211,9 +268,9 @@ assert "unrelated prompt: emerge is not merge"         NO  "$(injected 'the patt
 # asks - a second copy, in the one place nobody would think to look for drift. This asserts the
 # injected text is the file's own bytes plus a pointer, and nothing else.
 body=$(python3 -c 'import json,sys; print(json.dumps({"prompt":"ready to merge?"}))' \
-    | "$HOOKS/inject-merge-checklist.sh" 2>/dev/null \
+    | CLAUDE_PROJECT_DIR="$REPO_ROOT" "$HOOKS/inject-merge-checklist.sh" 2>/dev/null \
     | python3 -c 'import json,sys; print(json.load(sys.stdin)["hookSpecificOutput"]["additionalContext"])')
-checklist_head=$(head -1 "$(dirname "$HOOKS")/../docs/merge-checklist.md" 2>/dev/null)
+checklist_head=$(head -1 "$REPO_ROOT/docs/merge-checklist.md" 2>/dev/null)
 case "$body" in
     *"$checklist_head"*) got=verbatim ;;
     *)                   got=missing ;;

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -190,6 +190,22 @@ assert "the phrase inside the SUBJECT does not disable the guard either" DENY \
 assert "an absolute path to gh is still matched" DENY \
     "$(verdict '/usr/local/bin/gh pr merge 1299 --squash --subject "tooling: thing"')"
 
+# Round five. A slice ran to the next `gh pr merge`, so it swallowed everything after `&&`/`;`/`|`
+# and an unrelated command's --subject became "the last one" - in BOTH directions.
+assert "a decoy --subject after && cannot vouch for a bad merge" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "bad" && echo --subject "decoy (#1299)"')"
+assert "a later --subject after && cannot condemn a good merge" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --subject "good (#1299)" && echo --subject "no number"')"
+assert "a pipe also ends the merge slice" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --subject "good (#1299)" | tee --subject "x"')"
+
+# `fix/pull/1299` is a legal branch name (`git check-ref-format --branch` accepts it). Reading it
+# as a PR URL cross-checked the merge against 1299 and DENIED a correct subject - a false positive.
+assert "a branch named like a URL is not read as one" ALLOW \
+    "$(verdict 'gh pr merge fix/pull/1299 --squash --subject "tooling: thing (#1300)"')"
+assert "a real URL selector still cross-checks" DENY \
+    "$(verdict 'gh pr merge https://github.com/astubbs/parallel-consumer/pull/1299 --squash --subject "w (#1206)"')"
+
 assert "a non-Bash tool is ignored" ALLOW \
     "$(printf '%s' '{"tool_name":"Read","tool_input":{"command":"gh pr merge 1299 --subject \"x\""}}' \
         | "$HOOKS/check-squash-subject.sh" 2>/dev/null | grep -c '"deny"' | sed 's/^0$/ALLOW/;s/^[1-9].*/DENY/')"
@@ -262,9 +278,13 @@ assert "absent gate script fails OPEN" 0 \
 echo
 echo "--- inject-merge-checklist.sh ---"
 
+# The prompt reaches the JSON builder on STDIN, never as argv - the harness has the same ~128 KiB
+# MAX_ARG_STRLEN ceiling as the hook it is testing, and a test that dies building its own fixture
+# would report the hook broken (or fixed) for reasons that have nothing to do with the hook.
 injected() { # <prompt> -> YES | NO
     local out
-    out=$(python3 -c 'import json,sys; print(json.dumps({"prompt":sys.argv[1]}))' "$1" \
+    out=$(printf '%s' "$1" \
+        | python3 -c 'import json,sys; print(json.dumps({"prompt":sys.stdin.read()}))' \
         | CLAUDE_PROJECT_DIR="$REPO_ROOT" "$HOOKS/inject-merge-checklist.sh" 2>/dev/null)
     [ -n "$out" ] && echo YES || echo NO
 }
@@ -293,6 +313,12 @@ assert "the checklist is injected verbatim from its own file" verbatim "$got"
 
 preamble=${body%%$'\n'*}
 if [ "${#preamble}" -le 200 ]; then got=pointer_only; else got="carries its own advice (${#preamble} chars)"; fi
+# A hook payload carries the whole prompt. Passed as argv it hit Linux's ~128 KiB MAX_ARG_STRLEN
+# and died with "Argument list too long" BEFORE python started - so on exactly the long, pasted-in
+# prompts a human is most likely to be mid-decision on, the checklist silently did not appear.
+big_prompt="ready to merge $(head -c 150000 /dev/zero | tr '\0' 'x')"
+assert "a 150 KB merge-prep prompt is still injected" YES "$(injected "$big_prompt")"
+
 assert "the preamble points at the doc rather than restating it" pointer_only "$got"
 
 echo

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Self-test for the three hooks in `.claude/hooks/`. Feeds each one a crafted hook payload on stdin
+# and asserts its verdict.
+#
+# WHY IT EXISTS. docs/agent-harness.md's own rule 3 is "give it a negative control - make it go red
+# on purpose before you trust it". The harness shipped without applying that rule to itself, and a
+# review found six defects in one 25-line parser, four of which let the exact mistake the hook is
+# named after straight through while two blocked legitimate merges. Every one of those is a case
+# below. A hook is unusually easy to get wrong this way: it runs inside another process, its output
+# is consumed by a model rather than a person, and a broken one looks identical to a quiet one.
+#
+# WHY THE `test-check-` PREFIX, given there is no `bin/check-agent-hooks.sh`. bin/AGENTS.md pairs
+# `test-check-X.sh` with `check-X.sh`, and this is a deliberate exception: the prefix is also what
+# grants a script to the review agent by pattern, and a self-test for the harness is exactly the
+# thing a reviewer should be able to run. It stays inside the grant's boundary - read-only, no
+# network, no writes outside its own mktemp directory.
+#
+# Run: bin/test-check-agent-hooks.sh
+
+set -uo pipefail
+
+HOOKS="$(cd "$(dirname "$0")/.." && pwd)/.claude/hooks"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+failures=0
+
+assert() { # <description> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "ok:   $1"
+    else
+        echo "FAIL: $1 (expected '$2', got '$3')"
+        failures=$((failures + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------------------------
+# check-squash-subject.sh
+#
+# The subject the hook must judge is the one `gh` will actually use: the LAST `--subject`, inside
+# the `gh pr merge` command, cross-checked against the PR being merged. Cases 1-6 are the six
+# defects found in review; the rest is behaviour that already worked and must not regress.
+#
+# The fixture numbers are four digits on purpose. bin/check-issue-refs.sh flags an unqualified
+# `#NNN` below 1000 on any added line, and it is right to - these literals are indistinguishable
+# from a real citation. The cases do not depend on the values, so they sit above the threshold.
+# ---------------------------------------------------------------------------------------------
+
+verdict() { # <bash-command> -> ALLOW | DENY
+    local payload out
+    payload=$(python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]}}))' "$1")
+    out=$(printf '%s' "$payload" | "$HOOKS/check-squash-subject.sh" 2>/dev/null)
+    case "$out" in
+        *'"deny"'*) echo DENY ;;
+        *)          echo ALLOW ;;
+    esac
+}
+
+echo "--- check-squash-subject.sh ---"
+
+# 1. `gh` honours the LAST --subject. Reading the first one allowed the bad subject to land while
+#    reporting the good one as proof it was fine.
+assert "two --subject flags, the LAST one is bad" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "ok (#1299)" --subject "bad no number"')"
+
+# 2. A `--subject` elsewhere on the command line is not part of the merge. A regex over the whole
+#    line matched the decoy and never looked at the real one.
+assert "a decoy --subject before the merge command" DENY \
+    "$(verdict 'echo --subject "x (#1001)" ; gh pr merge 1299 --squash --subject "bad no number"')"
+
+# 3. Any `(#N)` used to satisfy the check, so the astubbs#206 shape - a number pointing at a
+#    DIFFERENT PR - passed while the right number was sitting in the same command.
+assert "a (#N) naming the wrong PR" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "tooling: thing (#1206)"')"
+
+# 4. Same defect, the commoner spelling of it: an issue reference read as a PR number.
+assert "a (#N) that is an issue reference, not the PR" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "fixes the thing (#1012)"')"
+
+# 5. FALSE POSITIVE. An escaped apostrophe ends the shell string, so a regex capture stopped before
+#    the suffix and denied a correct merge. A PreToolUse deny is hard - the agent cannot argue.
+assert "escaped apostrophe inside the subject" ALLOW \
+    "$(verdict "gh pr merge 1299 --squash --subject 'don'\''t drop it (#1299)'")"
+
+# 6. FALSE POSITIVE. The words "--subject" inside --body text are body content, not a flag.
+assert "the word --subject appearing inside --body" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --body "we discussed --subject and why" --subject "tidy: thing (#1299)"')"
+
+assert "plain correct subject" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --subject "tooling: thing (#1299)"')"
+assert "plain subject with no (#N) at all" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "tooling: thing"')"
+assert "no --subject: GitHub appends the number itself" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --body-file /tmp/body.md')"
+assert "not a merge command at all" ALLOW \
+    "$(verdict 'git commit -m "hello"')"
+
+# Boundaries, pinned so a later tightening is a deliberate act rather than a surprise.
+assert "--subject=VALUE form is read too" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject="tooling: thing"')"
+assert "no PR argument, so no cross-check is possible" ALLOW \
+    "$(verdict 'gh pr merge --squash --subject "tooling: thing (#1206)"')"
+assert "two merges chained, the second is bad" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "a (#1299)" && gh pr merge 1300 --squash --subject "b"')"
+assert "unbalanced quotes fail OPEN, never on our own parse bug" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --subject "unterminated')"
+assert "a non-Bash tool is ignored" ALLOW \
+    "$(printf '%s' '{"tool_name":"Read","tool_input":{"command":"gh pr merge 1299 --subject \"x\""}}' \
+        | "$HOOKS/check-squash-subject.sh" 2>/dev/null | grep -c '"deny"' | sed 's/^0$/ALLOW/;s/^[1-9].*/DENY/')"
+
+# ---------------------------------------------------------------------------------------------
+# pre-commit-gate.sh
+#
+# CLAUDE_PROJECT_DIR points at a fixture holding a stub `.githooks/pre-commit`, so the gate's
+# pass/fail is controlled by the test rather than by the state of the real tree.
+# ---------------------------------------------------------------------------------------------
+
+echo
+echo "--- pre-commit-gate.sh ---"
+
+make_project() { # <gate-exit-code> -> project dir
+    local dir="$TMP/proj$RANDOM$RANDOM"
+    mkdir -p "$dir/.githooks"
+    printf '#!/bin/sh\necho "STUB GATE SPOKE"\nexit %s\n' "$1" > "$dir/.githooks/pre-commit"
+    chmod +x "$dir/.githooks/pre-commit"
+    echo "$dir"
+}
+
+gate_rc() { # <project-dir> <bash-command>
+    local payload
+    payload=$(python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]}}))' "$2")
+    printf '%s' "$payload" | CLAUDE_PROJECT_DIR="$1" "$HOOKS/pre-commit-gate.sh" >/dev/null 2>&1
+    echo $?
+}
+
+red=$(make_project 1)
+green=$(make_project 0)
+
+assert "green gate lets the commit through" 0 \
+    "$(gate_rc "$green" 'git commit -m "ordinary"')"
+
+# The block is exit 2 - PreToolUse's documented deny - not 1, which is merely a non-blocking error.
+assert "red gate blocks with exit 2" 2 \
+    "$(gate_rc "$red" 'git commit -m "ordinary"')"
+
+# THE POINT OF THE WHOLE SCRIPT. The first version was `pre-commit || exit 2` inline, which never
+# read the payload, so --no-verify was ignored and a red gate locked the agent out of committing at
+# all - including the commit that would have fixed the gate.
+assert "--no-verify bypasses a red gate" 0 \
+    "$(gate_rc "$red" 'git commit --no-verify -m "I have a reason"')"
+
+# ...but only as a real argument. A commit MESSAGE that merely mentions the flag is not a bypass,
+# or the escape hatch could be triggered by writing about it.
+assert "--no-verify inside a quoted message is NOT a bypass" 2 \
+    "$(gate_rc "$red" 'git commit -m "document the --no-verify escape hatch"')"
+
+# The blocked call must carry the reason, or the agent sees "hook error: No stderr output" and has
+# nothing to act on - the observed behaviour of the inline form.
+stderr_text=$(python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}))' \
+    | CLAUDE_PROJECT_DIR="$red" "$HOOKS/pre-commit-gate.sh" 2>&1 >/dev/null)
+case "$stderr_text" in
+    *"STUB GATE SPOKE"*) got=forwarded ;;
+    *)                   got="swallowed: $stderr_text" ;;
+esac
+assert "the failing gate's own output reaches stderr" forwarded "$got"
+
+# Fail open: no gate script in the project at all must not block every commit.
+empty="$TMP/empty$RANDOM"; mkdir -p "$empty"
+assert "absent gate script fails OPEN" 0 \
+    "$(gate_rc "$empty" 'git commit -m "ordinary"')"
+
+# ---------------------------------------------------------------------------------------------
+# inject-merge-checklist.sh
+# ---------------------------------------------------------------------------------------------
+
+echo
+echo "--- inject-merge-checklist.sh ---"
+
+injected() { # <prompt> -> YES | NO
+    local out
+    out=$(python3 -c 'import json,sys; print(json.dumps({"prompt":sys.argv[1]}))' "$1" \
+        | "$HOOKS/inject-merge-checklist.sh" 2>/dev/null)
+    [ -n "$out" ] && echo YES || echo NO
+}
+
+assert "merge-prep prompt: 'ready to merge?'"          YES "$(injected 'is this ready to merge?')"
+assert "merge-prep prompt: 'squash it'"                YES "$(injected 'squash it and land it')"
+assert "merge-prep prompt: 'tidy up the commits'"      YES "$(injected 'can you tidy up the commits')"
+assert "merge-prep prompt: 'rebase onto master'"       YES "$(injected 'rebase onto master please')"
+assert "unrelated prompt: a test failure"              NO  "$(injected 'why is ShardTest failing under load')"
+assert "unrelated prompt: reading code"                NO  "$(injected 'explain how offset encoding works')"
+assert "unrelated prompt: emerge is not merge"         NO  "$(injected 'the pattern should emerge from the data')"
+
+# NEUTRALITY, ENFORCED. docs/merge-checklist.md is the single source; the hook is a delivery
+# mechanism. An earlier version also prepended its own summary of the checklist's two standing
+# asks - a second copy, in the one place nobody would think to look for drift. This asserts the
+# injected text is the file's own bytes plus a pointer, and nothing else.
+body=$(python3 -c 'import json,sys; print(json.dumps({"prompt":"ready to merge?"}))' \
+    | "$HOOKS/inject-merge-checklist.sh" 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["hookSpecificOutput"]["additionalContext"])')
+checklist_head=$(head -1 "$(dirname "$HOOKS")/../docs/merge-checklist.md" 2>/dev/null)
+case "$body" in
+    *"$checklist_head"*) got=verbatim ;;
+    *)                   got=missing ;;
+esac
+assert "the checklist is injected verbatim from its own file" verbatim "$got"
+
+preamble=${body%%$'\n'*}
+if [ "${#preamble}" -le 200 ]; then got=pointer_only; else got="carries its own advice (${#preamble} chars)"; fi
+assert "the preamble points at the doc rather than restating it" pointer_only "$got"
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "All .claude/hooks self-tests passed"
+    exit 0
+fi
+echo "$failures self-test(s) FAILED"
+exit 1

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -176,6 +176,20 @@ assert "a branch-name selector with NO number is still denied" DENY \
 assert "a flag value is not mistaken for the PR selector" ALLOW \
     "$(verdict 'gh pr merge --body 1206 --squash 1299 --subject "thing (#1299)"')"
 
+# Round four. Segmenting the command with a regex over the RAW line found `gh pr merge` inside
+# quoted body text, cut the line into two slices that each had unbalanced quotes, and fail-opened
+# both - so the real --subject was never judged. Body text could switch the hook off. Segmentation
+# now runs over shlex TOKENS, where a quoted body is a single token and cannot look like a command.
+assert "the phrase 'gh pr merge' inside --body does not disable the guard" DENY \
+    "$(verdict 'gh pr merge 1299 --body "text gh pr merge here" --subject "bad no number"')"
+assert "...and the same body with a correct subject still passes" ALLOW \
+    "$(verdict 'gh pr merge 1299 --body "text gh pr merge here" --subject "tooling: thing (#1299)"')"
+assert "the phrase inside the SUBJECT does not disable the guard either" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "how to gh pr merge safely"')"
+# An absolute path to gh is still gh; a word merely ending in those letters is not a command.
+assert "an absolute path to gh is still matched" DENY \
+    "$(verdict '/usr/local/bin/gh pr merge 1299 --squash --subject "tooling: thing"')"
+
 assert "a non-Bash tool is ignored" ALLOW \
     "$(printf '%s' '{"tool_name":"Read","tool_input":{"command":"gh pr merge 1299 --subject \"x\""}}' \
         | "$HOOKS/check-squash-subject.sh" 2>/dev/null | grep -c '"deny"' | sed 's/^0$/ALLOW/;s/^[1-9].*/DENY/')"

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -104,6 +104,17 @@ assert "--subject=VALUE form is read too" DENY \
     "$(verdict 'gh pr merge 1299 --squash --subject="tooling: thing"')"
 assert "no PR argument, so no cross-check is possible" ALLOW \
     "$(verdict 'gh pr merge --squash --subject "tooling: thing (#1206)"')"
+# The convention puts (#N) in the TRAILING slot, and this hook deliberately does not require it -
+# raised in review, kept on purpose. What is unfixable after a merge is a number that is MISSING or
+# points at the WRONG PR, and both of those are denied above. A number that is present and correct
+# but sits mid-subject is a visible, cosmetic deviation that review catches and that still links
+# correctly; a hard PreToolUse deny for it would block "port (#N) to master" and every other
+# unusual-but-fine subject, with no way for the agent to argue. Pinned so tightening it later is a
+# deliberate act - see the BOUNDARY note in .claude/hooks/check-squash-subject.sh.
+assert "a correct (#N) outside the trailing slot is allowed (stated boundary)" ALLOW \
+    "$(verdict 'gh pr merge 1299 --squash --subject "fix(core) (#1299): detail"')"
+assert "...but the same shape with the WRONG number is still denied" DENY \
+    "$(verdict 'gh pr merge 1299 --squash --subject "fix(core) (#1206): detail"')"
 assert "two merges chained, the second is bad" DENY \
     "$(verdict 'gh pr merge 1299 --squash --subject "a (#1299)" && gh pr merge 1300 --squash --subject "b"')"
 assert "unbalanced quotes fail OPEN, never on our own parse bug" ALLOW \

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -85,6 +85,8 @@ expect DENY  "--subject with no (#N)"              'gh pr merge 2999 --squash --
 expect DENY  "-t, the documented SHORT form"       'gh pr merge 2999 --squash -t "foo"'
 expect DENY  "--subject= equals form"              'gh pr merge 2999 --squash --subject=foo'
 expect DENY  "-t= equals form"                     'gh pr merge 2999 --squash -t=foo'
+expect DENY  "-tVALUE attached short form"         'gh pr merge 2999 --squash -tfoo'
+expect ALLOW "-tVALUE attached, with (#N)"         'gh pr merge 2999 --squash -t"foo (#2999)"'
 expect DENY  "(#N) present but not at the END"     'gh pr merge 2999 --squash --subject "port (#2999) to master"'
 expect ALLOW "--subject ending with (#N)"          'gh pr merge 2999 --squash --subject "foo (#2999)"'
 expect ALLOW "-t ending with (#N)"                 'gh pr merge 2999 --squash -t "foo (#2999)"'
@@ -181,6 +183,12 @@ assert "a later commit's --no-verify does not exempt an earlier one" 2 \
     "$(gate_rc "$red" 'git commit -m first; git commit --no-verify -m second')"
 assert "both commits asking for a bypass is honoured" 0 \
     "$(gate_rc "$red" 'git commit --no-verify -m a; git commit --no-verify -m b')"
+# A quoted MULTILINE message containing the flag. Lexing line-by-line split this down the middle,
+# the first line raised ValueError, and the fallback then found the flag in the message text.
+assert "a multiline message mentioning the flag is not a bypass" 2 \
+    "$(gate_rc "$red" 'git commit -m "line1
+--no-verify
+line3"')"
 assert "git -C <path> commit --no-verify is still a bypass" 0 \
     "$(gate_rc "$red" 'git -C /some/path commit --no-verify -m x')"
 

--- a/bin/test-check-quarantine-registry.sh
+++ b/bin/test-check-quarantine-registry.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Self-test for bin/lib/quarantine-common.sh - the scan that check-quarantine-registry.sh,
+# check-quarantine-owners.sh and quarantined-test.sh all read their file list from.
+#
+# WHY THIS EXISTS. The exclusion of `.claude` from the scan is a behaviour change with a specific
+# cause: `.claude/worktrees/<name>` holds a full checkout of some OTHER branch, so without it the
+# scan reports drift from every sibling worktree - annotations that are not on this branch at all,
+# against a registry that is. `bin/AGENTS.md` is explicit that a checker fix arrives with a case in
+# its self-test, and that the case must go red against the old code; `docs/agent-harness.md` rule 3
+# says the same. That is what the last review caught here: the fix shipped without one, so a later
+# edit could delete or misspell `--exclude-dir=.claude` and every test would stay green.
+#
+# THE NEGATIVE CONTROL IS BUILT IN, not a claim in a commit message. `previous_implementation()`
+# below is the exact grep this repo shipped before the fix. The fixture is asserted against BOTH:
+# the current scan must not see the sibling worktree, and the previous one must - if a future
+# refactor makes the fixture stop exercising the exclusion, the old-code assertion fails and says
+# so, rather than the suite passing on a fixture that no longer reaches the bug.
+#
+# Read-only, no network, ~0.1s: safe under the `test-check-*` reviewer grant (bin/AGENTS.md).
+
+set -euo pipefail
+
+failures=0
+
+assert() { # <description> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        printf 'ok:   %s\n' "$1"
+    else
+        printf 'FAIL: %s\n        expected: %s\n        actual:   %s\n' "$1" "$2" "$3" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck source=bin/lib/quarantine-common.sh
+. "$repo_root/bin/lib/quarantine-common.sh"
+
+# The scan as it stood before the worktree-pollution fix: `target` excluded, nothing else. Kept
+# verbatim so the fixture is proven to reach the defect rather than assumed to.
+previous_implementation() {
+    grep -rlE --include='*.java' --exclude-dir=target "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null || true
+}
+
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+annotated() { # <path>
+    mkdir -p "$(dirname "$1")"
+    cat > "$1" <<'JAVA'
+package fixture;
+
+class Sample {
+    @Test
+    @Quarantined(fixedBy = "astubbs#1234", reason = "fixture")
+    void aTest() {}
+}
+JAVA
+}
+
+# On this branch, and so in the registry.
+annotated "$fixture/parallel-consumer-core/src/test/java/Ordinary.java"
+
+# A sibling worktree: a full checkout of a DIFFERENT branch, carrying annotations this branch's
+# registry has never heard of. This is the file the whole exclusion exists for.
+annotated "$fixture/.claude/worktrees/some-other-branch/parallel-consumer-core/src/test/java/Sibling.java"
+
+# Cheap neighbours of the same shape, pinned so removing either exclusion is a deliberate act.
+annotated "$fixture/target/generated-sources/Generated.java"
+annotated "$fixture/.git/some-tooling-copy/Stashed.java"
+
+# A string literal is NOT annotation usage - the tooling's own sources contain "@Quarantined(" as
+# data, and matching it would block a release. This pins the anchoring described in the lib.
+mkdir -p "$fixture/bin/fixtures"
+cat > "$fixture/bin/fixtures/Literal.java" <<'JAVA'
+class Literal {
+    String pattern = "@Quarantined(";
+}
+JAVA
+
+cd "$fixture"
+
+echo "--- quarantined_files(): what the registry is checked against ---"
+
+found=$(quarantined_files | sed 's|^\./||' | sort)
+contains() { # <haystack> <needle> -> YES | NO
+    case $'\n'"$1"$'\n' in
+        *$'\n'"$2"$'\n'*) echo YES ;;
+        *)                echo NO ;;
+    esac
+}
+
+assert "a file on this branch is scanned" YES \
+    "$(contains "$found" "parallel-consumer-core/src/test/java/Ordinary.java")"
+assert "a sibling worktree under .claude is NOT scanned" NO \
+    "$(contains "$found" ".claude/worktrees/some-other-branch/parallel-consumer-core/src/test/java/Sibling.java")"
+assert "build output under target is NOT scanned" NO \
+    "$(contains "$found" "target/generated-sources/Generated.java")"
+assert "a copy under .git is NOT scanned" NO \
+    "$(contains "$found" ".git/some-tooling-copy/Stashed.java")"
+assert "a string literal is not annotation usage" NO \
+    "$(contains "$found" "bin/fixtures/Literal.java")"
+
+echo "--- quarantined_audit(): the human listing, same exclusions ---"
+
+# quarantined_audit greps with -A 4, so its output carries file:line prefixes rather than paths.
+audit=$(quarantined_audit || true)
+audit_names() { # <substring> -> YES | NO
+    case "$audit" in
+        *"$1"*) echo YES ;;
+        *)      echo NO ;;
+    esac
+}
+
+assert "the audit lists a file on this branch" YES "$(audit_names "Ordinary.java")"
+assert "the audit does NOT list a sibling worktree" NO "$(audit_names "Sibling.java")"
+assert "the audit does NOT list build output" NO "$(audit_names "Generated.java")"
+
+echo "--- negative control: the fixture must reach the defect ---"
+
+# If this passes, the fixture has stopped exercising the exclusion and every assertion above is
+# vacuous. That is the failure mode bin/AGENTS.md means by "a regression test that has never failed
+# proves nothing", so it is asserted rather than trusted.
+old=$(previous_implementation | sed 's|^\./||' | sort)
+assert "the PREVIOUS implementation does leak the sibling worktree" YES \
+    "$(contains "$old" ".claude/worktrees/some-other-branch/parallel-consumer-core/src/test/java/Sibling.java")"
+assert "the PREVIOUS implementation does leak the .git copy" YES \
+    "$(contains "$old" ".git/some-tooling-copy/Stashed.java")"
+assert "the PREVIOUS implementation already excluded target" NO \
+    "$(contains "$old" "target/generated-sources/Generated.java")"
+
+echo
+if [ "$failures" -gt 0 ]; then
+    printf '%d quarantine-scan self-test(s) failed\n' "$failures" >&2
+    exit 1
+fi
+echo "All quarantine-scan self-tests passed"

--- a/bin/test-check-quarantine-registry.sh
+++ b/bin/test-check-quarantine-registry.sh
@@ -65,8 +65,11 @@ JAVA
 annotated "$fixture/parallel-consumer-core/src/test/java/Ordinary.java"
 
 # A sibling worktree: a full checkout of a DIFFERENT branch, carrying annotations this branch's
-# registry has never heard of. This is the file the whole exclusion exists for.
+# registry has never heard of. This is the file the whole exclusion exists for. BOTH worktree roots
+# get one - .gitignore names `.claude/worktrees` and `/.worktrees/`, and the first version of this
+# fix excluded only the first, which review caught precisely because no fixture covered the second.
 annotated "$fixture/.claude/worktrees/some-other-branch/parallel-consumer-core/src/test/java/Sibling.java"
+annotated "$fixture/.worktrees/another-branch/parallel-consumer-core/src/test/java/OtherRoot.java"
 
 # Cheap neighbours of the same shape, pinned so removing either exclusion is a deliberate act.
 annotated "$fixture/target/generated-sources/Generated.java"
@@ -97,6 +100,8 @@ assert "a file on this branch is scanned" YES \
     "$(contains "$found" "parallel-consumer-core/src/test/java/Ordinary.java")"
 assert "a sibling worktree under .claude is NOT scanned" NO \
     "$(contains "$found" ".claude/worktrees/some-other-branch/parallel-consumer-core/src/test/java/Sibling.java")"
+assert "a sibling worktree under .worktrees is NOT scanned" NO \
+    "$(contains "$found" ".worktrees/another-branch/parallel-consumer-core/src/test/java/OtherRoot.java")"
 assert "build output under target is NOT scanned" NO \
     "$(contains "$found" "target/generated-sources/Generated.java")"
 assert "a copy under .git is NOT scanned" NO \
@@ -117,6 +122,7 @@ audit_names() { # <substring> -> YES | NO
 
 assert "the audit lists a file on this branch" YES "$(audit_names "Ordinary.java")"
 assert "the audit does NOT list a sibling worktree" NO "$(audit_names "Sibling.java")"
+assert "the audit does NOT list the other worktree root" NO "$(audit_names "OtherRoot.java")"
 assert "the audit does NOT list build output" NO "$(audit_names "Generated.java")"
 
 echo "--- negative control: the fixture must reach the defect ---"
@@ -127,6 +133,8 @@ echo "--- negative control: the fixture must reach the defect ---"
 old=$(previous_implementation | sed 's|^\./||' | sort)
 assert "the PREVIOUS implementation does leak the sibling worktree" YES \
     "$(contains "$old" ".claude/worktrees/some-other-branch/parallel-consumer-core/src/test/java/Sibling.java")"
+assert "the PREVIOUS implementation does leak the other worktree root" YES \
+    "$(contains "$old" ".worktrees/another-branch/parallel-consumer-core/src/test/java/OtherRoot.java")"
 assert "the PREVIOUS implementation does leak the .git copy" YES \
     "$(contains "$old" ".git/some-tooling-copy/Stashed.java")"
 assert "the PREVIOUS implementation already excluded target" NO \

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -127,6 +127,26 @@ non-zero:
 And the positive control, which is the half that is easy to forget - after moving `if`, a
 `git commit` prompt still fires the gate, so the fix filtered the hook rather than disabling it.
 
+### ...and `if` matches a PREFIX, so only one of the two hooks can use it
+
+`if: "Bash(gh pr merge *)"` fires only when the command *starts* with `gh pr merge`. Every other
+shape the merge guard exists for - `/usr/local/bin/gh pr merge ...`, `echo ready && gh pr merge ...`
+- never reached it. That is worse than a plain gap: `bin/test-check-agent-hooks.sh` asserted those
+shapes were denied, and they were, *by the script* - which the harness was never going to invoke for
+them. **A self-test can only prove what the script does; whether the script is reached is a
+different question, and it needs asking separately.**
+
+So the two hooks are registered differently, on purpose:
+
+| Hook | `if` | Why |
+|---|---|---|
+| `check-squash-subject.sh` | **none** - runs on every Bash call | It can only ever allow, or deny a real `gh pr merge`. A `grep` for `merge` in the payload rejects the overwhelming majority before python starts, so the cost is a shell test. |
+| `pre-commit-gate.sh` | `Bash(git commit *)` | It runs the gates and can `exit 2`. Firing it on every Bash call is the outage described above - and it must stay prefix-matched anyway, because it gates *the session's* repository, which is only the right one when the command has no `cd` in front of it. |
+
+The `git commit` case that `if` therefore misses (`cd sub && git commit`) is covered by
+`.githooks/pre-commit`, which git runs inside the target repository. That is the layering working
+as intended, not a hole - see *Known gaps*.
+
 ## What is wired up today
 
 **`.githooks/pre-commit`** - runs the fast read-only gates (~1.5s total): copyright headers, issue

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -1,0 +1,124 @@
+# The agent harness - making rules fire instead of hoping they are read
+
+How this repo gets agents to do things **reliably**. Not a style guide: a map of the mechanisms that
+execute without anyone choosing to invoke them, what each can and cannot do, and how to add to them.
+
+**This file is deliberately open for additions.** Everything here exists to meta-program the agents
+working on this repo, and the set is nowhere near complete - see *Worth adding* at the end. If you
+find yourself writing a rule into a document and wondering whether anyone will read it, that is the
+signal to come here and give it a mechanism instead.
+
+## The problem it solves
+
+Every convention in this repo was already written down, correctly, before this harness existed. They
+were still missed - by humans and by agents - because **a document only fires when somebody chooses
+to open it**. The specific failure that prompted this: an agent added a note to `docs/inflight/`
+describing work its own PR was landing, which `docs/inflight/AGENTS.md` forbids in its first rule.
+The rule existed, was correct, and was linked from the root `AGENTS.md`. It was simply never read.
+
+The lesson generalises: **if a rule must not be missed, it cannot live only in a doc an agent chooses
+to read.** It needs a layer that fires on its own.
+
+## What actually loads, and what does not
+
+Verified against Claude Code **2.1.223**. This is the part most people get wrong:
+
+| File | Loaded? |
+|---|---|
+| `CLAUDE.md` (repo root) | **Yes** - automatically, every session |
+| `CLAUDE.md` (subdirectory) | **Yes** - lazily, when a file in that directory is read or written |
+| `CLAUDE.local.md` | Yes, after `CLAUDE.md` at the same level |
+| `~/.claude/CLAUDE.md` | Yes, across all projects |
+| **`AGENTS.md` (any location)** | **NO. Never auto-loaded.** |
+
+`AGENTS.md` is the portable, tool-neutral convention other agents use, and this repo keeps its rules
+there. Claude Code does not read it. The bridge is a `CLAUDE.md` alongside each `AGENTS.md`
+containing `@AGENTS.md`, which imports it:
+
+- `CLAUDE.md` -> imports root `AGENTS.md`, plus the invariants worth stating twice
+- `bin/CLAUDE.md` -> imports `bin/AGENTS.md`, arriving when you touch a script
+- `docs/inflight/CLAUDE.md` -> imports `docs/inflight/AGENTS.md`, arriving when you touch a note
+
+**The nested ones are the interesting half.** They load *at the moment you work in that directory* -
+which is exactly the "inject the right prompt at the right time" that a routing table in a doc
+cannot do. Adding a nested `AGENTS.md` without its `CLAUDE.md` sibling means Claude Code never sees
+it.
+
+## The layers
+
+| Layer | Fires when | Injects context? | Can block? | Binds |
+|---|---|---|---|---|
+| Root `CLAUDE.md` | session start | yes | no | Claude Code |
+| Nested `CLAUDE.md` | file in that dir is touched | yes | no | Claude Code |
+| `SessionStart` / `UserPromptSubmit` hooks | session start / each prompt | **yes** | `UserPromptSubmit` only | Claude Code |
+| `PreToolUse` hook | before a matched tool call | **no** | **yes** | Claude Code |
+| Git hook (`core.hooksPath`) | `git commit`, `git push` | no | **yes** | **everyone** |
+| CI gate | push / PR | no | **yes** | everyone, authoritatively |
+
+Two properties decide where a rule belongs:
+
+- **`PreToolUse` cannot inject context.** Its stdout never reaches the model. It can allow, deny, or
+  ask - nothing else. A rule you want the agent to *know* goes in a `CLAUDE.md` or a context-injecting
+  hook; a rule you want *enforced* goes in `PreToolUse` or a git hook.
+- **Only git hooks and CI bind non-Claude actors.** Anything that must hold for a human, a different
+  agent, or a cron job cannot live in `.claude/`.
+
+## What is wired up today
+
+**`.githooks/pre-commit`** - runs the fast read-only gates (~1.5s total): copyright headers, issue
+references, docs data, shell sigpipe, quarantine registry, action versions. Enable per clone, once:
+
+```
+git config core.hooksPath .githooks
+```
+
+One clone's config covers every worktree of that clone. Bypass with `git commit --no-verify`, which
+is deliberately easy - a gate people cannot skip when they have a reason is a gate they disable
+permanently. CI remains the authority; this is its fast mirror.
+
+It distinguishes **failed** from **could not run**. `bin/check-issue-refs.sh` exits 2 when `node` is
+absent, and blocking a commit for that would teach everyone to bypass the hook, taking the real
+violations with it. Soft exits warn; only genuine violations block.
+
+**`.claude/settings.json`** - a `PreToolUse` hook on `Bash` matching `git commit *`, running the same
+script. This is belt-and-braces: it catches the agent even in a clone where `core.hooksPath` was
+never set, which is the likely state of a fresh worktree on a new machine.
+
+## Adding to it
+
+1. **Decide what the rule needs.** To be *known* -> a `CLAUDE.md`. To be *enforced* -> a hook or a
+   gate. To bind humans too -> git hook or CI, never `.claude/`.
+2. **Prefer the cheapest layer that actually fires.** A nested `CLAUDE.md` costs nothing and loads at
+   exactly the right moment.
+3. **Give it a negative control.** This repo's standing rule: a check that has never failed proves
+   nothing. Make it go red on purpose before you trust it - `bin/AGENTS.md` says the same about
+   `test-check-*.sh`.
+4. **Keep pre-commit under a couple of seconds.** A slow hook gets `--no-verify`'d by habit and then
+   protects nothing. Slower checks belong in CI only.
+5. **Write down what you verified**, especially harness behaviour - the auto-load table above was
+   wrong in three different ways when guessed at, and right only once checked against the docs.
+
+## Known gaps
+
+- **Sub-agent hook inheritance is undocumented.** Whether `.claude/settings.json` hooks apply to
+  agents spawned via the Agent tool is not stated in the Claude Code docs. Assume they may not, and
+  put anything load-bearing in the git hook, which binds every process that runs `git`.
+- **`core.hooksPath` cannot be committed.** A fresh clone has no hooks until someone runs the config
+  command. The `PreToolUse` hook covers Claude Code in that window; nothing covers a human.
+- **Nothing enforces that a nested `AGENTS.md` has its `CLAUDE.md` bridge.** A check could;
+  see below.
+
+## Worth adding
+
+Open list - add to it, or take from it:
+
+- A gate asserting every `AGENTS.md` has a sibling `CLAUDE.md` importing it, so a future nested
+  convention cannot be invisible to Claude Code the way `docs/inflight/AGENTS.md` was.
+- A `SessionStart` hook surfacing repo state an agent otherwise has to think to ask for: open PRs
+  needing an LGTM, worktrees with uncommitted work, gates currently red on master.
+- A `PreToolUse` deny on `git push --force` / `git rebase` against shared branches, which several
+  skill definitions already forbid in prose.
+- A `UserPromptSubmit` hook injecting the current PR's review state, so "is this LGTM'd" never has to
+  be asked.
+- Pre-push rather than pre-commit for the slower gates, keeping commits fast while still catching
+  things before they reach CI.

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -1,7 +1,14 @@
 # The agent harness - making rules fire instead of hoping they are read
 
-How this repo gets agents to do things **reliably**. Not a style guide: a map of the mechanisms that
-execute without anyone choosing to invoke them, what each can and cannot do, and how to add to them.
+**Owns the layer map** - which mechanisms fire on their own, what each can and cannot do, and how to
+add to them. `AGENTS.md` carries the pointer and nothing else, because this only matters once you
+are already writing a rule and wondering whether anyone will read it. Not a style guide: the rules
+themselves live in `AGENTS.md` and the topic docs; this describes the machinery that delivers them.
+
+Claims about harness behaviour here are **tested, not read off the documentation** - every one below
+that says "verified" was checked by running it against a live session, and the commands are named so
+you can repeat them. That habit is not decoration: the first version of this file asserted four
+things about Claude Code that turned out to be false, and each one had a design built on top of it.
 
 **This file is deliberately open for additions.** Everything here exists to meta-program the agents
 working on this repo, and the set is nowhere near complete - see *Worth adding* at the end. If you
@@ -76,17 +83,49 @@ agents read it directly, and `CLAUDE.md` is only the adapter that makes Claude C
 | Root `CLAUDE.md` | session start | yes | no | Claude Code |
 | Nested `CLAUDE.md` | file in that dir is touched | yes | no | Claude Code |
 | `SessionStart` / `UserPromptSubmit` hooks | session start / each prompt | **yes** | `UserPromptSubmit` only | Claude Code |
-| `PreToolUse` hook | before a matched tool call | **no** | **yes** | Claude Code |
+| `PreToolUse` hook | before a matched tool call | **yes**, per tool call | **yes** | Claude Code |
 | Git hook (`core.hooksPath`) | `git commit`, `git push` | no | **yes** | **everyone** |
 | CI gate | push / PR | no | **yes** | everyone, authoritatively |
 
 Two properties decide where a rule belongs:
 
-- **`PreToolUse` cannot inject context.** Its stdout never reaches the model. It can allow, deny, or
-  ask - nothing else. A rule you want the agent to *know* goes in a `CLAUDE.md` or a context-injecting
-  hook; a rule you want *enforced* goes in `PreToolUse` or a git hook.
+- **A hook's stdout is not the injection channel; `additionalContext` is.** An earlier version of
+  this file said "`PreToolUse` cannot inject context - it can allow, deny, or ask, nothing else",
+  and both hook headers cited that as the reason they were built the way they are. The first half is
+  true and the conclusion is false. **Verified against 2.1.223**: a `PreToolUse` hook printing
+  `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow",
+  "additionalContext": "<marker passphrase>"}}` and nothing else caused the model to report
+  receiving that passphrase verbatim, delivered as a `PreToolUse:Bash hook additional context`
+  system-reminder alongside the tool call. A `permissionDecisionReason` on a deny reaches the model
+  too. What *is* true is that raw stdout is discarded - the JSON envelope is mandatory.
+- **So choose the event by WHEN it fires, not by what it can carry.** That is why the merge
+  checklist is still on `UserPromptSubmit`: `PreToolUse` fires per tool call, so the checklist would
+  arrive stapled to whichever command ran next, over and over, and never at the moment the merge
+  strategy is being chosen. `UserPromptSubmit` fires when the human states the intent. Same
+  capability, different instant, and the instant is the whole point.
 - **Only git hooks and CI bind non-Claude actors.** Anything that must hold for a human, a different
   agent, or a cron job cannot live in `.claude/`.
+
+### `if` goes on the HOOK, not on the matcher group
+
+The most expensive thing in this file, because it fails silently and it fails *open-ended*. A
+`PreToolUse` entry has a matcher group (`matcher`, `hooks`) and, inside it, hook objects (`type`,
+`command`, `if`). **`if` is only honoured on the hook object.** Put it on the group and it is
+silently dropped - no warning, no parse error - and the hook then runs on **every** call to the
+matched tool.
+
+That is not merely wasteful. A gate that ends `|| exit 2` blocks the tool call when it fails, so
+with a misplaced `if` a single red gate takes away *every* Bash command in the session, including
+the one that would fix the gate. Verified both ways against 2.1.223, with a hook that always exits
+non-zero:
+
+| `if` position | `claude -p "...run: echo MARKER_OK"` |
+|---|---|
+| on the matcher group | "The command did not run - it was blocked before execution by a `PreToolUse` hook" |
+| on the hook object | `MARKER_OK` |
+
+And the positive control, which is the half that is easy to forget - after moving `if`, a
+`git commit` prompt still fires the gate, so the fix filtered the hook rather than disabling it.
 
 ## What is wired up today
 
@@ -102,27 +141,59 @@ is deliberately easy - a gate people cannot skip when they have a reason is a ga
 permanently. CI remains the authority; this is its fast mirror.
 
 It distinguishes **failed** from **could not run**. `bin/check-issue-refs.sh` exits 2 when `node` is
-absent, and blocking a commit for that would teach everyone to bypass the hook, taking the real
-violations with it. Soft exits warn; only genuine violations block.
+absent and `bin/check-docs-data.sh` exits 2 without Python 3 or PyYAML, and blocking a commit for
+that would teach everyone to bypass the hook, taking the real violations with it. Soft exits warn;
+only genuine violations block. Keeping the soft list right means reading each gate's exit codes -
+the `check-docs-data.sh` entry was written without one, so a contributor missing PyYAML (which
+nothing in this repo installs) was hard-blocked from committing anything at all.
 
-**`.claude/settings.json`** - two hooks, and the file is **tracked**. `.gitignore` excludes
+It also reports a gate that is **present but not executable**, rather than skipping it the way it
+skips a gate a branch simply does not have. A lost exec bit otherwise reads as "this branch predates
+that check" and the gate stops running with nobody told - a silent miss, in a tool built to stop
+silent misses.
+
+**What it reads is the working tree, not the index.** That gap is documented in the hook's own
+header and listed under *Known gaps* below; it is an open decision, not an oversight.
+
+**The three `CLAUDE.md` bridges** - `CLAUDE.md`, `bin/CLAUDE.md`, `docs/inflight/CLAUDE.md`, each a
+pure `@AGENTS.md` import. They are **tracked**, which took a `.gitignore` change: line 4 carried a
+bare `CLAUDE.md` rule from when these were personal scratch files, so all three were ignored and
+existed only on the author's machine. Everything looked correctly wired locally and would have
+merged as a no-op - `git ls-files | grep -c CLAUDE.md` returned **0**. The three paths are now
+negated individually rather than with a blanket `!CLAUDE.md`; the reasoning is in `.gitignore`
+itself, next to the rule.
+
+**`.claude/settings.json`** - three hooks, and the file is **tracked**. `.gitignore` excludes
 `/.claude/*` by contents rather than excluding the directory, with a comment anticipating exactly
 this; the negations `!/.claude/settings.json` and `!/.claude/hooks/**` open that door. Personal
 grants stay in `settings.local.json`, still ignored.
 
-- `PreToolUse` on `Bash` matching `git commit *` runs the same pre-commit script. Belt-and-braces:
-  it catches the agent even in a clone where `core.hooksPath` was never set, which is the likely
-  state of a fresh worktree on a new machine.
+- `PreToolUse` on `Bash`, `if` `Bash(git commit *)`, runs `.claude/hooks/pre-commit-gate.sh`, a
+  wrapper around the same pre-commit script. Belt-and-braces: it catches the agent even in a clone
+  where `core.hooksPath` was never set, which is the likely state of a fresh worktree on a new
+  machine. The wrapper exists so the hook can **read the payload and honour `--no-verify`** - the
+  original inline `pre-commit || exit 2` could not see the command it was gating, which left the
+  agent with no escape hatch at all while the pre-commit header promises an easy one. It exits 2
+  with the failing gate's output on stderr, so the model is told *why* rather than just "no".
+- `PreToolUse` on `Bash`, `if` `Bash(gh pr merge *)`, runs `.claude/hooks/check-squash-subject.sh`,
+  which refuses a `--subject` that would drop or misstate the PR number.
 - `UserPromptSubmit` runs `.claude/hooks/inject-merge-checklist.sh`, which puts
   `docs/merge-checklist.md` in front of the agent when a prompt looks like merge prep - "squash",
   "rebase", "ready to merge", "tidy up the commits" and friends. It never blocks; the point is to
-  inject the thought at the decision, not to gate anything. The checklist's two standing asks are to
-  **offer** to write the squash message and to **offer** to reorganise the commits into cohesive
-  units. Matching is deliberately broad on verbs and narrow on nouns: a false positive costs a few
-  hundred tokens, a false negative costs the thing it exists to prevent.
+  inject the thought at the decision, not to gate anything. Matching is deliberately broad on verbs
+  and narrow on nouns: a false positive costs a few hundred tokens, a false negative costs the thing
+  it exists to prevent.
 
 The checklist itself is a plain doc, not embedded in the hook, so Codex and anything else reading
-`AGENTS.md` gets the same words from the same file. Only the delivery is Claude-specific.
+`AGENTS.md` gets the same words from the same file. Only the delivery is Claude-specific - and the
+hook injects the file's bytes with a one-line pointer, not a summary of them, because a summary is a
+second copy in the one place nobody would think to check for drift.
+
+**`bin/test-check-agent-hooks.sh`** - the negative control for all three hooks, feeding each one
+crafted payloads and asserting its verdict. It is what rule 3 below asks for, and the harness
+shipped its first version without it: a review then found six defects in one 25-line parser, four
+letting the exact mistake it was named after through and two hard-blocking legitimate merges. Every
+one is a case in that file, and the suite goes red against the old parser.
 
 ## Adding to it
 
@@ -140,13 +211,34 @@ The checklist itself is a plain doc, not embedded in the hook, so Codex and anyt
 
 ## Known gaps
 
-- **Sub-agent hook inheritance is undocumented.** Whether `.claude/settings.json` hooks apply to
-  agents spawned via the Agent tool is not stated in the Claude Code docs. Assume they may not, and
-  put anything load-bearing in the git hook, which binds every process that runs `git`.
+- **Pre-commit gates read the working tree; the commit records the index.** Stage a clean hunk and
+  leave an unrelated dirty one and you are blocked for content you are not committing; stage a
+  violation and fix it unstaged and the violation is gated green. Documented in the hook header
+  rather than fixed: the usual remedy, `git stash push --keep-index` around the run, can destroy
+  uncommitted work if the hook dies mid-run, and a pre-commit hook that can eat your changes is
+  worse than one with a stated blind spot. CI reads the pushed commit and has no such gap.
+  **Open decision** - the alternatives are a stash with a robust trap, gating `git diff --cached`
+  instead of the tree (which several of these gates cannot do, being whole-tree scans), or leaving
+  it as is.
 - **`core.hooksPath` cannot be committed.** A fresh clone has no hooks until someone runs the config
   command. The `PreToolUse` hook covers Claude Code in that window; nothing covers a human.
+- **The `PreToolUse` `if` matches the command as written.** `Bash(git commit *)` does not fire on
+  `cd sub && git commit ...`. The git hook covers that case; the Claude-side belt-and-braces does
+  not.
 - **Nothing enforces that a nested `AGENTS.md` has its `CLAUDE.md` bridge.** A check could;
-  see below.
+  see below. Until then the `.gitignore` negation is the only place the question is asked - which is
+  why the three bridges are enumerated there rather than blanket-negated.
+
+## Settled by testing, so nobody re-opens them
+
+- **Sub-agent hooks DO fire.** Whether `.claude/settings.json` hooks apply to agents spawned via the
+  Agent tool is not stated in the Claude Code docs, and this file previously said to assume they may
+  not. **Verified against 2.1.223**: with a `PreToolUse` hook logging every payload, a `claude -p`
+  told to spawn a sub-agent to run `echo SUBAGENT_RAN_THIS` and to run no bash itself produced a log
+  containing exactly that command. Inheritance is real, which cuts both ways - it is why the `if`
+  bug above was so damaging, since the blast radius included every sub-agent too.
+  Put load-bearing rules in the git hook anyway, for the reason in the layer table: it binds every
+  process that runs `git`, not just this tool.
 
 ## Worth adding
 

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -228,6 +228,15 @@ one is a case in that file, and the suite goes red against the old parser.
 - **Nothing enforces that a nested `AGENTS.md` has its `CLAUDE.md` bridge.** A check could;
   see below. Until then the `.gitignore` negation is the only place the question is asked - which is
   why the three bridges are enumerated there rather than blanket-negated.
+- **Tracking `.claude/settings.json` silently overwrites the local one it replaces - once.** Git
+  refuses to clobber an *untracked* file and clobbers an *ignored* one without a word, and this file
+  was ignored in every clone until it became tracked. So the first pull past that commit replaces
+  any local `.claude/settings.json` with the shared version: no conflict, no warning, and nothing to
+  recover from, because the old contents were never in git. Verified against a scratch clone rather
+  than reasoned about. This is unfixable from inside the repo - git resolves the checkout before any
+  hook here runs - and it is a **one-time** hazard: it only bites a clone that predates the change.
+  The mitigation is to move anything local into `.claude/settings.local.json`, which stays ignored,
+  before pulling; the `.gitignore` comment says so at the point someone reads it.
 
 ## Settled by testing, so nobody re-opens them
 

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -196,8 +196,13 @@ grants stay in `settings.local.json`, still ignored.
   original inline `pre-commit || exit 2` could not see the command it was gating, which left the
   agent with no escape hatch at all while the pre-commit header promises an easy one. It exits 2
   with the failing gate's output on stderr, so the model is told *why* rather than just "no".
-- `PreToolUse` on `Bash`, `if` `Bash(gh pr merge *)`, runs `.claude/hooks/check-squash-subject.sh`,
-  which refuses a `--subject` that would drop or misstate the PR number.
+- `PreToolUse` on `Bash`, **with no `if`** - it runs on every Bash call and filters itself - runs
+  `.claude/hooks/check-squash-subject.sh`, which refuses a `--subject` that would drop or misstate
+  the PR number. It carried `if: Bash(gh pr merge *)` until review pointed out that a prefix match
+  misses every shape it exists for (`/usr/local/bin/gh pr merge`, `echo x && gh pr merge`); see
+  *`if` matches a PREFIX* above for the reasoning and the measured cost of removing it. Because it
+  now sees every command, it only matches `gh` in **command position**, so `echo gh pr merge ...`
+  is text rather than a merge.
 - `UserPromptSubmit` runs `.claude/hooks/inject-merge-checklist.sh`, which puts
   `docs/merge-checklist.md` in front of the agent when a prompt looks like merge prep - "squash",
   "rebase", "ready to merge", "tidy up the commits" and friends. It never blocks; the point is to

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -156,9 +156,10 @@ silent misses.
 header and listed under *Known gaps* below; it is an open decision, not an oversight.
 
 **The three `CLAUDE.md` bridges** - `CLAUDE.md`, `bin/CLAUDE.md`, `docs/inflight/CLAUDE.md`, each a
-pure `@AGENTS.md` import. They are **tracked**, which took a `.gitignore` change: line 4 carried a
-bare `CLAUDE.md` rule from when these were personal scratch files, so all three were ignored and
-existed only on the author's machine. Everything looked correctly wired locally and would have
+pure `@AGENTS.md` import. They are **tracked**, which took a `.gitignore` change: a bare `CLAUDE.md`
+rule there (the one whose comment begins "A `CLAUDE.md` is ignored BY DEFAULT") dated from when
+these were personal scratch files, so all three were ignored and existed only on the author's
+machine. Everything looked correctly wired locally and would have
 merged as a no-op - `git ls-files | grep -c CLAUDE.md` returned **0**. The three paths are now
 negated individually rather than with a blanket `!CLAUDE.md`; the reasoning is in `.gitignore`
 itself, next to the rule.

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -35,7 +35,7 @@ Verified against Claude Code **2.1.223**. This is the part most people get wrong
 there. Claude Code does not read it. The bridge is a `CLAUDE.md` alongside each `AGENTS.md`
 containing `@AGENTS.md`, which imports it:
 
-- `CLAUDE.md` -> imports root `AGENTS.md`, plus the invariants worth stating twice
+- `CLAUDE.md` -> imports root `AGENTS.md`
 - `bin/CLAUDE.md` -> imports `bin/AGENTS.md`, arriving when you touch a script
 - `docs/inflight/CLAUDE.md` -> imports `docs/inflight/AGENTS.md`, arriving when you touch a note
 
@@ -43,6 +43,31 @@ containing `@AGENTS.md`, which imports it:
 which is exactly the "inject the right prompt at the right time" that a routing table in a doc
 cannot do. Adding a nested `AGENTS.md` without its `CLAUDE.md` sibling means Claude Code never sees
 it.
+
+### Import or symlink?
+
+Both work, and git handles both. A symlink is stored as mode `120000` with the target path as its
+blob, so `ln -s AGENTS.md CLAUDE.md` commits and clones fine.
+
+| | Symlink | `@AGENTS.md` import, kept as a pure stub |
+|---|---|---|
+| Drift between the two | impossible - one file | **impossible - the stub has no content to drift** |
+| Windows without Developer Mode | **silently broken**: `core.symlinks` defaults false, and the file checks out as plain text containing the literal string `AGENTS.md` | fine |
+| Claude-only content | impossible | possible, but see below |
+
+This repo uses the **import**, and the reason is worth stating precisely, because the obvious version
+of the argument is wrong. The usual objection to two files is drift - but a stub containing *only*
+`@AGENTS.md` has nothing to drift *with*. Drift is a cost of putting rules in the stub, not a cost of
+the stub existing. So keep them pure: every `CLAUDE.md` here is an import and a sentence about why
+the file exists, and nothing else. On those terms the import strictly dominates - same zero drift,
+and no silent Windows breakage.
+
+That is also why the "Claude-only content" row is not the advantage it looks like. Rules written into
+a `CLAUDE.md` are invisible to Codex and every other agent reading `AGENTS.md`, so taking that option
+is how the two copies start diverging in the first place.
+
+Neutrality is unaffected either way: `AGENTS.md` stays the tool-neutral source, Codex and other
+agents read it directly, and `CLAUDE.md` is only the adapter that makes Claude Code see it.
 
 ## The layers
 
@@ -80,9 +105,24 @@ It distinguishes **failed** from **could not run**. `bin/check-issue-refs.sh` ex
 absent, and blocking a commit for that would teach everyone to bypass the hook, taking the real
 violations with it. Soft exits warn; only genuine violations block.
 
-**`.claude/settings.json`** - a `PreToolUse` hook on `Bash` matching `git commit *`, running the same
-script. This is belt-and-braces: it catches the agent even in a clone where `core.hooksPath` was
-never set, which is the likely state of a fresh worktree on a new machine.
+**`.claude/settings.json`** - two hooks, and the file is **tracked**. `.gitignore` excludes
+`/.claude/*` by contents rather than excluding the directory, with a comment anticipating exactly
+this; the negations `!/.claude/settings.json` and `!/.claude/hooks/**` open that door. Personal
+grants stay in `settings.local.json`, still ignored.
+
+- `PreToolUse` on `Bash` matching `git commit *` runs the same pre-commit script. Belt-and-braces:
+  it catches the agent even in a clone where `core.hooksPath` was never set, which is the likely
+  state of a fresh worktree on a new machine.
+- `UserPromptSubmit` runs `.claude/hooks/inject-merge-checklist.sh`, which puts
+  `docs/merge-checklist.md` in front of the agent when a prompt looks like merge prep - "squash",
+  "rebase", "ready to merge", "tidy up the commits" and friends. It never blocks; the point is to
+  inject the thought at the decision, not to gate anything. The checklist's two standing asks are to
+  **offer** to write the squash message and to **offer** to reorganise the commits into cohesive
+  units. Matching is deliberately broad on verbs and narrow on nouns: a false positive costs a few
+  hundred tokens, a false negative costs the thing it exists to prevent.
+
+The checklist itself is a plain doc, not embedded in the hook, so Codex and anything else reading
+`AGENTS.md` gets the same words from the same file. Only the delivery is Claude-specific.
 
 ## Adding to it
 

--- a/docs/inflight/CLAUDE.md
+++ b/docs/inflight/CLAUDE.md
@@ -1,0 +1,7 @@
+# docs/inflight/CLAUDE.md
+
+Bridge only. Claude Code lazy-loads a nested `CLAUDE.md` when it reads or writes a file in that
+directory, and does not load `AGENTS.md` at all - so this arrives with the rules for these notes at
+the moment you are about to add one.
+
+@AGENTS.md

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -1,0 +1,57 @@
+# Getting a PR ready to merge
+
+**Owns the merge-strategy decision** and what to offer the author before a PR lands. `AGENTS.md`
+keeps the one-line rule and points here; this doc holds the detail. Tool-neutral: Claude Code has it
+injected when a prompt looks like merge prep (`docs/agent-harness.md`), everything else reaches it
+from `AGENTS.md`. One source, so the two cannot drift.
+
+## Recommend a merge strategy - and say why
+
+A long-lived PR accumulates fix-ups nobody wants in the permanent log, but usually also two or three
+genuinely separate pieces of work. **Do not default; look at the actual commits.** Release notes are
+generated from the commit log, so this choice decides what a future changelog has to work with.
+
+### Re-cut the commits
+
+`git reset --mixed <merge-base>`, restage into a handful of atomic commits, rebase-merge. Right when
+the branch holds distinct workstreams someone will later want to bisect to or revert independently.
+The test for "atomic" is whether the message needs an "and also".
+
+- **`git fetch origin master` first, every time**, and reset to the **merge-base**, not to
+  `origin/master`. A stale ref or the wrong base silently reverts whatever master gained meanwhile,
+  and the tell is files appearing in the staged set that the branch never touched.
+- Verify with `git diff <old-tip> HEAD` - it must be **empty**, proving history changed and content
+  did not.
+
+### Squash-merge
+
+When the branch is one idea and the intermediate commits are noise. If you recommend this, **write
+the suggested squash message out in full.** It becomes the permanent record, and GitHub's default -
+the PR title plus every commit subject concatenated - is a log of how the work happened rather than
+an explanation of what changed and why. The PR discussion is not in `git log`; the squash message is
+all a future reader gets.
+
+### Rebase-merge as-is
+
+Only when the existing commits are already clean and atomic.
+
+## Offer, do not just do
+
+Both of the above rewrite history the author may want kept, and both are easy to forget precisely
+when the PR feels finished. **Offer them and say what you would write; do not silently rewrite.**
+Rewriting history someone else may have pulled is not reversible from inside a PR.
+
+## Also confirm before merge
+
+- **Is the PR description still true?** Long-running branches drift; a description written before
+  three rounds of review usually describes a PR that no longer exists.
+- **Has a human reviewed it and said LGTM?** Automated review is not approval, and neither is green
+  CI.
+- **Do the commit messages explain WHY?** The diff already says what.
+- **Is any scaffolding left?** Scratch tests, debug logging, commented-out experiments, a stray
+  `.class`.
+- **Did a rename or deletion leave a dangling reference?** Grep docs, scripts, workflows and the
+  quarantine registry. A rename that compiles can still break a doc pointer or a gate that matches
+  by name.
+- **Other instances of the same defect** - `AGENTS.md`, "PR Discipline", owns that rule; it belongs
+  at merge prep, once the defect class is understood.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -38,6 +38,15 @@ the thing they actually have to answer. Say the strategy and why in a line or tw
 That is a delivery rule, not a licence to skip it: the message still gets written, and written
 properly.
 
+**`--subject` suppresses the PR number.** `gh pr merge --squash` lands a subject ending `... (#265)`
+because GitHub appends the number - but only when the subject is *not* overridden. Pass
+`--subject "..."` and your text is used verbatim, so the number silently never appears, and the
+commit lands out of step with every neighbour on master. It is not fixable afterwards without
+rewriting a pushed commit, which is how astubbs#206 ended up needing one. Either put `(#<pr>)` in the
+subject yourself, or omit `--subject` and let the PR title be used; `--body-file` on its own does not
+affect the subject. `.claude/hooks/check-squash-subject.sh` refuses the bad form for Claude Code, but
+the rule binds anyone merging by hand.
+
 ### Rebase-merge as-is
 
 Only when the existing commits are already clean and atomic.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -38,14 +38,14 @@ the thing they actually have to answer. Say the strategy and why in a line or tw
 That is a delivery rule, not a licence to skip it: the message still gets written, and written
 properly.
 
-**Do not pass `--subject`.** `gh pr merge --squash` lands a subject ending `... (#265)` because
-GitHub appends the PR number - but only when the subject is not overridden. Passing `--subject` uses
-your text verbatim, so the number silently never appears and the commit lands out of step with every
-neighbour on master; astubbs#206 needed a force-push to master to correct. Omit the flag and the PR
-title is used. If the title is wrong, **fix the title** - it is what reviewers saw, and `AGENTS.md`
-already asks for it to be kept in step. `--body-file` on its own does not affect the subject, so a
-hand-written message still works. `.claude/hooks/check-squash-subject.sh` refuses the flag for Claude
-Code; the rule binds anyone merging by hand.
+**If you override the subject, end it with `(#N)`.** `gh pr merge --squash` lands a subject ending
+`... (#265)` because GitHub appends the PR number - but only when the subject is not overridden.
+Pass `--subject` (or its short form `-t`) and your text is used verbatim, so the number silently
+never appears and the commit lands out of step with every neighbour on master; astubbs#206 needed a
+force-push to master to correct. Simplest is to omit the flag entirely and let the PR title be used
+- and if the title is wrong, fix the title, since it is what reviewers saw.
+`.claude/hooks/check-squash-subject.sh` refuses an override without the suffix for Claude Code; the
+rule binds anyone merging by hand.
 
 ### Rebase-merge as-is
 

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -38,14 +38,14 @@ the thing they actually have to answer. Say the strategy and why in a line or tw
 That is a delivery rule, not a licence to skip it: the message still gets written, and written
 properly.
 
-**`--subject` suppresses the PR number.** `gh pr merge --squash` lands a subject ending `... (#265)`
-because GitHub appends the number - but only when the subject is *not* overridden. Pass
-`--subject "..."` and your text is used verbatim, so the number silently never appears, and the
-commit lands out of step with every neighbour on master. It is not fixable afterwards without
-rewriting a pushed commit, which is how astubbs#206 ended up needing one. Either put `(#<pr>)` in the
-subject yourself, or omit `--subject` and let the PR title be used; `--body-file` on its own does not
-affect the subject. `.claude/hooks/check-squash-subject.sh` refuses the bad form for Claude Code, but
-the rule binds anyone merging by hand.
+**Do not pass `--subject`.** `gh pr merge --squash` lands a subject ending `... (#265)` because
+GitHub appends the PR number - but only when the subject is not overridden. Passing `--subject` uses
+your text verbatim, so the number silently never appears and the commit lands out of step with every
+neighbour on master; astubbs#206 needed a force-push to master to correct. Omit the flag and the PR
+title is used. If the title is wrong, **fix the title** - it is what reviewers saw, and `AGENTS.md`
+already asks for it to be kept in step. `--body-file` on its own does not affect the subject, so a
+hand-written message still works. `.claude/hooks/check-squash-subject.sh` refuses the flag for Claude
+Code; the rule binds anyone merging by hand.
 
 ### Rebase-merge as-is
 

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -25,11 +25,18 @@ The test for "atomic" is whether the message needs an "and also".
 
 ### Squash-merge
 
-When the branch is one idea and the intermediate commits are noise. If you recommend this, **write
-the suggested squash message out in full.** It becomes the permanent record, and GitHub's default -
-the PR title plus every commit subject concatenated - is a log of how the work happened rather than
-an explanation of what changed and why. The PR discussion is not in `git log`; the squash message is
-all a future reader gets.
+When the branch is one idea and the intermediate commits are noise. GitHub's default message - the PR
+title plus every commit subject concatenated - is a log of how the work happened rather than an
+explanation of what changed and why, and the PR discussion is not in `git log`, so the squash message
+is all a future reader gets. **Write a real one.**
+
+**Write it where it is used, not into the conversation.** Put it in the merge when you perform it, or
+in the PR body if the author is merging. Do not print it out in chat unless asked - it is long, the
+author is being asked for a decision rather than a proofread, and pasting it makes them scroll past
+the thing they actually have to answer. Say the strategy and why in a line or two; offer the message.
+
+That is a delivery rule, not a licence to skip it: the message still gets written, and written
+properly.
 
 ### Rebase-merge as-is
 


### PR DESCRIPTION
## Description

Every convention in this repo was already written down, correctly. They still got missed — most recently by an agent that added a `docs/inflight/` note describing work its own PR was landing, which `docs/inflight/AGENTS.md` forbids in its first rule. The rule existed, was correct, and was linked from the root `AGENTS.md`. It was simply never read.

**A document only fires when somebody chooses to open it.** This PR gives the conventions mechanisms that fire on their own.

### The finding that drove the design

**Claude Code reads `CLAUDE.md` and never reads `AGENTS.md`** — verified against 2.1.223, not assumed. So every `AGENTS.md` rule in this repo has been opt-in reading, and the routing tables pointing at them only ever helped an agent that had already decided to look. This repo had no `CLAUDE.md` at all.

### What lands

| Layer | Fires when | Binds |
|---|---|---|
| `CLAUDE.md` | session start | Claude Code |
| `bin/CLAUDE.md`, `docs/inflight/CLAUDE.md` | **a file in that directory is touched** | Claude Code |
| `.githooks/pre-commit` | `git commit` | **everyone** |
| `.claude/settings.json` → `PreToolUse` | agent runs `git commit`, or `gh pr merge` | Claude Code |
| `.claude/settings.json` → `UserPromptSubmit` | prompt looks like merge prep | Claude Code |

The **nested** bridges are the interesting half: Claude Code lazy-loads a nested `CLAUDE.md` when it touches a file in that directory, so the rules arrive at the moment you are about to break them. That is right-time injection a routing table cannot do, and it is native — no hook involved. It is also the direct fix for the failure above.

All three `CLAUDE.md` files are **pure imports** (`@AGENTS.md`) plus a sentence on why the file exists. That is deliberate: a stub with no content of its own has nothing to drift with, which is also why it beats a symlink — identical zero-drift, without a symlink's silent breakage on Windows checkouts where `core.symlinks` defaults false and the file arrives as text reading `AGENTS.md`. Rules written into a `CLAUDE.md` would also be invisible to Codex and anything else reading `AGENTS.md`.

`.githooks/pre-commit` runs six fast read-only gates in ~1.7s: copyright headers, issue references, docs data, shell sigpipe, quarantine registry, action versions. It distinguishes a gate that **failed** from one that **could not run** — three of the six exit 2 for a missing interpreter or a shallow clone while reserving 1 for a real finding, and blocking a commit for that would teach everyone to `--no-verify`, taking the real violations with it. Bypass is deliberately easy; CI remains the authority.

The `UserPromptSubmit` hook prints `docs/merge-checklist.md` when a prompt looks like merge prep — `squash`, `rebase`, "ready to merge", "tidy up the commits". It never blocks.

### Three things that contradicted the plan

- **`.claude/*` is gitignored**, so the hook config could not have been shared as first written. The `.gitignore` comment anticipates exactly this — it ignores by *contents* "so that shared config can be un-ignored later with a negation, e.g. `!/.claude/settings.json`". This takes that door. `settings.local.json` stays ignored.
- **A `.claude/settings.json` already existed** with a permissions allow-list. The hooks are merged into it, not over it.
- **The merge-strategy rule already existed** in `AGENTS.md` "PR Discipline". A new doc restating it would have been the duplication `AGENTS.md` forbids in its own rules, so the detail **moves** to `docs/merge-checklist.md`, which now owns it, and `AGENTS.md` keeps rule-plus-pointer.

## Review round: the harness did not apply its own rule 3 to itself

A CE review ran this branch against live Claude Code 2.1.223 and found it did not do what it documented. The common cause is `docs/agent-harness.md` rule 3 — *"give it a negative control, make it go red on purpose before you trust it"* — which the branch applied to every gate except its own hooks. Fixed in `fd9079377`; every claim below was re-confirmed by running it, before and after.

**The headline deliverable was not in the PR.** `.gitignore:4` carried a bare `CLAUDE.md` rule from when those were personal scratch files, so all three bridges were ignored and **untracked** — `git ls-files | grep -c CLAUDE.md` returned **0** while the docs described them as wired. They existed only in the author's worktree, which is why it looked correct locally; on merge nobody would have got the bridge at all. The three paths are now negated individually (reasoning in `.gitignore` itself), and `git ls-tree -r HEAD` confirms all three are in the commit.

**The `if` key was silently dropped, and it cost every Bash call.** `if` is honoured on the hook object, not the matcher group. On the group it is stripped with no warning, so both `PreToolUse` hooks ran on **every** Bash call — and since the gate ended `|| exit 2`, one red gate took away every Bash command in the session, including the one that would fix the gate. Sub-agents inherit hooks, so the blast radius was larger still.

| `if` position | `claude -p "…run: echo MARKER_OK"` |
|---|---|
| on the matcher group (as shipped) | *"The command did not run — it was blocked before execution by a PreToolUse hook"* |
| on the hook object (fixed) | `MARKER_OK` |

**The `--subject` guard let through the exact mistake it exists for.** It read the *first* `--subject` with a regex over the whole command line; `gh` honours the *last*. It **allowed** a second `--subject` overriding a good one, a decoy `--subject` in an earlier command, and a `(#N)` naming a different PR — the precise astubbs#206 shape it is named after. It **denied** an escaped apostrophe and a `--subject` mentioned inside `--body`; a `PreToolUse` deny is hard, so those stopped legitimate merges. Now: slice at each `gh pr merge`, `shlex.split`, take the last `--subject`, cross-check `(#N)` against the PR being merged, fail open on any parse error.

**The gate ignored `--no-verify`** while its own header made the bypass load-bearing. The inline `pre-commit || exit 2` never read the payload. Replaced with `.claude/hooks/pre-commit-gate.sh`, which honours a real `--no-verify` argument and exits 2 with the failing gate's output on stderr — the inline form produced *"hook error: No stderr output"*.

**`docs/agent-harness.md`'s central capability claim was false.** It said *"PreToolUse cannot inject context… it can allow, deny, or ask - nothing else"*, repeated in both hook headers as the reason `UserPromptSubmit` was chosen. Verified live: a `PreToolUse` hook returning `hookSpecificOutput.additionalContext` with a marker passphrase had the model report it verbatim as a `PreToolUse:Bash hook additional context` system-reminder. The narrow claim is true (raw stdout is discarded); the conclusion is not. `UserPromptSubmit` remains right for the checklist, so the **justification** is fixed rather than the design — it fires when the intent is stated, where `PreToolUse` would staple the checklist to whatever command ran next. Likewise *"assume sub-agent hooks may not fire"* is now settled the other way, verified with a payload log.

**Smaller:** `check-docs-data.sh` and `check-copyright-headers.sh` both document exit 2 as "could not run" and both were missing their soft code, hard-blocking a contributor without PyYAML or with a shallow clone; a gate present but not executable is now reported rather than silently skipped; the injection hook no longer prepends its own summary of the checklist (it claimed to hold no advice of its own eleven lines above); `bin/quarantined-test.sh` now sources the shared quarantine lib instead of its own copy of the grep without the worktree exclusions.

### New: `bin/test-check-agent-hooks.sh`

The negative control for all three hooks, wired into `repo-hygiene.yml`. All ten `--subject` cases from the review plus five boundaries, the `--no-verify` hatch, the stderr forwarding, both fail-open paths, and the injection hook's match/no-match set. **It goes red against the code this branch previously shipped** — 8 failures on the old parser, 3 on the old inline gate — which is the property that makes it worth having.

### Verification

- Pre-commit: clean (rc 0, ~1.7s); against a seeded `docs/features` violation (rc 1); against a seeded missing copyright header (rc 1); with `python3` shimmed to 127 (rc 0, *skipped … could not run*); with a shallow-clone fork point (rc 0, skipped); with a gate's exec bit removed (rc 0, *present but NOT EXECUTABLE*); with a gate absent (rc 0, silent).
- All six gates and the affected `test-check-*.sh` self-tests green.
- Hook self-tests: 30/30 green; red against the previously shipped hooks.
- Live against Claude Code 2.1.223, using the shipped `settings.json`: an unrelated Bash call runs while a gate is red; `git commit` blocks *with the gate's reason*; `git commit --no-verify` commits; `gh pr merge … --subject "… (#206)"` on a different PR is denied with the reason delivered to the model.
- `git ls-tree -r HEAD` shows all three bridges tracked; `git check-ignore -v` shows `.claude/worktrees` and `settings.local.json` still ignored.

### Known gaps, documented rather than hidden

- **The gates read the working tree; the commit records the index.** Selective staging can both block a commit for content it is not committing and let a staged violation through. Documented in the hook header and under *Known gaps* rather than fixed — `git stash push --keep-index` can destroy uncommitted work if the hook dies mid-run. **Open decision.**
- **`core.hooksPath` cannot be committed** — a fresh clone needs `git config core.hooksPath .githooks` once (covers all its worktrees). The `PreToolUse` hook covers Claude Code in that window; nothing covers a human.
- **`Bash(git commit *)` matches the command as written**, so it does not fire on `cd sub && git commit …`. The git hook covers that.
- Nothing enforces that a nested `AGENTS.md` has its `CLAUDE.md` bridge. Listed under *Worth adding*; until then the `.gitignore` negation is the only place the question is asked.

## Review round two: the same rule missed the same way

A second review round found six things. Three were already fixed in `fd9079377` and had been reviewed against an older commit; two were judged and kept as they are, now pinned by tests rather than left implicit; one was a real gap and is the most interesting finding on the branch.

**The quarantine-scan fix had no negative control - again.** `bin/lib/quarantine-common.sh` gained `--exclude-dir=.claude` so a sibling worktree's annotations stop polluting this branch's registry check, and nothing held it. There were no quarantine self-tests at all, so deleting or misspelling that flag left the whole repo green. `bin/AGENTS.md` says a checker fix arrives with a case in its self-test, verified red against the old code; `docs/agent-harness.md` rule 3 says the same. This is a PR *about* making conventions fire on their own, and it is now the **second** time it skipped its own.

`bin/test-check-quarantine-registry.sh` is that control, and it carries its own: `previous_implementation()` is the exact pre-fix grep, and the same fixture is asserted against **both** scans - so a refactor that stops the fixture reaching the defect fails loudly instead of the suite passing vacuously. **3 red against the pre-fix lib, 12 green against this one.** It runs in `quarantine-lane.yml` ahead of the two checks that read the scan.

**Tracking `.claude/settings.json` silently destroys the local one it replaces.** Git refuses to overwrite an *untracked* file and overwrites an *ignored* one without a word - and that file was ignored in every clone until this branch. Reproduced in a scratch clone: a fast-forward replaced the local contents with no conflict, no warning, and nothing recoverable, because the file was never in git. No hook here can prevent it; git resolves the checkout before any repo code runs, and a genuinely staged migration needs two releases. So it is written where it will be read in time - the `.gitignore` comment and *Known gaps* - with the actual mitigation: **move local grants into `.claude/settings.local.json` before pulling.** It is strictly one-time, and a fresh clone has nothing to lose.

**Two findings judged and kept.** Reviewer feedback is judged on merits here, not complied with:

- **The `--subject` guard does not require `(#N)` in the trailing slot.** What is unfixable after a merge is a number that is *missing* or names the *wrong PR*, and both are denied - including the reviewer's own `fix(core): detail (#206)` example, verified by running the hook. A correct number sitting mid-subject is visible in the subject the author just typed and still links right. Requiring the slot would make `"port (#N) to master"` a **hard** `PreToolUse` deny that an agent cannot argue with - the exact false-positive class the previous round found blocking legitimate merges. Now asserted in both directions.
- **The Claude-side commit gate reads the session's repo, and the worktree hazard raised against it cannot arrive there.** `if: Bash(git commit *)` matches the command as written, so `cd worktree && git commit` never fires the hook at all; every command that does fire it is a bare `git commit` in the session's own cwd. The `cd`'d case is covered by `.githooks/pre-commit`, which git runs *inside* the target repository - which is why the git hook is the primary mechanism. The header now says which repository it gates.

**Left open for the owner:** the pre-commit gates read the working tree while the commit records the index. The reviewer suggested an index-backed snapshot, which is the better of the two known fixes - `git stash push --keep-index` can destroy uncommitted work if the hook dies mid-run - but two gates diff against the fork point and need real history, and the rest are whole-tree scans, so it is a design change against a ~1.5s budget whose own failure mode is people reaching for `--no-verify`. That trade-off is Antony's call. **The thread is deliberately unresolved.**

## Review round three: one spelling of a flag is one spelling of the mistake

A dispatched review found three blocking defects, all in `check-squash-subject.sh`'s parser - the same 25 lines two earlier rounds already fixed six defects in. Each was reproduced before being fixed, and **9 of the new test cases go red against the parser they replace**.

**`-t` was not read at all.** It is `gh`'s documented short form of `--subject`, so `gh pr merge 1299 --squash -t "no number"` fell through the *"no override, GitHub appends the number itself"* branch and was **allowed**, while `gh` used the text verbatim. That is the astubbs#206 shape this hook is named after, reached through an unhandled spelling. The parser now reads `--subject`, `--subject=X`, `-t X`, `-tX`, `-t=X` and `-t` inside a shorthand group, following pflag's rule that the first value-taking letter in a group takes the rest of it - which is also what stops `-bt` being misread as a subject.

**An unresolvable subject was hard-denied.** `shlex` does not expand `$VAR` or `$(...)`, so the hook was judging a string that is not the one `gh` will send - and denying it. That contradicted the file's own *fail open, always* header, and it is the expensive direction: a `PreToolUse` deny is hard and the agent cannot argue with it.

**The PR cross-check only fired on a bare number**, so a URL selector switched it off and any `(#N)` - including one naming a different PR - was accepted. URLs now yield their number. A branch-name selector still cannot be resolved without a network call, so it keeps the documented allow, now pinned by a test.

**And the self-test was measuring the wrong tree.** `inject-merge-checklist.sh` resolves its checklist from `CLAUDE_PROJECT_DIR` or the cwd's toplevel, so running the suite from the primary checkout pointed the hook at *master's* `docs/` and read the missing file as "not injected". The root is now pinned from `$0`. This file's own failure mode, inside this file - the third time this branch has done that, and the reason rule 3 exists.

## Review rounds four and five: the tests were true and the system was not

Two more rounds, seven more defects, all in the harness itself. Each was reproduced before being fixed and each is asserted red against the code it replaces.

**Body text could switch the merge guard off.** Command boundaries were found with a regex over the raw line, so `--body "text gh pr merge here"` matched a second `gh pr merge` inside quoted text; both resulting slices had unbalanced quotes, both fail-opened, and the real `--subject` was never judged. Segmentation runs over `shlex` tokens now. Searching for the *class* found a second instance the report did not name - the same phrase in the **subject** did it too.

**A merge slice ran past `&&`, `;` and `|`**, so an unrelated later command's `--subject` became "the last one" - a decoy could vouch for a bad merge, and a trailing `echo --subject "no number"` condemned a good one. Slices end at a shell operator now, which needs `shlex.shlex(punctuation_chars=True)`; plain `shlex.split` leaves `a;b` as one token.

**All three hooks died on a large payload, silently.** They passed it as argv, which Linux caps at ~128 KiB, so a prompt carrying a pasted diff failed with *Argument list too long* before python started - and since the hooks fail open, the checklist simply did not appear on exactly the long prompts a human is most likely to be mid-decision on. The payload arrives by temp file now. **The self-test had the same ceiling in its own fixture builder**, so it would have reported the hook broken for reasons unrelated to the hook.

**`fix/pull/1299` is a legal branch name**, and searching every non-numeric selector for `/pull/<digits>` read it as PR 1299 - denying a correct subject. URL detection is anchored to a real URL.

**The quarantine scan excluded one of the two worktree roots.** `.gitignore` names both, calling `/.worktrees/` "the other root in use". Same bug as the `.claude` one, smaller blast radius - and review caught it precisely because no fixture covered that root. Both are excluded, both have a fixture and a negative-control assertion.

**And the sharpest one: `if: Bash(gh pr merge *)` matches a command PREFIX.** So `/usr/local/bin/gh pr merge ...` and `echo x && gh pr merge ...` never reached the guard - *while the self-test asserted they were denied*. They were, by a script the harness was never going to invoke for them. **The test was true and the system was not.** A self-test proves what a script does; whether it is reached is a separate question, and it had not been asked. The merge guard now runs on every Bash call and filters itself, fronted by a `grep` for `merge` that settles the common case without starting python - measured at 6.5ms per ordinary call, which is the only reason the `if` was safe to drop. The commit gate keeps its `if`: it can `exit 2`, and it must stay prefix-matched because it gates the session's repository.

## Checklist

- [x] Docs updated - `docs/agent-harness.md` (the layer map, corrected against a live session and now carrying an ownership statement), `docs/merge-checklist.md` (new owner of the merge-strategy rule), `AGENTS.md` (two routing rows, detail moved out)
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - contributor tooling, no runtime or API surface`
- [x] Tests added/updated - `bin/test-check-agent-hooks.sh` covers all three hooks and runs in repo-hygiene; verified red against the previously shipped versions
- [x] Title & body reflect the final content of this PR



