### PR TITLE
docs #208: design the versioned documentation site, and repoint the Maven Central badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,7 +44,11 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-image:https://maven-badges.herokuapp.com/maven-central/bz.stub.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
+// Served by shields.io, not maven-badges.herokuapp.com: that host died with Heroku's free tier and now
+// 404s for EVERY artifact, published or not, so it cannot recover when a release lands. shields.io reads
+// Maven Central live, so this badge self-heals the moment 0.6.0.0 publishes - until then it renders
+// "not found", which is accurate rather than broken.
+image:https://img.shields.io/maven-central/v/bz.stub.parallelconsumer/parallel-consumer-parent?label=maven-central[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
 
 image:https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml/badge.svg?branch=master[link=https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml,Build and Test]
 
@@ -490,7 +494,7 @@ Where `${project.version}` is the version to be used:
 
 * group ID: `bz.stub.parallelconsumer`
 * artifact ID: `parallel-consumer-core`
-* version: image:https://maven-badges.herokuapp.com/maven-central/bz.stub.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
+* version: image:https://img.shields.io/maven-central/v/bz.stub.parallelconsumer/parallel-consumer-parent?label=maven-central[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
 
 .Core Module Dependency
 [source,xml,indent=0]

--- a/docs/plans/2026-08-06-001-docs-documentation-site-design.md
+++ b/docs/plans/2026-08-06-001-docs-documentation-site-design.md
@@ -1,26 +1,32 @@
 # Documentation site: design for astubbs#208
 
