### PR TITLE
ci(dups): bump the duplicate-code-cross-check pin to stop re-posting review threads

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astubbs/duplicate-code-cross-check@d3140ef6e9a4adf68c9f729a789e8b7ec8d058f7 # v1
+      - uses: astubbs/duplicate-code-cross-check@c828d78862927d89f6b851a7b0fdba9af6875b3b # v1 + astubbs/duplicate-code-cross-check#8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           directories: 'parallel-consumer-core/src parallel-consumer-vertx/src parallel-consumer-reactor/src parallel-consumer-mutiny/src'


### PR DESCRIPTION
## Description

Bumps the `dups: clones` action pin from `d3140ef6e` to `c828d7886`, picking up
[astubbs/duplicate-code-cross-check#8](https://github.com/astubbs/duplicate-code-cross-check/pull/8).

**Why it matters here.** The old pin opened a **brand-new inline review thread for the same finding on every push**. Measured on astubbs/parallel-consumer#31: **25** duplicate-code threads, **24 at the identical anchor** with byte-identical bodies, and **100% of every review thread on that PR**. Unresolved threads block merge on "unresolved conversations", so each had to be replied to and resolved by hand — and a genuine human finding would have been buried among them.

The new version fetches existing review comments once before the loop, paginated, and skips a finding already posted at that path with that body. A comment on a **resolved** thread still counts as existing, which is what stops a dismissed finding returning.

**A second fix rides along.** `countTotalLines` built a `find … | xargs wc -l` pipeline by string concatenation and ran it through bash. Beyond the CodeQL injection finding, `xargs` splits on whitespace — so **any path containing a space contributed zero lines to the total**, silently deflating the denominator behind every duplication percentage the job reports. Nothing in this repo's scanned directories has a space today, so our numbers were unaffected, but they were one directory rename away from being wrong with no signal.

Two pre-existing instances of the same missing-pagination class were filed rather than folded in: [#9](https://github.com/astubbs/duplicate-code-cross-check/issues/9) and [#10](https://github.com/astubbs/duplicate-code-cross-check/issues/10).

## Test plan

- [x] Pinned SHA verified to be `main`'s tip in the action repo after the squash-merge of astubbs/duplicate-code-cross-check#8
- [x] Action repo CI green on that commit (`test`, `validate-action`, `self-test`); 59 unit tests, up from 48
- [x] Both fixes proven by control arm in the action repo — neutralising the idempotency guard fails 2 tests, removing pagination fails 3, restoring the old shell implementation fails 2 of the new counting tests
- [x] This PR's own `dups: clones` run is the live check: it should annotate at most once per finding

## Checklist

- [x] Docs updated — `N/A - CI pin bump; the reasoning lives in the commit body and the action repo's PR`
- [x] User-facing feature documentation data added under `docs/features/` — `N/A - CI tooling, no user-facing surface`
- [x] Tests added/updated — `N/A - tests live in the action's own repo, where they were added and control-armed`
- [x] Title & body reflect the final content of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
