### PR TITLE
docs(roadmap): the ideation tracks, a stage ladder with its enforcing gate, and the self-tuning promotion

### DIFF
--- a/.github/scripts/roadmap-stage-gate.js
+++ b/.github/scripts/roadmap-stage-gate.js
@@ -9,16 +9,19 @@
 //
 // MECHANICS: the roadmap names its carriers - entries carry `pull_request: astubbs#NNN`. The gate
 // reads the BASE branch's roadmap (the authority on what master currently claims), finds entries
-// naming this PR, and requires the PR to either touch docs/data/roadmap.yaml or opt out with
-// `roadmap-stage: N/A - <reason>` on its own line in the PR body (same convention as
-// `changelog-ref: N/A` / `issue-refs: N/A`). Entries without a pull_request field are out of this
-// gate's reach by design - a tracking issue is not a mergeable event.
+// naming this PR, and requires the CLAIMING ENTRY's stage block (stage / stage_delivery /
+// stage_detail) to differ between the base and head versions of the file - merely touching the
+// file elsewhere does not count, because a wording pass on entry B says nothing about entry A's
+// stage. The escape hatch is `roadmap-stage: N/A - <reason>` on its own line in the PR body (same
+// convention as `changelog-ref: N/A` / `issue-refs: N/A`). Entries without a pull_request field
+// are out of this gate's reach by design - a tracking issue is not a mergeable event.
 //
 // THE PARSE IS DELIBERATELY NARROW. No YAML library ships with the runner and the sibling gates
-// are dependency-free, so this scans the two lines it needs: `- id:` opens an entry block,
-// `pull_request:` inside it names the carrier. That holds for the file's actual shape (flat
-// entries under `entries:`), and the unit tests pin it; a structural rewrite of roadmap.yaml
-// should expect to revisit this.
+// are dependency-free, so this scans the lines it needs: `- id:` opens an entry block, and inside
+// it `pull_request:` names the carrier while `stage*` fields (with their folded continuations)
+// form the compared block. That holds for the file's actual shape (flat entries under `entries:`),
+// and the unit tests pin it - one against the real file - so a structural rewrite of roadmap.yaml
+// fails the tests rather than silently blinding the gate.
 //
 // Pulled out of the workflow so it can be unit tested; roadmap-stage-gate.test.js runs first in CI.
 
@@ -34,7 +37,9 @@ function findOptOut(body) {
 }
 
 // Scans roadmap YAML text for entries whose pull_request names the given PR number.
