### PR TITLE
docs: give every module a README, and correct what ordering actually decides

### DIFF
--- a/parallel-consumer-core/README.md
+++ b/parallel-consumer-core/README.md
@@ -62,13 +62,26 @@ the editable original is `src/docs/README_TEMPLATE.adoc`, and its own banner say
   [`docs/features/offset-map-acknowledgement.yaml`](../docs/features/offset-map-acknowledgement.yaml).
   Do not re-derive either here.
 
-- **Ordering is a shard-assignment decision and nothing more.** `ShardKey.of` switches on
-  `ProcessingOrder`: `KEY` shards by the record's key, `PARTITION` and `UNORDERED` both shard by
-  topic-partition. Two consequences that surprise people: key-ordered shards key on the *topic
-  name*, not the topic-partition, so the same key arriving on two assigned partitions still runs in
-  one shard; and `UNORDERED` shards *identically* to `PARTITION` - what differs is
-  `ProcessingShard.isOrderRestricted`, which is what stops an ordered shard handing out a second
-  record before the first resolves.
+- **Ordering decides two separate things, and reading it as one is the commonest mistake.** First,
+  *which shard a record lands in* - `ShardKey.of` switches on `ProcessingOrder`, so `KEY` shards by
+  the record's key while `PARTITION` and `UNORDERED` both shard by topic-partition. Second, and
+  independently, *whether a shard hands out a second record before the first resolves* -
+  `ProcessingShard.isOrderRestricted`, which is false only for `UNORDERED`.
+
+  That second axis is why **`UNORDERED` is not "`PARTITION` with a different name" even though the
+  two compute the same shard key**, and why its relationship to partition count is the awkward one:
+
+  | Mode | Shard per | Concurrency ceiling |
+  |---|---|---|
+  | `KEY` | key, per *topic* | one in flight per distinct key |
+  | `PARTITION` | topic-partition | **the number of assigned partitions** |
+  | `UNORDERED` | topic-partition | **the executor pool - shard count does not bound it** |
+
+  So under `UNORDERED` the shard count still equals the partition count while concurrency is not
+  bounded by it at all. The shards remain the unit of *accounting*, not of *parallelism*.
+
+  A second surprise on the first axis: key-ordered shards key on the **topic name**, not the
+  topic-partition, so the same key arriving on two assigned partitions still runs in one shard.
 
 ## Where the topics are really owned
 

