### PR TITLE
docs(upstream): register the actor-IPC and thread-model branch families, back-fill five entries, preserve ten upstream branch tips

### DIFF
--- a/docs/inflight/next-branch-audit-orphans.md
+++ b/docs/inflight/next-branch-audit-orphans.md
@@ -1,0 +1,89 @@
+# Branch audit 2026-08-17: orphans to investigate, and upstream tips not preserved on origin
+
+A full sweep of all 196 origin branches against the tracking corpus (upstream-map.yaml,
+docs/refactoring.md, upstream-pr-analysis.adoc, docs/inflight/, docs/upstream.md) found the
+actor-IPC family and the thread-model family had no manifest entries (fixed in the same PR as this
+note), plus the two lists below, which are NOT yet resolved. Method note: "referenced" meant the
+full branch name, or its basename, appearing anywhere in that corpus - existing references were not
+verified correct (one, in `sweep-2023-async-produce`, was already known wrong and is fixed
+alongside this note).
+
+## 1. Interesting orphans - branches referenced nowhere, likely carrying real work
+
+Each needs a look: read the diff vs its merge-base, then either register it in the manifest /
+refactoring.md, or record it as dead. Do NOT delete any of these before that look.
+
+Observability cohort (plausibly one work group):
+
+- `feature/auto-tuning-pressure`
+- `feature/progress-monitoring`
+- `feature/health-metrics`
+- `feature/micrometer` (basename-only reference; confirm what tracks it)
+
+Defect / correctness cohort:
+
+- `commit-timeout-supervise` - name suggests confluentinc#857-adjacent supervision work; check
+  against the bug-857 family before any new work there
+- `bugs/issue-184-reproduce-using-cfacade` and `bugs/issue-184-reproduce-w-cf-reverted` -
+  reproduction pair for confluentinc#184
+- `bugs/prod-tx-manager-retries` - plausibly belongs to `sweep-2023-tx-failure-taxonomy`
+  (confluentinc#144); verify before attaching
+- `features/partial-batch-failure`
+- `tests/less-keys-than-threads-broker-test`
+
+Feature drafts with likely manifest homes (attribute, then back-fill the entry):
+
+- `features/retry-exception`, `features/retry-exception-w-terminal` - likely confluentinc#291 /
+  confluentinc#268 (adoc A10/E1); no dedicated manifest entry exists for that pair yet
+- `features/configure-retry` - possibly confluentinc#66 (which was deliberately REMOVED from the
+  sweep cohort - see sweep-2023-admin-closure notes); needs its own entry if real
+- `features/failure-history`
+- `features/broker-connection-status` - likely confluentinc#185/confluentinc#353 (adoc A9);
+  related to but distinct from `sweep-2023-broker-disconnect-commit`
+- `features/long-encoding` - likely confluentinc#408 runlength-v3 (adoc B4)
+- `features/key-partition-combine` - check against `sweep-2023-null-key-ordering` before assuming
+- `features/extend-functional` - likely confluentinc#303 (adoc C6); `sweep-2023-api-shape` is the
+  nearest entry but its issues are confluentinc#175/confluentinc#372 - verify before attaching
+- `feats/jstream-bounded-blocking-buffer` - relates to `refactor/deprecate-jstream`?
+
+## 2. Upstream branches NOT preserved on origin
+
+Answer to "do we have every upstream branch?": **no.** Every tip exists in local clones with the
+`upstream` remote, but only origin-pushed refs survive confluentinc deleting or GC-ing branches.
+Verified 2026-08-17 by checking every `upstream/*` tip for reachability from any origin ref:
+
+Same-name pairs where the UPSTREAM side has commits origin's copy lacks:
+
+- `0.5.3.x` - upstream ahead
+- `improvements/rebalance-messages` - upstream ahead
+- `improvements/remove-static` - upstream ahead
+- `features/dynamic-concurrency-control` - DIVERGED (upstream tip ba6b71f10 is the SHA the
+  manifest cites for draft PR confluentinc#22; origin's copy @6f85eac41 is older)
+- `features/retry-exception` - DIVERGED
+
+Upstream-only branches with no origin counterpart (bot branches excluded):
+
+- `PL-176/DontDrainIssue` - unknown content, name suggests a real bug investigation; NOT in
+  docs/upstream.md's ruled-out orphan list
+- `features/batching` (2022, "Batching feature and Event system improvements")
+- `docs/back-pressure` (PR confluentinc#508, adoc E3)
+- `improvements/vertx-vertical` @02ab32894 (draft PR confluentinc#204 - the SHA the manifest
+  cites; the manifest citation currently resolves only via the upstream remote)
+- `fix-charts` (despite the name, tip is "more tests", 2022)
+- `pyallel-consumer` + `python-cd-pipeline` (PR confluentinc#443 family)
+- `correct-failing-license-check` (2025-10)
+- `upstream/master` itself - the 2026 tip (rmoff, "Add link to fork") is ahead of
+  `origin/master-confluent`
+
+Proposed preservation action (cheap, one-off, decision pending): push each unpreserved upstream
+tip to origin under `upstream-archive/<name>` so the fork holds a durable copy; then
+docs/upstream.md's orphan-branch section should be updated to cover the full list above, not just
+the five it names.
+
+## 3. Tooling follow-up
+
+`scripts/upstream-sweep.sh --audit` checks for untracked upstream *issues/PRs*; nothing checks for
+*branches* unreferenced by the manifest or refactoring.md - which is exactly how the actor family
+stayed invisible for three years. Add a branch-audit mode (origin branches vs manifest
+`fork.branches` + refactoring.md, with an explicit junk allowlist) so this list cannot silently
+regrow.

--- a/docs/inflight/next-branch-audit-orphans.md
+++ b/docs/inflight/next-branch-audit-orphans.md
@@ -1,12 +1,18 @@
-# Branch audit 2026-08-17: orphans to investigate, and upstream tips not preserved on origin
+# Branch audit 2026-08-17: orphans to investigate
 
 A full sweep of all 196 origin branches against the tracking corpus (upstream-map.yaml,
 docs/refactoring.md, upstream-pr-analysis.adoc, docs/inflight/, docs/upstream.md) found the
-actor-IPC family and the thread-model family had no manifest entries (fixed in the same PR as this
-note), plus the two lists below, which are NOT yet resolved. Method note: "referenced" meant the
-full branch name, or its basename, appearing anywhere in that corpus - existing references were not
-verified correct (one, in `sweep-2023-async-produce`, was already known wrong and is fixed
-alongside this note).
+actor-IPC and thread-model families had no manifest entries (fixed in the same PR as this note).
+The list below is what remains OPEN. Method note: "referenced" meant the full branch name, or its
+basename, appearing anywhere in that corpus - existing references were not verified correct (one,
+in `sweep-2023-async-produce`, was already known wrong and is fixed alongside this note).
+
+Upstream-tip preservation is DONE, not open: every non-bot `upstream/*` branch tip is now reachable
+from an origin branch or pinned under `archive/upstream-branch/*` /
+`archive/upstream-pr-*` tags. `preserved_branch_tips` in upstream-map.yaml owns the tag/SHA record;
+docs/upstream.md owns the method, including the trap that the 2026-08-14 containment command
+(`git branch -r --contains`) cannot see tags, so re-running it verbatim reports already-preserved
+heads as lost.
 
 ## 1. Interesting orphans - branches referenced nowhere, likely carrying real work
 
@@ -34,7 +40,9 @@ Defect / correctness cohort:
 Feature drafts with likely manifest homes (attribute, then back-fill the entry):
 
 - `features/retry-exception`, `features/retry-exception-w-terminal` - likely confluentinc#291 /
-  confluentinc#268 (adoc A10/E1); no dedicated manifest entry exists for that pair yet
+  confluentinc#268 (adoc A10/E1); no dedicated manifest entry exists for that pair yet. NB the
+  upstream same-named branch tip diverged from origin's but is contained in another origin branch -
+  attribution should look at both lines
 - `features/configure-retry` - possibly confluentinc#66 (which was deliberately REMOVED from the
   sweep cohort - see sweep-2023-admin-closure notes); needs its own entry if real
 - `features/failure-history`
@@ -46,44 +54,21 @@ Feature drafts with likely manifest homes (attribute, then back-fill the entry):
   nearest entry but its issues are confluentinc#175/confluentinc#372 - verify before attaching
 - `feats/jstream-bounded-blocking-buffer` - relates to `refactor/deprecate-jstream`?
 
-## 2. Upstream branches NOT preserved on origin
+Newly preserved upstream tips whose CONTENT was never assessed (read before judging):
 
-Answer to "do we have every upstream branch?": **no.** Every tip exists in local clones with the
-`upstream` remote, but only origin-pushed refs survive confluentinc deleting or GC-ing branches.
-Verified 2026-08-17 by checking every `upstream/*` tip for reachability from any origin ref:
+- `archive/upstream-branch/PL-176/DontDrainIssue` - name suggests a real drain-behaviour
+  investigation; not in docs/upstream.md's earlier ruled-out orphan list
+- `archive/upstream-branch/features/batching` - batching shipped upstream separately; the tip may
+  carry unmerged event-system work
 
-Same-name pairs where the UPSTREAM side has commits origin's copy lacks:
-
-- `0.5.3.x` - upstream ahead
-- `improvements/rebalance-messages` - upstream ahead
-- `improvements/remove-static` - upstream ahead
-- `features/dynamic-concurrency-control` - DIVERGED (upstream tip ba6b71f10 is the SHA the
-  manifest cites for draft PR confluentinc#22; origin's copy @6f85eac41 is older)
-- `features/retry-exception` - DIVERGED
-
-Upstream-only branches with no origin counterpart (bot branches excluded):
-
-- `PL-176/DontDrainIssue` - unknown content, name suggests a real bug investigation; NOT in
-  docs/upstream.md's ruled-out orphan list
-- `features/batching` (2022, "Batching feature and Event system improvements")
-- `docs/back-pressure` (PR confluentinc#508, adoc E3)
-- `improvements/vertx-vertical` @02ab32894 (draft PR confluentinc#204 - the SHA the manifest
-  cites; the manifest citation currently resolves only via the upstream remote)
-- `fix-charts` (despite the name, tip is "more tests", 2022)
-- `pyallel-consumer` + `python-cd-pipeline` (PR confluentinc#443 family)
-- `correct-failing-license-check` (2025-10)
-- `upstream/master` itself - the 2026 tip (rmoff, "Add link to fork") is ahead of
-  `origin/master-confluent`
-
-Proposed preservation action (cheap, one-off, decision pending): push each unpreserved upstream
-tip to origin under `upstream-archive/<name>` so the fork holds a durable copy; then
-docs/upstream.md's orphan-branch section should be updated to cover the full list above, not just
-the five it names.
-
-## 3. Tooling follow-up
+## 2. Tooling follow-up
 
 `scripts/upstream-sweep.sh --audit` checks for untracked upstream *issues/PRs*; nothing checks for
 *branches* unreferenced by the manifest or refactoring.md - which is exactly how the actor family
-stayed invisible for three years. Add a branch-audit mode (origin branches vs manifest
-`fork.branches` + refactoring.md, with an explicit junk allowlist) so this list cannot silently
-regrow.
+stayed invisible for three years. Two audit modes wanted:
+
+- branch-audit: origin branches vs manifest `fork.branches` + refactoring.md, with an explicit junk
+  allowlist, so untracked work cannot silently regrow
+- containment re-check: every `preserved_heads` / `preserved_branch_tips` SHA still reachable on
+  origin (branch OR tag - see the docs/upstream.md trap above); docs/upstream.md already records
+  this as manual-only, tracked in astubbs#300

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -128,9 +128,12 @@ Do not start one casually.
   blocking poll when work arrives), `origin/improvements/poller-bus-actor` @b1598f21 (poller
   as an actor), `origin/improvements/rebalance-messages` @49e977bf (rebalance via messages),
   `origin/refactor/control-loop` @c3a0f28a, `origin/refactor/extract-controller` @25db90e3 (extract a
-  `SubscriptionHandler` interface, pull Poll up), `origin/refactor/infinite-retry` @80feb470
+  `SubscriptionHandler` interface, pull Poll up), `origin/refactor/controller-extract-base` @540b0b9a5
+  (extract-controller's base - MockConsumer-with-PC demonstration; missed by every earlier
+  catalogue, added by the 2026-08-17 branch audit), `origin/refactor/infinite-retry` @80feb470
   (move timeout-retry into the controller; poller just forwards the error),
   `origin/refactor/function-runner` @3fd8caac, `origin/massive-refactor` @f96e0bc4 (the umbrella attempt).
+  Registered in the manifest as `refactor-thread-model-god-class` (this doc stays the editorial owner).
 
 ### Decompose the God class - `AbstractParallelEoSStreamProcessor` (1533 lines)
 - Control loop + lifecycle/state machine + commit orchestration + threading +
@@ -147,8 +150,12 @@ Do not start one casually.
   via actor instead of a blocking `future.get` - relates to draft `confluentinc#356`),
   `origin/improvements/transactions-dont-block` @17f019b8 (non-blocking tx, depends on the
   actor system), `origin/improvements/scheduled-commit` @b6f0a542,
-  `origin/improvements/actor-scheduled` @4db0da0f, `origin/improvements/remove-commit-queue` @381d6997.
+  `origin/improvements/actor-scheduled` @4db0da0f, `origin/improvements/remove-commit-queue` @381d6997,
+  `origin/improvements/poller-bus-actor` @b1598f21 (also listed under the thread-model section
+  above - it carries the *second*, unreconciled actor base: `IActor`/`Actor` + `ActorRef`, vs
+  lambda-actor-bus's `Actor`/`ActorImpl`; its commit d391398f1 records the unification as unfinished).
   Only meaningful as part of the [confluentinc#200](https://github.com/confluentinc/parallel-consumer/issues/200) (mirror astubbs#142) rework.
+  Registered in the manifest as `sweep-2023-actor-ipc` (this doc stays the editorial owner).
 
 ### Remove static state (unblocks parallel test execution)
 *Mirror: [#131](https://github.com/astubbs/parallel-consumer/issues/131).*

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -312,6 +312,21 @@ leaves all six fork-only tags unavailable. Verifying
 the tags still exist needs no fetch at all: `git ls-remote --tags origin 'archive/upstream-pr-*'`
 asks the remote directly.
 
+**The same pass, run over branch tips instead of swept PR heads (2026-08-17):** every
+`upstream/*` branch tip was checked for containment in any origin branch *or tag* (the tag half is
+what the 2026-08-14 command missed - `git branch -r --contains` cannot see the archive tags, so
+re-running it verbatim would report four already-preserved heads as lost). Ten non-bot tips were
+reachable from nothing on this fork and are now pinned as `archive/upstream-branch/<name>` annotated
+tags: the release-line branches (`0.5.3.x`, `v0.5.2.x-dev`, `v0.6.x`), upstream's final `master`,
+`docs/back-pressure` (the swept confluentinc#508 head, out of the 2026-08-14 pass's scope),
+`features/batching`, `PL-176/DontDrainIssue` (content unassessed - flagged in
+`docs/inflight/next-branch-audit-orphans.md`), `python-cd-pipeline`, `correct-failing-license-check`,
+and `DP-12547` (already ruled out as content below; pinned so the ruling stays checkable). The 18
+dependabot/renovate/chore branches were deliberately not preserved - recreatable version bumps, not
+work. Tag names, SHAs and check date live only in `preserved_branch_tips` in
+[`upstream-map.yaml`](../src/docs/development/upstream-map.yaml), same contract as
+`preserved_heads`.
+
 **Re-running this is not yet automated.** Branches get deleted, so a head safe today can be orphaned
 tomorrow - but no script checks it: `--audit` covers tracking and mirroring, not reachability, and
 would report clean with every tag above deleted. Until a containment check is wired into

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -61,6 +61,28 @@ last_swept: 2026-08-06
 upstream_repo: confluentinc/parallel-consumer
 fork_repo: astubbs/parallel-consumer
 
+# Upstream BRANCH tips reachable from nothing on this fork (no origin branch, no tag),
+# pinned as annotated tags 2026-08-17 -- the branch-tip counterpart of
+# sweep-2023-admin-closure.preserved_heads, which covers swept PR heads. Same contract:
+# SHAs recorded here so the containment check can be redone without re-querying
+# upstream; a missing tag, or one no longer pointing at its SHA, means the copy is
+# gone. Re-verify with:
+#   git ls-remote --tags origin 'archive/upstream-branch/*'
+# Deliberately excluded: 18 dependabot/renovate/chore bot branches (recreatable
+# version bumps, not work) and upstream/HEAD (duplicates master).
+preserved_branch_tips:
+  - {branch: 0.5.3.x, sha: c097a3745, tag: archive/upstream-branch/0.5.3.x}
+  - {branch: DP-12547, sha: 87cdcf48c, tag: archive/upstream-branch/DP-12547}
+  - {branch: PL-176/DontDrainIssue, sha: 4869ccf65, tag: archive/upstream-branch/PL-176/DontDrainIssue}
+  - {branch: correct-failing-license-check, sha: e8c6ff5fa, tag: archive/upstream-branch/correct-failing-license-check}
+  - {branch: docs/back-pressure, sha: 50cd1cf01, tag: archive/upstream-branch/docs/back-pressure}
+  - {branch: features/batching, sha: 7e2607560, tag: archive/upstream-branch/features/batching}
+  - {branch: master, sha: 9b582c246, tag: archive/upstream-branch/master}
+  - {branch: python-cd-pipeline, sha: c3796a2fd, tag: archive/upstream-branch/python-cd-pipeline}
+  - {branch: v0.5.2.x-dev, sha: 5f5de9154, tag: archive/upstream-branch/v0.5.2.x-dev}
+  - {branch: v0.6.x, sha: 58159a0b9, tag: archive/upstream-branch/v0.6.x}
+preserved_branch_tips_checked: 2026-08-17
+
 entries:
 
   # ---------------------------------------------------------------------------

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -414,7 +414,7 @@ entries:
   - id: sweep-2023-retry-lifecycle
     group: features
     summary: Retry expiry, stall detection and scheduled retry -- the unfinished half of the retry epic
-    fork: {branches: [], prs: [], fork_issues: [239, 231, 234], status: none}
+    fork: {branches: [features/retry-dlq], prs: [], fork_issues: [239, 231, 234], status: none}
     upstream: {repo: confluentinc/parallel-consumer, issues: [65, 34, 48], prs: [366], related: [196, 310, 71, 82, 92, 197, 242], status: mixed, last_checked: 2026-08-07}
     adoc_anchor: null
     notes: >
@@ -477,7 +477,7 @@ entries:
   - id: sweep-2023-async-produce
     group: features
     summary: Consume-process-produce still blocks on producer acks
-    fork: {branches: [], prs: [], fork_issues: [230], status: none}
+    fork: {branches: [improvements/async-process-send-results-using-actor], prs: [], fork_issues: [230], status: none}
     upstream: {repo: confluentinc/parallel-consumer, issues: [29], prs: [356], related: [], status: closed, last_checked: 2026-08-07}
     adoc_anchor: null
     notes: >
@@ -486,13 +486,80 @@ entries:
       naming PR #356 is still in the tree. Needs work-unit limbo state + back pressure
       so producer timeouts do not feed themselves. Interacts with the produce lock in
       PERIODIC_TRANSACTIONAL_PRODUCER: async produce changes when a commit cycle may
-      safely begin. Draft: PR #356 astubbs/improvements/async-process-send-results
-      @a89f0bce2.
+      safely begin. Draft: PR confluentinc#356, branch
+      improvements/async-process-send-results-using-actor @00f350166 (2026-08-17: the
+      2026-08-07 note recorded the branch name without its -using-actor suffix and a
+      SHA, a89f0bce2, that is not the tip; corrected against origin). The conversion
+      is built on the actor framework -- see sweep-2023-actor-ipc.
+
+  - id: sweep-2023-actor-ipc
+    group: rebalance-stability
+    summary: "Micro actor / mailbox IPC framework and its call-site conversions (2022 drafts, swept 2023-06-15)"
+    fork:
+      branches: [improvements/lambda-actor-bus, improvements/commit-command-actor,
+                 improvements/poller-bus-actor, improvements/actor-scheduled,
+                 improvements/transactions-dont-block, improvements/scheduled-commit,
+                 improvements/remove-commit-queue]
+      prs: []
+      status: none
+    upstream:
+      repo: confluentinc/parallel-consumer
+      prs: [325, 524]
+      related: [356, 200, 488]
+      status: closed
+      last_checked: 2026-08-17
+    adoc_anchor: null
+    notes: >
+      Added 2026-08-17: until this entry, confluentinc#325/confluentinc#524 appeared
+      only inside sweep-2023-admin-closure's bulk PR list, so the branch family was
+      invisible to every audit. The framework proper (Actor/ActorImpl +
+      FunctionWithException + Interruptible, io.confluent.csid.actors) is 537 lines
+      across 4 files whose only PC coupling is the 16-line MultithreadingAPI marker
+      interface -- structurally separable from the God-class rewiring the branches
+      also carry. Two unreconciled actor bases exist (poller-bus-actor commit
+      d391398f1: "needs unifying of the two actor classes"); lambda-actor-bus's
+      interface is a strict superset of poller-bus-actor's, verified by diffing both
+      2026-08-17. The async-produce conversion branch is tracked by
+      sweep-2023-async-produce; transactions-dont-block depends on this framework.
+      Editorial verdicts under review: docs/refactoring.md "Actor / IPC message bus"
+      section and upstream-pr-analysis.adoc Group C. upstream remote also carries
+      refactor/actor-base-fixes (review fixes on the wiring, no csid/actors files;
+      content contained in origin refs).
+
+  - id: refactor-thread-model-god-class
+    group: rebalance-stability
+    summary: "Shared-nothing thread model (confluentinc#200) and God-class decomposition (confluentinc#488) -- the branch graveyard, registered"
+    fork:
+      branches: [massive-refactor, refactor/state-machine, refactor/extract-controller,
+                 refactor/controller-extract-base, refactor/control-loop,
+                 refactor/infinite-retry, refactor/function-runner,
+                 improvements/interrupt-reason, improvements/rebalance-messages]
+      prs: []
+      fork_issue: 142
+      status: none
+    upstream:
+      repo: confluentinc/parallel-consumer
+      issues: [200]
+      prs: [488, 270, 271]
+      related: [186]
+      status: mixed
+      last_checked: 2026-08-17
+    adoc_anchor: null
+    notes: >
+      Added 2026-08-17 by the same branch audit as sweep-2023-actor-ipc: the work
+      group existed only in docs/refactoring.md (which stays the editorial owner --
+      this entry is the fork<->upstream registration). confluentinc#200 and
+      confluentinc#186 verified still OPEN upstream 2026-08-17; PRs
+      confluentinc#488/confluentinc#270/confluentinc#271 closed unmerged in the
+      2023-06-15 sweep. refactor/controller-extract-base @540b0b9a5 was in no
+      tracking doc at all until this entry (its sibling refactor/extract-controller
+      was). Killing the poll/control split would remove the confluentinc#857
+      deadlock class -- see bug-857-stall-after-rebalance.
 
   - id: sweep-2023-tx-failure-taxonomy
     group: rebalance-stability
     summary: ProducerManager retries every transaction commit failure identically
-    fork: {branches: [], prs: [], fork_issues: [241], status: none}
+    fork: {branches: [tx-commit-failure], prs: [], fork_issues: [241], status: none}
     upstream: {repo: confluentinc/parallel-consumer, issues: [144], prs: [], related: [112], status: closed, last_checked: 2026-08-07}
     adoc_anchor: null
     notes: >
@@ -524,7 +591,7 @@ entries:
   - id: sweep-2023-topic-priority
     group: features
     summary: Prioritise some subscribed topics over others via reserved concurrency shares
-    fork: {branches: [], prs: [], fork_issues: [236], status: none}
+    fork: {branches: [features/queue-priority], prs: [], fork_issues: [236], status: none}
     upstream: {repo: confluentinc/parallel-consumer, issues: [50], prs: [441], related: [372], status: closed, last_checked: 2026-08-07}
     adoc_anchor: null
     notes: >
@@ -552,15 +619,22 @@ entries:
   - id: sweep-2023-long-tail
     group: features
     summary: "Swept issues tracked but not scheduled: tracing, dynamic concurrency, rate limiting, proxy, Connect, multi-cluster, per-record tx, drain-to-plain-offsets, vertx verticle"
-    fork: {branches: [], prs: [], fork_issues: [227, 228, 229, 232, 235, 240, 242, 249, 253], status: none}
+    fork: {branches: [features/dynamic-concurrency-control, features/rate-limiting, features/connect-in-pc, features/multi-cluster], prs: [], fork_issues: [227, 228, 229, 232, 235, 240, 242, 249, 253], status: none}
     upstream: {repo: confluentinc/parallel-consumer, issues: [21, 24, 28, 40, 49, 119, 154, 205, 320], prs: [22, 204, 443], related: [], status: closed, last_checked: 2026-08-07}
     adoc_anchor: null
     notes: >
-      All verified absent from fork source 2026-08-07. #28 tracing: re-scope to
+      All verified absent from fork source 2026-08-07. Branch drafts back-filled
+      2026-08-17 (found by branch audit; fork branches carry per-item drafts:
+      dynamic-concurrency confluentinc#21/confluentinc#22, rate-limiting
+      confluentinc#24, connect-in-pc confluentinc#119, multi-cluster
+      confluentinc#320). #28 tracing: re-scope to
       OpenTelemetry (OpenTracing archived 2022); PC is a strong candidate because it
       reorders work, which logs cannot show. #21 dynamic concurrency: distinct from
       DynamicLoadFactor, which sizes the buffer feeding a fixed pool, not the pool
-      (draft PR #22 @ba6b71f10). #24 distributed rate limiting: note internal.RateLimiter
+      (draft PR #22 @ba6b71f10 -- NB that SHA is the UPSTREAM branch tip; the fork's
+      same-named branch features/dynamic-concurrency-control @6f85eac41 has DIVERGED
+      from it and the upstream side is not preserved on origin -- see
+      docs/inflight/next-branch-audit-orphans.md). #24 distributed rate limiting: note internal.RateLimiter
       is unrelated (throttles status logging in tests). #119 Connect: reporter offered
       to do the work and was told there was no demand; maintainer later had working
       hacks both directions and judged "Connect sinks inside PC" publishable -- that


### PR DESCRIPTION
## Description

A full audit of all 196 origin branches against the tracking corpus (upstream-map.yaml, `docs/refactoring.md`, upstream-pr-analysis.adoc, `docs/inflight/`, `docs/upstream.md`) found the manifest blind to whole families of 2022 draft work, and several upstream branch tips preserved nowhere on this fork. Two commits:

**Commit 1 - register what the manifest could not see:**

- New entry `sweep-2023-actor-ipc`: the micro-actor framework branch family (`lambda-actor-bus`, `commit-command-actor`, `poller-bus-actor`, `actor-scheduled`, `transactions-dont-block`, `scheduled-commit`, `remove-commit-queue`). Until now confluentinc/parallel-consumer#325 / confluentinc/parallel-consumer#524 appeared only inside `sweep-2023-admin-closure`'s bulk PR list, so no audit could see the family.
- New entry `refactor-thread-model-god-class`: registers the confluentinc/parallel-consumer#200 / confluentinc/parallel-consumer#488 branch graveyard (fork mirror astubbs/parallel-consumer#142). `refactor/controller-extract-base` was in no tracking doc at all. `docs/refactoring.md` stays the editorial owner; both sections now cross-reference their manifest ids.
- Back-filled `fork.branches` on five entries that recorded the upstream item but not the fork branch carrying its draft: `sweep-2023-async-produce` (also fixes its wrong branch name and stale SHA), `sweep-2023-tx-failure-taxonomy`, `sweep-2023-retry-lifecycle`, `sweep-2023-topic-priority`, `sweep-2023-long-tail`.
- `docs/refactoring.md`: `poller-bus-actor` added to the Actor/IPC section it was missing from (it carries the second, unreconciled actor base).
- New `docs/inflight/next-branch-audit-orphans.md`: the unreferenced branches still needing attribution, and the sweep-tool branch-audit mode that would keep this from regrowing.

**Commit 2 - extend the preserved-heads pass from swept PR heads to ALL upstream branch tips:**

- Ten non-bot tips were reachable from nothing on this fork; now pinned as annotated `archive/upstream-branch/<name>` tags on origin (release lines `0.5.3.x` / `v0.5.2.x-dev` / `v0.6.x`, upstream's final `master`, `docs/back-pressure` = the swept confluentinc/parallel-consumer#508 head, `features/batching`, `PL-176/DontDrainIssue`, `python-cd-pipeline`, `correct-failing-license-check`, `DP-12547`). Tag/SHA record: `preserved_branch_tips` in upstream-map.yaml, same single-source contract as `preserved_heads`.
- 18 dependabot/renovate/chore branches deliberately not preserved - recreatable version bumps, not work.
- Corrects commit 1's inflight note: its containment check used `git branch -r --contains`, which cannot see tags, so it wrongly reported four already-tag-preserved heads as lost. The trap is now recorded in `docs/upstream.md` next to the command.

**Defect-class check (same-defect search):** the class is "manifest entry exists, `fork.branches: []`, while origin carries the draft branch". All 28 pre-existing entries were checked: 5 back-filled here with verified tips; the remaining empty-branch entries either genuinely have no branch or their candidate attribution is uncertain and is listed (with the candidate named) in the inflight note rather than guessed into the manifest - the manifest's own header warns a wrong ref hides work from every future audit.

Verification: `scripts/upstream-map.py validate` green (29 entries); `bin/check-issue-refs.sh` green; every back-filled branch's existence and tip checked against origin; confluentinc/parallel-consumer#200 and confluentinc/parallel-consumer#186 re-checked OPEN upstream 2026-08-17; `git ls-remote --tags origin 'archive/upstream-branch/*'` returns all 10.

## Checklist

- [x] Docs updated
- [x] User-facing feature documentation data added under `docs/features/` - N/A - tracking/docs-only change, no product feature
- [x] Tests added/updated - N/A - no code changed; the map's schema validator (`scripts/upstream-map.py validate`) covers the manifest edits
- [x] Title & body reflect the final content of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqHpNSXC39ANv9kG1ZvUzn
