### PR TITLE
docs(releasing): the release label rule, what 0.5.3.3 never was, and two traps found cleaning up

### DIFF
--- a/docs/inflight/next-agent-polling-loops-need-a-bound.md
+++ b/docs/inflight/next-agent-polling-loops-need-a-bound.md
@@ -1,0 +1,65 @@
+# Agent polling loops leak, because nothing bounds them
+
+Found 2026-08-18 while clearing a merged worktree: it could not be removed because a shell from a
+session **five days earlier** still held it as its working directory.
+
+That process was an `until` loop waiting for a CI check to report, waking every 15 seconds:
+
+```bash
+until gh api repos/.../commits/<sha>/check-runs -q '...' | grep -qE 'success|failure|neutral'; do
+  sleep 15
+done
+```
+
+**The check it waited for did not exist on that commit.** No run had produced it, so the `grep` could
+never match and the loop had no other exit. It had been running for 5 days 22 hours - on the order of
+34,000 `gh api` calls - and would have run until the machine rebooted.
+
+## Why this is a shape, not an incident
+
+Measured the same day, once the first one was noticed: **four more** shells older than an hour, the
+oldest **6.3 days**, about **20 process-days** of accumulated idle polling between them. Re-measure
+rather than trusting that figure - the point is the shape, and `ps -eo pid,etimes,cmd` with a filter
+on age and on `sleep`/`until` finds them in one command.
+
+Three properties make it silent:
+
+- **The failure mode is waiting, not erroring.** A loop that will never exit looks exactly like a
+  loop that has not exited yet. Nothing goes red, nothing is logged, no budget is exceeded.
+- **The condition can be unsatisfiable from the first iteration.** Waiting on a check that is never
+  created, a job on a re-run attempt that no longer exists, or a workflow that was skipped are all
+  the same to the loop: the predicate is simply always false.
+- **It outlives its session.** The agent that started it moves on or is compacted away; the process
+  keeps its worktree pinned, which is how this one was found rather than by anyone looking.
+
+## The rule worth adopting
+
+**A polling loop gets a deadline, and says so when it hits it.** Not a retry count - a wall-clock
+bound, because the failure is duration:
+
+```bash
+deadline=$(( $(date +%s) + 900 ))
+until <condition>; do
+  [ "$(date +%s)" -lt "$deadline" ] || { echo "gave up waiting for <thing> after 15m" >&2; break; }
+  sleep 15
+done
+```
+
+The `echo` matters as much as the bound. A loop that exits silently at its deadline is
+indistinguishable from one whose condition came true, which reproduces the original defect one level
+up - the same false-clean shape as
+[a check that reports success without having run](../solutions/workflow-issues/a-check-that-reports-success-without-having-run.md).
+
+**Prefer not writing the loop at all.** Most of these waits exist to watch CI, and the harness
+already has a change-detector for that; where one is available, it wakes on the event instead of
+asking every 15 seconds. Reach for a loop only when nothing else can observe the thing.
+
+## What this needs to become
+
+Unowned. Two candidate homes, neither written yet: a line in
+[`bin/AGENTS.md`](../../bin/AGENTS.md) if the rule should bind anything committed under `bin/`, and
+a line wherever agent shell conventions live if it should bind ad-hoc commands too - which is where
+all five of these came from, none of them committed anywhere.
+
+Sweeping the current leaks is a separate, cheap job: they belong to sessions that may still be live,
+so check before killing rather than matching on age alone.

