### PR TITLE
docs #300: record the misnamed produce-send failure, and preserve the swept PR heads only upstream had

### DIFF
--- a/docs/inflight/bug-poisoned-transaction-not-aborted-while-running.md
+++ b/docs/inflight/bug-poisoned-transaction-not-aborted-while-running.md
@@ -58,11 +58,14 @@ away.
   set *when* to retry, never *whether to stop*. There is no max-attempt count and no terminal
   outcome, so a permanently unsendable record retries forever. `confluentinc#196` asks for exactly
   that missing max-retries-plus-callback.
-- **Terminal-vs-retryable exceptions were never built - but for the *user function*, not for sends.**
-  `confluentinc#242` (issue, closed) asked to let the user function throw a retry exception instead
-  of raw errors; its PR `confluentinc#291` is closed unmerged. Both are about exceptions the user's
-  code throws, so neither classifies a *send* failure - read them as precedent for the shape, not as
-  cover for this. Both are already accounted for and must not be re-mirrored: `confluentinc#291`
+- **The retryable half exists; the terminal half does not - and neither covers sends.** A user
+  function can already signal retry by throwing the public `PCRetriableException`, which
+  `AbstractParallelEoSStreamProcessor` recognises on the user-function failure path. What was never
+  built is its opposite: no exception says *stop, this will never succeed*, so nothing can classify
+  a failure as terminal. `confluentinc#242` (issue, closed) asked for the retry half and got it; its
+  PR `confluentinc#291`, which added explicit terminal *and* retry types, is closed unmerged. Both
+  concern exceptions the user's **code** throws, so neither classifies a *send* failure - read them
+  as precedent for the shape, not as cover for this. Both are already accounted for and must not be re-mirrored: `confluentinc#291`
   fell in the 2023-06-15 swept-PR half of `sweep-2023-admin-closure` and is recorded in
   `upstream-map.yaml`; `confluentinc#242` is not sweep-affected, having been closed as completed by
   astubbs in 2022.

--- a/docs/inflight/bug-poisoned-transaction-not-aborted-while-running.md
+++ b/docs/inflight/bug-poisoned-transaction-not-aborted-while-running.md
@@ -58,9 +58,18 @@ away.
   set *when* to retry, never *whether to stop*. There is no max-attempt count and no terminal
   outcome, so a permanently unsendable record retries forever. `confluentinc#196` asks for exactly
   that missing max-retries-plus-callback.
-- **Terminal-vs-retryable exceptions were never built.** `confluentinc#291` proposed explicit
-  terminal and retry exception types precisely so poison pills could be classified; it is closed
-  unmerged.
+- **Terminal-vs-retryable exceptions were never built - but for the *user function*, not for sends.**
+  `confluentinc#242` (issue, closed) asked to let the user function throw a retry exception instead
+  of raw errors; its PR `confluentinc#291` is closed unmerged. Both are about exceptions the user's
+  code throws, so neither classifies a *send* failure - read them as precedent for the shape, not as
+  cover for this. Both are already accounted for and must not be re-mirrored: `confluentinc#291`
+  fell in the 2023-06-15 swept-PR half of `sweep-2023-admin-closure` and is recorded in
+  `upstream-map.yaml`; `confluentinc#242` is not sweep-affected, having been closed as completed by
+  astubbs in 2022.
+- **The send failure's own exception is misnamed**, which costs a rediscovery every time: the
+  non-transactional path throws `InternalRuntimeException` for what is an expected operational
+  state. Tracked in `docs/refactoring.md` under `internal/ProducerManager.java`; naming only, no
+  behaviour change, and it does not wait on the retry work.
 - **The failure-history control is inert.** See `bug-max-failure-history-is-inert.md` - a related
   decision that has to be made in the same area.
 

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -282,13 +282,15 @@ Do not start one casually.
   brute-force transaction-commit retry.
 - **`InternalRuntimeException` names the wrong thing at the produce-callback site**, and the cost is
   rediscovery. `sendCallback` throws it when a send fails in non-transactional mode, but that is an
-  **expected operational state**, not an internal fault: the throw is observable only on the
-  synchronous pre-accumulator path, because Kafka's `ProducerBatch` swallows callback throws on the
-  async one - and everything `KafkaProducer#doSend` raises before the accumulator arrives there, not
-  just size rejections. `RecordTooLargeException` is the one `TransactionalPartialResultSetIT`
-  exercises, but metadata and authorization failures on that same path (`TimeoutException`,
-  `TopicAuthorizationException` - both `ApiException`) reach it too, so the name has to cover
-  environment failures as well as bad result records.
+  **expected operational state**, not an internal fault. The callback is reached from exactly one
+  place: `KafkaProducer#doSend`'s `catch (ApiException)` handler, before the accumulator. That is
+  narrower than "any pre-accumulator failure" - a serializer throwing `SerializationException`
+  propagates out of `doSend` without ever invoking the callback - and wider than "oversized records":
+  `RecordTooLargeException` is the case `TransactionalPartialResultSetIT` exercises, while metadata
+  and authorization failures on that same handler (`TimeoutException`,
+  `TopicAuthorizationException`) reach it too. So the type has to cover environment failures as well
+  as bad result records, but only those arriving as an `ApiException`. Asynchronous failures never
+  reach it at all - Kafka's own `ProducerBatch` catches and logs whatever a callback throws.
   A name that says "internal" sends every reader, human or agent, to re-derive that whole chain
   before they can conclude it is ordinary failure handling. It was verified from source and
   kafka-clients bytecode during astubbs#261 review, and nothing in the code records the answer.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -282,10 +282,13 @@ Do not start one casually.
   brute-force transaction-commit retry.
 - **`InternalRuntimeException` names the wrong thing at the produce-callback site**, and the cost is
   rediscovery. `sendCallback` throws it when a send fails in non-transactional mode, but that is an
