### PR TITLE
docs(review-gate): record that the per-push auto-review is off, and that its gap is accepted

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,9 +25,13 @@ name: review gate
 # IT NO LONGER ASKS WHETHER THE REVIEW COVERED THE CURRENT HEAD. It used to, and the strict
 # implementation is archived at the tag `archive/review-gate-strict-head-freshness` with the
 # reasoning in docs/inflight/parked-strict-review-gate-freshness.md. Short version: strict is
-# the stronger guarantee, but per-push coverage already comes from an auto-reviewer, and
-# enforcing strictness here cost a write-scoped job on every review route plus a page of
-# timestamp plumbing. Do not re-add it without reading that entry.
+# the stronger guarantee, but enforcing it here cost a page of timestamp plumbing, and the
+# per-push coverage it protected came from an auto-reviewer - which was switched off on
+# 2026-08-19 on cost grounds and now runs on request only. The gap that leaves is accepted
+# deliberately; docs/ci.md, "The gate asks ...", owns why. Do not re-add strictness without
+# reading that entry. (An earlier version of this comment also charged strictness for the
+# `actions: write` scope on the refresh-gate jobs; that was wrong - the scope is a cost of the
+# check being produced by a `pull_request` workflow, and it survives leniency unchanged.)
 #
 # THE JOB NAME `claude-review` IS AN API. It is a required status check in the master ruleset
 # (`gh api repos/astubbs/parallel-consumer/rules/branches/master`), matched by name. Rename the

--- a/bin/check-review-posted.sh
+++ b/bin/check-review-posted.sh
@@ -57,8 +57,11 @@
 # It was not abandoned because it was wrong. It was abandoned because of what ENFORCING it
 # cost, and because the coverage it was protecting turned out to come from somewhere else:
 #
-#   * PER-PUSH COVERAGE ALREADY EXISTS. A separate reviewer auto-reviews every push. Strictness
-#     here was buying a guarantee that was already being provided, at a price paid on every PR.
+#   * PER-PUSH COVERAGE EXISTED ELSEWHERE. A separate reviewer auto-reviewed every push, so
+#     strictness here was buying a guarantee already being provided, at a price paid on every PR.
+#     THAT AUTO-REVIEW WAS SWITCHED OFF ON 2026-08-19 on cost grounds and is now on request only.
+#     The gap is accepted deliberately rather than covered, and re-adding freshness here is the
+#     wrong answer to it - the reasoning is in docs/ci.md, "The gate asks ...", which owns it.
 #   * IT NEEDED CONTESTABLE TIMESTAMPS. Deciding "newer than the head" meant choosing between
 #     the contributor-controlled committer date and the server-side check-suite time, handling
 #     same-second ties, and paginating an endpoint with undocumented ordering - three rounds of

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -176,6 +176,12 @@ review" tightly enough that people batched pushes to avoid it. The two are now s
 | **Gate** (`claude-code-review.yml`) | every PR push | none - no Claude, no JDK, no build | the required check `claude-review` |
 | **Reviewer** (`claude-code-review-dispatch.yml`) | when dispatched | a full review | the review itself |
 