--- a/docs/inflight/next-three-mirrors-release-label-undecided.md
+++ b/docs/inflight/next-three-mirrors-release-label-undecided.md
@@ -1,0 +1,55 @@
+# Three closed mirrors that may belong in 0.6.0.0
+
+astubbs#118, astubbs#233 and astubbs#252 are closed `upstream-mirror` issues carrying no `0.6.0.0`
+label. Whether they should is undecided - but for two of them the *code* question is already
+answered, and the remaining question is narrower than it looks.
+
+## Already answered: astubbs#233 and astubbs#252 are fixed
+
+`src/docs/development/upstream-map.yaml`, entry `sweep-2023-already-fixed` (`last_checked:
+2026-08-07`, `status: merged`), records the code-level check for both - and opens with *"Recorded so
+nobody re-investigates."*
+
+- **astubbs#233** (`confluentinc#41`): `findCompletedEligibleOffsetsAndRemove` is gone;
+  `PartitionState.incompleteOffsets` is a `ConcurrentSkipListMap` and
+  `getOffsetHighestSequentialSucceeded()` is a `ceiling()` lookup - *"exactly the proposed design"*.
+  The manifest notes one residue: the code's own comment still points at `confluentinc#200` for the
+  complete solution, so that exact variant stays open.
+- **astubbs#252** (`confluentinc#319`): the `ConcurrentModificationException` is structurally
+  impossible - `PartitionMonitor` became `PartitionStateManager`, `partitionStates` is a
+  `ConcurrentHashMap`, and `getAssignedPartitions()` collects into a fresh map before any stream.
+
+**Do not re-derive this.** An earlier draft of this note did exactly that, concluded astubbs#233
+"cannot be assessed by name" and astubbs#252 was "probably not fixed", and was corrected by review.
+The manifest is named in [`AGENTS.md`](../../AGENTS.md) as the source of truth for fork↔upstream
+mapping; it is the first place to look, not the last.
+
+## The open question is the label, not the fix
+
+Both were fixed **by inherited upstream code** rather than by fork work - the `PartitionStateManager`
+rework for astubbs#252, and whatever removed the offset scan for astubbs#233 (`confluentinc#270`, the
+PR that proposed it, was swept unmerged). So the question is the one 0.5.3.3 raises elsewhere in
+[`release-0.6.0.0.md`](release-0.6.0.0.md): **was that code in an upstream release users can already
+consume?**
+
+- If yes, 0.6.0.0 delivers nothing new for these two and the label would overstate it.
+- If no, 0.6.0.0 is their first delivery and the label is right, exactly as for astubbs#182.
+
+Settling it means finding which upstream version contains those changes - not re-checking whether
+the code is fixed.
+
+## Genuinely open: astubbs#118
+
+Not in the manifest at all. It carries `partially-fixed-in/0.5.2.6`, and nothing records which part
+remained. Commit `ed78d6cc9` is on master, and its subject quotes this issue's own failure -
+*"fix(core) #118: foreign offset metadata no longer kills the consumer on assignment"* <!-- issue-refs: exempt -->
+- with the `RuntimeException: Unexpected magic: 1` reproduced in the body.
+
+What is unestablished is whether that fork commit closes the part 0.5.2.6 left open, or fixes a
+different symptom raising the same exception. That is a code question, and the answer belongs in a
+comment on the issue - one is already posted stating exactly this, so start there.
+
+## Do not label them on the strength of being closed
+
+A mirror's closure describes upstream's state, never the fork's. An audit nearly labelled all three
+for that reason alone, which would have asserted a delivery that may not exist.

--- a/docs/inflight/release-0.6.0.0.md
+++ b/docs/inflight/release-0.6.0.0.md
@@ -170,6 +170,26 @@ All four now exist as data. Each keeps its planning note, which holds the reason
 
 What does not exist yet is the rendered documentation an agent generates from all of it.
 