-  **expected operational state**, not an internal fault: the reachable causes are client-side
-  rejections of the user's own result records - `RecordTooLargeException` is the one
-  `TransactionalPartialResultSetIT` exercises - and the throw is observable only on the synchronous
-  pre-accumulator path, because Kafka's `ProducerBatch` swallows callback throws on the async one.
+  **expected operational state**, not an internal fault: the throw is observable only on the
+  synchronous pre-accumulator path, because Kafka's `ProducerBatch` swallows callback throws on the
+  async one - and everything `KafkaProducer#doSend` raises before the accumulator arrives there, not
+  just size rejections. `RecordTooLargeException` is the one `TransactionalPartialResultSetIT`
+  exercises, but metadata and authorization failures on that same path (`TimeoutException`,
+  `TopicAuthorizationException` - both `ApiException`) reach it too, so the name has to cover
+  environment failures as well as bad result records.
   A name that says "internal" sends every reader, human or agent, to re-derive that whole chain
   before they can conclude it is ordinary failure handling. It was verified from source and
   kafka-clients bytecode during astubbs#261 review, and nothing in the code records the answer.
@@ -306,7 +309,7 @@ Do not start one casually.
     for why, and do not re-mirror either.
 
 *Prior art: [confluentinc#291](https://github.com/confluentinc/parallel-consumer/pull/291), closed
-unmerged in the 2023-06-15 sweep · already cited in `README_TEMPLATE.adoc`, and worth adding to
+unmerged in the 2023-06-15 sweep · already cited in `src/docs/README_TEMPLATE.adoc`, and worth adding to
 [astubbs#239](https://github.com/astubbs/parallel-consumer/issues/239)'s "Prior work", which names
 [confluentinc#366](https://github.com/confluentinc/parallel-consumer/pull/366) from the same cohort
 but not this.*

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -282,15 +282,23 @@ Do not start one casually.
   brute-force transaction-commit retry.
 - **`InternalRuntimeException` names the wrong thing at the produce-callback site**, and the cost is
   rediscovery. `sendCallback` throws it when a send fails in non-transactional mode, but that is an
-  **expected operational state**, not an internal fault. The callback is reached from exactly one
-  place: `KafkaProducer#doSend`'s `catch (ApiException)` handler, before the accumulator. That is
-  narrower than "any pre-accumulator failure" - a serializer throwing `SerializationException`
-  propagates out of `doSend` without ever invoking the callback - and wider than "oversized records":
-  `RecordTooLargeException` is the case `TransactionalPartialResultSetIT` exercises, while metadata
-  and authorization failures on that same handler (`TimeoutException`,
-  `TopicAuthorizationException`) reach it too. So the type has to cover environment failures as well
-  as bad result records, but only those arriving as an `ApiException`. Asynchronous failures never
-  reach it at all - Kafka's own `ProducerBatch` catches and logs whatever a callback throws.
+  **expected operational state**, not an internal fault. Two different questions decide the scope
+  here, and conflating them has been the recurring error:
+  - **Where is the callback invoked?** On broker-side asynchronous failures too - `ProducerBatch`
+    calls the same `onCompletion`. So the `log.error` fires for effectively every failed send.
+  - **Where can its throw escape?** Only from `KafkaProducer#doSend`'s synchronous
+    `catch (ApiException)` handler. `ProducerBatch` catches and logs whatever the callback throws,
+    so on the asynchronous path the throw is swallowed rather than propagated.
+
+  It is the second question that governs the exception type, since only there is the thrown type
+  observable to a caller. That set is narrower than "any pre-accumulator failure" - a serializer
+  throwing `SerializationException` propagates out of `doSend` without invoking the callback at all -
+  and wider than "oversized records": `RecordTooLargeException` is the case
+  `TransactionalPartialResultSetIT` exercises, while metadata and authorization failures on the same
+  handler (`TimeoutException`, `TopicAuthorizationException`) reach it too. So the type has to cover
+  environment failures as well as bad result records, but only those arriving as an `ApiException`.
+  **Do not model this as "the callback only runs on the synchronous path"** - it runs on both, and a
+  refactor built on that mistake would drop logging for every asynchronous send failure.
   A name that says "internal" sends every reader, human or agent, to re-derive that whole chain
   before they can conclude it is ordinary failure handling. It was verified from source and
   kafka-clients bytecode during astubbs#261 review, and nothing in the code records the answer.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -298,6 +298,14 @@ Do not start one casually.
     be user-visible and belongs in
     [Breaking changes](#breaking-changes-queued-for-next-major-version) instead; the subclass avoids
     needing that.
+    - **The subclass alone is not enough, and this is the part that is easy to get wrong.** A
+      synchronous callback failure escapes `produceMessages` into
+      `ParallelEoSStreamProcessor#processAndProduceResults`, whose `catch (Exception e)` immediately
+      rethrows `new InternalRuntimeException("Error while waiting for produce results", e)`. The
+      specific type would survive only as a nested cause, so a caller still could not catch it and
+      the observable failure type would be exactly as generic as today. The refactor has to preserve
+      the subtype through that outer wrapper too - rethrow it unchanged, or introduce the specific
+      type at the wrapping point - otherwise it buys nothing beyond a better log line.
   - **Drive-by while there:** the lambda parameter is bare `exception`. It is the *send* failure, not
     a user-code exception (those are caught by `runUserFunction`, which wraps the `usersFunction.apply`
     call made in `runUserFunctionInternal`), so name it `sendFailure`. Do **not** name it after user

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -280,6 +280,40 @@ Do not start one casually.
   lock-hygiene: a dedicated private lock is safer (same idea as the PCMetrics `confluentinc#859`
   fix); low priority, separate concern. `alternatives to this brute force approach`:
   brute-force transaction-commit retry.
+- **`InternalRuntimeException` names the wrong thing at the produce-callback site**, and the cost is
+  rediscovery. `sendCallback` throws it when a send fails in non-transactional mode, but that is an
+  **expected operational state**, not an internal fault: the reachable causes are client-side
+  rejections of the user's own result records - `RecordTooLargeException` is the one
+  `TransactionalPartialResultSetIT` exercises - and the throw is observable only on the synchronous
+  pre-accumulator path, because Kafka's `ProducerBatch` swallows callback throws on the async one.
+  A name that says "internal" sends every reader, human or agent, to re-derive that whole chain
+  before they can conclude it is ordinary failure handling. It was verified from source and
+  kafka-clients bytecode during astubbs#261 review, and nothing in the code records the answer.
+  - **Preferred, non-breaking:** throw a specific subclass - e.g. `RecordPublishFailedException
+    extends InternalRuntimeException` - so existing `catch (InternalRuntimeException)` keeps
+    working while the type states the situation. Renaming `InternalRuntimeException` itself would
+    be user-visible and belongs in
+    [Breaking changes](#breaking-changes-queued-for-next-major-version) instead; the subclass avoids
+    needing that.
+  - **Drive-by while there:** the lambda parameter is bare `exception`. It is the *send* failure, not
+    a user-code exception (those are caught around `usersFunction.apply` in
+    `runUserFunctionInternal`), so name it `sendFailure`. Do **not** name it after user code - that
+    is the exact confusion this entry exists to stop.
+  - Adjacent but **not** the same thing: `confluentinc#242` (issue) and its PR `confluentinc#291`
+    cover the **user function** throwing terminal/retry exceptions, so neither classifies a *send*
+    failure. Send-retry semantics live under astubbs#141 / astubbs#149, epic astubbs#239. This item
+    is naming only - it changes no behaviour and does not wait on any of them.
+  - Both are already accounted for, so do not re-mirror them. `confluentinc#291` was closed unmerged
+    on 2023-06-15 in the PR half of the administrative sweep and is recorded in
+    [`upstream-map.yaml`](../src/docs/development/upstream-map.yaml) under `sweep-2023-admin-closure`;
+    it has no dedicated fork issue because that cohort mirrored the 28 swept *issues*, with the 35
+    swept *PRs* carried in the map and surfaced under the relevant mirror's "Prior work".
+    `confluentinc#242` is not sweep-affected at all - astubbs closed it as completed on 2022-10-21.
+    `README_TEMPLATE.adoc` already cites `confluentinc#291` as the refinement reference for
+    throwing failure exceptions from the processing function.
+  - **Small gap worth closing while here:** astubbs#239's "Prior work" names `confluentinc#366` from
+    that same swept-PR cohort but not `confluentinc#291`, which is equally prior art for the retry /
+    terminal-exception half of that epic.
 
 ### internal/DynamicLoadFactor.java
 - `private synchronized boolean doStep` locks on `this` - same lock-hygiene note as

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -296,24 +296,20 @@ Do not start one casually.
     [Breaking changes](#breaking-changes-queued-for-next-major-version) instead; the subclass avoids
     needing that.
   - **Drive-by while there:** the lambda parameter is bare `exception`. It is the *send* failure, not
-    a user-code exception (those are caught around `usersFunction.apply` in
-    `runUserFunctionInternal`), so name it `sendFailure`. Do **not** name it after user code - that
-    is the exact confusion this entry exists to stop.
-  - Adjacent but **not** the same thing: `confluentinc#242` (issue) and its PR `confluentinc#291`
-    cover the **user function** throwing terminal/retry exceptions, so neither classifies a *send*
-    failure. Send-retry semantics live under astubbs#141 / astubbs#149, epic astubbs#239. This item
-    is naming only - it changes no behaviour and does not wait on any of them.
-  - Both are already accounted for, so do not re-mirror them. `confluentinc#291` was closed unmerged
-    on 2023-06-15 in the PR half of the administrative sweep and is recorded in
-    [`upstream-map.yaml`](../src/docs/development/upstream-map.yaml) under `sweep-2023-admin-closure`;
-    it has no dedicated fork issue because that cohort mirrored the 28 swept *issues*, with the 35
-    swept *PRs* carried in the map and surfaced under the relevant mirror's "Prior work".
-    `confluentinc#242` is not sweep-affected at all - astubbs closed it as completed on 2022-10-21.
-    `README_TEMPLATE.adoc` already cites `confluentinc#291` as the refinement reference for
-    throwing failure exceptions from the processing function.
-  - **Small gap worth closing while here:** astubbs#239's "Prior work" names `confluentinc#366` from
-    that same swept-PR cohort but not `confluentinc#291`, which is equally prior art for the retry /
-    terminal-exception half of that epic.
+    a user-code exception (those are caught by `runUserFunction`, which wraps the `usersFunction.apply`
+    call made in `runUserFunctionInternal`), so name it `sendFailure`. Do **not** name it after user
+    code - that is the exact confusion this entry exists to stop.
+  - Naming only: it changes no behaviour and waits on nothing. `confluentinc#242` and its PR
+    `confluentinc#291` are precedent for the *shape* but cover the **user function** throwing
+    terminal/retry exceptions, not send-failure classification - see
+    [`docs/inflight/bug-poisoned-transaction-not-aborted-while-running.md`](inflight/bug-poisoned-transaction-not-aborted-while-running.md)
+    for why, and do not re-mirror either.
+
+*Prior art: [confluentinc#291](https://github.com/confluentinc/parallel-consumer/pull/291), closed
+unmerged in the 2023-06-15 sweep · already cited in `README_TEMPLATE.adoc`, and worth adding to
+[astubbs#239](https://github.com/astubbs/parallel-consumer/issues/239)'s "Prior work", which names
+[confluentinc#366](https://github.com/confluentinc/parallel-consumer/pull/366) from the same cohort
+but not this.*
 
 ### internal/DynamicLoadFactor.java
 - `private synchronized boolean doStep` locks on `this` - same lock-hygiene note as

--- a/docs/todo-index.md
+++ b/docs/todo-index.md
@@ -84,7 +84,7 @@ that line, leave it in the code - it will show up here.
 
 **`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java`**
 
-- TODO(refactor): InternalRuntimeException misnames this - a failed send is an expected state, not an
+- TODO(refactor): InternalRuntimeException misnames a failed send; throw a specific subclass and rename `exception` to `sendFailure`
 - todo consider wrapping all client calls with a catch and new exception in the ProducerWrapper, so can get stack traces
 - TODO talk about alternatives to this brute force approach for retrying committing transactions
 

--- a/docs/todo-index.md
+++ b/docs/todo-index.md
@@ -84,6 +84,7 @@ that line, leave it in the code - it will show up here.
 
 **`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java`**
 
+- TODO(refactor): InternalRuntimeException misnames this - a failed send is an expected state, not an
 - todo consider wrapping all client calls with a catch and new exception in the ProducerWrapper, so can get stack traces
 - TODO talk about alternatives to this brute force approach for retrying committing transactions
 

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -241,11 +241,15 @@ tracked in
 
 A mirror records what a closed PR *said*. It does not keep the code. The 35 PRs closed in the
 2023-06-15 sweep were reachable through `refs/pull/<n>/head` **in the upstream repository**, which is
-not a copy we control: if that repo is deleted, or the branch behind a PR is, the commits go with it,
-and a mirror describing work whose diff no longer exists is close to useless.
+not a copy we control: if that repository goes, the commits go with it, and a mirror describing work
+whose diff no longer exists is close to useless.
+
+Deleting the *branch* behind a PR is **not** a loss event - `refs/pull/<n>/head` is held by the base
+repository and keeps the commit after its branch is gone. The exposure is loss of
+`confluentinc/parallel-consumer` itself.
 
 All 35 heads were raised from branches in `confluentinc/parallel-consumer` itself (every `head.label`
-is `confluentinc:<branch>`), so the exposure is **upstream branch or repository loss** - not a
+is `confluentinc:<branch>`), so the exposure is **upstream repository loss** - not a
 contributor's fork vanishing. That distinction matters because it is the upstream branch, not a third
 party, that has to be watched.
 
@@ -268,17 +272,18 @@ confluentinc#405 have same-named fork branches that do **not** contain their hea
 are in the table below. **Six were reachable from nothing on this fork.** They are now pinned as
 annotated tags:
 
-| Tag | Upstream PR | Head | Author |
-|---|---|---|---|
-| `archive/upstream-pr-22` | confluentinc#22 | `ba6b71f1` | astubbs |
-| `archive/upstream-pr-204` | confluentinc#204 | `02ab3289` | astubbs |
-| `archive/upstream-pr-270` | confluentinc#270 | `007ae090` | astubbs |
-| `archive/upstream-pr-405` | confluentinc#405 | `77a021ee` | astubbs |
-| `archive/upstream-pr-443` | confluentinc#443 | `4533f6d8` | **Robbie-Palmer** |
-| `archive/upstream-pr-506` | confluentinc#506 | `33d93af0` | astubbs |
+confluentinc#22, confluentinc#204, confluentinc#270, confluentinc#405, confluentinc#443 and
+confluentinc#506. Each is pinned as `archive/upstream-pr-<n>`.
+
+**The tag name, target SHA and check date live in one place only** -
+`sweep-2023-admin-closure.preserved_heads` in
+[`upstream-map.yaml`](../src/docs/development/upstream-map.yaml), which is this repo's owner of
+fork-upstream facts. They are deliberately not repeated here: a corrected SHA updated in one copy
+while the other still read as authoritative is exactly the failure this section exists to prevent.
 
 Each tag's message carries the upstream title, author, head branch name and closure date, so the
-provenance survives without the upstream thread.
+provenance survives without the upstream thread. confluentinc#443 is the one raised by an outside
+contributor (Robbie-Palmer); see below for why that turned out not to matter.
 
 confluentinc#443 is the one raised by an outside contributor (Robbie-Palmer), but its head lives on
 `confluentinc:pyallel-consumer` like the rest - that contributor's own fork is already gone, and it
@@ -291,9 +296,8 @@ objects outside the GitHub fork network; that is acceptable because deleting a p
 the network to a surviving fork rather than destroying its objects. If an out-of-network copy is ever
 wanted, `git bundle` is the tool, and nobody has decided it is needed.
 
-**The SHAs above are the record.** They are duplicated into `sweep-2023-admin-closure` in
-[`upstream-map.yaml`](../src/docs/development/upstream-map.yaml) so the check can be redone without
-re-querying upstream, which the PR numbers alone did not allow.
+Recording the SHAs in the manifest is what makes the check redoable without re-querying upstream; the
+PR numbers alone did not allow it.
 
 Their objects are not reachable from any branch, so a plain `git fetch` in a clone made before they
 were pushed will not bring them down - use `git fetch --tags` to get the commits locally. Verifying

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -285,6 +285,11 @@ wanted, `git bundle` is the tool, and nobody has decided it is needed.
 [`upstream-map.yaml`](../src/docs/development/upstream-map.yaml) so the check can be redone without
 re-querying upstream, which the PR numbers alone did not allow.
 
+Their objects are not reachable from any branch, so a plain `git fetch` in a clone made before they
+were pushed will not bring them down - use `git fetch --tags` to get the commits locally. Verifying
+the tags still exist needs no fetch at all: `git ls-remote --tags origin 'archive/upstream-pr-*'`
+asks the remote directly.
+
 **Re-running this is not yet automated.** Branches get deleted, so a head safe today can be orphaned
 tomorrow - but no script checks it: `--audit` covers tracking and mirroring, not reachability, and
 would report clean with every tag above deleted. Until a containment check is wired into

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -249,9 +249,19 @@ is `confluentinc:<branch>`), so the exposure is **upstream branch or repository 
 contributor's fork vanishing. That distinction matters because it is the upstream branch, not a third
 party, that has to be watched.
 
-Checked 2026-08-14 with `git branch -r --contains <head>` per PR, against remote-tracking refs
-reconciled with a live `git ls-remote --heads origin` (three stale local tracking refs would
-otherwise have counted as safe). **29 were reachable from a branch that still exists on this fork** -
+Checked 2026-08-14 per PR with
+
+```bash
+git branch -r --contains <head> --list 'origin/*'
+```
+
+reconciled against a live `git ls-remote --heads origin`, because three stale local tracking refs
+would otherwise have counted as safe. **Restricting to `origin/*` is the whole point of the check**:
+a full clone of this fork also carries `upstream` (see AGENTS.md - `gh` defaults to the wrong repo
+here), and a head contained only in `upstream/*` is exactly the case being looked for. A bare
+`git branch -r --contains` searches every remote, so it would report the upstream-only heads as
+preserved and the archive would never have been created. **29 were reachable from a branch that
+still exists on this fork** -
 note *reachable from*, not *raised from*: confluentinc#271's own branch is long gone and its head
 survives only because an unrelated branch contains it, while confluentinc#22, confluentinc#270 and
 confluentinc#405 have same-named fork branches that do **not** contain their heads, which is why they

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -241,12 +241,21 @@ tracked in
 
 A mirror records what a closed PR *said*. It does not keep the code. The 35 PRs closed in the
 2023-06-15 sweep were reachable through `refs/pull/<n>/head` **in the upstream repository**, which is
-not a copy we control: if that repo is deleted or a contributor's fork disappears, the commits go
-with it, and a mirror describing work whose diff no longer exists is close to useless.
+not a copy we control: if that repo is deleted, or the branch behind a PR is, the commits go with it,
+and a mirror describing work whose diff no longer exists is close to useless.
 
-Checked 2026-08-14 (`git branch -r --contains <head>` for each of the 35): **29 were already safe**,
-because their PRs were raised from branches that still exist on this fork. **Six were reachable only
-from upstream** - not on this fork, and not even present in a local clone. They are now pinned as
+All 35 heads were raised from branches in `confluentinc/parallel-consumer` itself (every `head.label`
+is `confluentinc:<branch>`), so the exposure is **upstream branch or repository loss** - not a
+contributor's fork vanishing. That distinction matters because it is the upstream branch, not a third
+party, that has to be watched.
+
+Checked 2026-08-14 with `git branch -r --contains <head>` per PR, against remote-tracking refs
+reconciled with a live `git ls-remote --heads origin` (three stale local tracking refs would
+otherwise have counted as safe). **29 were reachable from a branch that still exists on this fork** -
+note *reachable from*, not *raised from*: confluentinc#271's own branch is long gone and its head
+survives only because an unrelated branch contains it, while confluentinc#22, confluentinc#270 and
+confluentinc#405 have same-named fork branches that do **not** contain their heads, which is why they
+are in the table below. **Six were reachable from nothing on this fork.** They are now pinned as
 annotated tags:
 
 | Tag | Upstream PR | Head | Author |
@@ -261,13 +270,26 @@ annotated tags:
 Each tag's message carries the upstream title, author, head branch name and closure date, so the
 provenance survives without the upstream thread.
 
-confluentinc#443 was the sharpest case: a third-party fork can vanish independently of Confluent's
-repository, and nothing would have flagged it. Tagging is deliberate over branching - tags are not
-swept by branch-cleanup tooling and read as archival rather than live work.
+confluentinc#443 is the one raised by an outside contributor (Robbie-Palmer), but its head lives on
+`confluentinc:pyallel-consumer` like the rest - that contributor's own fork is already gone, and it
+made no difference. Do not read this as fork-loss risk; the branch upstream is what matters.
 
-**This is a recurring check, not a one-off.** Branches get deleted, so a head safe today can be
-orphaned tomorrow. Re-run it whenever the sweep cohort is revisited; the decision backlog it feeds
-is astubbs#300.
+Tagging is deliberate over branching: tags are not swept by branch-cleanup tooling and read as
+archival rather than live work. An annotated tag is also fetched by every clone, which
+`refs/pull/<n>/head` is not - so the copy actually propagates. Note the tags do **not** put the
+objects outside the GitHub fork network; that is acceptable because deleting a public parent re-roots
+the network to a surviving fork rather than destroying its objects. If an out-of-network copy is ever
+wanted, `git bundle` is the tool, and nobody has decided it is needed.
+
+**The SHAs above are the record.** They are duplicated into `sweep-2023-admin-closure` in
+[`upstream-map.yaml`](../src/docs/development/upstream-map.yaml) so the check can be redone without
+re-querying upstream, which the PR numbers alone did not allow.
+
+**Re-running this is not yet automated.** Branches get deleted, so a head safe today can be orphaned
+tomorrow - but no script checks it: `--audit` covers tracking and mirroring, not reachability, and
+would report clean with every tag above deleted. Until a containment check is wired into
+`upstream-sweep.sh`, this is a manual step to repeat whenever the sweep cohort is revisited. Tracked
+with the rest of the decision backlog in astubbs#300.
 
 ### Surfaces checked and ruled out
 

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -272,18 +272,23 @@ confluentinc#405 have same-named fork branches that do **not** contain their hea
 are in the table below. **Six were reachable from nothing on this fork.** They are now pinned as
 annotated tags:
 
-confluentinc#22, confluentinc#204, confluentinc#270, confluentinc#405, confluentinc#443 and
-confluentinc#506. Each is pinned as `archive/upstream-pr-<n>`.
+| Upstream PR | Author | What it was |
+|---|---|---|
+| confluentinc#22 | astubbs | Dynamic concurrency control (WIP) |
+| confluentinc#204 | astubbs | Run user functions on a Vert.x verticle instead of a Java thread pool |
+| confluentinc#270 | astubbs | Shared-nothing architecture - partition events |
+| confluentinc#405 | astubbs | Remove static state |
+| confluentinc#443 | **Robbie-Palmer** | Python support |
+| confluentinc#506 | astubbs | Fix chart links |
 
-**The tag name, target SHA and check date live in one place only** -
-`sweep-2023-admin-closure.preserved_heads` in
-[`upstream-map.yaml`](../src/docs/development/upstream-map.yaml), which is this repo's owner of
-fork-upstream facts. They are deliberately not repeated here: a corrected SHA updated in one copy
-while the other still read as authoritative is exactly the failure this section exists to prevent.
+Each is tagged `archive/upstream-pr-<n>`. **The tag name, target SHA and check date are deliberately
+not repeated here** - they live only in `sweep-2023-admin-closure.preserved_heads` in
+[`upstream-map.yaml`](../src/docs/development/upstream-map.yaml), this repo's owner of fork-upstream
+facts. A corrected SHA updated in one copy while the other still read as authoritative is exactly the
+drift this section exists to prevent; the table above carries only what does not change.
 
 Each tag's message carries the upstream title, author, head branch name and closure date, so the
-provenance survives without the upstream thread. confluentinc#443 is the one raised by an outside
-contributor (Robbie-Palmer); see below for why that turned out not to matter.
+provenance survives without the upstream thread.
 
 confluentinc#443 is the one raised by an outside contributor (Robbie-Palmer), but its head lives on
 `confluentinc:pyallel-consumer` like the rest - that contributor's own fork is already gone, and it

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -244,14 +244,16 @@ A mirror records what a closed PR *said*. It does not keep the code. The 35 PRs 
 not a copy we control: if that repository goes, the commits go with it, and a mirror describing work
 whose diff no longer exists is close to useless.
 
-Deleting the *branch* behind a PR is **not** a loss event - `refs/pull/<n>/head` is held by the base
-repository and keeps the commit after its branch is gone. The exposure is loss of
-`confluentinc/parallel-consumer` itself.
+Two things are **not** loss events, and both are easy to assume are. Deleting the *branch* behind a
+PR does not lose the commit - `refs/pull/<n>/head` is held by the base repository and outlives its
+branch. Nor does a contributor's fork vanishing: all 35 heads were raised from branches in
+`confluentinc/parallel-consumer` itself (every `head.label` is `confluentinc:<branch>`), so no third
+party holds any of them. **The single exposure is loss of `confluentinc/parallel-consumer`.**
 
-All 35 heads were raised from branches in `confluentinc/parallel-consumer` itself (every `head.label`
-is `confluentinc:<branch>`), so the exposure is **upstream repository loss** - not a
-contributor's fork vanishing. That distinction matters because it is the upstream branch, not a third
-party, that has to be watched.
+There is a second, narrower risk, and it belongs to this fork rather than upstream: the 29 heads that
+are safe are safe only because some `origin/*` branch *contains* them. Deleting one of those fork
+branches can orphan a head that reads as preserved today. That - not any upstream branch - is what
+the recurring check below has to watch.
 
 Checked 2026-08-14 per PR with
 
@@ -288,11 +290,10 @@ facts. A corrected SHA updated in one copy while the other still read as authori
 drift this section exists to prevent; the table above carries only what does not change.
 
 Each tag's message carries the upstream title, author, head branch name and closure date, so the
-provenance survives without the upstream thread.
-
-confluentinc#443 is the one raised by an outside contributor (Robbie-Palmer), but its head lives on
-`confluentinc:pyallel-consumer` like the rest - that contributor's own fork is already gone, and it
-made no difference. Do not read this as fork-loss risk; the branch upstream is what matters.
+provenance survives without the upstream thread. confluentinc#443 is worth one note: it is the only
+one raised by an outside contributor, that contributor's own fork is already gone, and it made no
+difference - the head was on `confluentinc:pyallel-consumer` like every other, which is why the
+exposure above is stated as upstream-repository loss and nothing else.
 
 Tagging is deliberate over branching: tags are not swept by branch-cleanup tooling and read as
 archival rather than live work. An annotated tag is also fetched by every clone, which
@@ -305,7 +306,9 @@ Recording the SHAs in the manifest is what makes the check redoable without re-q
 PR numbers alone did not allow it.
 
 Their objects are not reachable from any branch, so a plain `git fetch` in a clone made before they
-were pushed will not bring them down - use `git fetch --tags` to get the commits locally. Verifying
+were pushed will not bring them down - use `git fetch origin --tags` to get the commits locally.
+Name the remote: on a branch tracking `upstream`, a bare `git fetch --tags` fetches from there and
+leaves all six fork-only tags unavailable. Verifying
 the tags still exist needs no fetch at all: `git ls-remote --tags origin 'archive/upstream-pr-*'`
 asks the remote directly.
 

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -237,6 +237,38 @@ on a quiet day never trips the bulk-day heuristic, and a discussion with one dis
 tracked in
 [`docs/inflight/next-upstream-coverage-completeness.md`](inflight/next-upstream-coverage-completeness.md).
 
+### Swept PR heads that only upstream had - now preserved as tags
+
+A mirror records what a closed PR *said*. It does not keep the code. The 35 PRs closed in the
+2023-06-15 sweep were reachable through `refs/pull/<n>/head` **in the upstream repository**, which is
+not a copy we control: if that repo is deleted or a contributor's fork disappears, the commits go
+with it, and a mirror describing work whose diff no longer exists is close to useless.
+
+Checked 2026-08-14 (`git branch -r --contains <head>` for each of the 35): **29 were already safe**,
+because their PRs were raised from branches that still exist on this fork. **Six were reachable only
+from upstream** - not on this fork, and not even present in a local clone. They are now pinned as
+annotated tags:
+
+| Tag | Upstream PR | Head | Author |
+|---|---|---|---|
+| `archive/upstream-pr-22` | confluentinc#22 | `ba6b71f1` | astubbs |
+| `archive/upstream-pr-204` | confluentinc#204 | `02ab3289` | astubbs |
+| `archive/upstream-pr-270` | confluentinc#270 | `007ae090` | astubbs |
+| `archive/upstream-pr-405` | confluentinc#405 | `77a021ee` | astubbs |
+| `archive/upstream-pr-443` | confluentinc#443 | `4533f6d8` | **Robbie-Palmer** |
+| `archive/upstream-pr-506` | confluentinc#506 | `33d93af0` | astubbs |
+
+Each tag's message carries the upstream title, author, head branch name and closure date, so the
+provenance survives without the upstream thread.
+
+confluentinc#443 was the sharpest case: a third-party fork can vanish independently of Confluent's
+repository, and nothing would have flagged it. Tagging is deliberate over branching - tags are not
+swept by branch-cleanup tooling and read as archival rather than live work.
+
+**This is a recurring check, not a one-off.** Branches get deleted, so a head safe today can be
+orphaned tomorrow. Re-run it whenever the sweep cohort is revisited; the decision backlog it feeds
+is astubbs#300.
+
 ### Surfaces checked and ruled out
 
 Recorded here so they are not re-investigated (established 2026-08-07):

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java
@@ -93,6 +93,9 @@ public class ProducerManager<K, V> extends AbstractOffsetCommitter<K, V> impleme
      * path in the first place - when a send fails asynchronously, Kafka's own {@code ProducerBatch} catches and logs
      * whatever a callback throws, so it was already inert there in both modes.
      */
+    // TODO(refactor): InternalRuntimeException misnames this - a failed send is an expected state, not an
+    //  internal fault. Throw a specific subclass, and rename the callback's `exception` to `sendFailure`.
+    //  See docs/refactoring.md, internal/ProducerManager.java.
     private final Callback sendCallback;
 
     public ProducerManager(ProducerWrapper<K, V> newProducer,

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java
@@ -93,9 +93,10 @@ public class ProducerManager<K, V> extends AbstractOffsetCommitter<K, V> impleme
      * path in the first place - when a send fails asynchronously, Kafka's own {@code ProducerBatch} catches and logs
      * whatever a callback throws, so it was already inert there in both modes.
      */
-    // TODO(refactor): InternalRuntimeException misnames this - a failed send is an expected state, not an
-    //  internal fault. Throw a specific subclass, and rename the callback's `exception` to `sendFailure`.
-    //  See docs/refactoring.md, internal/ProducerManager.java.
+    // TODO(refactor): InternalRuntimeException misnames a failed send; throw a specific subclass and rename `exception` to `sendFailure`
+    //  The whole summary must stay on the TODO line itself: bin/todo-index.sh indexes only that physical
+    //  line, so anything wrapped onto a continuation is dropped from docs/todo-index.md.
+    //  Detail, including why the subclass alone is not enough: docs/refactoring.md, internal/ProducerManager.java.
     private final Callback sendCallback;
 
     public ProducerManager(ProducerWrapper<K, V> newProducer,

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -342,8 +342,13 @@ entries:
   # Do not trust the closure state of any 2023-era upstream item. Several of these
   # issue bodies claim "Implemented in #NNN" where #NNN was itself swept unmerged
   # (e.g. #372 -> PR #390, #319 -> PR #270, #203 -> PR #345, #191 -> PR #346).
-  # All swept PR head commits were verified reachable on 2026-08-07, so the work is
-  # recoverable; cite branch + SHA, not just the PR number.
+  # All swept PR head commits were verified reachable on 2026-08-07 - but only through
+  # upstream's own refs/pull/<n>/head. A containment re-check on 2026-08-14 found six of
+  # the 35 were reachable from NOTHING on this fork, and pinned them as archive tags
+  # (see preserved_heads below, and docs/upstream.md). The other 29 are reachable from a
+  # fork branch, which is not the same as being raised from one and is not permanent.
+  # Cite branch + SHA, not just the PR number - and re-run the containment check rather
+  # than trusting this note, which is a snapshot.
   #
   # MIRROR THE WHOLE COHORT, INCLUDING THE ITEMS WE THINK ARE WORTHLESS. The point is
   # a clean, known cutoff: "every issue upstream closed administratively is accounted
@@ -360,6 +365,20 @@ entries:
     fork: {branches: [docs/mirror-2023-admin-sweep], prs: [258], fork_issues: [227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254], status: pr-open}
     upstream: {repo: confluentinc/parallel-consumer, issues: [21, 24, 28, 29, 34, 40, 41, 48, 49, 50, 53, 57, 65, 119, 144, 154, 175, 183, 187, 191, 199, 203, 205, 246, 267, 319, 320, 372], prs: [22, 45, 46, 81, 106, 143, 179, 181, 204, 220, 270, 271, 291, 300, 303, 316, 325, 345, 346, 356, 366, 390, 405, 408, 441, 442, 443, 464, 473, 488, 492, 494, 496, 506, 524], status: closed, last_checked: 2026-08-07}
     adoc_anchor: null
+    # Swept PR heads that no ref on this fork contained, checked 2026-08-14. Pinned as
+    # annotated tags so they survive loss of the upstream branch or repository. The SHAs
+    # are recorded here, not only the PR numbers, so the containment check can be redone
+    # without re-querying upstream. Re-verify with:
+    #   git ls-remote --tags origin 'archive/upstream-pr-*'
+    # A missing tag, or one no longer pointing at the SHA below, means the copy is gone.
+    preserved_heads:
+      - {pr: 22, sha: ba6b71f10, tag: archive/upstream-pr-22}
+      - {pr: 204, sha: 02ab32894, tag: archive/upstream-pr-204}
+      - {pr: 270, sha: 007ae0906, tag: archive/upstream-pr-270}
+      - {pr: 405, sha: 77a021ee1, tag: archive/upstream-pr-405}
+      - {pr: 443, sha: 4533f6d8d, tag: archive/upstream-pr-443}
+      - {pr: 506, sha: 33d93af09, tag: archive/upstream-pr-506}
+    preserved_heads_checked: 2026-08-14
     notes: >
       Meta-entry for the cohort; the individual work items follow. All 28 issues were
       re-read in full (bodies + all 58 comments) and each verified against fork

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -342,13 +342,15 @@ entries:
   # Do not trust the closure state of any 2023-era upstream item. Several of these
   # issue bodies claim "Implemented in #NNN" where #NNN was itself swept unmerged
   # (e.g. #372 -> PR #390, #319 -> PR #270, #203 -> PR #345, #191 -> PR #346).
-  # All swept PR head commits were verified reachable on 2026-08-07 - but only through
-  # upstream's own refs/pull/<n>/head. A containment re-check on 2026-08-14 found six of
-  # the 35 were reachable from NOTHING on this fork, and pinned them as archive tags
-  # (see preserved_heads below, and docs/upstream.md). The other 29 are reachable from a
-  # fork branch, which is not the same as being raised from one and is not permanent.
-  # Cite branch + SHA, not just the PR number - and re-run the containment check rather
-  # than trusting this note, which is a snapshot.
+  # The 2026-08-07 pass verified all 35 swept PR heads reachable, but it only ever checked
+  # upstream's own refs/pull/<n>/head - it did not ask whether anything on THIS fork contained
+  # them. The 2026-08-14 containment re-check asked that, and split the cohort: 29 are contained
+  # by some origin/* branch here, and SIX are contained by no fork ref at all. Those six - not
+  # the whole cohort - are what the archive tags exist for (see preserved_heads below, and
+  # docs/upstream.md). Being contained by a fork branch is not the same as being raised from
+  # one, and is not permanent: deleting that branch re-orphans the head. Cite branch + SHA, not
+  # just the PR number - and re-run the containment check rather than trusting this note, which
+  # is a snapshot.
   #
   # MIRROR THE WHOLE COHORT, INCLUDING THE ITEMS WE THINK ARE WORTHLESS. The point is
   # a clean, known cutoff: "every issue upstream closed administratively is accounted


### PR DESCRIPTION
## Description

Docs only - no code changes. Two records, both from reading back the astubbs/parallel-consumer#261 fix.

### 1. `InternalRuntimeException` misnames the produce-send failure

`ProducerManager`'s send callback throws `InternalRuntimeException` when a send fails in non-transactional mode. That is an **expected operational state**, not an internal fault: the callback runs on asynchronous failures too (`ProducerBatch` invokes the same `onCompletion`), but only on `doSend`'s synchronous `catch (ApiException)` path can its throw escape to a caller - so that path, not callback reachability, governs the exception type. `RecordTooLargeException` is the case `TransactionalPartialResultSetIT` exercises, but metadata and authorization failures (`TimeoutException`, `TopicAuthorizationException`) reach it too.

The cost is rediscovery. A name saying "internal" sends every reader, human or agent, to re-derive that whole chain - which path is reachable, why the async one is not, what actually throws - before they can conclude it is ordinary failure handling. That derivation was done from source and kafka-clients bytecode during review and was recorded nowhere.

Recorded in `docs/refactoring.md` under the existing `internal/ProducerManager.java` section, with:

- **A non-breaking fix**: throw a specific subclass (e.g. `RecordPublishFailedException extends InternalRuntimeException`) so existing `catch (InternalRuntimeException)` keeps working while the type states the situation. The entry also records that the subclass **alone is not enough** - `processAndProduceResults` re-wraps into a generic `InternalRuntimeException`, so the subtype must be preserved through that outer wrapper or callers still cannot catch it. Renaming the base type would be user-visible, so that route is pointed at the breaking-changes section instead - the subclass avoids needing it.
- **A drive-by**: the lambda parameter is bare `exception`. It is the *send* failure, **not** a user-code exception (those are caught by `runUserFunction`, which wraps the `usersFunction.apply` call made in `runUserFunctionInternal`), so it should be `sendFailure`. The entry explicitly warns against naming it after user code, because that is the exact confusion it exists to stop.

This also **corrects the in-flight note added by astubbs/parallel-consumer#261**, which mischaracterised confluentinc/parallel-consumer#291. It is a PR, not an issue; it implements confluentinc/parallel-consumer#242; and both concern exceptions the **user function** throws, not send-failure classification. Reading them as cover for send retries was wrong - that work sits under astubbs/parallel-consumer#141 and astubbs/parallel-consumer#149, epic astubbs/parallel-consumer#239.

Both are already accounted for and must not be re-mirrored: confluentinc/parallel-consumer#291 was closed unmerged on 2023-06-15 in the PR half of the administrative sweep and is carried in `upstream-map.yaml` under `sweep-2023-admin-closure`; confluentinc/parallel-consumer#242 is not sweep-affected, closed as completed by astubbs in 2022.

One small gap noted for later: astubbs/parallel-consumer#239's "Prior work" cites confluentinc/parallel-consumer#366 from that cohort but not confluentinc/parallel-consumer#291, which is equally prior art for the retry/terminal-exception half of that epic.

### 2. Six swept PR heads existed only upstream - now preserved

**The tags in this section are already pushed**; they are refs, so they do not appear in this diff. Only the `docs/upstream.md` write-up does.

A mirror records what a closed PR *said*. It does not keep the code. The 35 PRs closed in the 2023-06-15 sweep were reachable through `refs/pull/<n>/head` **in the upstream repository** - not a copy we control. If that repository goes, the commits go with it, and a mirror describing work whose diff no longer exists is close to useless.

Checked each of the 35 against this fork's refs, with the containment query restricted to `origin/*` - a full clone also carries `upstream`, and a bare `git branch -r --contains` would report the upstream-only heads as preserved. **29 were already safe**, raised from branches that still exist here. **Six were reachable only from upstream** - not on this fork, and not even present in a local clone:

| Upstream PR | Author | What it was |
|---|---|---|
| confluentinc/parallel-consumer#22 | astubbs | Dynamic concurrency control (WIP) |
| confluentinc/parallel-consumer#204 | astubbs | Run user functions on a Vert.x verticle instead of a Java thread pool |
| confluentinc/parallel-consumer#270 | astubbs | Shared-nothing architecture - partition events |
| confluentinc/parallel-consumer#405 | astubbs | Remove static state |
| confluentinc/parallel-consumer#443 | **Robbie-Palmer** | Python support |
| confluentinc/parallel-consumer#506 | astubbs | Fix chart links |

Each is tagged `archive/upstream-pr-<n>`. The tag name, target SHA and check date live in **one** place - `sweep-2023-admin-closure.preserved_heads` in `upstream-map.yaml` - deliberately not duplicated into prose, so a corrected SHA cannot be updated in one copy while the other still reads as authoritative. The table carries only what does not change.


confluentinc/parallel-consumer#443 was raised by an outside contributor, but its head lives on `confluentinc:pyallel-consumer` like the rest - that contributor's own fork is already gone and it made no difference. The exposure is loss of `confluentinc/parallel-consumer` itself; deleting the *branch* behind a PR is not a loss event, because `refs/pull/<n>/head` is held by the base repository.

Annotated tags rather than branches - they are not swept by branch-cleanup tooling and read as archival rather than live work, matching the existing `refs/tags/archive/...` convention. Each tag message carries the upstream title, author, head branch and closure date, so provenance survives without the upstream thread.

Recorded as a **recurring** check, not a one-off - but explicitly *not* automated: `--audit` covers tracking and mirroring, not reachability, and would report clean with every archive tag deleted.

### Verification

- Every tag confirmed present on the fork via `git ls-remote`, and each annotated tag confirmed to peel to the expected commit.
- `bin/check-issue-refs.sh` passes on the added lines.
- The unreferenced-PR analysis behind astubbs/parallel-consumer#300 was grep over `docs/`, `src/docs/` and the 28 mirror bodies; it does not cover code comments, commit messages or branch names, and that caveat is stated where the finding is recorded.

## Checklist

- [x] Docs updated - this PR is the documentation
- [ ] User-facing feature documentation data added under `docs/features/` - N/A - no user-facing feature or option is added or changed; this records deferred work and preserves history
- [ ] Tests added/updated - N/A - documentation only, no code changes
- [x] Title & body reflect the final content of this PR