-// Returns [{id, ref}] - id for the failure message, ref as written in the file.
+// Only the fork's own qualified form counts: `astubbs#NNN`. A confluentinc#NNN (or any other
+// prefix) names a different repository's PR, so a coinciding number must never claim this one.
+// Returns [{id, ref}] - id for the failure message and stage comparison, ref as written.
 function entriesClaimingPr(roadmapText, prNumber) {
   const claims = [];
   let currentId = null;
@@ -46,7 +51,7 @@ function entriesClaimingPr(roadmapText, prNumber) {
     }
     const pr = line.match(/^\s*pull_request:\s*(\S+)\s*$/);
     if (pr && currentId) {
-      const num = pr[1].match(/#(\d+)$/);
+      const num = pr[1].match(/^astubbs#(\d+)$/);
       if (num && Number(num[1]) === Number(prNumber)) {
         claims.push({ id: currentId, ref: pr[1] });
       }
@@ -55,21 +60,64 @@ function entriesClaimingPr(roadmapText, prNumber) {
   return claims;
 }
 
-// True when the PR's changed files include the roadmap.
-function touchesRoadmap(files) {
-  return (files || []).some((f) => f.filename === ROADMAP_PATH);
+// Returns the entry's stage block - its stage / stage_delivery / stage_detail lines, including
+// folded-scalar continuation lines - or null when the entry does not exist in this text.
+// Comparing this snapshot between base and head is what "the entry's stage moved" means.
+function entryStageSnapshot(roadmapText, id) {
+  const lines = (roadmapText || "").split(/\r?\n/);
+  let inEntry = false;
+  let capturing = false;
+  let fieldIndent = 0;
+  const out = [];
+  for (const line of lines) {
+    const idMatch = line.match(/^\s*-\s*id:\s*(\S+)\s*$/);
+    if (idMatch) {
+      if (inEntry) break; // the next entry starts - done
+      inEntry = idMatch[1] === id;
+      continue;
+    }
+    if (!inEntry) continue;
+    if (/^\S/.test(line)) break; // dedent to a new top-level key ends the entries list
+    const field = line.match(/^(\s*)(stage|stage_delivery|stage_detail):/);
+    if (field) {
+      out.push(line);
+      capturing = true;
+      fieldIndent = field[1].length;
+      continue;
+    }
+    if (capturing) {
+      const cont = line.match(/^(\s*)\S/);
+      if (cont && cont[1].length > fieldIndent) {
+        out.push(line); // folded-scalar continuation of the field above
+        continue;
+      }
+      capturing = false;
+    }
+  }
+  return inEntry || out.length > 0 ? out.join("\n") : null;
+}
+
+// True when the claiming entry's stage block differs between base and head - including the entry
+// disappearing at head (a rename or removal is a change the PR is accountable for describing).
+function stageMoved(baseText, headText, id) {
+  const before = entryStageSnapshot(baseText, id);
+  const after = entryStageSnapshot(headText, id);
+  return before !== after;
 }
 
 function formatFailure(claims, prNumber) {
   return (
     `This PR is the carrier of ${claims.length === 1 ? "a roadmap entry" : "roadmap entries"} - ` +
-    `merging it changes how real ${claims.length === 1 ? "that entry is" : "they are"}, so the same ` +
-    `PR must move the stage:\n` +
+    `merging it changes how real ${claims.length === 1 ? "that entry is" : "they are"}, but the ` +
+    `entry's stage block is unchanged in this PR:\n` +
     claims.map((c) => `  - entry '${c.id}' names this PR (${c.ref}) in ${ROADMAP_PATH}`).join("\n") +
-    `\n\nUpdate the entry's stage/stage_detail (and stage_delivery) in ${ROADMAP_PATH} in this PR - ` +
-    `the 'stages' block there defines the ladder. If the stage genuinely does not move ` +
-    `(a mid-flight fixup, say), put "roadmap-stage: N/A - <reason>" on its own line in the PR body.`
+    `\n\nUpdate that entry's stage/stage_detail (and stage_delivery) in ${ROADMAP_PATH} in this PR - ` +
+    `the 'stages' block there defines the ladder, and editing other parts of the file does not ` +
+    `count. If the stage genuinely does not move (a mid-flight fixup, say), put ` +
+    `"roadmap-stage: N/A - <reason>" on its own line in the PR body.`
   );
 }
 
-module.exports = { ROADMAP_PATH, findOptOut, entriesClaimingPr, touchesRoadmap, formatFailure };
+module.exports = {
+  ROADMAP_PATH, findOptOut, entriesClaimingPr, entryStageSnapshot, stageMoved, formatFailure,
+};

--- a/.github/scripts/roadmap-stage-gate.js
+++ b/.github/scripts/roadmap-stage-gate.js
@@ -1,0 +1,75 @@
+// Makes the roadmap's stage ladder self-updating: when a PR is the carrier of a roadmap entry's
+// artifact, merging it changes how real that entry is - so the same PR must move the entry's
+// stage/stage_delivery, or say why not.
+//
+// docs/data/roadmap.yaml owns the rule (the `stages` block: "a PR that advances a track updates
+// its entry's stage in the same change"); this gate is what catches a miss. Without it the rule is
+// only documentation, and the stage field rots into exactly the stale second tracker the roadmap's
+// own update_policy warns about.
+//
+// MECHANICS: the roadmap names its carriers - entries carry `pull_request: astubbs#NNN`. The gate
+// reads the BASE branch's roadmap (the authority on what master currently claims), finds entries
+// naming this PR, and requires the PR to either touch docs/data/roadmap.yaml or opt out with
+// `roadmap-stage: N/A - <reason>` on its own line in the PR body (same convention as
+// `changelog-ref: N/A` / `issue-refs: N/A`). Entries without a pull_request field are out of this
+// gate's reach by design - a tracking issue is not a mergeable event.
+//
+// THE PARSE IS DELIBERATELY NARROW. No YAML library ships with the runner and the sibling gates
+// are dependency-free, so this scans the two lines it needs: `- id:` opens an entry block,
+// `pull_request:` inside it names the carrier. That holds for the file's actual shape (flat
+// entries under `entries:`), and the unit tests pin it; a structural rewrite of roadmap.yaml
+// should expect to revisit this.
+//
+// Pulled out of the workflow so it can be unit tested; roadmap-stage-gate.test.js runs first in CI.
+
+const ROADMAP_PATH = "docs/data/roadmap.yaml";
+
+const OPT_OUT = /^\s*roadmap-stage:\s*N\/?A\b\s*-\s*\S[^\n]*/im;
+
+// Returns the opt-out line from a PR body, or null. The reason is mandatory: a bare "N/A" is not
+// a judgment, it is a bypass.
+function findOptOut(body) {
+  const m = (body || "").match(OPT_OUT);
+  return m ? m[0].trim() : null;
+}
+
+// Scans roadmap YAML text for entries whose pull_request names the given PR number.
+// Returns [{id, ref}] - id for the failure message, ref as written in the file.
+function entriesClaimingPr(roadmapText, prNumber) {
+  const claims = [];
+  let currentId = null;
+  for (const line of (roadmapText || "").split(/\r?\n/)) {
+    const id = line.match(/^\s*-\s*id:\s*(\S+)\s*$/);
+    if (id) {
+      currentId = id[1];
+      continue;
+    }
+    const pr = line.match(/^\s*pull_request:\s*(\S+)\s*$/);
+    if (pr && currentId) {
+      const num = pr[1].match(/#(\d+)$/);
+      if (num && Number(num[1]) === Number(prNumber)) {
+        claims.push({ id: currentId, ref: pr[1] });
+      }
+    }
+  }
+  return claims;
+}
+
+// True when the PR's changed files include the roadmap.
+function touchesRoadmap(files) {
+  return (files || []).some((f) => f.filename === ROADMAP_PATH);
+}
+
+function formatFailure(claims, prNumber) {
+  return (
+    `This PR is the carrier of ${claims.length === 1 ? "a roadmap entry" : "roadmap entries"} - ` +
+    `merging it changes how real ${claims.length === 1 ? "that entry is" : "they are"}, so the same ` +
+    `PR must move the stage:\n` +
+    claims.map((c) => `  - entry '${c.id}' names this PR (${c.ref}) in ${ROADMAP_PATH}`).join("\n") +
+    `\n\nUpdate the entry's stage/stage_detail (and stage_delivery) in ${ROADMAP_PATH} in this PR - ` +
+    `the 'stages' block there defines the ladder. If the stage genuinely does not move ` +
+    `(a mid-flight fixup, say), put "roadmap-stage: N/A - <reason>" on its own line in the PR body.`
+  );
+}
+
+module.exports = { ROADMAP_PATH, findOptOut, entriesClaimingPr, touchesRoadmap, formatFailure };

--- a/.github/scripts/roadmap-stage-gate.test.js
+++ b/.github/scripts/roadmap-stage-gate.test.js
@@ -1,0 +1,99 @@
+// Unit tests for roadmap-stage-gate.js. Run by the PR Checklist job before the gate itself, so a
+// broken rule fails loudly rather than silently passing - or failing - every PR.
+// issue-refs: exempt-file - fixtures and check names are deliberately full of bare PR numbers;
+// qualifying them would stop testing what the parser actually sees.
+const assert = require("assert");
+const {
+  ROADMAP_PATH, findOptOut, entriesClaimingPr, touchesRoadmap, formatFailure,
+} = require("./roadmap-stage-gate.js");
+
+let run = 0;
+function check(name, fn) {
+  fn();
+  run++;
+  console.log("  ok  " + name);
+}
+
+// A roadmap fragment in the file's real shape: flat entries, two of them carriers.
+const ROADMAP = [
+  "entries:",
+  "  - id: web-gui",
+  "    title: A web view showing what a running instance is actually doing",
+  "    stage: limited-poc",
+  "    stage_delivery: draft",
+  "    tracking: astubbs#215",
+  "    pull_request: astubbs#268",
+  "",
+  "  - id: language-proxy-sidecar",
+  "    stage: limited-poc",
+  "    pull_request: astubbs#293",
+  "",
+  "  - id: distributed-throttling",
+  "    stage: ideated",
+  "    tracking: astubbs#228",
+].join("\n");
+
+check("finds the entry that names the PR", () => {
+  assert.deepStrictEqual(entriesClaimingPr(ROADMAP, 268), [
+    { id: "web-gui", ref: "astubbs#268" },
+  ]);
+});
+
+check("a PR nothing names produces no claims", () => {
+  assert.deepStrictEqual(entriesClaimingPr(ROADMAP, 999), []);
+});
+
+check("an entry with only a tracking issue is out of reach by design", () => {
+  // astubbs#228 is distributed-throttling's tracking issue, not a pull_request - no claim.
+  assert.deepStrictEqual(entriesClaimingPr(ROADMAP, 228), []);
+});
+
+check("the number must match exactly - #26 is not #268", () => {
+  assert.deepStrictEqual(entriesClaimingPr(ROADMAP, 26), []);
+});
+
+check("string and numeric PR numbers agree", () => {
+  assert.strictEqual(entriesClaimingPr(ROADMAP, "293").length, 1);
+});
+
+check("empty or missing roadmap text claims nothing", () => {
+  assert.deepStrictEqual(entriesClaimingPr("", 268), []);
+  assert.deepStrictEqual(entriesClaimingPr(null, 268), []);
+});
+
+check("touchesRoadmap matches only the exact path", () => {
+  assert.ok(touchesRoadmap([{ filename: ROADMAP_PATH }]));
+  assert.ok(!touchesRoadmap([{ filename: "docs/data/schema.yaml" }]));
+  assert.ok(!touchesRoadmap([]));
+  assert.ok(!touchesRoadmap(null));
+});
+
+check("opt-out needs a reason - a bare N/A is a bypass, not a judgment", () => {
+  assert.ok(findOptOut("roadmap-stage: N/A - mid-flight fixup, stage moves with the final PR"));
+  assert.ok(findOptOut("body text\nroadmap-stage: NA - carrier unchanged\nmore"));
+  assert.strictEqual(findOptOut("roadmap-stage: N/A"), null);
+  assert.strictEqual(findOptOut("roadmap-stage: N/A -"), null);
+  assert.strictEqual(findOptOut("no marker here"), null);
+  assert.strictEqual(findOptOut(""), null);
+  assert.strictEqual(findOptOut(null), null);
+});
+
+check("the failure message names the entry, the file, and both ways out", () => {
+  const msg = formatFailure([{ id: "web-gui", ref: "astubbs#268" }], 268);
+  assert.ok(msg.includes("web-gui"));
+  assert.ok(msg.includes(ROADMAP_PATH));
+  assert.ok(msg.includes("roadmap-stage: N/A"));
+  assert.ok(msg.includes("stage_delivery"));
+});
+
+check("the gate finds today's real carriers in the real roadmap", () => {
+  // Pins the parse to the actual file, so a structural rewrite of roadmap.yaml fails here first
+  // rather than silently blinding the gate.
+  const fs = require("fs");
+  const path = require("path");
+  const real = fs.readFileSync(path.join(__dirname, "../../", ROADMAP_PATH), "utf8");
+  const claims = entriesClaimingPr(real, 293);
+  assert.deepStrictEqual(claims, [{ id: "language-proxy-sidecar", ref: "astubbs#293" }]);
+});
+
+console.log(`roadmap-stage-gate: ${run} checks passed`);

--- a/.github/scripts/roadmap-stage-gate.test.js
+++ b/.github/scripts/roadmap-stage-gate.test.js
@@ -4,7 +4,7 @@
 // qualifying them would stop testing what the parser actually sees.
 const assert = require("assert");
 const {
-  ROADMAP_PATH, findOptOut, entriesClaimingPr, touchesRoadmap, formatFailure,
+  ROADMAP_PATH, findOptOut, entriesClaimingPr, entryStageSnapshot, stageMoved, formatFailure,
 } = require("./roadmap-stage-gate.js");
 
 let run = 0;
@@ -21,6 +21,9 @@ const ROADMAP = [
   "    title: A web view showing what a running instance is actually doing",
   "    stage: limited-poc",
   "    stage_delivery: draft",
+  "    stage_detail: >-",
+  "      Phase one works and is tested - live page, offset ribbon - but it is a",
+  "      brand-new surface nobody has operated against.",
   "    tracking: astubbs#215",
   "    pull_request: astubbs#268",
   "",
@@ -52,6 +55,11 @@ check("the number must match exactly - #26 is not #268", () => {
   assert.deepStrictEqual(entriesClaimingPr(ROADMAP, 26), []);
 });
 
+check("only the fork's own qualified form claims - confluentinc#268 is another repo's PR", () => {
+  const upstream = ROADMAP.replace("pull_request: astubbs#268", "pull_request: confluentinc#268");
+  assert.deepStrictEqual(entriesClaimingPr(upstream, 268), []);
+});
+
 check("string and numeric PR numbers agree", () => {
   assert.strictEqual(entriesClaimingPr(ROADMAP, "293").length, 1);
 });
@@ -61,11 +69,44 @@ check("empty or missing roadmap text claims nothing", () => {
   assert.deepStrictEqual(entriesClaimingPr(null, 268), []);
 });
 
-check("touchesRoadmap matches only the exact path", () => {
-  assert.ok(touchesRoadmap([{ filename: ROADMAP_PATH }]));
-  assert.ok(!touchesRoadmap([{ filename: "docs/data/schema.yaml" }]));
-  assert.ok(!touchesRoadmap([]));
-  assert.ok(!touchesRoadmap(null));
+check("the stage snapshot captures stage fields with their folded continuations, nothing else", () => {
+  const snap = entryStageSnapshot(ROADMAP, "web-gui");
+  assert.ok(snap.includes("stage: limited-poc"));
+  assert.ok(snap.includes("stage_delivery: draft"));
+  assert.ok(snap.includes("brand-new surface"));
+  assert.ok(!snap.includes("tracking"));
+  assert.ok(!snap.includes("title"));
+});
+
+check("a missing entry snapshots to null, not empty", () => {
+  assert.strictEqual(entryStageSnapshot(ROADMAP, "no-such-entry"), null);
+});
+
+check("an untouched file means the entry's stage did not move", () => {
+  assert.strictEqual(stageMoved(ROADMAP, ROADMAP, "web-gui"), false);
+});
+
+check("editing a DIFFERENT entry does not count as moving this one - the coarse-gate hole", () => {
+  const otherEdit = ROADMAP.replace("stage: ideated", "stage: planned"); // distributed-throttling
+  assert.strictEqual(stageMoved(ROADMAP, otherEdit, "web-gui"), false);
+  assert.strictEqual(stageMoved(ROADMAP, otherEdit, "distributed-throttling"), true);
+});
+
+check("a stage value change moves the entry", () => {
+  const bumped = ROADMAP.replace("stage: limited-poc\n    stage_delivery: draft",
+    "stage: poc\n    stage_delivery: pending-merge");
+  assert.strictEqual(stageMoved(ROADMAP, bumped, "web-gui"), true);
+});
+
+check("a stage_detail rewording alone also counts as movement", () => {
+  const reworded = ROADMAP.replace("brand-new surface nobody has operated against.",
+    "operated in production by one team since 0.6.0.0.");
+  assert.strictEqual(stageMoved(ROADMAP, reworded, "web-gui"), true);
+});
+
+check("an entry removed or renamed at head counts as moved - the PR answers for it", () => {
+  const removed = ROADMAP.replace("  - id: web-gui", "  - id: web-gui-renamed");
+  assert.strictEqual(stageMoved(ROADMAP, removed, "web-gui"), true);
 });
 
 check("opt-out needs a reason - a bare N/A is a bypass, not a judgment", () => {
@@ -84,6 +125,7 @@ check("the failure message names the entry, the file, and both ways out", () => 
   assert.ok(msg.includes(ROADMAP_PATH));
   assert.ok(msg.includes("roadmap-stage: N/A"));
   assert.ok(msg.includes("stage_delivery"));
+  assert.ok(msg.includes("unchanged"));
 });
 
 check("the gate finds today's real carriers in the real roadmap", () => {
@@ -94,6 +136,8 @@ check("the gate finds today's real carriers in the real roadmap", () => {
   const real = fs.readFileSync(path.join(__dirname, "../../", ROADMAP_PATH), "utf8");
   const claims = entriesClaimingPr(real, 293);
   assert.deepStrictEqual(claims, [{ id: "language-proxy-sidecar", ref: "astubbs#293" }]);
+  const snap = entryStageSnapshot(real, "language-proxy-sidecar");
+  assert.ok(snap && snap.includes("stage:"));
 });
 
 console.log(`roadmap-stage-gate: ${run} checks passed`);

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Self-test the issue-reference gate logic
         run: node .github/scripts/issue-ref-gate.test.js
 
+      - name: Self-test the roadmap stage gate logic
+        run: node .github/scripts/roadmap-stage-gate.test.js
+
       # The local mirror (bin/check-issue-refs.sh) fetches the PR body via gh to honour the
       # `issue-refs: N/A` opt-out the way this workflow does; that plumbing is shell, not gate
       # logic, so it has its own self-test.
@@ -242,3 +245,57 @@ jobs:
               `Entr${missing.length === 1 ? "y" : "ies"} missing one:\n` +
               missing.map(l => `  ${l.trim().slice(0, 160)}`).join("\n")
             );
+
+      # The roadmap's stage ladder says how real each entry is, and its own rule is that the PR
+      # advancing a track moves the stage in the same change (docs/data/roadmap.yaml, `stages`
+      # block). This step is what catches a miss: when the BASE branch's roadmap names this PR as
+      # an entry's carrier (`pull_request: astubbs#NNN`), the PR must touch the roadmap or opt out
+      # with `roadmap-stage: N/A - <reason>` in its body. Base, not head, is read deliberately:
+      # master is the authority on which entries currently claim this PR.
+      - name: Verify a roadmap-carrying PR moves its entry's stage
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const gate = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/roadmap-stage-gate.js`);
+            const pr = context.payload.pull_request;
+
+            if (pr.user && pr.user.type === "Bot") {
+              core.info(`Author ${pr.user.login} is a Bot - roadmap stage gate skipped.`);
+              return;
+            }
+            const optOut = gate.findOptOut(pr.body || "");
+            if (optOut) {
+              core.info(`Opted out via PR body: "${optOut}"`);
+              return;
+            }
+
+            let roadmapText = "";
+            try {
+              const res = await github.rest.repos.getContent({
+                ...context.repo, path: gate.ROADMAP_PATH, ref: pr.base.sha,
+                mediaType: { format: "raw" },
+              });
+              roadmapText = String(res.data);
+            } catch (e) {
+              core.info(`No ${gate.ROADMAP_PATH} on the base ref (${e.message}) - nothing to check.`);
+              return;
+            }
+
+            const claims = gate.entriesClaimingPr(roadmapText, pr.number);
+            if (claims.length === 0) {
+              core.info("No roadmap entry names this PR as its carrier - nothing to check.");
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo, pull_number: pr.number, per_page: 100,
+            });
+            if (gate.touchesRoadmap(files)) {
+              core.info(
+                `Roadmap entr${claims.length === 1 ? "y" : "ies"} ` +
+                `${claims.map(c => c.id).join(", ")} name this PR and it touches ` +
+                `${gate.ROADMAP_PATH} - OK.`);
+              return;
+            }
+
+            core.setFailed(gate.formatFailure(claims, pr.number));

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -249,9 +249,10 @@ jobs:
       # The roadmap's stage ladder says how real each entry is, and its own rule is that the PR
       # advancing a track moves the stage in the same change (docs/data/roadmap.yaml, `stages`
       # block). This step is what catches a miss: when the BASE branch's roadmap names this PR as
-      # an entry's carrier (`pull_request: astubbs#NNN`), the PR must touch the roadmap or opt out
-      # with `roadmap-stage: N/A - <reason>` in its body. Base, not head, is read deliberately:
-      # master is the authority on which entries currently claim this PR.
+      # an entry's carrier (`pull_request: astubbs#NNN`), that ENTRY's stage block must differ
+      # between base and head - touching the file elsewhere does not count - or the PR opts out
+      # with `roadmap-stage: N/A - <reason>` in its body. Base is read deliberately: master is the
+      # authority on which entries currently claim this PR.
       - name: Verify a roadmap-carrying PR moves its entry's stage
         uses: actions/github-script@v7
         with:
@@ -269,33 +270,43 @@ jobs:
               return;
             }
 
-            let roadmapText = "";
-            try {
+            const fetchRoadmap = async (ref) => {
               const res = await github.rest.repos.getContent({
-                ...context.repo, path: gate.ROADMAP_PATH, ref: pr.base.sha,
+                ...context.repo, path: gate.ROADMAP_PATH, ref,
                 mediaType: { format: "raw" },
               });
-              roadmapText = String(res.data);
+              return String(res.data);
+            };
+
+            let baseText = "";
+            try {
+              baseText = await fetchRoadmap(pr.base.sha);
             } catch (e) {
               core.info(`No ${gate.ROADMAP_PATH} on the base ref (${e.message}) - nothing to check.`);
               return;
             }
 
-            const claims = gate.entriesClaimingPr(roadmapText, pr.number);
+            const claims = gate.entriesClaimingPr(baseText, pr.number);
             if (claims.length === 0) {
               core.info("No roadmap entry names this PR as its carrier - nothing to check.");
               return;
             }
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              ...context.repo, pull_number: pr.number, per_page: 100,
-            });
-            if (gate.touchesRoadmap(files)) {
+            // A missing head file means the roadmap was deleted or moved - every claiming entry's
+            // snapshot then differs from base, which is the accountable-change signal we want.
+            let headText = "";
+            try {
+              headText = await fetchRoadmap(pr.head.sha);
+            } catch (e) {
+              core.info(`${gate.ROADMAP_PATH} unreadable at head (${e.message}) - treating as changed.`);
+            }
+
+            const unmoved = claims.filter((c) => !gate.stageMoved(baseText, headText, c.id));
+            if (unmoved.length === 0) {
               core.info(
                 `Roadmap entr${claims.length === 1 ? "y" : "ies"} ` +
-                `${claims.map(c => c.id).join(", ")} name this PR and it touches ` +
-                `${gate.ROADMAP_PATH} - OK.`);
+                `${claims.map(c => c.id).join(", ")} name this PR and the stage block moved - OK.`);
               return;
             }
 
-            core.setFailed(gate.formatFailure(claims, pr.number));
+            core.setFailed(gate.formatFailure(unmoved, pr.number));

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -54,10 +54,14 @@ stages:
   values:
     idea: Named and argued for; nothing more structured than notes exists yet.
     ideated: A ranked, verified ideation document exists; direction not yet chosen.
-    requirements-drafted: Requirements or brainstorm output exists; the product decisions are being made.
-    planned: A dated implementation plan exists; implementation not started.
-    poc: A limited proof-of-concept runs; stage_detail states its boundaries.
-    implemented: A working implementation exists on an open PR, subject to review and landing.
+    requirements-drafted: The product decisions are drafted - what it must do and why; the how is not yet planned.
+    planned: An implementation design or plan exists - the how; the build has not started.
+    limited-poc: A slice runs, but the central claim is not proven end-to-end; stage_detail says exactly what is missing.
+    poc: A working proof answers the central question within stated boundaries; it is not the shipping implementation.
+    implemented: >-
+      The implementation intended to ship exists and works on an open PR, subject to review. A draft
+      that will be replaced is not implemented - it is at most a poc, and if it is not even the
+      direction that will stay, it does not advance the stage at all.
 
 entries:
   - id: known-defects-cleared
@@ -81,10 +85,11 @@ entries:
     serves: [flexibility, performance]
     horizon: "0.6.0.0"
     blocks_1_0: false
-    stage: poc
+    stage: limited-poc
     stage_detail: >-
-      Measured spike on astubbs#271 - 8x median on the target shape - proven for one partition,
-      one task, one instance, at-least-once, caching off; windowing, joins and EOS out of scope.
+      The spike on astubbs#271 measured 8x median, but only for one partition, one task, one
+      instance, at-least-once, caching off - the general claim is unproven; windowing, joins and
+      EOS out of scope.
     why_now: Streams users hit the same head-of-line blocking, and the idea can be shown to work before it is committed to.
     done_when: An opt-in alpha module exists, isolated from the stable modules, with setup a reader can follow.
     tracking: astubbs#255
@@ -96,10 +101,11 @@ entries:
     serves: [flexibility]
     horizon: "0.6.0.0"
     blocks_1_0: false
-    stage: poc
+    stage: limited-poc
     stage_detail: >-
-      Direction proven on astubbs#269: the patched sink task shadows the stock one and a failing
-      lane no longer stalls the others; the live delivery path is still partial.
+      On astubbs#269 the patched sink task shadows the stock one and a failing lane no longer
+      stalls the others - a slice; the live delivery path is unfinished, so end-to-end sink
+      processing through PC is not yet demonstrated.
     why_now: The same reasoning as the Streams preview, for a different and widely deployed surface.
     done_when: An opt-in alpha module exists, isolated from the stable modules.
     tracking: astubbs#240
@@ -176,10 +182,11 @@ entries:
     serves: [compatibility]
     horizon: next-0x
     blocks_1_0: false
-    stage: poc
+    stage: idea
     stage_detail: >-
-      astubbs#53 compiles the tree at release 17 with zero source changes, Jabel removed; the
-      Kafka 4 client work has not started.
+      astubbs#53 shows the tree compiles at release 17 with Jabel removed, but the target is Java
+      11 with Kafka 4 clients and that work has not started - the draft is exploration, not the
+      implementation.
     why_now: A recent constraint rather than long-standing debt, and one an adopter on a modern JDK hits immediately.
     done_when: The library builds and runs on the current Java LTS and against Kafka 4.x.
     tracking: astubbs#181
@@ -190,9 +197,10 @@ entries:
     serves: [observability, usability]
     horizon: next-0x
     blocks_1_0: false
-    stage: implemented
+    stage: poc
     stage_detail: >-
-      astubbs#226 is review-hardened and carries two breaking changes staged for 0.6.0.0.
+      A working draft on astubbs#226, review-hardened and carrying two staged breaking changes;
+      not yet accepted as the shipping surface.
     why_now: Orchestrators need a liveness answer better than "the process is up".
     done_when: A supported health surface exists on the public interface.
     tracking: astubbs#126
@@ -202,10 +210,10 @@ entries:
     serves: [performance, flexibility]
     horizon: next-0x
     blocks_1_0: false
-    stage: implemented
+    stage: idea
     stage_detail: >-
-      astubbs#51 carries the upstream implementation (confluentinc#908) with its author's concerns
-      unresolved; gated on the Java-baseline decision.
+      The upstream draft (confluentinc#908) rides astubbs#51, but it is not the implementation
+      that will stay; gated on the Java-baseline decision, and no fork design exists yet.
     why_now: Blocking work is the case virtual threads help most, and supporting them removes a reason to reach for an adapter module.
     done_when: A user can run the processing function on virtual threads.
     tracking: astubbs#147
@@ -242,9 +250,10 @@ entries:
     serves: [usability]
     horizon: next-0x
     blocks_1_0: false
-    stage: idea
+    stage: planned
     stage_detail: >-
-      Direction agreed - render the feature data - and nothing renders it yet.
+      The site design is drafted on astubbs#316 - explicitly design only, no site is built there;
+      astubbs#302 holds the intent.
     why_now: >-
       The feature data exists and nothing renders it. Until something does, the README stays the only
       documentation and the data is a second corpus rather than a source.
@@ -349,10 +358,10 @@ entries:
     serves: [performance, reliability]
     horizon: next-0x
     blocks_1_0: false
-    stage: planned
+    stage: requirements-drafted
     stage_detail: >-
-      The self-scaling concurrency plan landed with the strategy bet (astubbs#308); implementation
-      not started.
+      The requirements plan landed with the strategy bet (astubbs#308); it decides the what, not
+      the how - no implementation plan yet.
     why_now: >-
       Deploy-time configuration guesses runtime-dependent quantities and is wrong in both directions.
       The engine already measures what it needs to decide for itself; STRATEGY.md carries this as the

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -51,10 +51,12 @@ stages:
     Maintained by the PRs that do the work: a PR that advances a track updates its entry's stage in
     the same change, from the PR that introduced this field onward. Stage does not wait for release
     review; a stale stage is a defect in the PR that made it stale. stage_delivery is set whenever
-    the stage's artifact rides an open PR, and mirrors that PR's own state - draft (a GitHub draft
-    PR) or pending-merge (open and marked ready) - so there is exactly one source of truth for it.
-    Entries whose artifact has landed, or spans many PRs, carry no stage_delivery. Drafted does not
-    mean doomed: a draft PR is simply not yet pending merge.
+    the stage's artifact rides an open PR, and records a judgment no command can answer: draft (still
+    being worked) or pending-merge (believed ready to land). GitHub's own draft flag is not the
+    source of truth - it has not been used consistently here - though flipping PRs recorded as draft
+    to actual GitHub drafts is the direction of travel. Entries whose artifact has landed, or spans
+    many PRs, carry no stage_delivery. Drafted does not mean doomed: a draft PR is simply not yet
+    pending merge.
   values:
     idea: Named and argued for; nothing more structured than notes exists yet.
     ideated: A ranked, verified ideation document exists; direction not yet chosen.
@@ -94,7 +96,7 @@ entries:
     horizon: "0.6.0.0"
     blocks_1_0: false
     stage: limited-poc
-    stage_delivery: pending-merge
+    stage_delivery: draft
     stage_detail: >-
       The spike on astubbs#271 measured 8x median, but only for one partition, one task, one
       instance, at-least-once, caching off - the general claim is unproven; windowing, joins and
@@ -111,7 +113,7 @@ entries:
     horizon: "0.6.0.0"
     blocks_1_0: false
     stage: limited-poc
-    stage_delivery: pending-merge
+    stage_delivery: draft
     stage_detail: >-
       On astubbs#269 the patched sink task shadows the stock one and a failing lane no longer
       stalls the others - a slice; the live delivery path is unfinished, so end-to-end sink
@@ -129,7 +131,7 @@ entries:
     previewed_in: "0.6.0.0"
     blocks_1_0: true
     stage: limited-poc
-    stage_delivery: pending-merge
+    stage_delivery: draft
     stage_detail: >-
       Phase one of astubbs#268 works and is tested - live page, offset ribbon - but it is a
       brand-new surface nobody has operated against, blocked on the listener-registration fix
@@ -210,7 +212,7 @@ entries:
     horizon: next-0x
     blocks_1_0: false
     stage: poc
-    stage_delivery: pending-merge
+    stage_delivery: draft
     stage_detail: >-
       A working proof on astubbs#226, review-hardened and carrying two staged breaking changes;
       not yet accepted as the shipping surface.

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -50,7 +50,10 @@ stages:
     spent. stage_detail is one honest line on how far that artifact goes - for a poc, its boundaries.
     Maintained by the PRs that do the work: a PR that advances a track updates its entry's stage in
     the same change, from the PR that introduced this field onward. Stage does not wait for release
-    review; a stale stage is a defect in the PR that made it stale.
+    review; a stale stage is a defect in the PR that made it stale. The optional stage_delivery says
+    how the artifact is arriving - draft (an open PR still being worked) or pending-merge (its
+    author considers it ready to land). Drafted does not mean doomed: a draft PR is simply not yet
+    pending merge.
   values:
     idea: Named and argued for; nothing more structured than notes exists yet.
     ideated: A ranked, verified ideation document exists; direction not yet chosen.
@@ -59,9 +62,10 @@ stages:
     limited-poc: A slice runs, but the central claim is not proven end-to-end; stage_detail says exactly what is missing.
     poc: A working proof answers the central question within stated boundaries; it is not the shipping implementation.
     implemented: >-
-      The implementation intended to ship exists and works on an open PR, subject to review. A draft
-      that will be replaced is not implemented - it is at most a poc, and if it is not even the
-      direction that will stay, it does not advance the stage at all.
+      The implementation intended to ship exists, works, and has been proven in use - not merely
+      built. A brand-new system nobody has run in anger is a poc however large it is, and an
+      implementation that is not the direction that will stay - a superseded upstream draft, an
+      exploration - does not advance the stage at all.
 
 entries:
   - id: known-defects-cleared
@@ -118,10 +122,12 @@ entries:
     horizon: "1.0"
     previewed_in: "0.6.0.0"
     blocks_1_0: true
-    stage: implemented
+    stage: limited-poc
+    stage_delivery: draft
     stage_detail: >-
-      Phase one of astubbs#268 works and is tested - live page, offset ribbon - blocked on the
-      listener-registration fix (astubbs#267); preview-grade, not the finished surface.
+      Phase one of astubbs#268 works and is tested - live page, offset ribbon - but it is a
+      brand-new surface nobody has operated against, blocked on the listener-registration fix
+      (astubbs#267); preview-grade, not the finished view.
     why_now: >-
       Moving scheduling and offset state into the JVM leaves ordinary broker tooling blind to most of
       what matters. An operator has metrics today and no picture.
@@ -198,6 +204,7 @@ entries:
     horizon: next-0x
     blocks_1_0: false
     stage: poc
+    stage_delivery: draft
     stage_detail: >-
       A working draft on astubbs#226, review-hardened and carrying two staged breaking changes;
       not yet accepted as the shipping surface.
@@ -250,10 +257,11 @@ entries:
     serves: [usability]
     horizon: next-0x
     blocks_1_0: false
-    stage: planned
+    stage: limited-poc
+    stage_delivery: draft
     stage_detail: >-
-      The site design is drafted on astubbs#316 - explicitly design only, no site is built there;
-      astubbs#302 holds the intent.
+      Actively being implemented in early draft against astubbs#302; the site design is drafted on
+      astubbs#316.
     why_now: >-
       The feature data exists and nothing renders it. Until something does, the README stays the only
       documentation and the data is a second corpus rather than a source.
@@ -285,11 +293,12 @@ entries:
     serves: [flexibility, usability]
     horizon: next-0x
     blocks_1_0: false
-    stage: implemented
+    stage: limited-poc
+    stage_delivery: pending-merge
     stage_detail: >-
       astubbs#293 carries the module, the frozen v1 protocol and eleven clients under one
-      conformance suite; every client negotiates only the dispatch capability so far - broad,
-      deliberately shallow.
+      conformance suite - broad, but an experimental brand-new system nobody has used in anger,
+      and every client negotiates only the dispatch capability so far.
     why_now: >-
       The engine's guarantees are locked to the JVM today. A sidecar speaking a frozen protocol makes
       them a capability any language can adopt, and the conformance suite makes every client answer to

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -50,10 +50,11 @@ stages:
     spent. stage_detail is one honest line on how far that artifact goes - for a poc, its boundaries.
     Maintained by the PRs that do the work: a PR that advances a track updates its entry's stage in
     the same change, from the PR that introduced this field onward. Stage does not wait for release
-    review; a stale stage is a defect in the PR that made it stale. The optional stage_delivery says
-    how the artifact is arriving - draft (an open PR still being worked) or pending-merge (its
-    author considers it ready to land). Drafted does not mean doomed: a draft PR is simply not yet
-    pending merge.
+    review; a stale stage is a defect in the PR that made it stale. stage_delivery is set whenever
+    the stage's artifact rides an open PR, and mirrors that PR's own state - draft (a GitHub draft
+    PR) or pending-merge (open and marked ready) - so there is exactly one source of truth for it.
+    Entries whose artifact has landed, or spans many PRs, carry no stage_delivery. Drafted does not
+    mean doomed: a draft PR is simply not yet pending merge.
   values:
     idea: Named and argued for; nothing more structured than notes exists yet.
     ideated: A ranked, verified ideation document exists; direction not yet chosen.
@@ -61,6 +62,9 @@ stages:
     planned: An implementation design or plan exists - the how; the build has not started.
     limited-poc: A slice runs, but the central claim is not proven end-to-end; stage_detail says exactly what is missing.
     poc: A working proof answers the central question within stated boundaries; it is not the shipping implementation.
+    in-progress: >-
+      Work is landing on master across multiple PRs - past any single artifact, and not finished:
+      the entry's done_when is what closes it, not a merge.
     implemented: >-
       The implementation intended to ship exists, works, and has been proven in use - not merely
       built. A brand-new system nobody has run in anger is a poc however large it is, and an
@@ -73,7 +77,7 @@ entries:
     serves: [reliability]
     horizon: "0.6.0.0"
     blocks_1_0: false
-    stage: implemented
+    stage: in-progress
     stage_detail: >-
       Fixes land on master continuously, each with a guard; the open critical is the poll/control
       deadlock (confluentinc#857), mitigation drafted on astubbs#29.
@@ -90,6 +94,7 @@ entries:
     horizon: "0.6.0.0"
     blocks_1_0: false
     stage: limited-poc
+    stage_delivery: pending-merge
     stage_detail: >-
       The spike on astubbs#271 measured 8x median, but only for one partition, one task, one
       instance, at-least-once, caching off - the general claim is unproven; windowing, joins and
@@ -106,6 +111,7 @@ entries:
     horizon: "0.6.0.0"
     blocks_1_0: false
     stage: limited-poc
+    stage_delivery: pending-merge
     stage_detail: >-
       On astubbs#269 the patched sink task shadows the stock one and a failing lane no longer
       stalls the others - a slice; the live delivery path is unfinished, so end-to-end sink
@@ -123,7 +129,7 @@ entries:
     previewed_in: "0.6.0.0"
     blocks_1_0: true
     stage: limited-poc
-    stage_delivery: draft
+    stage_delivery: pending-merge
     stage_detail: >-
       Phase one of astubbs#268 works and is tested - live page, offset ribbon - but it is a
       brand-new surface nobody has operated against, blocked on the listener-registration fix
@@ -204,9 +210,9 @@ entries:
     horizon: next-0x
     blocks_1_0: false
     stage: poc
-    stage_delivery: draft
+    stage_delivery: pending-merge
     stage_detail: >-
-      A working draft on astubbs#226, review-hardened and carrying two staged breaking changes;
+      A working proof on astubbs#226, review-hardened and carrying two staged breaking changes;
       not yet accepted as the shipping surface.
     why_now: Orchestrators need a liveness answer better than "the process is up".
     done_when: A supported health surface exists on the public interface.
@@ -245,6 +251,7 @@ entries:
     horizon: next-0x
     blocks_1_0: false
     stage: requirements-drafted
+    stage_delivery: draft
     stage_detail: >-
       Prior-art report and demand ledger on astubbs#313, requirements decisions in progress; the
       2022 draft (astubbs#8) is the seed implementation.
@@ -258,6 +265,7 @@ entries:
     horizon: next-0x
     blocks_1_0: false
     stage: planned
+    stage_delivery: pending-merge
     stage_detail: >-
       The site design is drafted on astubbs#316 - explicitly design only, no site is built there;
       astubbs#302 holds the intent.

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -203,6 +203,95 @@ entries:
     tracking: astubbs#139
     related: astubbs#158
 
+  - id: language-proxy-sidecar
+    title: Key-ordered concurrency for non-JVM languages, through a sidecar
+    serves: [flexibility, usability]
+    horizon: next-0x
+    blocks_1_0: false
+    why_now: >-
+      The engine's guarantees are locked to the JVM today. A sidecar speaking a frozen protocol makes
+      them a capability any language can adopt, and the conformance suite makes every client answer to
+      one definition of correct instead of eleven.
+    done_when: >-
+      The sidecar and its frozen v1 protocol ship as an opt-in module, with language clients validated
+      by the shared conformance suite rather than by their own tests.
+    tracking: astubbs#242
+    pull_request: astubbs#293
+    caveat: At-least-once through the proxy in v1; transactional produce stays JVM-only until lifted.
+
+  - id: polyglot-proof-demo
+    title: Prove the language story in one view
+    serves: [usability]
+    horizon: next-0x
+    blocks_1_0: false
+    why_now: >-
+      Eleven clients that each pass privately is a claim; all of them visibly reading the same records
+      at once is a proof, and the conformance runners already speak the grammar the demo needs.
+    done_when: >-
+      One command runs every language binding against the same topic and a machine-checked view shows
+      they converged - not a human eyeballing logs.
+    tracking: astubbs#242
+
+  - id: performance-comparison-matrix
+    title: Measured performance, per scenario and per language, published as data
+    serves: [performance, usability]
+    horizon: next-0x
+    blocks_1_0: false
+    why_now: >-
+      The README's performance story is hand-pasted charts from a spreadsheet. Scenarios, arms and
+      languages measured in the conformance harness make the claim reproducible - and the attribution
+      ladder separates engine cost from protocol cost from language runtime cost.
+    done_when: >-
+      Blessed runs are committed as data behind the docs-data gate, the README chart is generated from
+      them, and a fairness charter forbids the language-vs-language leaderboard.
+    tracking: astubbs#242
+
+  - id: distributed-throttling
+    title: Respect a downstream budget across the whole consumer group
+    serves: [flexibility, reliability]
+    horizon: next-0x
+    blocks_1_0: false
+    why_now: >-
+      N instances each assuming they own the whole budget overload the downstream by a factor of N, and
+      the maxConcurrency javadoc has pointed at this gap for years. The consumer group itself can divide
+      the budget - no coordination service required for the first version.
+    done_when: >-
+      A configured group-wide rate is respected across instances and rebalances, throttling defers work
+      rather than erroring it, and liveness outranks the limit.
+    tracking: astubbs#228
+
+  - id: self-tuning-concurrency
+    title: Discover sustainable concurrency instead of asking for a guess
+    serves: [performance, reliability]
+    horizon: next-0x
+    blocks_1_0: false
+    why_now: >-
+      Deploy-time configuration guesses runtime-dependent quantities and is wrong in both directions.
+      The engine already measures what it needs to decide for itself; STRATEGY.md carries this as the
+      self-tuning bet. Promoted from the backlog 2026-08-18.
+    done_when: >-
+      An instance converges on a sustainable concurrency it discovered, and the discovered-vs-configured
+      gap is visible in the metrics.
+    tracking: astubbs#227
+    related: astubbs#228
+
+  - id: batch-composition-settlement
+    title: Decide batch composition once, before the second batching option ships
+    serves: [flexibility, performance]
+    horizon: next-0x
+    blocks_1_0: false
+    why_now: >-
+      Batch composition today is emergent, not designed, and the upstream batch-strategy proposal
+      (confluentinc#915) would freeze a shape into the options API. Choosing the shape deliberately -
+      with batch ordering, telemetry and validation underneath it - is one deprecation cycle instead of
+      four.
+    done_when: >-
+      One chosen composition API answers same-key batching (astubbs#145, confluentinc#266) and the
+      strategy proposal, batches hand records over in offset order, and batch composition is observable
+      in the metrics.
+    related: astubbs#165
+    tracking: astubbs#145
+
 not_planned:
   note: Decided against, with the reason. Not a backlog.
   entries:
@@ -229,12 +318,29 @@ backlog:
         Someday, and its deprecation is proposed separately. Nothing to do with Kafka Streams: these
         are the JStream processors that hand back a JDK Stream of produce results.
       tracking: astubbs#116
-    - subject: Dynamic concurrency control using flow-control theory
-      status: Undecided. Architectural rather than incremental.
-      tracking: astubbs#227
     - subject: Backpressure per partition rather than across the whole assignment
       status: Undecided. Architectural rather than incremental.
       tracking: astubbs#160
+    - subject: An HTTP dialect for the proxy, and a Confluent REST Proxy compatible gateway
+      status: >-
+        Demand-gated - nobody has asked yet. Feasibility is settled compatible-and-beneficial: REST
+        Proxy v2's progress unit is the per-partition watermark the engine already computes, so existing
+        REST Proxy users would gain beyond-partition concurrency by changing a hostname. The ideation
+        rides astubbs#293.
+      tracking: astubbs#242
+    - subject: A Dapr pluggable pub/sub component backed by the engine
+      status: >-
+        Demand-gated behind the sidecar landing, and probe-gated before that: whether the Dapr sidecar
+        serializes delivery to the app decides whether the benefit survives the extra hop. The probe and
+        positioning are banked in docs/inflight/next-dapr-adapter.md.
+      tracking: astubbs#242
+    - subject: Reviving the actor/IPC family from the 2022 branches
+      status: >-
+        Direction undecided - measure the mailbox against the poll/control deadlock, or land the
+        thread-ownership seams first. The one-day falsification probe and the async-produce promotion
+        (astubbs#230, confluentinc#356) come first either way; the ideation records why the "too stale"
+        verdict is under test.
+      tracking: astubbs#230
 
 one_point_zero:
   meaning: >-

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -267,7 +267,7 @@ entries:
     horizon: next-0x
     blocks_1_0: false
     stage: planned
-    stage_delivery: pending-merge
+    stage_delivery: draft
     stage_detail: >-
       The site design is drafted on astubbs#316 - explicitly design only, no site is built there;
       astubbs#302 holds the intent.

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -42,12 +42,33 @@ horizons:
     "1.0": Required before 1.0. See one_point_zero.
     backlog: Wanted, undecided, or waiting on a reason to start. Gates nothing.
 
+stages:
+  note: >-
+    How real an entry is right now, separate from where it sits on the horizon - two entries at the
+    same horizon can differ by years of actual work, and a release announcement should be able to say
+    which is which. The ladder is ordered by the most advanced artifact that exists, not by effort
+    spent. stage_detail is one honest line on how far that artifact goes - for a poc, its boundaries.
+    Maintained by the PRs that do the work: a PR that advances a track updates its entry's stage in
+    the same change, from the PR that introduced this field onward. Stage does not wait for release
+    review; a stale stage is a defect in the PR that made it stale.
+  values:
+    idea: Named and argued for; nothing more structured than notes exists yet.
+    ideated: A ranked, verified ideation document exists; direction not yet chosen.
+    requirements-drafted: Requirements or brainstorm output exists; the product decisions are being made.
+    planned: A dated implementation plan exists; implementation not started.
+    poc: A limited proof-of-concept runs; stage_detail states its boundaries.
+    implemented: A working implementation exists on an open PR, subject to review and landing.
+
 entries:
   - id: known-defects-cleared
     title: Every known critical defect resolved, each with a guard that would catch its return
     serves: [reliability]
     horizon: "0.6.0.0"
     blocks_1_0: false
+    stage: implemented
+    stage_detail: >-
+      Fixes land on master continuously, each with a guard; the open critical is the poll/control
+      deadlock (confluentinc#857), mitigation drafted on astubbs#29.
     why_now: The release claim rests on it, and the evidence has to be inspectable rather than asserted.
     done_when: >-
       No known critical defect open in release scope, and each resolution has a named guard that
@@ -60,6 +81,10 @@ entries:
     serves: [flexibility, performance]
     horizon: "0.6.0.0"
     blocks_1_0: false
+    stage: poc
+    stage_detail: >-
+      Measured spike on astubbs#271 - 8x median on the target shape - proven for one partition,
+      one task, one instance, at-least-once, caching off; windowing, joins and EOS out of scope.
     why_now: Streams users hit the same head-of-line blocking, and the idea can be shown to work before it is committed to.
     done_when: An opt-in alpha module exists, isolated from the stable modules, with setup a reader can follow.
     tracking: astubbs#255
@@ -71,6 +96,10 @@ entries:
     serves: [flexibility]
     horizon: "0.6.0.0"
     blocks_1_0: false
+    stage: poc
+    stage_detail: >-
+      Direction proven on astubbs#269: the patched sink task shadows the stock one and a failing
+      lane no longer stalls the others; the live delivery path is still partial.
     why_now: The same reasoning as the Streams preview, for a different and widely deployed surface.
     done_when: An opt-in alpha module exists, isolated from the stable modules.
     tracking: astubbs#240
@@ -83,6 +112,10 @@ entries:
     horizon: "1.0"
     previewed_in: "0.6.0.0"
     blocks_1_0: true
+    stage: implemented
+    stage_detail: >-
+      Phase one of astubbs#268 works and is tested - live page, offset ribbon - blocked on the
+      listener-registration fix (astubbs#267); preview-grade, not the finished surface.
     why_now: >-
       Moving scheduling and offset state into the JVM leaves ordinary broker tooling blind to most of
       what matters. An operator has metrics today and no picture.
@@ -96,6 +129,9 @@ entries:
     serves: [observability, performance]
     horizon: next-0x
     blocks_1_0: false
+    stage: idea
+    stage_detail: >-
+      Named as the strategy's own measures; nothing emits them yet.
     why_now: >-
       STRATEGY.md names head-of-line blocking avoided, end-to-end record latency and achieved fan-out as
       the measures of the whole proposition, and concedes the central ones are not emitted. Until they
@@ -110,6 +146,9 @@ entries:
     serves: [reliability, observability]
     horizon: next-0x
     blocks_1_0: false
+    stage: idea
+    stage_detail: >-
+      Scoped by the streaming-results deprecation reasoning; no design yet.
     why_now: >-
       An unbounded buffer is a memory-safety problem rather than a monitoring gap, and the streaming
       results API is being deprecated for exactly that, so the two are one piece of work.
@@ -122,6 +161,10 @@ entries:
     serves: [reliability]
     horizon: next-0x
     blocks_1_0: false
+    stage: idea
+    stage_detail: >-
+      Mechanism analysis banked in the inflight note - the fatal path and the Kafka Streams
+      precedent are mapped; no design yet.
     why_now: >-
       Fencing is an ordinary consequence of a rebalance under transactions and it currently kills the
       instance. Kafka Streams treats the equivalent as a migrated task and rejoins.
@@ -133,6 +176,10 @@ entries:
     serves: [compatibility]
     horizon: next-0x
     blocks_1_0: false
+    stage: poc
+    stage_detail: >-
+      astubbs#53 compiles the tree at release 17 with zero source changes, Jabel removed; the
+      Kafka 4 client work has not started.
     why_now: A recent constraint rather than long-standing debt, and one an adopter on a modern JDK hits immediately.
     done_when: The library builds and runs on the current Java LTS and against Kafka 4.x.
     tracking: astubbs#181
@@ -143,6 +190,9 @@ entries:
     serves: [observability, usability]
     horizon: next-0x
     blocks_1_0: false
+    stage: implemented
+    stage_detail: >-
+      astubbs#226 is review-hardened and carries two breaking changes staged for 0.6.0.0.
     why_now: Orchestrators need a liveness answer better than "the process is up".
     done_when: A supported health surface exists on the public interface.
     tracking: astubbs#126
@@ -152,6 +202,10 @@ entries:
     serves: [performance, flexibility]
     horizon: next-0x
     blocks_1_0: false
+    stage: implemented
+    stage_detail: >-
+      astubbs#51 carries the upstream implementation (confluentinc#908) with its author's concerns
+      unresolved; gated on the Java-baseline decision.
     why_now: Blocking work is the case virtual threads help most, and supporting them removes a reason to reach for an adapter module.
     done_when: A user can run the processing function on virtual threads.
     tracking: astubbs#147
@@ -161,6 +215,10 @@ entries:
     serves: [performance, flexibility]
     horizon: next-0x
     blocks_1_0: false
+    stage: ideated
+    stage_detail: >-
+      The batching ideation's knob-free triggering direction answers the stalled upstream attempt
+      (confluentinc#560) without adding an option; decision rides the composition settlement.
     why_now: Downstream systems that are cheaper per batch cannot exploit batching without a minimum size and a maximum wait.
     done_when: A batch can be bounded by both a minimum size and a maximum wait.
     tracking: astubbs#165
@@ -171,6 +229,10 @@ entries:
     serves: [reliability, flexibility]
     horizon: next-0x
     blocks_1_0: false
+    stage: requirements-drafted
+    stage_detail: >-
+      Prior-art report and demand ledger on astubbs#313, requirements decisions in progress; the
+      2022 draft (astubbs#8) is the seed implementation.
     why_now: Retrying forever is the only built-in answer today, and it is the wrong one for a poison record.
     done_when: A record that exhausts its retries can be diverted rather than blocking or being dropped silently.
     tracking: astubbs#149
@@ -180,6 +242,9 @@ entries:
     serves: [usability]
     horizon: next-0x
     blocks_1_0: false
+    stage: idea
+    stage_detail: >-
+      Direction agreed - render the feature data - and nothing renders it yet.
     why_now: >-
       The feature data exists and nothing renders it. Until something does, the README stays the only
       documentation and the data is a second corpus rather than a source.
@@ -192,6 +257,9 @@ entries:
     serves: [reliability, flexibility]
     horizon: "1.0"
     blocks_1_0: true
+    stage: idea
+    stage_detail: >-
+      Deliberately not started while known defects gate it.
     why_now: >-
       This is the remaining reason not to call the stable modules 1.0. Reliability is already
       release-gated; the API surface is not settled.
@@ -208,6 +276,11 @@ entries:
     serves: [flexibility, usability]
     horizon: next-0x
     blocks_1_0: false
+    stage: implemented
+    stage_detail: >-
+      astubbs#293 carries the module, the frozen v1 protocol and eleven clients under one
+      conformance suite; every client negotiates only the dispatch capability so far - broad,
+      deliberately shallow.
     why_now: >-
       The engine's guarantees are locked to the JVM today. A sidecar speaking a frozen protocol makes
       them a capability any language can adopt, and the conformance suite makes every client answer to
@@ -224,6 +297,10 @@ entries:
     serves: [usability]
     horizon: next-0x
     blocks_1_0: false
+    stage: ideated
+    stage_detail: >-
+      Ranked directions with a named skateboard - conformance runners in demo costume; direction
+      not chosen.
     why_now: >-
       Eleven clients that each pass privately is a claim; all of them visibly reading the same records
       at once is a proof, and the conformance runners already speak the grammar the demo needs.
@@ -237,6 +314,9 @@ entries:
     serves: [performance, usability]
     horizon: next-0x
     blocks_1_0: false
+    stage: ideated
+    stage_detail: >-
+      Ranked directions and a fairness charter; the harness architecture is the next brainstorm.
     why_now: >-
       The README's performance story is hand-pasted charts from a spreadsheet. Scenarios, arms and
       languages measured in the conformance harness make the claim reproducible - and the attribution
@@ -251,6 +331,10 @@ entries:
     serves: [flexibility, reliability]
     horizon: next-0x
     blocks_1_0: false
+    stage: ideated
+    stage_detail: >-
+      Eight verified directions; the enforcement fork - dispatch-seam gate vs in-flight controller
+      - is the pending decision.
     why_now: >-
       N instances each assuming they own the whole budget overload the downstream by a factor of N, and
       the maxConcurrency javadoc has pointed at this gap for years. The consumer group itself can divide
@@ -265,6 +349,10 @@ entries:
     serves: [performance, reliability]
     horizon: next-0x
     blocks_1_0: false
+    stage: planned
+    stage_detail: >-
+      The self-scaling concurrency plan landed with the strategy bet (astubbs#308); implementation
+      not started.
     why_now: >-
       Deploy-time configuration guesses runtime-dependent quantities and is wrong in both directions.
       The engine already measures what it needs to decide for itself; STRATEGY.md carries this as the
@@ -280,6 +368,10 @@ entries:
     serves: [flexibility, performance]
     horizon: next-0x
     blocks_1_0: false
+    stage: ideated
+    stage_detail: >-
+      Seven verified directions plus two confirmed defect records; the composition-API shape is
+      the pending one-way-door decision.
     why_now: >-
       Batch composition today is emergent, not designed, and the upstream batch-strategy proposal
       (confluentinc#915) would freeze a shape into the options API. Choosing the shape deliberately -
@@ -382,6 +474,7 @@ update_policy:
     - An entry meets its done_when.
     - A release changes the supported module posture.
     - A backlog entry is promoted, or a planned entry is dropped.
+    - A PR advances a track's stage - updated in that PR, not held for release review.
   rule: >-
     Do not copy individual issue state into this document; link readers to the issue tracker instead.
     Entries are big-picture: if one could be closed by a single pull request, it is too small to be here.

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -219,6 +219,7 @@ entries:
     why_now: Orchestrators need a liveness answer better than "the process is up".
     done_when: A supported health surface exists on the public interface.
     tracking: astubbs#126
+    pull_request: astubbs#226
 
   - id: virtual-threads
     title: Support virtual threads
@@ -260,6 +261,7 @@ entries:
     why_now: Retrying forever is the only built-in answer today, and it is the wrong one for a poison record.
     done_when: A record that exhausts its retries can be diverted rather than blocking or being dropped silently.
     tracking: astubbs#149
+    pull_request: astubbs#313
 
   - id: docs-site
     title: A documentation site, rendered from the feature data rather than one enormous README
@@ -276,6 +278,7 @@ entries:
       documentation and the data is a second corpus rather than a source.
     done_when: A versioned documentation site renders the feature records, and the README defers to it.
     tracking: astubbs#208
+    pull_request: astubbs#316
     evidence: ../features/README.md
 
   - id: api-settlement

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -116,7 +116,7 @@ entries:
     pull_request: astubbs#269
     caveat: Alpha. Depending on the artifact is the entire opt-in.
 
-  - id: running-instance-visibility
+  - id: web-gui
     title: A web view showing what a running instance is actually doing
     serves: [observability, usability]
     horizon: "1.0"
@@ -149,7 +149,7 @@ entries:
       the measures of the whole proposition, and concedes the central ones are not emitted. Until they
       are, no performance claim is checkable, including by this project.
     done_when: Head-of-line blocking avoided, end-to-end record latency and per-shard queue depth are published meters.
-    unblocks: [running-instance-visibility]
+    unblocks: [web-gui]
     tracking: astubbs#222
     evidence: ../features/micrometer-metrics.yaml
 
@@ -257,11 +257,10 @@ entries:
     serves: [usability]
     horizon: next-0x
     blocks_1_0: false
-    stage: limited-poc
-    stage_delivery: draft
+    stage: planned
     stage_detail: >-
-      Actively being implemented in early draft against astubbs#302; the site design is drafted on
-      astubbs#316.
+      The site design is drafted on astubbs#316 - explicitly design only, no site is built there;
+      astubbs#302 holds the intent.
     why_now: >-
       The feature data exists and nothing renders it. Until something does, the README stays the only
       documentation and the data is a second corpus rather than a source.

--- a/docs/data/schema.yaml
+++ b/docs/data/schema.yaml
@@ -35,6 +35,7 @@ kinds:
       - reader_contract
       - concerns
       - horizons
+      - stages
       - entries
       - one_point_zero
       - update_policy
@@ -44,7 +45,9 @@ kinds:
       - backlog
     # An entry is something a reader can watch finish. blocks_1_0 is what separates a 1.0 gate from
     # something merely targeted at it - the distinction the upstream release train drew, and the
-    # reason its checklist stayed workable.
+    # reason its checklist stayed workable. stage/stage_detail are required so no entry can claim a
+    # horizon without saying how real the work behind it is - the PR that advances a track updates
+    # them in the same change.
     item_contracts:
       entry_required: entries
     entry_optional:
@@ -62,6 +65,8 @@ kinds:
       - serves
       - horizon
       - blocks_1_0
+      - stage
+      - stage_detail
       - why_now
       - done_when
   testing-evidence:

--- a/docs/data/schema.yaml
+++ b/docs/data/schema.yaml
@@ -59,6 +59,7 @@ kinds:
       - blocked_by
       - evidence
       - caveat
+      - stage_delivery
     entry_required:
       - id
       - title

--- a/docs/inflight/next-experimental-module-records.md
+++ b/docs/inflight/next-experimental-module-records.md
@@ -10,8 +10,13 @@ copy-pasteable for an artifact that will not resolve. The corpus's own standard,
 work, is not to assert what the tree contradicts.
 
 **When they return.** Whichever PR lands each module restores its record in the same change, with
-`status: published`, a real `since`, and setup that resolves. Recover the drafted content from git
-history rather than rewriting it: they were removed on this branch, and both are good drafts.
+`status: published`, a real `since`, and setup that resolves. Do not rewrite the drafts - but do not
+look for them in master's history either: the astubbs#273 squash-merge made them unreachable from
+here. Where each draft actually is:
+
+- **Streams**: its staged successor already lives at `docs/features/staging/kafka-streams-integration.yaml`.
+- **Connect**: recovered verbatim from the side-line `origin/docs/v6-release-ideas-codex` and
+  committed on the module-landing PR itself (astubbs#269, as `docs/features/staging/kafka-connect-experimental.yaml`).
 
 Tracking: astubbs#255 for Streams, astubbs#240 for Connect.
 

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -77,3 +77,7 @@ Rewriting history someone else may have pulled is not reversible from inside a P
   by name.
 - **Other instances of the same defect** - `AGENTS.md`, "PR Discipline", owns that rule; it belongs
   at merge prep, once the defect class is understood.
+- **Does this PR advance a roadmap entry?** Then its `stage`/`stage_delivery` in
+  `docs/data/roadmap.yaml` move in the same change - the `stages` block there owns the rule. The
+  roadmap-stage gate enforces it when the entry's `pull_request` names this PR; entries carried by
+  a tracking issue only are on you.


### PR DESCRIPTION
## Description

The 2026-08-14..17 ideation wave produced decisions and directions the roadmap did not carry.
`docs/data/roadmap.yaml` still described the pre-proxy world - the largest open workstream in the
repo (the language-proxy sidecar, astubbs/parallel-consumer#242, PR astubbs/parallel-consumer#293)
appeared nowhere a reader could watch it finish. Four strands:

**Roadmap: six new entries at `next-0x`, three new backlog entries, one promotion.** `next-0x` is
the horizon the 1.0 exit criterion `intended-functionality-present` inspects, so placing an entry
there is what records "intended before 1.0":

- `language-proxy-sidecar` - the sidecar, the frozen v1 protocol, and clients answering to one
  conformance suite (astubbs/parallel-consumer#242, PR astubbs/parallel-consumer#293).
- `polyglot-proof-demo` - every binding visibly reading the same records, machine-checked.
- `performance-comparison-matrix` - scenarios x arms x languages measured in the conformance
  harness, published as data, under a fairness charter.
- `distributed-throttling` - divide a downstream budget across the group using the group itself
  (astubbs/parallel-consumer#228); throttling defers work, liveness outranks the limit.
- `self-tuning-concurrency` - promoted from the backlog's "dynamic concurrency control" entry
  (astubbs/parallel-consumer#227); STRATEGY.md now carries this as the self-tuning bet
  (PR astubbs/parallel-consumer#308), so the roadmap follows.
- `batch-composition-settlement` - choose the composition API once, before
  confluentinc/parallel-consumer#915 freezes a shape into the options; answers
  astubbs/parallel-consumer#145 / confluentinc/parallel-consumer#266 in the same decision.

Backlog (considered, deliberately not scheduled, with the reasoning needed to restart): the proxy
HTTP dialect + REST Proxy compat gateway (feasibility settled compatible-and-beneficial,
demand-gated), the Dapr pluggable component (probe-gated, then demand-gated), and the actor/IPC
revival (direction undecided; the probes and the async-produce promotion
astubbs/parallel-consumer#230 come first either way). No new entry carries `blocks_1_0` - that
promotion is a deliberate owner decision, not something this PR smuggles in.

**A stage ladder: every entry now says how real it is.** A horizon says when; it does not say
how much work exists - two entries at `next-0x` can differ by years of actual artifacts, and the
v6 release announcement needs to say which is which. Each entry now carries `stage` (an eight-value
ladder ordered by the most advanced artifact that exists: `idea`, `ideated`,
`requirements-drafted`, `planned`, `limited-poc`, `poc`, `in-progress`, `implemented` - with
`in-progress` for programmes like known-defects-cleared that land across many PRs and finish only
at their `done_when`) and `stage_detail` (one honest line on how far that artifact goes). The definitions are deliberately hard to flatter:
`implemented` requires proven use, not mere existence - a brand-new system nobody has run in anger
is a poc however large it is, which is why the proxy sidecar and the web view sit at `limited-poc`;
`limited-poc` marks a running slice whose central claim is not proven end-to-end, where the Streams
and Connect previews honestly sit too. An optional `stage_delivery` axis records how the artifact
is arriving: `draft` (an open PR still being worked) vs `pending-merge` (its author considers it
ready to land) - drafted does not mean doomed. The vocabulary lives in a new top-level
`stages` block. Ownership: **the PR that advances a track updates its entry's stage in the same
change, from this PR onward** - and the schema enforces it rather than documenting it: `stage` and
`stage_detail` are `entry_required` in `docs/data/schema.yaml`, so no entry can claim a horizon
without saying how real the work behind it is. One entry id is renamed:
`running-instance-visibility` becomes `web-gui` - the name the issue, the branch and every
conversation actually use - with its `unblocks` cross-reference moved in the same change.

**The ladder's rule gets its gate.** `roadmap-stage-gate.js` (+10 unit tests, wired into the
`PR Checklist` workflow, mirroring the issue-ref gate's shape) reads the base branch's roadmap,
finds entries whose `pull_request` names the PR under check, and requires that PR to touch
`docs/data/roadmap.yaml` or opt out with `roadmap-stage: N/A - <reason>` in its body. A
merge-checklist line covers the entries the gate cannot reach (tracking-issue-only carriers), and
`pull_request` fields were added to the three carrying entries that lacked one so the gate reaches
all seven carriers. The seven carrying PRs have each been told on-PR.

**Fix the module-records note that pointed at history master cannot see.**
`docs/inflight/next-experimental-module-records.md` told the module-landing PRs to recover the
drafted feature records "from git history" - but the astubbs/parallel-consumer#273 squash-merge
made those drafts unreachable from master; the only copies sit on the unmerged side-line
`origin/docs/v6-release-ideas-codex`. The Streams draft's staged successor already lives in
`docs/features/staging/`; the Connect draft has now been recovered verbatim and committed on its
module-landing PR (astubbs/parallel-consumer#269). The note now says where each draft actually is.

Gates run locally: `bin/check-docs-data.sh` (39 files valid), `bin/check-issue-refs.sh` (clean,
including this body), `bin/check-copyright-headers.sh` (clean).

## Checklist

- [x] Docs updated
- [ ] User-facing feature documentation data added under `docs/features/` - N/A - roadmap data and an inflight note; the recovered Connect record rides astubbs/parallel-consumer#269 instead
- [x] Tests added/updated - the roadmap-stage gate ships with 10 unit tests, run first in CI
- [x] Title & body reflect the final content of this PR