+## 0.5.3.3 was never released, by anyone
+
+Worth knowing before writing release copy or triaging a mirror: **`0.5.3.3` exists as a changelog
+section and a tag, and was never published as an artifact.** Upstream's last release on Maven Central
+is `0.5.3.2`; it was abandoned before cutting 0.5.3.3, and this fork has published nothing yet. Check
+with a Maven Central search for `g:io.confluent.parallelconsumer` rather than trusting the changelog,
+which lists 0.5.3.3 like any other section.
+
+Two consequences:
+
+- **Anything labelled `fixed-in/0.5.3.3` is unreachable today.** No user can consume those fixes, so
+  0.6.0.0 is their first delivery - which is why astubbs#182, astubbs#184 and astubbs#188 all carry
+  the `0.6.0.0` label despite naming an earlier fix version. That combination looks like a mistake
+  and is not.
+- **A user on `io.confluent...:0.5.3.2` is further behind than the changelog suggests**, by a whole
+  section's worth of fixes they never had access to.
+
+This is specific to 0.5.3.3. Every other `fixed-in/0.5.x` label names a version that really shipped,
+and those fixes are already in users' hands.
+
 ## Do at release: one sweep over the upstream mirrors
 
 The upstream issues are mirrored here, labelled `upstream-mirror`, and each carries a **Fork status** section

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -83,7 +83,10 @@ gh pr list    -R astubbs/parallel-consumer --state all --label 0.6.0.0 --limit 2
 ```
 
 **Two labelling schemes coexist, and they answer different questions.** The version label
-(`0.6.0.0`) says *this shipped in that release* and is carried by both issues and PRs. The relative
+(`0.6.0.0`) says *this is targeted at that release* - that is its own description, and it sits on open
+issues as well as closed ones, so it marks intent rather than delivery. Reconcile it against what
+actually shipped at release time rather than trusting it as a manifest. It is carried by both issues
+and PRs. The relative
 labels (`next-feature-release`, `next-breaking-release`, `next-patch-release`) say *this is queued for
 whichever release comes next* and are used on issues only. Queue with the relative label while the
 work is pending; add the version label when it lands. At release time the version label is the one to

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -66,6 +66,33 @@ says what changed and, where it matters to a user, what it changed *for them*; t
 experiment and the rejected alternatives in the body. A good commit message is now doing double
 duty, which is a reason to keep writing them properly rather than a new process.
 
+## Label the issue with the release it ships in
+
+**When work lands, put the release's version label on its issue** - `0.6.0.0` today. Nothing enforces
+this, and the failure is silent: the work ships, the changelog entry gets written from the commit log,
+and only the label is missing, so nothing looks wrong until someone asks the tracker what went into
+the release. astubbs#209 shipped in 0.6.0.0 unlabelled and was caught by hand afterwards.
+
+**The label is the exact version string, not a `v`-prefixed short form.** There is no `v6` label, so
+`gh issue list --label v6` returns nothing - which reads as "no issues in this release" rather than as
+a bad query. The right search is:
+
+```bash
+gh issue list -R astubbs/parallel-consumer --state all --label 0.6.0.0 --limit 200
+gh pr list    -R astubbs/parallel-consumer --state all --label 0.6.0.0 --limit 200
+```
+
+**Two labelling schemes coexist, and they answer different questions.** The version label
+(`0.6.0.0`) says *this shipped in that release* and is carried by both issues and PRs. The relative
+labels (`next-feature-release`, `next-breaking-release`, `next-patch-release`) say *this is queued for
+whichever release comes next* and are used on issues only. Queue with the relative label while the
+work is pending; add the version label when it lands. At release time the version label is the one to
+search - the relative ones move as releases cut, so they cannot tell you what a *past* release
+contained.
+
+This is a convenience, not the record. `CHANGELOG.adoc` and the commit log remain the source of
+truth, and a missing label never makes a release wrong - it makes it harder to audit.
+
 ## At release time
 
 An agent reads `git log <last-tag>..HEAD` - full messages, not just subjects - and drafts the


### PR DESCRIPTION
Five notes from cleaning up after astubbs/parallel-consumer#296 merged. No product code; every commit
is documentation, and each is independently revertible.

## Description

**Release labelling.** astubbs/parallel-consumer#209 shipped in 0.6.0.0 without the version label and
was caught by hand. `docs/releasing.md` said nothing about labels at all, so the rule is now written
down along with the trap that makes a missing label worse than it sounds: the label is the exact
version string, so `gh issue list --label v6` returns nothing, and an empty result reads as *"no
issues in this release"* rather than as a bad query.

A second commit corrects that same section. It first said the version label means *"this shipped in
that release"*; it does not — the label's own description is *"Targeted at the 0.6.0.0 release"* and
it sits on 23 open issues. It marks intent, not delivery, so a release-time search needs reconciling
against the changelog rather than reading as a manifest. That error is not academic: an audit run on
the wrong meaning proposed labelling eight closed upstream mirrors that shipped years ago.

**0.5.3.3 was never released, by anyone.** It exists as a changelog section and a tag, and was never
published as an artifact — upstream's last release on Maven Central is 0.5.3.2, abandoned before
cutting 0.5.3.3, and this fork has published nothing yet. That changes what a label means: anything
marked `fixed-in/0.5.3.3` is unreachable by any user today, so 0.6.0.0 is its first delivery. It is
why astubbs/parallel-consumer#182, astubbs/parallel-consumer#184 and astubbs/parallel-consumer#188
carry `0.6.0.0` while naming an earlier fix version — a pairing that reads as an error and was nearly
"corrected" away. Deliberately not generalised: every other `fixed-in/0.5.x` names a version that
really shipped.

**Three mirrors whose fork fix status is unestablished.** astubbs/parallel-consumer#118,
astubbs/parallel-consumer#233 and astubbs/parallel-consumer#252 are closed with no `0.6.0.0` label,
and the tracker cannot say whether they should have one — one is `partially-fixed-in` an upstream
release with no record of what remained, and two were closed by upstream's 2023 administrative sweep,
which fixed nothing. The note records the evidence one pass already found so the next person starts
from it rather than repeating it.

**Agent polling loops leak.** A merged worktree could not be removed because a shell from a session
five days earlier still held it — an `until` loop waiting on a CI check that did not exist on the
commit it watched, so its `grep` could never match. Roughly 34,000 API calls, and it would have run
until the machine rebooted. Measuring for the shape found four more, the oldest 6.3 days. Proposes a
wall-clock deadline that announces itself on expiry, because a loop exiting silently at its deadline
is indistinguishable from one whose condition came true.

## Checklist

- [x] Docs updated - this PR is documentation only: `docs/releasing.md`,
      `docs/inflight/release-0.6.0.0.md`, and two new `docs/inflight/` notes.
- [ ] N/A - user-facing feature documentation data. Nothing here changes the published artifact, the
      API, configuration or observable behaviour; `docs/features/` records what the library does for
      a user, and this changes only how the project records its own work.
- [ ] N/A - tests. No executable code changes. The claims that could rot are cited by greppable
      anchor, and the two measurable ones (0.5.3.3 absent from Maven Central, the leaked-process
      count) name the command that re-derives them rather than freezing a number.
- [x] Title & body reflect the final content of this PR