+**The second reviewer, Codex, is on request too - comment `@codex review` on the PR.** It reviewed
+every push automatically until 2026-08-19, and that setting lives in the Codex account settings
+rather than in this repo, so nothing here changes when it is toggled. Turning it off is why the
+review gate's coverage gap is now accepted rather than covered - see
+["The gate asks..."](#the-gate-asks-has-this-pr-been-reviewed-not-was-every-commit-reviewed).
+
 **`--ref master` is required, not cosmetic.** It is what lets the reviewer review a PR that edits
 the reviewer - see "Editing the reviewer" below. Dispatching from the PR's own branch reintroduces
 the trap it avoids.
@@ -355,7 +361,8 @@ turn the gate green" below.)
 ### The gate asks "has this PR been reviewed?", not "was every commit reviewed?"
 
 <!-- CANONICAL: the gate contract. Nowhere else states what satisfies the gate - everything else
-     links here. If you change this paragraph, run bin/check-review-gate-contract.sh. -->
+     links here. Before you change this paragraph, find the mentions that link to it:
+     grep -rn "claude-review" . --exclude-dir=.git --exclude-dir=target -->
 
 **Any finished `claude[bot]` review on the PR satisfies it**, whenever it was posted. A review of
 the first commit therefore vouches for the twentieth, and that is a deliberate reversal of the
@@ -369,8 +376,8 @@ mention now links here instead of paraphrasing.
 It is a real trade, so it is worth knowing why it was made rather than discovering the cost by
 surprise. Strict is the stronger guarantee - a review of commit N genuinely does not vouch for
 commit N+1 - and it was abandoned not because it was wrong but because of **what enforcing it
-cost**, and because the per-commit coverage it protected already arrives from elsewhere: a
-separate auto-reviewer reads every push. What freshness cost was the **timestamp machinery**: a
+cost**, and because the per-commit coverage it protected arrived from elsewhere at the time: a
+separate auto-reviewer read every push. What freshness cost was the **timestamp machinery**: a
 contested comparison between the contributor-controlled committer date and the server-side
 check-suite time, same-second ties, an endpoint with undocumented ordering, and the reviewed-SHA
 plumbing crossing job boundaries. All of that is gone.
@@ -383,10 +390,19 @@ never have paid it off; retiring it needs the reviewer to raise a check run on t
 The distinction matters to anyone weighing a return to strictness: restoring it buys back the
 guarantee at the price of the timestamp machinery alone, not of a new privilege escalation.
 
-**The assumption that makes this safe is that the auto-review keeps happening.** If it ever stops,
-per-commit coverage stops coming from anywhere and nothing announces it - the gate keeps passing,
-because "a review exists on this PR" is still true. That trigger, and the archived strict
-implementation, are recorded in
+**The assumption that made leniency safe - that the auto-review keeps happening - expired on
+2026-08-19, and the answer is to accept the gap rather than close it.** That auto-review was
+switched off because a full review of every push spends more than the coverage is worth; it is now
+on request only, like the dispatched reviewer above. So a PR reviewed at commit 1 can merge at
+commit 20 with commits 2-20 read by nobody, and every check stays green.
+
+**Do not answer that by making a push invalidate the Claude review.** That moves the per-push spend
+onto the more expensive reviewer, which is the cost both splits were made to remove - the freshness
+rule was parked and the reviewer was taken off `pull_request` for the same reason. The condition
+that reopens the decision is the price of a review falling by roughly two orders of magnitude, not
+the rediscovery that the gap exists. Ask for a review when a PR is ready, and ask again after a
+push that changes what a reviewer already looked at; that judgement is deliberately a person's, not
+a gate's. The reasoning and the archived strict implementation are in
 [`docs/inflight/parked-strict-review-gate-freshness.md`](inflight/parked-strict-review-gate-freshness.md).
 Read it before re-proposing strictness; it is a considered trade, not an oversight.
 

--- a/docs/data/testing-evidence.yaml
+++ b/docs/data/testing-evidence.yaml
@@ -234,9 +234,11 @@ quality_system:
     detects: A review that never happened or never finished, rather than claiming a review because a job was green.
     posture: >-
       Split in two: the review is requested on demand, and a cheap always-on gate requires that a finished
-      review already exists on the PR. Deliberately not per-commit - that coverage comes from an auto-reviewer
-      on every push, and enforcing it here cost a contested timestamp comparison and the reviewed-SHA plumbing;
-      trigger to restore it are parked in docs/inflight/parked-strict-review-gate-freshness.md. There is no
+      review already exists on the PR. Deliberately not per-commit: enforcing that here cost a contested
+      timestamp comparison and the reviewed-SHA plumbing, and the coverage it protected came from an
+      auto-reviewer on every push, switched off on 2026-08-19 on cost grounds and now on request only. No
+      check reads the commits after the reviewed one, and that gap is accepted rather than covered; the
+      reasoning is parked in docs/inflight/parked-strict-review-gate-freshness.md. There is no
       skip word, and a fork head is refused outright, so a red gate on an unreviewed PR is the expected state,
       not a fault. Comment metadata only; it cannot judge whether the review was any good, nor tell a review
       from any other answer the bot gave.

--- a/docs/inflight/parked-strict-review-gate-freshness.md
+++ b/docs/inflight/parked-strict-review-gate-freshness.md
@@ -38,17 +38,31 @@ see the correction below - and it matters here, because it inflates the apparent
 back: restoring strictness buys the guarantee for the price of the timestamp machinery alone, not
 for a new privilege-escalation surface.
 
-## The assumption this rests on - and the trigger to restore
+## The trigger fired on 2026-08-19, and strictness stays parked anyway
 
-**Per-push coverage now comes from the auto-reviewer, not from this gate.** Codex reviews every
-push; the gate's job is to assert that somebody deliberately asked for a Claude review of this
-PR and that it finished.
+This entry used to end by naming a trigger: parking rested on Codex auto-reviewing every push,
+so if that auto-review ever stopped, per-commit coverage would stop coming from anywhere at all
+and nothing would announce it - the gate would keep passing, because "a review exists on this
+PR" is still true.
 
-**If that auto-review ever stops - disabled, unsubscribed, rate-limited, or quietly changed to
-run on fewer events - per-commit coverage stops coming from anywhere at all,** and nothing will
-announce it. The gate will keep passing, because "a review exists on this PR" is still true.
-That is the trigger to restore strictness, and it is the reason this entry exists rather than
-just the tag.
+**It stopped.** Automatic review on every push was turned off in the Codex settings on
+2026-08-19, because reviewing every push spends more than the coverage is worth at current
+prices. Codex still reviews **on request**, by commenting `@codex review` on the PR.
+
+**The decision that follows is to leave strictness parked, and to accept the gap knowingly.**
+Restoring it would make every push want a fresh Claude review, which moves the per-push spend
+onto the more expensive reviewer - the exact cost that both this parking and the reviewer's move
+off `pull_request` were made to remove. The gap is therefore real and stated rather than
+covered: a PR reviewed at commit 1 can merge at commit 20 with commits 2-20 unread.
+
+**What would change the decision is price, not principle.** Strict is still the better guarantee;
+it is unaffordable per push, and nothing else about the trade has moved. If a review ever costs
+around two orders of magnitude less, restore it - the archive above is the implementation, and the
+bill is the timestamp machinery alone. Rediscovering that the gap exists is not a trigger; it is
+written down here on purpose so it does not read as an oversight to the next person who finds it.
+
+Until then the coverage is a person's judgement: ask for a review when the PR is ready, and ask
+again after a push that changes what the reviewer already looked at.
 
 ## One correction to the tag's reasoning
 


### PR DESCRIPTION
## Description

Automatic Codex review on every push was **switched off on 2026-08-19**, in the Codex account
settings rather than anywhere in this repo. It now reviews **on request only**, via an
`@codex review` comment. The reason is cost: a full review of every push spends more than the
coverage is worth at current token prices.

That is precisely the trigger `docs/inflight/parked-strict-review-gate-freshness.md` named for
restoring the strict, head-fresh `claude-review` gate - so left alone, the entry would read to the
next person as an unnoticed regression. Five places asserted the same now-expired premise, each in
its own words:

| File | What it said |
|---|---|
| `docs/ci.md` | the canonical gate contract - "a separate auto-reviewer reads every push" |
| `bin/check-review-posted.sh` | the `PER-PUSH COVERAGE ALREADY EXISTS` bullet in its header |
| `.github/workflows/claude-code-review.yml` | its "no longer asks about head freshness" note |
| `docs/data/testing-evidence.yaml` | the `review-delivery` posture |
| `docs/inflight/parked-strict-review-gate-freshness.md` | the trigger itself |

### The decision recorded is NOT to restore strictness

Restoring it would make every push want a fresh Claude review, which moves the per-push spend onto
the **more expensive** reviewer - the exact cost that parking freshness and taking the reviewer off
`pull_request` were both meant to remove.

So the gap is stated plainly rather than covered: **a PR reviewed at commit 1 can merge at commit 20
with commits 2-20 read by nobody, and every check stays green.** What reopens the decision is the
price of a review falling by roughly two orders of magnitude - not the rediscovery that the gap
exists. That is written down on purpose, so the next reader does not take it for an oversight and
"fix" it.

`docs/ci.md` also gains one line in "The automated review" naming Codex as the second route and
saying where its toggle lives, so a reader learns the route exists without the coverage reasoning
being restated twice.

### Two stale claims fixed in passing

Both sit inside comments this change already rewrites:

- **`docs/ci.md` cited `bin/check-review-gate-contract.sh`** as the check to run when editing the
  canonical paragraph. That script has never existed - the citation was born dangling in
  astubbs/parallel-consumer#287 - so it promised an enforcer that was not there. Replaced with the
  grep that actually finds the mentions linking to that paragraph. (A real checker for dangling file
  references like this one is worth having repo-wide; that is separate work, not this PR.)
- **`claude-code-review.yml` still charged strictness for the `actions: write` scope** on the
  refresh-gate jobs. `docs/ci.md` and the parked entry both corrected that already: the scope is a
  cost of the check being produced by a `pull_request` workflow, and it survives leniency unchanged.

### Contributor impact

No change to the library. Pushes are no longer reviewed automatically - ask for a review when the PR
is ready, and again after a push that changes what the reviewer already looked at.

### Verification

Run locally on this branch, all passing:

```
bin/check-docs-data.sh          39 file(s) structurally valid
bin/check-issue-refs.sh         no unqualified references on added lines
bin/check-copyright-headers.sh  241 java files, 0 violations
bin/test-check-review-posted.sh all 16 review-gate cases passed
```

Both edited YAML files parse; `bash -n bin/check-review-posted.sh` is clean. `actionlint` is not
installed on this machine, so the workflow got YAML-parse validation only - the change there is
comment-only.

**Known conflicts:** astubbs/parallel-consumer#274 and astubbs/parallel-consumer#275 both touch
`bin/check-review-posted.sh`, and astubbs/parallel-consumer#274 also touches `claude-code-review.yml`. They carry the package
rename too, so they conflict broadly regardless; flagged rather than worked around.

## Checklist

- [x] Docs updated - this PR is the doc update
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - no user-facing feature; contributor-facing CI/review-process documentation only`
- [x] Tests added/updated - `N/A - comment and prose only, no executable behaviour changed; bin/test-check-review-posted.sh re-run unchanged and green`
- [x] Title & body reflect the final content of this PR