-**Status:** design agreed, not yet implemented.
-**Written:** 2026-08-06
+**Status:** signed off by the maintainer; phase 1 not yet implemented.
+**Written:** 2026-08-06. **Rewritten:** 2026-08-14, around Starlight.
 **Issue:** [astubbs#208](https://github.com/astubbs/parallel-consumer/issues/208) - *Publish the docs as a
 versioned documentation site, not one 1578-line README*
 **Parked note superseded:** [`docs/inflight/parked-docs-site.md`](../inflight/parked-docs-site.md), which
 is deleted when this work lands.
 
-This document records the design and, more usefully, the four places it **departs from astubbs#208's own
-recommendation** and why. The issue is unusually complete - it already carries an options table and a
-recommendation - so the value here is in what changed after checking the facts, not in restating it.
+The generator was decided by spike, not argument, and the decision reversed once mid-way. This document
+records the design as signed off, and - more usefully - **which claims are measured and which are still
+open**, because three of the earlier version's load-bearing claims turned out to be wrong.
 
 ---
 
-## 0. What changed against the issue, and why
+## 0. Decision log: what changed, and who changed it
 
-| astubbs#208 says | This design does | Because |
-|---|---|---|
-| Version with `mike` | **No `mike`** | Read the Docs versions natively from git tags/branches and supplies its own flyout. `mike` does the same job by committing built HTML to `gh-pages`. Both means two mechanisms disagreeing over what `latest` is. |
-| Deploy to GitHub Pages, "consider RTD" | **Read the Docs** | The account exists, and it brings PR preview builds - reviewing a docs change by reading the rendered page beats reading a diff. |
-| (silent on where site source lives) | **`src/docs/site/`**, not `docs/` | MkDocs defaults `docs_dir` to `docs/`, which in this repo is contributor scratch that astubbs#208 explicitly puts **out of scope for publication**. |
-| Native snippet includes "might" fail silently, so plan a custom injection script | **Native `pymdownx.snippets`, no custom script** | Verified in the extension's source: with `check_paths: true` a missing **section** raises `SnippetMissingError`, not just a missing file. The constraint is met natively. |
+| Decision | Earlier position | Now | Whose call |
+|---|---|---|---|
+| Generator | MkDocs + Material | **Starlight** (Astro) | Maintainer, after the spike |
+| Hosting | Read the Docs | **Cloudflare Pages** | Maintainer - RTD Community is ads-supported |
+| Versioning | `mike`, then RTD-native | **None in phase 1** - one version | Maintainer |
+| Branch flow | Two stacked PRs | **Long-lived `docs-site` branch**, PRs in parallel | Maintainer |
+| Site source | `src/docs/site/` | **`src/docs/site/content/docs/`** - see §2 | Measured, §2 |
+| Loud failure | Native `check_paths` was enough | **Custom remark plugin + `build:done` guard** | Measured, §5 |
+
+**Withdrawn, for the record.** Material for MkDocs has a published EOL of **5 November 2026**, which
+killed the original recommendation; MkDocs itself last released 1.6.1 in August 2024. Zensical (the
+Material team's successor) lost to Starlight on the maintainer's one non-negotiable - see §5.
 
 ---
 
@@ -32,10 +38,11 @@ recommendation - so the value here is in what changed after checking the facts, 
 // STOP!!! Make sure you're editing the TEMPLATE version of the README, in /src/docs/README_TEMPLATE.adoc
 ```
 
-Source of truth is `src/docs/README_TEMPLATE.adoc` (1396 lines), rendered to `README.adoc` (1654 lines)
-by `asciidoc-template-maven-plugin` 1.0.21 at `process-sources` (`pom.xml:604-624`). The plugin resolves
-**19 `include::` directives across 10 distinct source files**, each naming a tagged region of real,
-compiling code:
+Source of truth is `src/docs/README_TEMPLATE.adoc`, rendered to `README.adoc` by
+`asciidoc-template-maven-plugin` 1.0.21 at `process-sources` (`pom.xml:603-623`). It resolves
+**19 `include::` directives, 17 distinct file/tag pairs** (verified by `grep -c` and
+`grep -o ... | sort -u`; earlier comments on the issue said 19 distinct, then 14 - both wrong), each
+naming a tagged region of real, compiling code:
 
 | Source | Tags |
 |---|---|
@@ -49,41 +56,82 @@ astubbs#208 is explicit that this property is **non-negotiable**: Asciidoc "was 
 `include::` pulls named, tagged regions straight out of the real source files, so a documented example
 cannot drift from the code that compiles."
 
-So the risk in this work is not markup conversion - that is mechanical. It is that a documented example
-can start lying about the code.
+So the risk here is not markup conversion - that is mechanical. It is that a documented example can start
+lying about the code, **quietly**. Every §5 decision follows from that.
 
 ---
 
-## 2. Constraint: `docs/` is already occupied
+## 2. Where the site source lives - and why it is deeper than expected
 
-MkDocs defaults `docs_dir: docs`. This repo's `docs/` holds contributor scratch - `inflight/`, `plans/`,
-`solutions/`, `refactoring.md`, `TODO_INDEX.md`, `QUARANTINED_TESTS.md`, `SELF_HOSTED_RUNNER.md` -
-about 45 files that `AGENTS.md` devotes its "Where things live" table to keeping separate, and that
-astubbs#208 lists under **out of scope**.
+Two constraints, pulling against each other.
 
-Publishing them would be wrong, and `exclude`-ing them one by one would be a permanent tax paid every
-time someone adds an inflight note.
+**`docs/` is occupied.** MkDocs' default `docs_dir` was `docs/`, and this repo's `docs/` is contributor
+scratch - `inflight/`, `plans/`, `solutions/`, `refactoring.md`, `TODO_INDEX.md` - which astubbs#208 puts
+explicitly **out of scope for publication**, and which `AGENTS.md` devotes its "Where things live" table
+to keeping separate. Publishing it would be wrong; an `exclude:` list would be a tax paid every time
+someone adds an inflight note. That argument survives the generator change intact.
 
-**Decision:** site source lives in **`src/docs/site/`**, beside the existing `src/docs/README_TEMPLATE.adoc`
-and `src/docs/development/`. That directory already means "documentation source" here, so it is the
-idiomatic home rather than a new convention. `mkdocs.yml` sets `docs_dir: src/docs/site`.
+**Starlight will not simply be pointed elsewhere.** `docsLoader()` hardcodes its base to
+`src/content/docs` (verified in `@astrojs/starlight/loaders.ts` - it wraps Astro's `glob()` with
+`base: getCollectionPathFromRoot(...)` and exposes no `base` option).
 
-**Consequence:** MkDocs writes output to `site/`, and `.gitignore` currently ignores only `target`
-(`.gitignore:92`). `site/` must be added, or the first local build offers 100+ HTML files for commit.
+The obvious workaround is to skip `docsLoader()` and call `glob({ base: './src/docs/site' })` directly,
+which Starlight's own test fixtures demonstrate. **Measured: it half-works, and the half that fails is
+the important half.** Pages render and routes generate correctly (`/quickstart/`,
+`/concepts/ordering/`), but every internal link is then reported invalid:
+
+```
+╭─ docs/site/concepts/ordering.md
+14 | /guides/retries/
+   ·               ╰── invalid link
+Found 4 invalid links in 3 files.
+```
+
+`starlight-links-validator` computes a page's identity by stripping the literal string `content/docs`
+from its path (`libs/markdown.ts:67`, `libs/validation.ts:315`). Relocate the collection and every page
+resolves to a slug that does not match the routes Astro actually built, so **a green build becomes
+impossible while the link checker is on**. There is no option to change it - the full option schema is
+`components`, `errorOnFallbackPages`, `errorOnInconsistentLocale`, `errorOnRelativeLinks`,
+`errorOnInvalidHashes`, `errorOnLocalLinks`, `exclude`, `failOnError`, `reporters`, `sameSitePolicy`.
+Nothing addresses the base path.
+
+**Control run**, because "the validator is wrong" and "my links are wrong" produce the identical error:
+the same four pages with the same four links, at the default location, report *All internal links are
+valid*. The relocation is the cause.
+
+**Decision:** move Astro's **`srcDir`**, not the collection. `srcDir: './src/docs/site'` keeps content at
+`<srcDir>/content/docs`, so `docsLoader()` and the validator both keep their assumption, while the tree
+still lives where this repo wants it:
+
+```
+src/docs/site/               <- Astro srcDir
+  content.config.ts          <- must be INSIDE srcDir, not at src/
+  content/docs/*.md          <- the pages
+  assets/
+astro.config.mjs             <- repo root
+```
+
+**Verified end to end:** `5 page(s) built`, *All internal links are valid*, exit 0. Two traps found by
+running it rather than reasoning about it: `content.config.ts` must move inside `srcDir` (leave it at
+`src/` and the collection is silently empty, surfacing as the *misleading* error `The slug "quickstart"
+specified in the Starlight sidebar config does not exist`), and image assets resolve relative to the new
+`srcDir`.
+
+**Consequences:** `.gitignore` currently ignores only `target` (`.gitignore:92`); it needs `dist/`,
+`node_modules/`, `.astro/` and `.starlight-links-validator/`. Note the output directory is `dist/`, not
+the `site/` the MkDocs-era version of this document said.
 
 ---
 
-## 3. PR 1 - restructure the content (tool-agnostic)
+## 3. Content restructure (its own PR, tool-agnostic)
 
-astubbs#208 step 1, and worth doing on its own: it lets the tool decision be made late and keeps a
-~1600-line content move out of the same diff as a new toolchain.
-
-Convert with `npx downdoc` (Node 22 available locally; no global install), then hand-correct. The
-constructs that convert badly and need eyes: admonition blocks (`[IMPORTANT]` + `====`), `[qanda]`
-definition lists, `image::` macros, and the `ifdef::env-github[]` conditionals which have no Markdown
+astubbs#208 step 1, signed off as worth doing alone. Convert with `npx downdoc`, then hand-correct.
+Constructs that convert badly and need eyes: admonition blocks (`[IMPORTANT]` + `====`), `[qanda]`
+definition lists, `image::` macros, and the `ifdef::env-github[]` conditionals, which have no Markdown
 equivalent and simply go.
 
-Chapter mapping from today's sections:
+Chapter mapping from today's sections - the maintainer approved this list as-is ("it's the README's
+existing sections, which is exactly the right amount of change for a migration PR"):
 
 | Chapter | From `README.adoc` |
 |---|---|
@@ -104,177 +152,215 @@ Chapter mapping from today's sections:
 | `roadmap.md` | Roadmap |
 | `contributing.md` | Development Information, Maven targets, Build Scripts, Testing, Releasing |
 
-`README.adoc` shrinks to: badges, the one-paragraph description, the fork / drop-in-replacement
-`IMPORTANT` block with the Maven coordinates, one quickstart snippet, and links onward. It stays,
-because Maven Central and GitHub both render it - astubbs#208's own recommendation on its third open
-question.
+**Diátaxis:** the maintainer raised <https://diataxis.fr> and was explicit that reorganising around it is
+**not phase 1**. Where a page falls naturally into tutorial / how-to / reference / explanation and the
+move is free, take it; **do not rewrite anything to make it fit**.
 
-**KIP-932 scope:** the existing `When to use` section migrates unchanged. astubbs#208 wants that chapter
-*extended* into a full share-groups comparison plus a "who cannot adopt share groups" subsection, and is
-explicit that the facts need checking at writing time rather than taken from the issue. That is real
-research and would swamp a migration PR - it becomes follow-up work. The landing route stays free so the
-stretch pitch page can drop in without an information-architecture rewrite.
+**Link style is forced.** `starlight-links-validator` sets `errorOnRelativeLinks: true` by default, so
+cross-references are root-relative (`/concepts/ordering/`), not `../concepts/ordering/`. This cuts
+against the maintainer's "write portable Markdown" insurance policy, and it is the one place where the
+default pushes the less portable way. Flagging rather than burying it: the alternative is turning the
+flag off and losing the check that already caught a stale link in the spike.
+
+`README.adoc` shrinks to badges, the one-paragraph description, the fork / drop-in-replacement
+`IMPORTANT` block with Maven coordinates, one quickstart snippet, and links onward. It stays, because
+Maven Central and GitHub both render it.
+
+**KIP-932 scope:** `When to use` migrates unchanged. Extending it into a full share-groups comparison
+needs current per-vendor facts checked at writing time - that is research, not migration, and phase 2 is
+explicitly decided after phase 1 lands.
 
 ---
 
-## 4. PR 2 - toolchain
+## 4. Toolchain
 
 ### 4.1 Files added
 
-- **`mkdocs.yml`** - Material theme, `docs_dir: src/docs/site`, nav mirroring §3, `pymdownx.snippets`
-  with `check_paths: true`. **No `site_url`** - see §6.
-- **`.readthedocs.yaml`** - `mkdocs` build, pinned Python and deps.
-- **`.gitignore`** - add `site/`.
+- **`astro.config.mjs`** (repo root) - `srcDir: './src/docs/site'`, the region-import remark plugin, the
+  region guard, `starlight-links-validator`, nested `sidebar` mirroring §3.
+- **`src/docs/site/content.config.ts`** - stock `docsLoader()` + `docsSchema()`. Inside `srcDir`, per §2.
+- **`package.json`** / **`package-lock.json`** - `astro`, `@astrojs/starlight`,
+  `starlight-links-validator`, `sharp`. The spike ran 251 packages / 231MB; the maintainer accepted this
+  against Zensical's 11 packages / 106MB, noting migration is cheap "these days".
+- **`.gitignore`** - `dist/`, `node_modules/`, `.astro/`, `.starlight-links-validator/`.
+- **`remark-region-import.mjs`** (~103 lines) and **`region-guard-integration.mjs`** (~26 lines),
+  promoted from the spike.
+- **No `site` / `site_url`** until the domain exists - see §6.
 
-### 4.2 Snippet migration
+### 4.2 Code inclusion
 
-The 19 `include::{project_root}/path[tag=name]` become `--8<-- "path:name"`.
-
-This needs a **second marker style** added to the Java and `pom.xml` sources, because the two syntaxes
-differ:
+The 19 `include::{project_root}/path[tag=name]` become fenced blocks with
+` ```java region="path:name" `. The plugin reads the **AsciiDoc markers already in the sources**, so no
+second marker style is added anywhere:
 
 ```java
-// tag::example[]                  <- AsciiDoc, read by the Maven plugin
-// --8<-- [start:example]          <- Snippets, read by MkDocs
+// tag::example[]      <- one set of markers, read by both the Maven plugin and the site
 ```
 
-Both sets coexist in the same file - each tool ignores the other's comments. That is what lets PR 1 and
-PR 2 be independent: the AsciiDoc tags keep working while the Markdown ones arrive, so `README.adoc` is
-never broken mid-migration.
+This was Starlight's clearest win over Zensical, which cannot read AsciiDoc tags and would have needed
+dual markers in two files. The maintainer's "the markers will get replaced, not added to" holds for 17 of
+the 19 includes; `tag::example[]` in `CoreApp.java` and `tag::exampleDep[]` in the example `pom.xml`
+**stay**, because the slimmed README still resolves them through the Maven plugin. So the plugin and its
+GitHub-Packages repository (`pom.xml:193`) remain, resolving 2 includes instead of 19.
 
-The slimmed README keeps the `exampleDep` include (Maven coordinates) and the `example` quickstart
-snippet, so the Maven plugin and its GitHub-Packages repository (`pom.xml:193`) stay - resolving 2
-includes instead of 19. Retiring the plugin entirely was considered and rejected: a hand-written
-quickstart snippet in the most-read file in the repo is exactly the drift astubbs#208 is trying to
-prevent.
+Retiring the plugin and hand-writing that snippet was considered and rejected: a hand-written quickstart
+in the most-read file in the repo is exactly the drift astubbs#208 exists to prevent.
 
 ### 4.3 Versioning
 
-No `mike`. RTD builds each git ref independently and supplies the version flyout.
+**None in phase 1** - one version, so no versioning tool at all. The URL shape is fixed now because it is
+expensive to change later: **root serves the newest release, older versions under a version path.**
+Nothing to build; just nothing designed that forecloses it.
 
-- `latest` <- `master`
-- activate from the **`v0.6.0.0`** tag onward
-
-0.5.x is **not** published: its tags predate the chapter split, so publishing them means back-porting
-this migration onto a released tag. (astubbs#208 leaves this open; this is the answer, and it is a
-dashboard toggle if the maintainer later disagrees.)
+`starlight-versions` is third-party and **untested** - a real gap, deferred to phase 2 rather than
+presented as settled.
 
 ---
 
-## 5. Error handling - the non-negotiable, and its test
+## 5. Loud failure - the non-negotiable, and what it actually took
 
-astubbs#208: *"a missing or renamed tag must fail the docs build loudly"* - because the failure mode
-where a tool emits an empty snippet is the worst outcome, docs going quietly wrong rather than visibly
-broken.
+astubbs#208: *"a missing or renamed tag must fail the docs build loudly"* - because a tool emitting an
+empty snippet is the worst outcome: docs going quietly wrong rather than visibly broken.
 
-**Verified** in `pymdownx/snippets.py`, `extract_section`:
+Two earlier claims in this document were wrong, and both mattered:
 
-```python
-if not found and self.check_paths:
-    raise SnippetMissingError(f"Snippet section '{section}' could not be located")
+1. **"Native `pymdownx.snippets` is enough."** Wrong. `check_paths` guards *entry* into a region, never
+   its termination: `found` is set by the start branch alone, so a renamed **end** marker splices the
+   remainder of the file - measured at **199 lines published, 15 leaked `tag::` markers, exit 0** even
+   under `--strict`. The maintainer spotted this before the spike did.
+2. **"Starlight can never fail the build."** Also wrong, and this reversed the recommendation. Astro does
+   swallow content-rendering errors (`astro/dist/content/loaders/glob.js:130-132`, core, not Starlight) -
+   but **`astro:build:done` propagates**. The remark plugin records failures into a shared array; a
+   ~26-line integration throws there if it is non-empty.
+
+Measured behaviour of the design as specified:
+
+| | start renamed | end renamed | broken cross-link |
+|---|---|---|---|
+| Zensical `--strict` | exit 1 | **exit 0**, 199 lines published | exit 1, native |
+| **Starlight + region guard** | **exit 1** | **exit 1** | **exit 1** (plugin) |
+
+**The cache difference decided it.** Both generators cache on the Markdown file, not the included source.
+Break a marker and rebuild without clearing: Starlight **exits 1** (the guard reads the filesystem at
+build time, so a warm cache cannot hide a break); Zensical **exits 0** and serves a stale but
+correct-looking page. Zensical's correctness depends on remembering `--clean`, and a discipline that must
+be remembered will eventually be forgotten.
+
+**Re-verified against the final §2 layout**, not just the spike's default one - the guard reads paths, so
+relocating `srcDir` could plausibly have broken it:
+
+```
+[ERROR] [region-guard] [remark-region-import] .../content/docs/quickstart.md: no end marker
+  "end::example[]" in CoreApp.java (start marker found - an unterminated region would
+  silently publish the rest of the file)
 ```
 
-`check_paths` governs missing **sections** as well as missing files. So the native mechanism satisfies
-the constraint and the custom pre-build injection script astubbs#208 describes as a fallback is not
-needed. This is the single fact that decides §0's fourth row.
+`EXIT=1` with the marker renamed, `EXIT=0` restored.
 
-astubbs#208 adds: *"that behaviour wants a test."* Two CI guards:
+**The guard needs its own test** - the same argument the maintainer made about `check_paths`, and it
+applies with more force to code we wrote ourselves. CI gates on: the guard's unit test, then the build
+(which carries the region guard and the link validator in-process). Note this repo already runs
+`node .github/scripts/*.test.js` in the `PR Checklist` job, with the precedent stated in that file's own
+words - "the gate's own logic is subtle enough to have shipped two real misjudgements already, so it is
+unit tested and the tests run before the gate does."
 
-1. **Snippet guard** - rename a tag in a scratch copy, assert `mkdocs build` exits non-zero, restore.
-   Proves `check_paths` is actually on and actually strict; a config flag with no test silently
-   regresses the moment someone reformats `mkdocs.yml`.
-2. **`mkdocs build --strict`** - fails on broken internal links.
-
-These are unrelated jobs and neither subsumes the other: `check_paths` catches broken *code*
-references, `--strict` catches broken *internal links*. The second matters here specifically because one
-1654-line file becomes ~16 cross-linked chapters, and every new cross-reference is a chance to typo.
+**Still open, for the maintainer:** whether the region guard should fail the build (as specified) or only
+a separate CI step. Asked on the issue, not yet answered; the in-build version is what the spike
+measured, and it is what makes the cache hazard go away.
 
 ---
 
-## 6. Read the Docs: no account coupling
+## 6. Publishing
 
-**`.readthedocs.yaml` v2 has no field for account, organisation, project name or slug.** Its complete
-top-level key set is `version`, `formats`, `python`, `conda`, `build`, `sphinx`, `mkdocs`, `submodules`,
-`search` - purely "how to build", never "whose docs these are".
+GitHub Actions builds; `wrangler pages deploy dist/ --branch=<branch>` publishes. A non-production
+`--branch` gives a stable preview URL per branch, posted on the PR - the same command produces production
+and previews, so they cannot drift. Custom domain and SSL are free, and the DNS is the maintainer's.
 
-Everything account-shaped lives in the RTD dashboard, outside git: which account owns the project, the
-slug that becomes `<slug>.readthedocs.io`, the GitHub App connection, active versions, custom domain.
+**Requires two repo secrets only the maintainer can add:** `CLOUDFLARE_API_TOKEN` and the account ID.
+This blocks *publishing*, not the content or the toolchain, so it is not on the critical path until the
+end.
 
-So the config is portable, and the project can be imported under a throwaway account to verify the build
-and re-imported under the maintainer's for production with **no repo change**.
-
-**Therefore PR 2 ships no site URL at all** - no `site_url`, no README link to the hosted site, no Maven
-`<url>` change. Nothing to un-pick on handover.
-
-**Known cost of omitting `site_url`:** Material uses it for canonical link tags and the sitemap, so SEO
-is weaker until it is set. That matters more than usual here, because part of astubbs#208's motivation is
-that users currently find the *unmaintained upstream* first and leave. It is a reason not to leave the
-handover sitting.
-
-### Maintainer handover (astubbs#208 step 4)
-
-Only the repo owner can do these:
-
-1. **Import on RTD under an account with `astubbs/parallel-consumer` admin rights.** RTD's guidance:
-   *"The Read the Docs user who sets up the project should also have admin rights to the Git
-   repository."* With them, the GitHub App wires builds on push - *"No need to create webhooks."*
-   A manual import works without admin but then needs a webhook added by hand, so builds would not
-   trigger on push.
-2. Activate `latest` + `v0.6.0.0` onward.
-3. Optionally `CNAME` for `parallelconsumer.stub.bz` (canonical) with `pc.stub.bz` redirecting, per
-   astubbs#208's open question, then set `site_url`.
-4. Point README, Maven Central metadata and the GitHub description at the live URL.
-
-RTD Community also supports inviting maintainers with full ownership rights, so a project imported
-elsewhere can have the maintainer added rather than re-imported - but re-importing under their account is
-cleaner, since it puts the GitHub App install on the side that has repo admin.
+**No `site` / `site_url` until the domain is decided.** Cost, stated rather than hidden: Starlight uses it
+for canonical tags and the sitemap (`@astrojs/sitemap` warns and skips without it), so SEO is weaker
+until it is set. That matters more than usual here, because part of astubbs#208's motivation is that
+users find the *unmaintained upstream* first - a reason not to let the handover sit.
 
 ---
 
 ## 7. Out of scope, deliberately
 
-- **The 45 internal `.md` files** - astubbs#208 says so, and §2 is the mechanism that keeps them out.
-- **The pitch page** - stretch in astubbs#208. `index.md` stays thin so it drops in later.
-- **Extending the KIP-932 comparison** - needs current per-vendor facts (Kafka 4.x early-access vs GA,
-  Redpanda / WarpStream / Event Hubs, managed-cloud gating); own issue.
+- **The ~45 internal `.md` files** - astubbs#208 says so; §2 is the mechanism that keeps them out.
+- **The pitch page** - stretch. `index.md` stays thin so it drops in later without an IA rewrite.
+- **Extending the KIP-932 comparison** - needs current per-vendor facts; phase 2.
 - **The domain** - needs DNS the implementer does not control.
-- **0.5.x docs** - see §4.3.
+- **0.5.x docs** - not published, not back-ported; its tags predate the chapter split.
+- **Diátaxis reorganisation** - §3.
+- **Generator-specific components** (`<Tabs>`, `<CardGrid>`) - the maintainer's insurance policy is to
+  treat each as a deliberate spend and keep usage near zero, so the cost of migrating off Starlight stays
+  proportional to almost nothing. MDX is explicitly **not** a requirement.
 
 ---
 
 ## 8. Repo conventions this must satisfy
 
-Not boilerplate: three CI gates sit between this work and a merge.
+Not boilerplate - CI gates sit between this work and a merge.
 
-- **Branch** `docs/208-documentation-site` - branches encode the number.
-- **Commit subject** `docs #208: ...` - issue at the **front**. The trailing `(#N)` slot belongs to the
-  PR number, which GitHub appends on squash-merge; putting the issue there produces two bare numbers
-  with no way to tell them apart.
-- **No `(scope)`** - `AGENTS.md` is explicit that a directory name is not a scope and that plain
-  `docs #208: ...` beats one that adds nothing.
-- **PR body from `.github/PULL_REQUEST_TEMPLATE.md`**, every box checked or `N/A - <reason>`. The
-  `PR Checklist` gate fails on a missing checklist *or* an unresolved box, so dropping the template is
-  not a bypass.
-- **Issue-ref gate** - fails added lines containing an unqualified `#NN` below 1000. The migrated
-  content carries many references, so each needs qualifying as `astubbs#NNN` or `confluentinc#NNN`,
-  hyperlinked where the format allows, and **resolved in both repos before choosing the prefix** - the
-  numbering ranges overlap almost entirely, so a wrong reference that resolves is worse than a broken
-  one.
+- **Branch** `docs/208-documentation-site`, merged up from `master` regularly; everything lands on the
+  long-lived **`docs-site`** branch, and one merge flips it live. No window where `master` has less
+  documentation than today.
+- **Commit subject** `docs #208: ...` - issue at the **front**. The trailing `(#N)` slot belongs to the PR
+  number, which GitHub appends on squash-merge (`AGENTS.md:402`). No `(scope)`: `AGENTS.md` is explicit
+  that a directory name is not a scope and that plain `docs #208: ...` beats one that adds nothing.
+- **PR body from `.github/PULL_REQUEST_TEMPLATE.md`**, every box ticked or `N/A - <reason>`. The
+  `PR Checklist` gate fails on a *missing* checklist as well as an unresolved box, so dropping the
+  template is not a bypass.
+- **Issue-ref gate** - fails added lines carrying an unqualified `#NN` below 1000, *even when it resolves*
+  ("resolving is not evidence the reference is right", `issue-ref-gate.test.js:26-31`). The migrated
+  content carries many references, so each needs qualifying as `astubbs#NNN` / `upstream #NNN` and
+  **resolved in both repos before choosing the prefix** - the ranges overlap almost entirely, so a wrong
+  reference that resolves is worse than a broken one.
 - **No `CHANGELOG.adoc` entry** - a PR never adds one; release notes are generated from the commit log.
 - **Delete `docs/inflight/parked-docs-site.md`** when this lands, per the inflight rules.
-- **Merge strategy** - recommend one at merge time with reasons, rather than defaulting.
+- **Fork-PR CI caveat** - self-hosted lanes are skipped for PRs from forks (`AGENTS.md:211`), so a branch
+  on the origin repo gets fuller CI than a fork PR. This bears on the access question in §10.
 
 ---
 
-## 9. Sequence
+## 9. Sequence - parallel, not stacked
 
-**PR 1** - restructure: `src/docs/site/*.md` chapters, `README_TEMPLATE.adoc` cut to a landing page,
-`README.adoc` re-rendered, references qualified. Reviewable as *content*.
+The `docs-site` branch removes the need to stack, which the maintainer called out explicitly: *"restructure
+and toolchain can run in parallel. Develop the toolchain against a couple of sample pages, rebase onto the
+content once it merges."*
 
-**PR 2** - toolchain: `mkdocs.yml`, `.readthedocs.yaml`, `.gitignore`, dual snippet markers in the 10
-source files, the two CI guards, handover notes in the PR body. Reviewable as *build config*.
+1. **Content** - `src/docs/site/content/docs/*.md` from `README.adoc`, references qualified, links made
+   root-relative. Reviewable as *content*.
+2. **Toolchain** - `astro.config.mjs`, `content.config.ts`, `package.json`, plugin + guard, `.gitignore`,
+   the guard's unit test. Developed against 2-3 sample pages; rebased onto (1). Reviewable as *build
+   config*.
+3. **README slim-down** - `README_TEMPLATE.adoc` cut to a landing page, `README.adoc` re-rendered, the
+   broken Maven Central badge removed (§10).
+4. **Publishing** - the Actions workflow and `wrangler` deploy. Needs the maintainer's secrets (§6).
 
-PR 2 declares `depends on #<PR 1>` in its description, per `AGENTS.md`'s stacked-PR convention. (That
-convention refers to a PR-dependency gate; no implementation of it was found under `.github/`, so it is
-presumably a repo ruleset or app rather than a workflow. Either way the line is what the convention asks
-for.)
+As many PRs as the work wants; (1) and (2) do not block each other.
+
+---
+
+## 10. Open with the maintainer
+
+Tracked here so they do not get lost between issue comments.
+
+1. **Push access.** The flow needs a long-lived `docs-site` branch on `origin`. It **does not exist yet**
+   (checked ~200 branches), the implementer has no push access (`GET /collaborators` → 403), and no fork
+   exists. Either the maintainer creates the branch and adds a collaborator, or the work goes via fork PRs
+   - at the cost of the self-hosted CI lanes (§8).
+2. **Cloudflare secrets** - §6.
+3. **Region guard: in-build or separate CI step?** - §5.
+4. **The broken badge** (their side-ask). It is the Maven Central badge,
+   `README_TEMPLATE.adoc:47`, and it is broken twice over: `maven-badges.herokuapp.com` died with Heroku's
+   free tier, **and** nothing is published under `bz.stub.parallelconsumer` yet (`repo1.maven.org` group
+   path → 404; `pom.xml:10-13` is `0.6.0.0-SNAPSHOT`), so *any* badge on *any* service reads "not found"
+   today. Repointing at shields.io returns HTTP 200 and an SVG whose text says `maven-central: not found`
+   - which is why the status code is not the thing to check. **Agreed course:** remove it now, re-add the
+   link when 0.6.0.0 publishes; the re-add note belongs in
+   [`docs/inflight/release-0.6.0.0.md`](../inflight/release-0.6.0.0.md). The GitHub Actions badge on
+   line 49 is fine (HTTP 200, renders).

--- a/docs/plans/2026-08-06-001-docs-documentation-site-design.md
+++ b/docs/plans/2026-08-06-001-docs-documentation-site-design.md
@@ -2,6 +2,9 @@
 
 **Status:** signed off by the maintainer; phase 1 not yet implemented.
 **Written:** 2026-08-06. **Rewritten:** 2026-08-14, around Starlight.
+**Citations repaired:** 2026-08-18, after ~68 commits of master landed under this branch - addresses
+only, per [`docs/citations.md`](../citations.md). Where a *convention* moved rather than a line number,
+it is flagged beside the original claim (§8) rather than silently rewritten.
 **Issue:** [astubbs#208](https://github.com/astubbs/parallel-consumer/issues/208) - *Publish the docs as a
 versioned documentation site, not one 1578-line README*
 **Parked note superseded:** [`docs/inflight/parked-docs-site.md`](../inflight/parked-docs-site.md), which
@@ -39,7 +42,8 @@ Material team's successor) lost to Starlight on the maintainer's one non-negotia
 ```
 
 Source of truth is `src/docs/README_TEMPLATE.adoc`, rendered to `README.adoc` by
-`asciidoc-template-maven-plugin` 1.0.21 at `process-sources` (`pom.xml:603-623`). It resolves
+`asciidoc-template-maven-plugin` 1.0.21 at `process-sources` (`pom.xml`, grep
+`<templateFile>README_TEMPLATE.adoc</templateFile>`). It resolves
 **19 `include::` directives, 17 distinct file/tag pairs** (verified by `grep -c` and
 `grep -o ... | sort -u`; earlier comments on the issue said 19 distinct, then 14 - both wrong), each
 naming a tagged region of real, compiling code:
@@ -66,7 +70,8 @@ lying about the code, **quietly**. Every §5 decision follows from that.
 Two constraints, pulling against each other.
 
 **`docs/` is occupied.** MkDocs' default `docs_dir` was `docs/`, and this repo's `docs/` is contributor
-scratch - `inflight/`, `plans/`, `solutions/`, `refactoring.md`, `TODO_INDEX.md` - which astubbs#208 puts
+scratch - `inflight/`, `plans/`, `solutions/`, `refactoring.md`, `todo-index.md` (`TODO_INDEX.md` when
+this was written; renamed upstream since) - which astubbs#208 puts
 explicitly **out of scope for publication**, and which `AGENTS.md` devotes its "Where things live" table
 to keeping separate. Publishing it would be wrong; an `exclude:` list would be a tax paid every time
 someone adds an inflight note. That argument survives the generator change intact.
@@ -88,7 +93,8 @@ Found 4 invalid links in 3 files.
 ```
 
 `starlight-links-validator` computes a page's identity by stripping the literal string `content/docs`
-from its path (`libs/markdown.ts:67`, `libs/validation.ts:315`). Relocate the collection and every page
+from its path (`starlight-links-validator` 0.25.3 - grep `'content/docs'` in `libs/markdown.ts` and
+`'content/docs/'` in `libs/validation.ts`). Relocate the collection and every page
 resolves to a slug that does not match the routes Astro actually built, so **a green build becomes
 impossible while the link checker is on**. There is no option to change it - the full option schema is
 `components`, `errorOnFallbackPages`, `errorOnInconsistentLocale`, `errorOnRelativeLinks`,
@@ -117,7 +123,8 @@ running it rather than reasoning about it: `content.config.ts` must move inside 
 specified in the Starlight sidebar config does not exist`), and image assets resolve relative to the new
 `srcDir`.
 
-**Consequences:** `.gitignore` currently ignores only `target` (`.gitignore:92`); it needs `dist/`,
+**Consequences:** `.gitignore` ignores `target` but nothing Node- or Astro-related (grep it for
+`dist`, `node_modules`, `astro`, `starlight` - all absent); it needs `dist/`,
 `node_modules/`, `.astro/` and `.starlight-links-validator/`. Note the output directory is `dist/`, not
 the `site/` the MkDocs-era version of this document said.
 
@@ -201,7 +208,8 @@ This was Starlight's clearest win over Zensical, which cannot read AsciiDoc tags
 dual markers in two files. The maintainer's "the markers will get replaced, not added to" holds for 17 of
 the 19 includes; `tag::example[]` in `CoreApp.java` and `tag::exampleDep[]` in the example `pom.xml`
 **stay**, because the slimmed README still resolves them through the Maven plugin. So the plugin and its
-GitHub-Packages repository (`pom.xml:193`) remain, resolving 2 includes instead of 19.
+GitHub-Packages repository (`pom.xml`, grep `github-asciidoc-template-maven-plugin`) remain, resolving
+2 includes instead of 19.
 
 Retiring the plugin and hand-writing that snippet was considered and rejected: a hand-written quickstart
 in the most-read file in the repo is exactly the drift astubbs#208 exists to prevent.
@@ -229,7 +237,9 @@ Two earlier claims in this document were wrong, and both mattered:
    remainder of the file - measured at **199 lines published, 15 leaked `tag::` markers, exit 0** even
    under `--strict`. The maintainer spotted this before the spike did.
 2. **"Starlight can never fail the build."** Also wrong, and this reversed the recommendation. Astro does
-   swallow content-rendering errors (`astro/dist/content/loaders/glob.js:130-132`, core, not Starlight) -
+   swallow content-rendering errors (`astro/dist/content/loaders/glob.js`, core not Starlight - grep
+   `Error rendering ${entry}`, which logs and continues; re-confirmed on astro 7.2.2, where the line
+   number had already moved) -
    but **`astro:build:done` propagates**. The remark plugin records failures into a shared array; a
    ~26-line integration throws there if it is non-empty.
 
@@ -309,20 +319,36 @@ Not boilerplate - CI gates sit between this work and a merge.
   long-lived **`docs-site`** branch, and one merge flips it live. No window where `master` has less
   documentation than today.
 - **Commit subject** `docs #208: ...` - issue at the **front**. The trailing `(#N)` slot belongs to the PR
-  number, which GitHub appends on squash-merge (`AGENTS.md:402`). No `(scope)`: `AGENTS.md` is explicit
+  number, which GitHub appends on squash-merge (`AGENTS.md`, "Commits", grep `the trailing`). No
+  `(scope)`: `AGENTS.md` is explicit
   that a directory name is not a scope and that plain `docs #208: ...` beats one that adds nothing.
 - **PR body from `.github/PULL_REQUEST_TEMPLATE.md`**, every box ticked or `N/A - <reason>`. The
   `PR Checklist` gate fails on a *missing* checklist as well as an unresolved box, so dropping the
   template is not a bypass.
 - **Issue-ref gate** - fails added lines carrying an unqualified `#NN` below 1000, *even when it resolves*
-  ("resolving is not evidence the reference is right", `issue-ref-gate.test.js:26-31`). The migrated
-  content carries many references, so each needs qualifying as `astubbs#NNN` / `upstream #NNN` and
+  ("Resolving is not evidence the reference is right" - `.github/scripts/issue-ref-gate.test.js`, grep
+  `the old blind spot`). The migrated
+  content carries many references, so each needs qualifying as `astubbs#NNN` / `confluentinc#NNN` and
   **resolved in both repos before choosing the prefix** - the ranges overlap almost entirely, so a wrong
   reference that resolves is worse than a broken one.
+  **Convention change since this was written (2026-08-18):** `upstream #NNN`, which the sentence above
+  originally recommended, is now *flagged* rather than accepted - it names a role, not a repo, and the
+  tolerance was deliberately removed rather than discouraged, "left in, it comes back the moment someone
+  copies old text" (`.github/scripts/issue-ref-gate.js`, grep `named a role rather than a repo`).
+  `docs/issue-references.md` owns the convention.
 - **No `CHANGELOG.adoc` entry** - a PR never adds one; release notes are generated from the commit log.
 - **Delete `docs/inflight/parked-docs-site.md`** when this lands, per the inflight rules.
-- **Fork-PR CI caveat** - self-hosted lanes are skipped for PRs from forks (`AGENTS.md:211`), so a branch
-  on the origin repo gets fuller CI than a fork PR. This bears on the access question in §10.
+- **Fork-PR CI caveat** - self-hosted lanes are skipped for PRs from forks, so a branch on the origin
+  repo gets fuller CI than a fork PR. This bears on the access question in §10.
+  **Sharpened since this was written (2026-08-18), and it is now stronger than a caveat:** a fork PR
+  **cannot turn the required `claude-review` check green at all**. The reviewer refuses any head not in
+  the repo, because reviewing a fork would run untrusted code beside a credential - verified in
+  `.github/workflows/claude-code-review.yml` (grep `Refuse fork heads`) and
+  `claude-code-review-dispatch.yml` (grep `refuse fork heads`), not only in the prose. The two options
+  the repo offers are pushing the same commits to a branch here, or a human merging with the check red;
+  letting a maintainer declare it reviewed is explicitly *not* offered. Owned by `docs/ci.md`, "A fork
+  PR cannot turn the gate green". This directly qualifies the maintainer's "just make a fork, then
+  submit a PR" (§10.1).
 
 ---
 
@@ -338,7 +364,8 @@ content once it merges."*
    the guard's unit test. Developed against 2-3 sample pages; rebased onto (1). Reviewable as *build
    config*.
 3. **README slim-down** - `README_TEMPLATE.adoc` cut to a landing page, `README.adoc` re-rendered, the
-   broken Maven Central badge removed (§10).
+   broken Maven Central badge dealt with - **done ahead of this step**, repointed rather than removed
+   (§10.4).
 4. **Publishing** - the Actions workflow and `wrangler` deploy. Needs the maintainer's secrets (§6).
 
 As many PRs as the work wants; (1) and (2) do not block each other.
@@ -353,14 +380,30 @@ Tracked here so they do not get lost between issue comments.
    (checked ~200 branches), the implementer has no push access (`GET /collaborators` → 403), and no fork
    exists. Either the maintainer creates the branch and adds a collaborator, or the work goes via fork PRs
    - at the cost of the self-hosted CI lanes (§8).
-2. **Cloudflare secrets** - §6.
+   **ANSWERED 2026-08-18: fork and PR.** The maintainer chose the fork route explicitly ("just make a
+   fork, then submit a PR"); `matthall-TM/parallel-consumer` now exists. Note what §8 records about what
+   that costs: it is no longer only the self-hosted lanes, since a fork PR cannot turn the required
+   `claude-review` check green. Worth putting to them, because the answer predates that mechanism.
+2. **Cloudflare secrets** - §6. **ANSWERED 2026-08-18:** after the PR is reviewed, not before.
 3. **Region guard: in-build or separate CI step?** - §5.
-4. **The broken badge** (their side-ask). It is the Maven Central badge,
-   `README_TEMPLATE.adoc:47`, and it is broken twice over: `maven-badges.herokuapp.com` died with Heroku's
-   free tier, **and** nothing is published under `bz.stub.parallelconsumer` yet (`repo1.maven.org` group
-   path → 404; `pom.xml:10-13` is `0.6.0.0-SNAPSHOT`), so *any* badge on *any* service reads "not found"
-   today. Repointing at shields.io returns HTTP 200 and an SVG whose text says `maven-central: not found`
-   - which is why the status code is not the thing to check. **Agreed course:** remove it now, re-add the
+4. **The broken badge** (their side-ask). It is the Maven Central badge in
+   `src/docs/README_TEMPLATE.adoc` (grep `maven-central`), and it is broken twice over:
+   `maven-badges.herokuapp.com` died with Heroku's free tier, **and** nothing is published under
+   `bz.stub.parallelconsumer` yet (`repo1.maven.org` group path → 404; `pom.xml` is
+   `0.6.0.0-SNAPSHOT`), so *any* badge on *any* service reads "not found" today. Repointing at
+   shields.io returns HTTP 200 and an SVG whose text says `maven-central: not found` - which is why the
+   status code is not the thing to check. **Agreed course:** remove it now, re-add the
    link when 0.6.0.0 publishes; the re-add note belongs in
-   [`docs/inflight/release-0.6.0.0.md`](../inflight/release-0.6.0.0.md). The GitHub Actions badge on
-   line 49 is fine (HTTP 200, renders).
+   [`docs/inflight/release-0.6.0.0.md`](../inflight/release-0.6.0.0.md). The GitHub Actions badge beside
+   it is fine (HTTP 200, renders).
+
+   **RESOLVED 2026-08-18, differently from both the above and the maintainer's instruction.** They said
+   to keep it: *"as long as the system still works, it'll just fix itself when the release lands"*. The
+   premise is false - the host is gone, not merely empty. Measured against
+   `io.confluent.parallelconsumer/parallel-consumer-parent`, which **is** published: it 404s identically
+   (548 bytes, Heroku's "No such app" page), so nothing about a release can revive it. shields.io reads
+   Maven Central live - `v0.5.3.3` for that same control, `not found` for the fork's groupId today - so
+   it delivers the *intent* of the instruction, self-healing on publish with no further edit. Repointed
+   rather than removed or kept, in both occurrences; **the deviation from the literal instruction is
+   disclosed to the maintainer rather than left in the diff.** This supersedes the "remove it now,
+   re-add later" course above, which no longer needs a `release-0.6.0.0.md` note at all.

--- a/docs/plans/2026-08-06-001-docs-documentation-site-design.md
+++ b/docs/plans/2026-08-06-001-docs-documentation-site-design.md
@@ -1,0 +1,280 @@
+# Documentation site: design for astubbs#208
+
+**Status:** design agreed, not yet implemented.
+**Written:** 2026-08-06
+**Issue:** [astubbs#208](https://github.com/astubbs/parallel-consumer/issues/208) - *Publish the docs as a
+versioned documentation site, not one 1578-line README*
+**Parked note superseded:** [`docs/inflight/parked-docs-site.md`](../inflight/parked-docs-site.md), which
+is deleted when this work lands.
+
+This document records the design and, more usefully, the four places it **departs from astubbs#208's own
+recommendation** and why. The issue is unusually complete - it already carries an options table and a
+recommendation - so the value here is in what changed after checking the facts, not in restating it.
+
+---
+
+## 0. What changed against the issue, and why
+
+| astubbs#208 says | This design does | Because |
+|---|---|---|
+| Version with `mike` | **No `mike`** | Read the Docs versions natively from git tags/branches and supplies its own flyout. `mike` does the same job by committing built HTML to `gh-pages`. Both means two mechanisms disagreeing over what `latest` is. |
+| Deploy to GitHub Pages, "consider RTD" | **Read the Docs** | The account exists, and it brings PR preview builds - reviewing a docs change by reading the rendered page beats reading a diff. |
+| (silent on where site source lives) | **`src/docs/site/`**, not `docs/` | MkDocs defaults `docs_dir` to `docs/`, which in this repo is contributor scratch that astubbs#208 explicitly puts **out of scope for publication**. |
+| Native snippet includes "might" fail silently, so plan a custom injection script | **Native `pymdownx.snippets`, no custom script** | Verified in the extension's source: with `check_paths: true` a missing **section** raises `SnippetMissingError`, not just a missing file. The constraint is met natively. |
+
+---
+
+## 1. The thing that makes this migration non-trivial
+
+`README.adoc` is **generated output, not a source file.** Its first line says so:
+
+```
+// STOP!!! Make sure you're editing the TEMPLATE version of the README, in /src/docs/README_TEMPLATE.adoc
+```
+
+Source of truth is `src/docs/README_TEMPLATE.adoc` (1396 lines), rendered to `README.adoc` (1654 lines)
+by `asciidoc-template-maven-plugin` 1.0.21 at `process-sources` (`pom.xml:604-624`). The plugin resolves
+**19 `include::` directives across 10 distinct source files**, each naming a tagged region of real,
+compiling code:
+
+| Source | Tags |
+|---|---|
+| `parallel-consumer-example-core/.../CoreApp.java` | `example`, `exampleSetup`, `exampleProduce`, `customRetryDelay`, `maxRetries`, `circuitBreaker`, `batching`, `closeModes` |
+| `parallel-consumer-core/.../ParallelConsumer.java` | `javadoc` |
+| `parallel-consumer-core/.../ParallelConsumerOptions.java` | `transactionalJavadoc` |
+| `VertxApp.java`, `ReactorApp.java`, `StreamsApp.java`, metrics `CoreApp.java` | `example` |
+| 3 example `pom.xml` files | `exampleDep` |
+
+astubbs#208 is explicit that this property is **non-negotiable**: Asciidoc "was chosen because
+`include::` pulls named, tagged regions straight out of the real source files, so a documented example
+cannot drift from the code that compiles."
+
+So the risk in this work is not markup conversion - that is mechanical. It is that a documented example
+can start lying about the code.
+
+---
+
+## 2. Constraint: `docs/` is already occupied
+
+MkDocs defaults `docs_dir: docs`. This repo's `docs/` holds contributor scratch - `inflight/`, `plans/`,
+`solutions/`, `refactoring.md`, `TODO_INDEX.md`, `QUARANTINED_TESTS.md`, `SELF_HOSTED_RUNNER.md` -
+about 45 files that `AGENTS.md` devotes its "Where things live" table to keeping separate, and that
+astubbs#208 lists under **out of scope**.
+
+Publishing them would be wrong, and `exclude`-ing them one by one would be a permanent tax paid every
+time someone adds an inflight note.
+
+**Decision:** site source lives in **`src/docs/site/`**, beside the existing `src/docs/README_TEMPLATE.adoc`
+and `src/docs/development/`. That directory already means "documentation source" here, so it is the
+idiomatic home rather than a new convention. `mkdocs.yml` sets `docs_dir: src/docs/site`.
+
+**Consequence:** MkDocs writes output to `site/`, and `.gitignore` currently ignores only `target`
+(`.gitignore:92`). `site/` must be added, or the first local build offers 100+ HTML files for commit.
+
+---
+
+## 3. PR 1 - restructure the content (tool-agnostic)
+
+astubbs#208 step 1, and worth doing on its own: it lets the tool decision be made late and keeps a
+~1600-line content move out of the same diff as a new toolchain.
+
+Convert with `npx downdoc` (Node 22 available locally; no global install), then hand-correct. The
+constructs that convert badly and need eyes: admonition blocks (`[IMPORTANT]` + `====`), `[qanda]`
+definition lists, `image::` macros, and the `ifdef::env-github[]` conditionals which have no Markdown
+equivalent and simply go.
+
+Chapter mapping from today's sections:
+
+| Chapter | From `README.adoc` |
+|---|---|
+| `index.md` | *deliberately thin - see §7* |
+| `quickstart.md` | Maven, Common Preparation, Simple Message Process, Demo |
+| `when-to-use.md` | When to use this library (vs KIP-932) - **migrated as-is** |
+| `concepts/motivation.md` | Motivation, Why would I need this, Background, FAQ, Scenarios |
+| `concepts/ordering.md` | Ordering Guarantees (all 5 subsections) |
+| `guides/retries.md` | Retries, Retry Delay Function, Skipping Records, Circuit Breaker, Head of Line Blocking |
+| `guides/batching.md` | Batching (usage + restrictions) |
+| `configuration.md` | Result Models, Commit Mode, Shutdown and Close Modes |
+| `modules/vertx.md`, `modules/reactor.md`, `modules/streams.md` | HTTP with Vert.x, Project Reactor, Kafka Streams Concurrent Processing |
+| `metrics.md` | Metrics (6 meter groups) + Example Metrics setup steps |
+| `migration.md` | Upgrading |
+| `requirements.md` | Usage Requirements, Java Version per Module |
+| `performance.md` | Performance, Illustrative Performance Example |
+| `internals.md` | Implementation Details, Core/Vert.x/Transactional architecture, Offset Map |
+| `roadmap.md` | Roadmap |
+| `contributing.md` | Development Information, Maven targets, Build Scripts, Testing, Releasing |
+
+`README.adoc` shrinks to: badges, the one-paragraph description, the fork / drop-in-replacement
+`IMPORTANT` block with the Maven coordinates, one quickstart snippet, and links onward. It stays,
+because Maven Central and GitHub both render it - astubbs#208's own recommendation on its third open
+question.
+
+**KIP-932 scope:** the existing `When to use` section migrates unchanged. astubbs#208 wants that chapter
+*extended* into a full share-groups comparison plus a "who cannot adopt share groups" subsection, and is
+explicit that the facts need checking at writing time rather than taken from the issue. That is real
+research and would swamp a migration PR - it becomes follow-up work. The landing route stays free so the
+stretch pitch page can drop in without an information-architecture rewrite.
+
+---
+
+## 4. PR 2 - toolchain
+
+### 4.1 Files added
+
+- **`mkdocs.yml`** - Material theme, `docs_dir: src/docs/site`, nav mirroring §3, `pymdownx.snippets`
+  with `check_paths: true`. **No `site_url`** - see §6.
+- **`.readthedocs.yaml`** - `mkdocs` build, pinned Python and deps.
+- **`.gitignore`** - add `site/`.
+
+### 4.2 Snippet migration
+
+The 19 `include::{project_root}/path[tag=name]` become `--8<-- "path:name"`.
+
+This needs a **second marker style** added to the Java and `pom.xml` sources, because the two syntaxes
+differ:
+
+```java
+// tag::example[]                  <- AsciiDoc, read by the Maven plugin
+// --8<-- [start:example]          <- Snippets, read by MkDocs
+```
+
+Both sets coexist in the same file - each tool ignores the other's comments. That is what lets PR 1 and
+PR 2 be independent: the AsciiDoc tags keep working while the Markdown ones arrive, so `README.adoc` is
+never broken mid-migration.
+
+The slimmed README keeps the `exampleDep` include (Maven coordinates) and the `example` quickstart
+snippet, so the Maven plugin and its GitHub-Packages repository (`pom.xml:193`) stay - resolving 2
+includes instead of 19. Retiring the plugin entirely was considered and rejected: a hand-written
+quickstart snippet in the most-read file in the repo is exactly the drift astubbs#208 is trying to
+prevent.
+
+### 4.3 Versioning
+
+No `mike`. RTD builds each git ref independently and supplies the version flyout.
+
+- `latest` <- `master`
+- activate from the **`v0.6.0.0`** tag onward
+
+0.5.x is **not** published: its tags predate the chapter split, so publishing them means back-porting
+this migration onto a released tag. (astubbs#208 leaves this open; this is the answer, and it is a
+dashboard toggle if the maintainer later disagrees.)
+
+---
+
+## 5. Error handling - the non-negotiable, and its test
+
+astubbs#208: *"a missing or renamed tag must fail the docs build loudly"* - because the failure mode
+where a tool emits an empty snippet is the worst outcome, docs going quietly wrong rather than visibly
+broken.
+
+**Verified** in `pymdownx/snippets.py`, `extract_section`:
+
+```python
+if not found and self.check_paths:
+    raise SnippetMissingError(f"Snippet section '{section}' could not be located")
+```
+
+`check_paths` governs missing **sections** as well as missing files. So the native mechanism satisfies
+the constraint and the custom pre-build injection script astubbs#208 describes as a fallback is not
+needed. This is the single fact that decides §0's fourth row.
+
+astubbs#208 adds: *"that behaviour wants a test."* Two CI guards:
+
+1. **Snippet guard** - rename a tag in a scratch copy, assert `mkdocs build` exits non-zero, restore.
+   Proves `check_paths` is actually on and actually strict; a config flag with no test silently
+   regresses the moment someone reformats `mkdocs.yml`.
+2. **`mkdocs build --strict`** - fails on broken internal links.
+
+These are unrelated jobs and neither subsumes the other: `check_paths` catches broken *code*
+references, `--strict` catches broken *internal links*. The second matters here specifically because one
+1654-line file becomes ~16 cross-linked chapters, and every new cross-reference is a chance to typo.
+
+---
+
+## 6. Read the Docs: no account coupling
+
+**`.readthedocs.yaml` v2 has no field for account, organisation, project name or slug.** Its complete
+top-level key set is `version`, `formats`, `python`, `conda`, `build`, `sphinx`, `mkdocs`, `submodules`,
+`search` - purely "how to build", never "whose docs these are".
+
+Everything account-shaped lives in the RTD dashboard, outside git: which account owns the project, the
+slug that becomes `<slug>.readthedocs.io`, the GitHub App connection, active versions, custom domain.
+
+So the config is portable, and the project can be imported under a throwaway account to verify the build
+and re-imported under the maintainer's for production with **no repo change**.
+
+**Therefore PR 2 ships no site URL at all** - no `site_url`, no README link to the hosted site, no Maven
+`<url>` change. Nothing to un-pick on handover.
+
+**Known cost of omitting `site_url`:** Material uses it for canonical link tags and the sitemap, so SEO
+is weaker until it is set. That matters more than usual here, because part of astubbs#208's motivation is
+that users currently find the *unmaintained upstream* first and leave. It is a reason not to leave the
+handover sitting.
+
+### Maintainer handover (astubbs#208 step 4)
+
+Only the repo owner can do these:
+
+1. **Import on RTD under an account with `astubbs/parallel-consumer` admin rights.** RTD's guidance:
+   *"The Read the Docs user who sets up the project should also have admin rights to the Git
+   repository."* With them, the GitHub App wires builds on push - *"No need to create webhooks."*
+   A manual import works without admin but then needs a webhook added by hand, so builds would not
+   trigger on push.
+2. Activate `latest` + `v0.6.0.0` onward.
+3. Optionally `CNAME` for `parallelconsumer.stub.bz` (canonical) with `pc.stub.bz` redirecting, per
+   astubbs#208's open question, then set `site_url`.
+4. Point README, Maven Central metadata and the GitHub description at the live URL.
+
+RTD Community also supports inviting maintainers with full ownership rights, so a project imported
+elsewhere can have the maintainer added rather than re-imported - but re-importing under their account is
+cleaner, since it puts the GitHub App install on the side that has repo admin.
+
+---
+
+## 7. Out of scope, deliberately
+
+- **The 45 internal `.md` files** - astubbs#208 says so, and §2 is the mechanism that keeps them out.
+- **The pitch page** - stretch in astubbs#208. `index.md` stays thin so it drops in later.
+- **Extending the KIP-932 comparison** - needs current per-vendor facts (Kafka 4.x early-access vs GA,
+  Redpanda / WarpStream / Event Hubs, managed-cloud gating); own issue.
+- **The domain** - needs DNS the implementer does not control.
+- **0.5.x docs** - see §4.3.
+
+---
+
+## 8. Repo conventions this must satisfy
+
+Not boilerplate: three CI gates sit between this work and a merge.
+
+- **Branch** `docs/208-documentation-site` - branches encode the number.
+- **Commit subject** `docs #208: ...` - issue at the **front**. The trailing `(#N)` slot belongs to the
+  PR number, which GitHub appends on squash-merge; putting the issue there produces two bare numbers
+  with no way to tell them apart.
+- **No `(scope)`** - `AGENTS.md` is explicit that a directory name is not a scope and that plain
+  `docs #208: ...` beats one that adds nothing.
+- **PR body from `.github/PULL_REQUEST_TEMPLATE.md`**, every box checked or `N/A - <reason>`. The
+  `PR Checklist` gate fails on a missing checklist *or* an unresolved box, so dropping the template is
+  not a bypass.
+- **Issue-ref gate** - fails added lines containing an unqualified `#NN` below 1000. The migrated
+  content carries many references, so each needs qualifying as `astubbs#NNN` or `confluentinc#NNN`,
+  hyperlinked where the format allows, and **resolved in both repos before choosing the prefix** - the
+  numbering ranges overlap almost entirely, so a wrong reference that resolves is worse than a broken
+  one.
+- **No `CHANGELOG.adoc` entry** - a PR never adds one; release notes are generated from the commit log.
+- **Delete `docs/inflight/parked-docs-site.md`** when this lands, per the inflight rules.
+- **Merge strategy** - recommend one at merge time with reasons, rather than defaulting.
+
+---
+
+## 9. Sequence
+
+**PR 1** - restructure: `src/docs/site/*.md` chapters, `README_TEMPLATE.adoc` cut to a landing page,
+`README.adoc` re-rendered, references qualified. Reviewable as *content*.
+
+**PR 2** - toolchain: `mkdocs.yml`, `.readthedocs.yaml`, `.gitignore`, dual snippet markers in the 10
+source files, the two CI guards, handover notes in the PR body. Reviewable as *build config*.
+
+PR 2 declares `depends on #<PR 1>` in its description, per `AGENTS.md`'s stacked-PR convention. (That
+convention refers to a PR-dependency gate; no implementation of it was found under `.github/`, so it is
+presumably a repo ruleset or app rather than a workflow. Either way the line is what the convention asks
+for.)

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -44,7 +44,11 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-image:https://maven-badges.herokuapp.com/maven-central/bz.stub.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
+// Served by shields.io, not maven-badges.herokuapp.com: that host died with Heroku's free tier and now
+// 404s for EVERY artifact, published or not, so it cannot recover when a release lands. shields.io reads
+// Maven Central live, so this badge self-heals the moment 0.6.0.0 publishes - until then it renders
+// "not found", which is accurate rather than broken.
+image:https://img.shields.io/maven-central/v/bz.stub.parallelconsumer/parallel-consumer-parent?label=maven-central[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
 
 image:https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml/badge.svg?branch=master[link=https://github.com/astubbs/parallel-consumer/actions/workflows/maven.yml,Build and Test]
 
@@ -488,7 +492,7 @@ Where `${project.version}` is the version to be used:
 
 * group ID: `bz.stub.parallelconsumer`
 * artifact ID: `parallel-consumer-core`
-* version: image:https://maven-badges.herokuapp.com/maven-central/bz.stub.parallelconsumer/parallel-consumer-parent/badge.svg?style=flat[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
+* version: image:https://img.shields.io/maven-central/v/bz.stub.parallelconsumer/parallel-consumer-parent?label=maven-central[link=https://mvnrepository.com/artifact/bz.stub.parallelconsumer/parallel-consumer-parent,Latest Parallel Consumer on Maven Central]
 
 .Core Module Dependency
 [source,xml,indent=0]


### PR DESCRIPTION
Serves astubbs/parallel-consumer#208 — does not close it: this is the design plus one side-ask, not the migration.

## Description

Phase 1 groundwork for the documentation site. **No site is built here** — three files: the design
document, and the Maven Central badge repoint (in the template and its generated output).

Opened from a fork, per your "just make a fork, then submit a PR". Please read the two deviations
below before the diff; both are places where I did something other than what was agreed, and neither
is visible as a deviation in the diff itself.

### Deviation 1 — the badge is repointed, not kept

You said to keep it: *"as long as the system still works, it'll just fix itself when the release
lands."* I tested that premise rather than the badge, and it is false — so keeping it could not have
produced the outcome you asked for.

`maven-badges.herokuapp.com` died with Heroku's free tier. Measured against a **published control**,
`io.confluent.parallelconsumer/parallel-consumer-parent`, which definitely resolves on Maven Central:

| Badge URL | published control | `bz.stub.parallelconsumer` |
|---|---|---|
| `maven-badges.herokuapp.com` | **404**, 548 bytes, Heroku "No such app" | **404**, identical |
| `img.shields.io/maven-central` | renders `v0.5.3.3` | renders `not found` |

The control 404s identically, so nothing about a release can revive it — it is not waiting on
0.6.0.0, the service is gone. shields.io reads Maven Central live, so it delivers the *intent* of
your instruction: it self-heals the moment 0.6.0.0 publishes, with no further edit. Today it reads
"not found", which is accurate rather than broken.

This also supersedes my own earlier "remove it now, re-add on release" course, so no
`release-0.6.0.0.md` note is needed. **If you would rather have it removed than repointed, say so and
I will** — the repoint is the reading of your instruction I could defend, not a preference.

Note for anyone verifying: shields.io returns **HTTP 200 with an SVG whose text says "not found"**.
The status code is not the thing to check.

### Deviation 2 — a fork PR cannot turn `claude-review` green, so this PR cannot go green

Not a choice of mine, but it changes what the fork route costs, and it postdates your answer.

The required `claude-review` check **refuses any head outside the repo**, before it looks at a
comment — reviewing a fork would run untrusted code beside `CLAUDE_CODE_OAUTH_TOKEN`. Verified in the
workflows, not just the prose: `.github/workflows/claude-code-review.yml` (grep `Refuse fork heads`)
and `claude-code-review-dispatch.yml` (grep `refuse fork heads`). `docs/ci.md`, "A fork PR cannot
turn the gate green", offers two routes — push the same commits to a branch here, or review by hand
and merge with the check red — and explicitly does *not* offer letting a maintainer declare it
reviewed.

**So a red `claude-review` here is expected, not a fault.** I have not touched the gate. My design
doc had this as "self-hosted lanes are skipped for fork PRs", which understated it; that is corrected
on the branch rather than rewritten, per `docs/citations.md`. If you would prefer the fuller CI, a
branch in the repo is the only route that gets it.

### A design gap the inherited commits exposed — flagged, not fixed

Reading the 68 commits that landed under this branch (per "Read the commits you inherit") surfaced
something my design contradicts, and I would rather raise it than quietly widen this PR:

`docs/features/` now holds **36 feature YAMLs** and `docs/data/` four more, structurally gated by
`bin/check-docs-data.sh` on every PR. `docs/data/README.md` says they exist so *"a future docs-site
renderer can turn them into pages, tables or navigation"*, and
`docs/plans/2026-08-10-004-docs-feature-catalogue-plan.md` names astubbs/parallel-consumer#208 as
their consumer: *"The docs site then imports the directory and renders each file as a page."*

My §2 excludes all of `docs/` from publication as contributor scratch. **Both cannot be true.** That
data is renderer input, not scratch, so the site needs a rendering path for it and my chapter list
does not have one. Two open questions for you, since this is scope rather than a bug:

1. Are the 36 feature records **published pages** in phase 1, or does the site render them later?
2. If published, does each become its own page, or do they feed a filterable feature table?

I have deliberately not answered these in the diff — it would grow a design PR into an IA decision
that is yours. The `parked-docs-site.md` constraint (don't build anything new depending on the README
embedding other documents) **is** satisfied: the design slims the README rather than adding embeds.

### Corrections to my own earlier claims on the issue thread

- The `include::` count is **19 directives, 17 distinct file/tag pairs**. I said 19 distinct, then 14;
  both were wrong. `grep -c` and `grep -o … | sort -u`.
- Starlight cannot simply be pointed at another directory. `docsLoader()` hardcodes its base, and
  `starlight-links-validator` independently re-derives the same convention by stripping the literal
  `content/docs`. Relocating the collection renders pages and correct routes but reports **every**
  internal link invalid. The fix is moving Astro's `srcDir`, with `content.config.ts` inside it.
- Build output is `dist/`, not the `site/` I said in the MkDocs-era draft.

Each was found by running it, with a control arm at the default location that passes on identical
pages and links — so "the validator is wrong" and "my links are wrong" were separated rather than
assumed.

### Re-verified on today's dependencies

The design's load-bearing claim is that a renamed tag fails the build loudly. Re-measured on
**astro 7.2.2** / **starlight-links-validator 0.25.3**, not just the versions of the original spike:
baseline 5 pages built, all internal links valid, exit 0; renamed `end::example[]` still exits 1 with
its diagnostic. Astro's error-swallowing `catch` had already moved line since I first cited it —
which is itself the argument for `docs/citations.md`'s anchor rule, so it is now cited by anchor.

Gates run locally: `bin/check-issue-refs.sh` clean, `bin/check-docs-data.sh` 39 files valid.

### Still open, and blocking nothing yet

- **Region guard: fail the build, or a separate CI step?** Asked three times on the issue, still
  unanswered. The in-build version is what was measured, and it is what makes the warm-cache hazard
  go away. I will build it in-build unless you say otherwise; it is a small change either way.
- `starlight-versions` is third-party and **untested** — a real gap, deferred to phase 2 rather than
  presented as settled.
- Cloudflare secrets are yours to add, and you have said after review — nothing here needs them.

## Checklist

- [x] Docs updated — this PR is documentation only: the design record, and the badge in
  `src/docs/README_TEMPLATE.adoc` with `README.adoc` regenerated via the Maven plugin rather than
  hand-edited (it is generated output; its first line says so).
- [x] User-facing feature documentation data added under `docs/features/` — `N/A - no user-visible
  feature changes.` No behaviour, API or configuration changes; the only user-visible effect is a
  README badge now rendering instead of 404ing. See the design-gap section above for the separate
  question of whether the *site* should publish these records.
- [x] Tests added/updated — `N/A - no code changes.` The claims here are verified by measurement
  recorded in the design doc and re-run for this PR (build exit codes, badge HTTP responses against a
  published control). The region guard the design specifies **does** get a unit test when it is
  built, per §5.
- [x] Title & body reflect the final content of this PR

---

The four commits are pushed unsquashed and carry their reasoning in the bodies, since release notes
are generated from the log and the diagnosis is the part worth keeping. **Recommended merge
strategy:** squash — the four are one coherent unit (design, rewrite, badge, citation repair) and the
intermediate rewrite is not worth preserving on master. Happy to write the squash message, or to
re-cut them, if you would rather.