--- a/parallel-consumer-core/README.md
+++ b/parallel-consumer-core/README.md
@@ -1,0 +1,94 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# The engine - the shipped library, and the module every other one is built on
+
+Parallel Consumer itself: it holds the Kafka connection, hands records to your function on a worker
+pool, and commits only what has actually completed. `vertx`, `reactor` and `mutiny` each extend it;
+the proxy sidecar wraps it. Nothing else in the tree replaces it.
+
+**The repo-root [`README.adoc`](../README.adoc) owns the user-facing introduction** - ordering
+guarantees, retries, commit modes, shutdown modes, the metrics catalogue, and the tables that pick a
+module for you (`java-version-per-module`, `Module maturity`). This file does not restate any of it;
+it is the map you want when you are about to open the source. Note that `README.adoc` is generated -
+the editable original is `src/docs/README_TEMPLATE.adoc`, and its own banner says so.
+
+## What is in it
+
+- **`bz.stub.parallelconsumer`** - the public API. `ParallelStreamProcessor` (`poll`,
+  `pollAndProduce`, `pollAndProduceMany`), `ParallelConsumerOptions` (the builder: `ordering`,
+  `commitMode`, `maxConcurrency`, `batchSize`, `retryDelayProvider`), `PollContext`/`RecordContext`
+  (what a user function is handed, including `getNumberOfFailedAttempts`), and
+  `PCRetriableException` for a retry that does not log at ERROR.
+- **`internal/`** - the threading. `AbstractParallelEoSStreamProcessor` is the control loop;
+  `BrokerPollSystem` is the broker poller. Alongside them: `ProducerManager` (the produce/commit
+  lock pair), `ConsumerOffsetCommitter`, `DynamicLoadFactor` (how far ahead of the pool records are
+  pre-fetched), and `PCModule` - a hand-rolled dependency-injection container, "modelled on how
+  Dagger works" and deliberately not Dagger.
+- **`internal/ExternalEngine`** - the seam the three integration modules extend. It overrides
+  `setupWorkerPool` down to a single dispatch thread and `getTargetOutForProcessing` to stop
+  pipelining, because their concurrency is the async engine's, not a pool's. It also **rejects
+  transactional commit mode outright**, which is why none of those three modules offers
+  exactly-once.
+- **`state/`** - work management. `WorkManager` over `ShardManager` (the shards, keyed by
+  `ShardKey`), `PartitionStateManager`/`PartitionState` (what each assigned partition has completed,
+  and what it may commit), `WorkContainer` (one record's attempt count and retry-due time), and
+  `RetryQueue` - a purpose-built sorted set whose uniqueness key (topic/partition/offset) is
+  deliberately different from its sort key (retry-due time first).
+- **`offsets/`** - the encoding written into commit metadata. `OffsetMapCodecManager` runs every
+  candidate through `OffsetSimultaneousEncoder` and takes `packSmallest`; `BitSetEncoder` and
+  `RunLengthEncoder` are the two families, each in a plain and a zstd-compressed form, and
+  `OffsetEncoding` maps every variant to its magic byte - including the two `KafkaStreams` values,
+  which exist only to recognise metadata Kafka Streams wrote into the same field and refuse it
+  cleanly, via `KafkaStreamsEncodingNotSupported`.
+- **`metrics/`** - `PCMetrics` and `PCMetricsDef`, the Micrometer meters. The meter-by-meter
+  catalogue is in the root `README.adoc` under `== Metrics`.
+
+## Three things to know before reading the code
+
+- **The poller and the control loop are separate threads, and the distinction is load-bearing.** A
+  stalled controller and a stalled poller are different failures with different symptoms, and the
+  poller is also what keeps group membership alive while the controller is busy. `BrokerPollSystem`
+  and `AbstractParallelEoSStreamProcessor` share `WorkManager` state across that boundary, which is
+  why so much of `state/` is explicitly documented as thread-safe.
+  [`CONCEPTS.md`](../CONCEPTS.md) **owns this vocabulary** - control loop, broker poller, shard,
+  in-flight work, commit frontier, the produce/commit lock pair - and any code comment that seems to
+  disagree with it should be read against it first.
+
+- **What gets committed is the highest *sequentially* succeeded offset; everything completed above
+  it lives in the commit metadata.** That is the whole reason `offsets/` exists, and it is bounded -
+  `DefaultMaxMetadataSize` mirrors the broker's 4096-byte limit, so the encoding can genuinely run
+  out of room. The mechanism and what it does and does not guarantee are described in `README.adoc`
+  at the `[[offset_map]]` anchor, and recorded as a capability in
+  [`docs/features/offset-map-acknowledgement.yaml`](../docs/features/offset-map-acknowledgement.yaml).
+  Do not re-derive either here.
+
+- **Ordering is a shard-assignment decision and nothing more.** `ShardKey.of` switches on
+  `ProcessingOrder`: `KEY` shards by the record's key, `PARTITION` and `UNORDERED` both shard by
+  topic-partition. Two consequences that surprise people: key-ordered shards key on the *topic
+  name*, not the topic-partition, so the same key arriving on two assigned partitions still runs in
+  one shard; and `UNORDERED` shards *identically* to `PARTITION` - what differs is
+  `ProcessingShard.isOrderRestricted`, which is what stops an ordered shard handing out a second
+  record before the first resolves.
+
+## Where the topics are really owned
+
+| Topic | Owner |
+|---|---|
+| User-facing introduction, ordering, retries, commit modes, metrics catalogue | repo-root `README.adoc` (edit `src/docs/README_TEMPLATE.adoc`) |
+| Per-capability records - maturity, limits, when to use | [`docs/features/`](../docs/features/), one YAML per capability, most of them `module: parallel-consumer-core` |
+| Domain vocabulary | [`CONCEPTS.md`](../CONCEPTS.md) |
+| Suites, quarantine lane, chaos suite, the ambient probe, shared test utilities | [`docs/testing.md`](../docs/testing.md) |
+| Deferred internal refactors and the `TODO`/`FIXME` triage | [`docs/refactoring.md`](../docs/refactoring.md) |
+
+## Two build facts that catch people out
+
+- **This module's `src/test/java` and `src/test-integration/java` ship as a `tests`-classifier
+  artifact, and eight other modules depend on it** - the three integration modules and all five
+  examples. `LongPollingMockConsumer`, `KafkaTestUtils`, `BrokerIntegrationTest` and the rest of the
+  shared harness live here, so a change to them is a change to eight other modules' tests. Search
+  before adding a helper; [`docs/testing.md`](../docs/testing.md) owns where they live.
+- **Test parallelism is configured per module, in the pom, on purpose.** The
+  `junit.parallelism.configuration.parameters` property is handed to both surefire and failsafe by
+  this pom; the comment above it records why it may not go back into a packaged
+  `junit-platform.properties` - that file sits at the root of the tests jar and silently overrode
+  all eight downstream modules.

--- a/parallel-consumer-examples/README.md
+++ b/parallel-consumer-examples/README.md
@@ -1,0 +1,52 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# The examples - copyable code that the build keeps honest
+
+An aggregator pom over five small applications, one per way of using the library. They exist to be
+copied from, and to stop the documentation lying: the root `README.adoc` does not contain pasted
+snippets, it `include::`s tagged regions of *these compiled files*.
+
+## The five
+
+| Module | Shows |
+|---|---|
+| [`parallel-consumer-example-core`](parallel-consumer-example-core) | The plain `poll` / `pollAndProduce` setup, plus retry, batching, circuit-breaker and shutdown recipes |
+| [`parallel-consumer-example-metrics`](parallel-consumer-example-metrics) | Wiring a Micrometer `PrometheusMeterRegistry` in and scraping it |
+| [`parallel-consumer-example-vertx`](parallel-consumer-example-vertx) | An HTTP call per record through the Vert.x module |
+| [`parallel-consumer-example-reactor`](parallel-consumer-example-reactor) | Returning a Reactor `Publisher` per record |
+| [`parallel-consumer-example-streams`](parallel-consumer-example-streams) | Preprocess in a Kafka Streams topology, then consume the output topic concurrently |
+
+## Two things that decide how you read them
+
+- **The tagged regions are the README's source code.** Blocks fenced by `// tag::example[]` and
+  friends are pulled into `src/docs/README_TEMPLATE.adoc` by the asciidoc-template plugin and
+  rendered into the repo-root `README.adoc`. `CoreApp.closeModes` carries the reasoning in its own
+  javadoc: the method is never called, and exists so that an API change breaks the *build* rather
+  than quietly leaving the README wrong. **So renaming a tag, or deleting a method that looks
+  unused, edits the published documentation.** Grep `README_TEMPLATE.adoc` for the file's path
+  before touching one.
+- **None of these has a `main` method.** They are wired up and driven by their own tests, and the
+  streams example additionally takes its bootstrap servers via the constructor so you can drive it
+  from your own code. Each module's README says which test runs it and what it needs.
+
+## Running them
+
+From the repo root, `./mvnw verify -pl :parallel-consumer-examples -am` builds and exercises all
+five. Two of them need Docker - failsafe selects on the **package name** `integrationTest*`, not the
+source root, so `example-metrics` and `example-streams` run under failsafe from `src/test/java`
+while the other three are ordinary surefire unit tests. [`docs/testing.md`](../docs/testing.md)
+**owns the suite split**, and `AGENTS.md` owns the repo-wide build scripts; the package-name detail
+is the one that catches people here.
+
+## Not published, deliberately
+
+This pom sets `maven.deploy.skip`, `maven.install.skip` and `gpg.skip`, and turns
+`skipPublishing` on for the central-publishing plugin: examples are sample code, not library
+artifacts. Its comment records the version trap behind that (a plugin version where skipping the
+last module in reactor order skipped the entire bundle upload).
+
+That non-publication is also why two of these modules carry **module-local dependency pins** -
+`example-metrics` on `jackson-databind`, `example-streams` on the `jackson-bom` - which would break
+`parallel-consumer-vertx`'s WireMock tests if promoted to the root pom. Each pin's own comment
+carries the reasoning, and
+[`docs/inflight/deps-deferred-majors.md`](../docs/inflight/deps-deferred-majors.md) tracks them.

--- a/parallel-consumer-examples/parallel-consumer-example-core/README.md
+++ b/parallel-consumer-examples/parallel-consumer-example-core/README.md
@@ -1,0 +1,35 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# Core example - the setup you copy first, plus the recipes around it
+
+One class, `CoreApp`, holding the minimal working setup and then a series of small self-contained
+patterns. Start here if you are copying anything.
+
+## What to look at
+
+- `setupParallelConsumer()` - the whole setup: build a `KafkaConsumer` and `KafkaProducer`, choose
+  `ordering(KEY)` and `maxConcurrency(1000)`, and `subscribe`. This is the block the root
+  `README.adoc` renders at its `[[common_preparation]]` anchor.
+- `run()` - `poll(record -> ...)`, the simplest form.
+- `runPollAndProduce()` - `pollAndProduce`, returning a `ProducerRecord` and taking a callback with
+  the resulting `RecordMetadata`.
+- Then, in decreasing order of how often you will want them: `batching()`, `customRetryDelay()`
+  (exponential backoff via `retryDelayProvider`), `maxRetries()`, `circuitBreaker()`, `closeModes()`
+  (`drainTimeout` / `shutdownTimeout` / `closeDrainFirst`).
+
+## Two things to know
+
+- **Most of these methods are never called.** `maxRetries`, `circuitBreaker` and `closeModes` exist
+  so that their `// tag::` regions can be included into the documentation and so that an API change
+  breaks compilation instead of leaving the README wrong. `closeModes`'s javadoc states this;
+  [the examples parent README](../README.md) covers what that means before you edit one.
+- **`RandomUtils.nextInt()` in the topic names is a test convenience**, not a pattern to copy - it
+  keeps repeated test runs from colliding on one broker.
+
+## Running it
+
+`./mvnw test -pl :parallel-consumer-example-core -am` (from the repo root). `CoreAppTest` subclasses
+`CoreApp` to swap in core's `LongPollingMockConsumer` and a `MockProducer`, feeds three records, and
+waits for the commit to reach offset 3 - so it is a **unit test and needs no Docker**. Those mock
+helpers come from `parallel-consumer-core`'s `tests`-classifier artifact;
+[`docs/testing.md`](../../docs/testing.md) owns where the shared harness lives.

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/README.md
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/README.md
@@ -1,0 +1,44 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# Metrics example - Parallel Consumer's meters, on a Prometheus endpoint
+
+The same core setup as the core example, with Micrometer wired in and scraped end to end: options
+take a `PrometheusMeterRegistry`, a tiny `HttpServer` serves `/prometheus` on port 7001, and the
+test stands up a real Prometheus container that scrapes it.
+
+## What to look at
+
+`CoreApp.setupParallelConsumer()` is the whole point, and it is five numbered lines in the root
+`README.adoc`'s metrics section:
+
+- `meterRegistry(meterRegistry)` - hand PC the registry; without it no PC meter is published.
+- `metricsTags(...)` and `pcInstanceTag(instanceId)` - the tags every PC meter carries. The instance
+  tag is what keeps two PCs in one JVM apart.
+- `new KafkaClientMetrics(kafkaConsumer).bindTo(meterRegistry)` - the *Kafka client's* own metrics,
+  which are separate from PC's and are not published unless you ask.
+
+Then `setupPrometheusEndpoint()` for the scrape endpoint - deliberately the smallest thing that
+works, `com.sun.net.httpserver.HttpServer`, so the example is about the wiring and not about a web
+framework.
+
+## Running it
+
+`./mvnw verify -pl :parallel-consumer-example-metrics -am` (from the repo root). **This one needs
+Docker.** `CoreAppMetricsIntegrationTest` lives in an `integrationTests` package, which is how
+failsafe selects it, and it starts a `PrometheusContainer` via Testcontainers, exposes host port
+7001 to it, and asserts that `pc_status`, `pc_partitions_number`, `pc_incomplete_offsets_total` and
+`pc_user_function_processing_time_seconds` all arrive. The scrape config it uses is
+`src/test/resources/prometheus.yml`.
+
+The meter-by-meter catalogue is in the root [`README.adoc`](../../README.adoc) under `== Metrics`,
+and [`docs/features/micrometer-metrics.yaml`](../../docs/features/micrometer-metrics.yaml) owns the
+capability record.
+
+## One trap in this module's pom
+
+`micrometer-registry-prometheus` is **pinned to 1.12.x**, because 1.13 renamed
+`io.micrometer.prometheus` to `io.micrometer.prometheusmetrics` and that breaks this file. Its own
+comment says so, and the bump is queued in
+[`docs/inflight/deps-deferred-majors.md`](../../docs/inflight/deps-deferred-majors.md). The
+test-scope `jackson-databind` pin next to it is module-local on purpose - promoting it to the root
+pom breaks WireMock in `parallel-consumer-vertx`.

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/README.md
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/README.md
@@ -1,0 +1,26 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# Reactor example - return a Publisher per record
+
+`ReactorApp` builds a `ReactorProcessor` and calls `react(...)`, returning a `Mono` for each record.
+The record completes when the publisher does.
+
+## What to look at
+
+- The options block is unchanged from the core example - `ordering(KEY)`, a consumer, a producer.
+  **Switching engines is a change of processor type, not of configuration**: `new
+  ReactorProcessor<>(options)` in place of `ParallelStreamProcessor.createEosStreamProcessor`.
+- `parallelConsumer.react(context -> Mono.just("something todo"))` - the tagged region the root
+  `README.adoc` renders at its `[[project-reactor]]` anchor. `Mono.just` is a placeholder for your
+  real publisher; the shape of the callback is the lesson, not its body.
+- `closeDrainFirst()` on the way out - finish what is in flight before shutting down.
+
+## Running it
+
+`./mvnw test -pl :parallel-consumer-example-reactor -am` (from the repo root). `ReactorAppTest` is a
+**unit test - no Docker**: it subclasses `ReactorApp` to swap in core's `LongPollingMockConsumer`
+and a `MockProducer`, feeds three records, and waits for the commit to reach offset 3.
+
+For what the module itself constrains - the single dispatch thread, no exactly-once, and error
+signals counting as failures - see [`parallel-consumer-reactor`](../../parallel-consumer-reactor/README.md),
+which owns those.

--- a/parallel-consumer-examples/parallel-consumer-example-streams/README.md
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/README.md
@@ -1,0 +1,44 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# Streams example - preprocess in Kafka Streams, then fan out concurrently
+
+`StreamsApp` runs a two-stage pipeline in one process: a Kafka Streams topology transforms records
+from an input topic onto an output topic, and a Parallel Consumer subscribes to *that* output topic
+and processes it concurrently. This is the answer to "my Streams topology has one slow stage" that
+does not involve adding partitions.
+
+## What to look at
+
+- `run()` - two calls, `preprocess()` then `concurrentProcess()`, and the whole pattern is in that
+  ordering. The root `README.adoc` renders this tagged region at its `[[streams-usage-code]]`
+  anchor.
+- `preprocess()` - an ordinary `StreamsBuilder` topology, `mapValues` then `.to(outputTopicName)`.
+  Nothing about it is Parallel-Consumer-aware.
+- `setupParallelConsumer()` - subscribes to `outputTopicName`, not to the input topic. That is the
+  join between the two halves.
+- `getKafkaConsumer()` - note `ENABLE_AUTO_COMMIT_CONFIG` set to `false`, with the comment
+  explaining it: Parallel Consumer manages commits itself.
+
+## Running it
+
+`./mvnw verify -pl :parallel-consumer-example-streams -am` (from the repo root). **This one needs
+Docker.** `StreamsAppTest` lives in an `integrationTests` package, which is how failsafe selects it,
+and it extends core's `BrokerIntegrationTest` to get a real broker, produces three records to the
+input topic, and waits for the app's counter to reach three - proving the records made it through
+both stages.
+
+Unlike the other examples, `StreamsApp` takes `bootstrapServers` through its constructor, so you can
+also drive it from your own code against a real cluster. There is still no `main` method.
+
+## Where the topic is owned
+
+[`docs/features/staging/kafka-streams-integration.yaml`](../../docs/features/staging/kafka-streams-integration.yaml)
+holds the capability record - **staged, not published**, because part of its evidence is a release
+that has not been cut; that directory's README owns the rule for moving it up.
+
+## One trap in this module's pom
+
+The `jackson-bom` import pinned to `2.18.9` is a CVE floor, not a routine bump: `kafka-streams`
+drags in a vulnerable 2.16.2, and 2.18.0-2.18.8 would trade one vulnerability for another. The pin's
+own comment carries the full reasoning, including why it must stay module-local - promoting it to
+the root pom breaks WireMock in `parallel-consumer-vertx`.

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/README.md
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/README.md
@@ -1,0 +1,29 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# Vert.x example - one HTTP call per record, non-blocking
+
+`VertxApp` builds a `JStreamVertxParallelStreamProcessor` and, for every record, returns a
+`RequestInfo` describing an HTTP request. The Vert.x module sends it, and the record completes when
+the response does.
+
+## What to look at
+
+- The options block is unchanged from the core example - `ordering(KEY)`, a consumer, a producer.
+  **Switching engines is a change of processor type, not of configuration.**
+- `parallelConsumer.vertxHttpReqInfoStream(context -> new RequestInfo(host, port, "/api", params))`
+  - the tagged region the root `README.adoc` renders at its `[[http-with-vertx]]` anchor. You return
+  a description of the request; you never touch the `WebClient`.
+- `resultStream.forEach(...)` - the `JStream` variant hands results back as a Java `Stream` instead
+  of a callback. `VertxParallelStreamProcessor` in the module has the callback forms, and
+  `vertxFuture` for work that is not HTTP.
+
+## Running it
+
+`./mvnw test -pl :parallel-consumer-example-vertx -am` (from the repo root). `VertxAppTest` is a
+**unit test - no Docker**: it stands up WireMock via core's shared `WireMockUtils`, subclasses
+`VertxApp` to point at the WireMock port and to swap in `LongPollingMockConsumer`, feeds three
+records and waits for the commit to reach offset 3.
+
+For what the module itself constrains - the single dispatch thread, no exactly-once, and the fact
+that this does not make blocking work non-blocking - see
+[`parallel-consumer-vertx`](../../parallel-consumer-vertx/README.md), which owns those.

--- a/parallel-consumer-mutiny/README.md
+++ b/parallel-consumer-mutiny/README.md
@@ -1,0 +1,55 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# The Mutiny engine - return a Uni, and the record completes when it resolves
+
+An adapter that lets your record handler return a SmallRye Mutiny `Uni` (or a `Multi`), completing
+and committing the record only when that asynchronous work resolves. Parallel Consumer still owns
+shard order, retries and commits; Mutiny owns the threading. Aimed squarely at applications that are
+already Mutiny-shaped - Quarkus, most often.
+
+## What is in it
+
+One class, `MutinyProcessor`, extending core's `ExternalEngine`. Its entry point is
+`onRecord(Function<PollContext, Uni<T>>)`. Subscription runs on an `Executor` you can supply to the
+constructor; the default is `Infrastructure.getDefaultWorkerPool()`. A returned `Multi` is
+subscribed as-is, a single item is wrapped, and `null` is treated as an empty result - all three
+count as success.
+
+## The one thing that makes this module different: it needs Java 17
+
+Every other module targets Java 8 bytecode via Jabel. This one does not, and it says so in its own
+`pom.xml` via `release.target` - **that comment is the full reasoning and this file will not
+duplicate it.** In one line: Mutiny's `Multi` implements `java.util.concurrent.Flow.Publisher`, and
+SmallRye Mutiny 2.x is itself compiled for Java 17, which the release level cannot detect.
+
+The user-facing consequence - a Java 8 or 11 application builds cleanly and then dies with
+`UnsupportedClassVersionError` - is stated in the root [`README.adoc`](../README.adoc) at the
+`[[java-version-per-module]]` anchor, which **owns that warning**. Adding this module to a project is
+the entire opt-in; nothing else in the build pulls Mutiny in.
+
+## Other constraints, before you write against it
+
+- **No exactly-once.** `ExternalEngine` rejects `PERIODIC_TRANSACTIONAL_PRODUCER` in its
+  constructor. Core's rule, shared with `vertx` and `reactor`.
+- **Do not block inside the function that builds the `Uni`.**
+  `ExternalEngine.setupWorkerPool` pins this module to a single dispatch thread; that thread exists
+  only to subscribe and return.
+- **A failure signal is a failure.** `MutinyProcessor.onError` calls `onUserFunctionFailure` for
+  every record in the context, so a failed `Uni` retries as a thrown exception would; a
+  `PCRetriableException` carried on the failure is recognised there and logged at debug rather than
+  error.
+- **`onRecord` takes one `PollContext`**, which is a batch when `batchSize` is set - the whole batch
+  succeeds or fails together.
+
+## Where the topics are owned
+
+- The capability record - maturity, setup coordinates, boundaries, and the validation this module
+  must pass: [`docs/features/mutiny-integration.yaml`](../docs/features/mutiny-integration.yaml).
+- The Java floor, from the user's side:
+  root [`README.adoc`](../README.adoc), `[[java-version-per-module]]`; from the build's side, the
+  `release.target` comment in this module's `pom.xml`.
+- Ordering, retries and commit behaviour: unchanged from
+  [`parallel-consumer-core`](../parallel-consumer-core) - this module changes *where the work runs*,
+  nothing else.
+- Testing mechanics: [`docs/testing.md`](../docs/testing.md). This module's tests are unit-only
+  (`MutinyPCTest`, `MutinyBatchTest`) and need no Docker.

--- a/parallel-consumer-reactor/README.md
+++ b/parallel-consumer-reactor/README.md
@@ -1,0 +1,49 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# The Reactor engine - return a Publisher, and the record completes when it does
+
+An adapter that lets your record handler return any Reactor `Publisher` - a `Mono`, a `Flux`, a
+WebClient call - and marks the record succeeded only when that publisher completes. Parallel
+Consumer still owns shard order, retries and commits; Reactor owns the threading.
+
+## What is in it
+
+One class, `ReactorProcessor`, extending core's `ExternalEngine`. Its single entry point is
+`react(Function<PollContext, Publisher<?>>)`. Subscription runs on a `Scheduler` you can supply to
+the constructor; the default is `Schedulers::boundedElastic`. There is no separate interface and no
+`Jstream` variant - the publisher *is* the result stream.
+
+## Pick this over core when
+
+Your handler already speaks Reactor, or your work is non-blocking IO. Core costs one pool thread per
+in-flight record; here the record's thread is released as soon as the publisher is returned, and
+concurrency is bounded by `ParallelConsumerOptions#getTargetAmountOfRecordsInFlight` rather than by
+a pool size. **If your work is CPU-bound, or blocking anyway, core is the simpler choice and gives
+up nothing.**
+
+[`docs/features/reactor-integration.yaml`](../docs/features/reactor-integration.yaml) **owns the
+capability record** - maturity, setup coordinates and the boundaries.
+
+## Constraints, before you write against it
+
+- **No exactly-once.** `ExternalEngine` rejects `PERIODIC_TRANSACTIONAL_PRODUCER` in its
+  constructor, naming Reactor in the message. Core's rule, shared with `vertx` and `mutiny`.
+- **Do not block inside the function that builds the publisher.**
+  `ExternalEngine.setupWorkerPool` pins this module to a single dispatch thread; that thread exists
+  only to subscribe and return.
+- **Completion, not return, is success - and an error *signal* is a failure.** `ReactorProcessor`'s
+  `onError` calls `onUserFunctionFailure` for every record in the context, so a publisher that
+  errors retries exactly as a thrown exception would; a `PCRetriableException` carried on the error
+  signal is recognised there and logged at debug rather than error, the same as in core.
+- **`react` takes one `PollContext`**, which is a batch when `batchSize` is set - the whole batch
+  succeeds or fails together.
+
+## Where the topics are owned
+
+- Usage, with the worked snippet: the root [`README.adoc`](../README.adoc), anchor
+  `[[project-reactor]]`.
+- Ordering, retries and commit behaviour: unchanged from
+  [`parallel-consumer-core`](../parallel-consumer-core) - this module changes *where the work runs*,
+  nothing else.
+- Testing mechanics: [`docs/testing.md`](../docs/testing.md). This module's tests are unit-only
+  (`ReactorPCTest`, `ReactorBatchTest`) and need no Docker.

--- a/parallel-consumer-vertx/README.md
+++ b/parallel-consumer-vertx/README.md
@@ -1,0 +1,56 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# The Vert.x engine - hand each record to Vert.x and let it own the concurrency
+
+An adapter that lets your record handler return a Vert.x `Future` - typically a `WebClient` HTTP
+call - and completes the record only when that future resolves. Parallel Consumer still decides
+shard order, retries and commits; Vert.x decides how many requests are in flight and on which
+threads.
+
+## What is in it
+
+Four types, and no engine of its own:
+
+- `VertxParallelStreamProcessor` - the interface. `vertxHttpReqInfo` (return a `RequestInfo` and the
+  module builds and sends the request), `vertxHttpRequest` (build the `HttpRequest` yourself),
+  `vertxHttpWebClient` (send it yourself, hand back the `Future`), `vertxFuture` (any Vert.x future
+  at all, not just HTTP), and `batchVertxFuture` for the batched form.
+- `VertxParallelEoSStreamProcessor` - the implementation, extending core's `ExternalEngine`.
+- `JStreamVertxParallelStreamProcessor` / `JStreamVertxParallelEoSStreamProcessor` - the same thing
+  exposed as a Java `Stream` of results (`vertxHttpReqInfoStream`) rather than callbacks.
+
+## Pick this over core when
+
+Your work is **non-blocking IO you would otherwise block a worker thread on**. Core gives you one
+pool thread per in-flight record, so concurrency costs threads; here the record's thread is released
+as soon as the future is handed back, and concurrency is bounded by
+`ParallelConsumerOptions#getTargetAmountOfRecordsInFlight` rather than by a pool size.
+`docs/features/vertx-integration.yaml` **owns the capability record** - maturity, setup coordinates,
+and the boundaries, including the one that matters most: *this does not make a blocking handler
+non-blocking*.
+
+## Constraints, before you write against it
+
+- **No exactly-once.** `ExternalEngine` rejects `PERIODIC_TRANSACTIONAL_PRODUCER` in its
+  constructor, with a message naming Vert.x explicitly. This is core's rule, not this module's, and
+  it applies to `reactor` and `mutiny` equally.
+- **The dispatch thread must never block.** `ExternalEngine.setupWorkerPool` forces the pool to a
+  single thread here, because that thread exists only to hand work to Vert.x. Blocking inside the
+  function that *constructs* the future serialises the whole module.
+- **A record is not done when your function returns - it is done when the future completes.**
+  `ExternalEngine.onUserFunctionSuccess` deliberately does not mark success for async work, and the
+  mailbox entry is deferred to the future's callback.
+- **Vert.x stays on 4.x.** `vertx.version` in this pom is a 4.5 line; the 5.x move is a tracked
+  deferred major in [`docs/inflight/deps-deferred-majors.md`](../docs/inflight/deps-deferred-majors.md).
+
+## Where the topics are owned
+
+- Usage, with the worked snippet: the root [`README.adoc`](../README.adoc), anchor
+  `[[http-with-vertx]]`.
+- The capability record: [`docs/features/vertx-integration.yaml`](../docs/features/vertx-integration.yaml).
+- Ordering, retries and commit behaviour: unchanged from
+  [`parallel-consumer-core`](../parallel-consumer-core) - this module changes *where the work runs*,
+  nothing else.
+- Testing mechanics: [`docs/testing.md`](../docs/testing.md). Worth knowing before you run anything
+  here: the unit tests stand up WireMock, and `VertxConcurrencyIT` under `src/test-integration/java`
+  needs Docker.


### PR DESCRIPTION
Serves no single issue, so none is cited - this is a documentation gap found while working on
astubbs/parallel-consumer#293, not work that issue asked for.

depends on astubbs/parallel-consumer#293

## Description

**Every Maven module now has a README.** Ten did not; two more were fixed in the parent PR. The rule
is the owner's, stated 2026-08-15, and nothing enforces it - the check that finds violations is
recorded in `docs/refactoring.md` alongside the entry this PR resolves.

**Stacked on `feats/proxy-requirements`** (astubbs/parallel-consumer#293) so this diff shows only the
READMEs. It is deliberately separate because it is tangential to the language-proxy work and should be
reviewable, revertable and mergeable on its own.

### What was written, and how

Each README was written **after reading the module**, not assembled from its pom and directory names -
a README that reads as documentation while being inferred is worse than none. Where another document
owns a topic it is cross-referenced and its owner named, rather than restated, because a second copy
drifts.

Findings that only came from reading the code, and that no existing document stated:

- **`parallel-consumer-core`** - ordering decides two independent things, and reading it as one is the
  common mistake: which shard a record lands in (`ShardKey.of` switches on `ProcessingOrder`), and
  separately whether a shard hands out a second record before the first resolves
  (`ProcessingShard.isOrderRestricted`, false only for `UNORDERED`). The consequence is tabulated,
  because it is counterintuitive: under `UNORDERED` the shard count still equals the partition count
  while concurrency is bounded by the executor pool instead, so shards are the unit of *accounting*
  rather than of *parallelism*. A second surprise on the first axis: key-ordered shards key on the
  **topic name**, not the topic-partition.
- **`vertx` / `reactor` / `mutiny`** - the three constraints that matter to a user of any of them are
  **core's, not theirs**: `ExternalEngine` rejects transactional commit mode outright, so none offers
  exactly-once; it pins the worker pool to one dispatch thread; and it defers success to async
  completion. Written once in core's README and cross-referenced from the other three, rather than
  three copies that will disagree within a year.
- Mutiny's Java 17 floor is **cited** to its pom's `release.target` comment rather than re-explained,
  as are core's junit parallelism property, example-metrics' micrometer pin and example-streams'
  jackson CVE floor. Where a pom carries load-bearing reasoning, the README names the comment and
  refuses to copy it.

### Two documentation defects found and NOT papered over

Both are recorded rather than silently worked around, and both are follow-ups this PR does not fix:

1. **No example has a `main` method**, but the root `README.adoc` module-maturity table calls them
   "runnable examples". No run command was invented; each README states that the app is driven by its
   own test, and the streams one notes it additionally takes `bootstrapServers` via constructor.
2. **The examples' integration tests live in `src/test/java/**/integrationTests/`**, not
   `src/test-integration/java`. Failsafe selects on the *package* name (`**/integrationTest*/**/*.java`
   in the root pom), which `AGENTS.md`'s one-line suite summary does not cover. The mechanism is stated
   in the examples parent README, routing to `docs/testing.md` as the owner.

### Verification

- `bin/check-copyright-headers.sh` - green, 0 violations across 720 files.
- `bin/check-issue-refs.sh` - green.
- **31 citations grepped** before commit; one broken relative link found and fixed.
- The module-coverage check re-run after committing: zero missing.

## Checklist

- [x] Docs updated - this PR is documentation; `docs/refactoring.md` carries the entry it resolves
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - no user-facing behaviour changes; `docs/features/` is routed to by name as the owner of per-capability records`
- [x] Tests added/updated - `N/A - documentation only, no code changes. The claims were verified by reading the source and grepping every citation, which is recorded above`
- [x] Title & body reflect the final content of this PR
