### PR TITLE
test(chaos) confluentinc#857: the chaos suite asserts ordering, detects a stalled instance, and can be watched mid-stall

### DIFF
--- a/docs/features/seeded-chaos-replay.yaml
+++ b/docs/features/seeded-chaos-replay.yaml
@@ -1,0 +1,59 @@
+# Copyright (C) 2026 Antony Stubbs and contributors
+
+schema_version: 1
+kind: feature
+title: Seeded chaos scenarios with deterministic replay
+category: observability
+module: parallel-consumer-core
+maturity: production-use
+availability:
+  status: published
+  since: 0.6.0.0
+  evidence:
+    tag: 0.6.0.0
+    path: docs/testing.md
+    basis: >-
+      The chaos suite, its progress probes and the correctness ledger were built during the 0.6.0.0
+      stability work. Every run logs its seed and the exact command to replay it.
+readme_anchor: ordering-guarantees
+summary: >-
+  Every chaos run is driven by a recorded seed, so a failure found once can be re-run as the same
+  scenario - and the run is judged by a correctness ledger and progress probes rather than only by
+  whether it threw.
+use_this_when:
+  - A rebalance or churn failure appeared once in CI and you need the same scenario back to diagnose it.
+  - You are evaluating whether this project's reliability claims are tested or asserted.
+  - You are probing a candidate fix and want the same disturbance before and after it.
+setup:
+  run:
+    - './mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true -Dincluded.groups=chaos -Dexcluded.groups='
+    - 'Replay a recorded scenario by adding -Dchaos.seed=<seed>; every run prints its own seed and replay command.'
+  observe:
+    - The ProgressProbe verdict - a named violation such as CLASS2_STALL/LAG_STAGNATION or ZOMBIE_MEMBER/REBALANCE_BLOCKED, or an explicit empty list.
+    - The correctness ledger, which must balance.
+    - The AMBIENT PROBE AUTOPSY block, captured in the failsafe XML rather than only on the console.
+opt_in:
+  mechanism: Excluded from default and gating suites by tag; run deliberately, or by the on-demand CI workflow.
+  isolated_from_stable_modules: false
+boundaries:
+  - >-
+    A seed fixes the SCENARIO - the sequence of instance stops and starts, and the workload - not the
+    thread interleaving. So a reproduction is strong evidence and a non-reproduction is weak, because
+    the replay may simply not have drawn the interleaving on a machine whose contention differs from
+    the original. Do not read "did not reproduce" as "the bug is not there".
+  - The ledger checks that no record is lost, that duplicates stay bounded per disturbance, and - in
+    the scenarios that claim it by overriding orderRecorder(), currently ChaosKeyOrderIT and
+    ChaosRevokeUnderWorkKeyOrderIT - that per-key ordering holds; the probes check liveness. Ordering is asserted only inside the window where PC promises it (one instance, one
+    partition, one assignment epoch, one key), because at-least-once redelivery after a revoke is the
+    contract working - KeyOrderLedger's javadoc owns that definition.
+  - A red chaos run is investigation material, not a merge blocker, and never a reason to loosen a
+    probe. Thresholds sit in measured gaps against a real historical defect; tune the workload
+    instead.
+  - Seeds are printed to the run log, and console logs have repeatedly truncated. Read the failsafe
+    XML or the run-logs archive, and name the attempt explicitly - after a re-run, a job id resolves
+    to the latest attempt.
+references:
+  - label: Chaos Pain Suite - how to run, replay and probe a fix
+    path: docs/testing.md
+  - label: What the probes check, and the Class 2 bound's open calibration question
+    path: docs/inflight/test-class2-probe-asserts-timing-not-correctness.md

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -502,6 +502,14 @@ clean". This one does not:
 | Local replay | `2b8b89183` (astubbs#204) | RED | 5 | 154429ms |
 | **Local control** | **`5c377ec04` (master)** | **RED** | **10** | **154387ms** |
 
+**A RED here does NOT mean every `CLASS2_STALL` is a family occurrence.**
+[`test-chaos-class2-red-was-runner-contention.md`](test-chaos-class2-red-was-runner-contention.md)
+records one with this same ~154s signature whose seed replays **green** on an uncontended box,
+peaking at 121.3s - self-hosted runner contention, from `Performance` and `Chaos Pain Suite` sharing
+the box. That note owns the discriminator; the short version is that ~154s is what a crossed 150s
+bound looks like regardless of cause, so only an uncontended replay of the seed separates the two.
+This arm earns its place precisely because it replayed RED.
+
 **The master arm is the point.** The same seed fails on plain master with no astubbs#204 code in the
 tree, so this is the family's own defect and not something that PR introduced. Two further checks
 agree: astubbs#204's tree at the passing run `45fd8f6f9` and the failing run `6b2d91370` have the
@@ -532,3 +540,109 @@ with `-Dit.test=ChaosRevokeUnderWorkIT` needs `-Dfailsafe.failIfNoSpecifiedTests
 `-am` puts the parent module in the reactor and its own failsafe execution then fails the build with
 "No tests matching pattern"; dropping `-am` instead fails the enforcer's `ReactorModuleConvergence`.
 The unnarrowed command above has neither problem.
+
+**Twelfth sighting, 2026-08-20 - three `Chaos Pain Suite` reds inside twenty minutes across two
+branches, and the first one is on the DRAIN control arm.** Four scenarios fired between 01:05 and
+01:21Z. All the numbers below come from the uploaded failsafe artifacts, per the retrieval note
+above, not from the console.
+
+| Time (Z) | Branch | Head | Run | Arm that fired | Violations | `lagStagnation` peak | Seed |
+|---|---|---|---|---|---|---|---|
+| 01:05 | `test/chaos-instrumentation` (astubbs#325) | `9698012d9` | [32319767471](https://github.com/astubbs/parallel-consumer/actions/runs/32319767471/job/96279438153) | `ChaosKeyOrderIT` | 1 `ZOMBIE_MEMBER` | 44074ms (dwell 15452ms) | `1055565754928226840` |
+| 01:05 | as above | as above | as above | `ChaosRevokeUnderWorkDrainIT` | 12 `CLASS2_STALL` | 154321ms | `3426636341371267227` |
+| 01:12 | `split/docs-ledger-and-plans` (astubbs#323) | `c748ca667` | [32320198063](https://github.com/astubbs/parallel-consumer/actions/runs/32320198063) | `ChaosChurnStormIT` | 23 `CLASS2_STALL` | 154064ms | `4156620401101833712` |
+| 01:12 | as above | as above | as above | `ChaosRevokeUnderWorkIT` | 3 `CLASS2_STALL` | 154360ms | `1680705091015468437` |
+| 01:21 | `test/chaos-instrumentation` (astubbs#325) | `4b7ffc6e6` | [32320705139](https://github.com/astubbs/parallel-consumer/actions/runs/32320705139/job/96282172263) | `ChaosRevokeUnderWorkDrainIT` | 34 `CLASS2_STALL` | 154239ms | `4044221734199516240` |
+
+Every `CLASS2_STALL` line is the familiar one - 154s of stagnation against the 150s bound, group
+STABLE with heartbeats flowing. Replay any of them with:
+
+    ./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true \
+      -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=<seed>
+
+**The four stagnation peaks land within 300ms of each other** (154064-154360ms), which is the same
+constant the eleventh sighting measured across CI, a local replay and a local master control
+(154627 / 154429 / 154387ms). That is corroboration of a known characteristic of the signature, and
+it is **not** evidence about the machine: the eleventh sighting produced ~154.4s from a single
+uncontended local run on plain master. Its warning applies here too - the same seed there yielded
+5, 7 and 10 violations, so the count is not a per-partition fingerprint and the 34-vs-12 difference
+between the two drain-arm runs says nothing on its own.
+
+**astubbs#323's head is the cleanest not-PR-introduced control this file has recorded.** Against the
+merge base, `c748ca667` changes exactly three lines of main code and they are all inside
+`// TODO(refactor):` comments - a `docs/inflight/` filename repointed after a rename, in
+`ConsumerManager` and `ConsumerOffsetCommitter` - plus one `@Quarantined` annotation on
+`PCMetricsTest`, which the chaos lane does not run. No executable main-code change exists on that
+branch to reach a broker with. Prior entries argued branch innocence from "docs and one constant";
+this one is a comment-only diff, and it agrees with the eleventh sighting's master arm rather than
+proposing anything new.
+
+**The new observation is the drain control arm.** `ChaosRevokeUnderWorkDrainIT` arrives with
+astubbs#325 and exists precisely to test the leading explanation for this signature: that the
+watermark pinning is redelivery of heavy work abandoned by a non-draining stop. Its own javadoc
+pre-declares both outcomes, and this is the second one - *"Drain arm ALSO red - the abandoned-work
+explanation is wrong and something else pins the watermark."*
+
+**Do not cash that in yet, for two reasons.** The arm is brand new and has four CI exposures in
+total: green at 21:17 on 2026-08-19 (run 32303069710, seed `754504705742948700`, all seven scenarios
+green), then red three times tonight on three different seeds (01:05, 01:21 and the 01:41 run
+below). One green and three reds is a rate worth noticing, not a calibration.
+More importantly, a fail-fast red proves the *bound* was crossed, not that the backlog never drained
+- which is exactly the critique in
+[`test-class2-probe-asserts-timing-not-correctness.md`](test-class2-probe-asserts-timing-not-correctness.md),
+where seed `4734674029169027864` trips this bound 53 times on the eager arm and still drains
+completely. Until one of tonight's drain seeds is replayed with
+`-Dchaos.diagnoseStallRecovery=true`, "the drain arm is also red" and "the drain arm is also slow"
+are the same observation.
+
+**What would settle it, and it is cheap:** replay `4044221734199516240` (34 violations, the larger
+sample) with `-Dchaos.diagnoseStallRecovery=true` and read whether the backlog drains. Drains ->
+this is the timing-proxy problem the probe note owns, and the abandoned-work explanation survives
+untouched. Does not drain -> the drain arm has done its job and the family has its first real lead
+on a Class 2 mechanism.
+
+**Every cooperative arm passed, in all three runs.** `ChaosRevokeUnderWorkCooperativeIT` was green
+each time (seed `4001744813866842738` in the astubbs#323 run, alongside the two eager reds), and
+`ChaosRevokeUnderWorkCooperativeDrainIT` green in both astubbs#325 runs. Each arm that fired
+`CLASS2_STALL` is an eager one. That is consistent with the second and sixth sightings'
+eager-protocol-specific reading and adds a third occasion to it - though the note recorded above the
+fifth sighting, of a `CLASS2_STALL` on the *cooperative* variant locally, still stands against
+treating it as settled.
+
+**Two sibling tests failed together in one run for the first time in this arm.** In the astubbs#323
+run, `ChaosChurnStormIT` and `ChaosRevokeUnderWorkIT` both fired `CLASS2_STALL` while the cooperative
+sibling passed. Earlier entries record the siblings as a *passing* control arm within the run (fourth,
+ninth, tenth, eleventh sightings all name two green siblings). Recorded as an observation; two of
+three arms drawing the signature on one broker in one run is not by itself evidence of anything the
+per-arm entries do not already say, but "the siblings always pass" is no longer true.
+
+**astubbs#325 is not a suspect for its own two reds, and the second one has a specific check.** That
+branch adds test-integration code only. The 01:21 run is at `4b7ffc6e6`, whose only change over
+`9698012d9` moves the drain arms' identical action-mix map into
+`AbstractRevokeUnderWorkScenario#drainOnlyChaosWeights()`; the run's own log confirms the mix is
+unchanged - `weights={STOP_DRAIN=3, RESTART=3, JOIN_NEW=2} tick=PT0.3S..PT1S joinAfterDrainBias=0.0`
+- and the same arm had already fired at 01:05, before that commit existed.
+
+**A fourth red the same night, on a documentation-only commit.** Run
+[32321963226](https://github.com/astubbs/parallel-consumer/actions/runs/32321963226/job/96285796525)
+at 01:41Z, head `202da9d0a` on astubbs#325 - which differs from `4b7ffc6e6` by two markdown files and
+nothing else. Three arms fired, all eager: `ChaosChurnStormIT` 23 `CLASS2_STALL` plus 2
+`ZOMBIE_MEMBER` (peaks `rebalanceDwell=15602ms lagStagnation=151882ms`, seed `989468380938115993`),
+`ChaosRevokeUnderWorkDrainIT` 43 `CLASS2_STALL` (`lagStagnation=152433ms`, seed
+`6334815371835997501`), `ChaosRevokeUnderWorkIT` 4 `CLASS2_STALL` (`lagStagnation=154211ms`, seed
+`2553818384688673562`). Both cooperative arms passed again, on seeds `7815585942040470933` and
+`2549365579181485261`.
+
+**Two things this adds.** A commit whose entire diff is prose cannot be a suspect, which is the same
+argument astubbs#323's head makes and this time on the branch that owns the chaos code. And the two
+`ZOMBIE_MEMBER` violations arrive **inside** a `CLASS2_STALL` autopsy again - the sixth sighting was
+the first time both arms fired in one run and said "these are unrelated signatures can no longer be
+assumed for free"; this is the third such run in the ledger, so that caution has now outlived being
+a one-off.
+
+**And then the next commit ran green, which is the tightest control this file has.** Head
+`41c8cda26` differs from the red `202da9d0a` by **one markdown file** - the paragraph above - and
+[run 32323037970](https://github.com/astubbs/parallel-consumer/actions/runs/32323037970/job/96288770167)
+passed all seven chaos scenarios. Two adjacent commits, a prose-only diff between them, red then
+green: whatever draws this signature is drawn per seed, and no tree-content explanation survives that
+pair. Every prior entry asserts seed-dependence from branch subject matter; this one measures it.

--- a/docs/inflight/ci-agent-self-review-as-blocking-pr-comments.md
+++ b/docs/inflight/ci-agent-self-review-as-blocking-pr-comments.md
@@ -61,6 +61,49 @@ So: **the agent proposes its candidate comments in chat and the maintainer appro
 posted.** Never auto-posted. That keeps the human as the filter on volume and keeps the blocking
 power meaningful.
 
+## Simpler variant, found by needing it: DRAFT plus a checklist comment
+
+Owner's refinement, and it removes the mechanism's dependency on a repository setting.
+
+**It does not need to be a review at all.** On 2026-08-20 the attempt to post a genuinely blocking
+review on astubbs/parallel-consumer#325 failed outright:
+
+    failed to create review: GraphQL: Review Can not request changes on your own pull request
+
+That is not a permissions quirk to work around - it is fatal to the mechanism above **for this
+repository specifically**, because the maintainer is the author of nearly every PR and an agent acts
+as him. The one route that carries real blocking weight is the one route unavailable here.
+
+**Draft mode is the block; a comment is the memory.** Two artefacts, each doing the job it is good
+at:
+
+- **Convert the PR to draft.** GitHub refuses to merge a draft, so this is mechanical rather than
+  advisory, and it needs no ruleset, no `required_review_thread_resolution`, and no cooperation from
+  a reviewer. `gh pr ready <n>` reverses it in one command, which keeps the cost of a false positive
+  near zero - the property that makes it safe to use liberally.
+- **Post the must-dos as an ordinary comment with a `- [ ]` checklist**, saying plainly that the
+  draft state is deliberate and naming what has to be true before it goes ready.
+
+**The recovery path is what makes it work, and it is self-documenting.** A future agent reaching for
+the merge finds the PR is a draft. That is an unmissable stop rather than a rule it might not have
+loaded. It then asks *why is this a draft* - a question with an answer sitting in the comments - and
+arrives at the checklist it or a predecessor wrote. Knowledge that did not survive the turn it was
+formed in now survives as repository state.
+
+**What draft actually changes, checked rather than assumed** (2026-08-20, this repo):
+
+- Merge is blocked; auto-merge cannot be enabled.
+- **CI still runs.** No workflow here gates on `draft == false` - verified by grepping every file in
+  `.github/workflows/`. This is the one thing to re-check before relying on the variant, because in a
+  repo that does gate on it, going draft silently costs all CI signal.
+- Reviewers are not auto-requested, and pending requests are dropped; marking ready re-requests them.
+- Agents will not babysit it - `ce-babysit-pr` treats drafts as opt-in and stops rather than watching.
+- It does not dismiss reviews, close threads, touch the branch, or change what depends on the PR.
+
+**The noise guard above still applies, and matters more here**, since draft is cheap enough to reach
+for reflexively. A draft with no checklist comment explaining it is worse than no draft: the next
+agent finds a stop with no reason and either guesses or reverses it.
+
 ## Open questions
 
 - **Does unresolved-conversation blocking actually apply here?** It is a repository setting;

--- a/docs/inflight/test-chaos-class2-red-was-runner-contention.md
+++ b/docs/inflight/test-chaos-class2-red-was-runner-contention.md
@@ -1,4 +1,4 @@
-# The Class 2 chaos RED has already fired, and it was the runner, not a stall
+# A Class 2 chaos RED that was the runner, not a stall - and how to tell which you have
 
 <!-- inflight-type: bug -->
 <!-- inflight-impact: misdirection -->
@@ -29,6 +29,43 @@ known fixes inside its own blast radius - rebalance, offsets, commit path, execu
 seen before those land is odds-on one of them, so hunting it as a new unknown spends effort on an
 already-solved bug. Land the backlog, then re-run. That also qualifies the neighbouring "0 hits in a
 9-seed sweep" claim, which was measured against the same incomplete tree.
+
+## Reconciled with the family ledger: the same signature has TWO causes
+
+[`bug-857-family.md`](bug-857-family.md) records a `CLASS2_STALL` whose seed
+(`6825864417772979246`) replays **RED on plain master, locally, uncontended** - 10 violations,
+`lagStagnation` 154387ms. This note records one whose seed replays **GREEN uncontended**, peaking at
+121.3s. Both measurements are sound; neither refutes the other, because they are different
+occurrences. What they jointly establish is more useful than either alone:
+
+**~154s `CLASS2_STALL/LAG_STAGNATION` is a signature, not a diagnosis.** The 154s figure appears in
+both, so it discriminates nothing on its own - it is roughly what a 150s bound produces once crossed,
+whatever crossed it. Do not read the number as evidence either way, and do not read "every partition
+stagnated at the same instant" as evidence of starvation: violation counts vary run to run on a fixed
+seed, and the ledger warns explicitly that the frozen-partition set is not a fingerprint.
+
+**The discriminator is a replay of that seed on an uncontended box**, and nothing cheaper works:
+
+| Replay uncontended | Reading | Replays needed |
+|---|---|---|
+| **RED**, unbounded, does not drain | A family occurrence. Record it in `bug-857-family.md`. | One is enough |
+| **GREEN**, drains, peaks under the bound | Contention. Record it here. | **Two or three** |
+
+**The two sides need different amounts of evidence, and an earlier version of this table implied they
+did not.** A RED replay is positive evidence: the schedule crossed the bound without contention, and
+one instance of that is enough - the eleventh sighting happened to get three (CI, local replay, local
+control on plain master), but the first would have carried it. A GREEN replay is an ABSENCE, and this
+family is intermittent: `bug-857-family.md` records the same seed swinging 5 / 7 / 10 violations
+across otherwise-identical uncontended runs. A genuinely intermittent family occurrence that simply
+does not fire on one replay is indistinguishable from contention, so a single green is the weakest
+evidence in the table and was being read as the strongest. The occurrence recorded in this note has
+exactly one green replay; it should get two more before anyone treats it as settled.
+
+A real Class 2 stall is unbounded, so a schedule that finishes on replay cannot encode one - that is
+the whole argument, and it is why the replay is worth the minutes it costs before a hunt begins.
+
+**Both records were written without knowing about the other**, which is how they came to look like
+disagreement. Neither cited the other until now.
 
 ## Delete when
 

--- a/docs/inflight/test-chaos-crash-fidelity-variant.md
+++ b/docs/inflight/test-chaos-crash-fidelity-variant.md
@@ -1,0 +1,60 @@
+# The chaos suite cannot model a CRASH, only a close - and the fleet's shared memory is why
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: test-debt -->
+<!-- inflight-state: deferred - the Class 2 stall it would chase is losing on the evidence; revisit when a crash-shaped stall is suspected on its own evidence, or when the fork wants a fidelity claim it cannot currently make -->
+## What is missing
+
+Every stop the chaos conductor performs is a `close()` of some kind. `ManagedPCInstance.stop()` and
+`stopAsync()` both call `pc.close()`, which is `closeDontDrainFirst()`; `STOP_DRAIN` reaches
+`closeDrainFirst()`. Both are ORDERLY: the consumer leaves the group, the coordinator is told, and a
+rebalance starts immediately.
+
+**A crashed process does none of that.** It stops heartbeating with its assignment still held, and
+nothing happens until the coordinator's session timeout expires. That is the shape most of the
+confluentinc#857 reports describe - a member that is gone but not seen to be gone - and no scenario
+in the suite currently produces it. So the family's most-reported condition is the one the suite
+cannot generate.
+
+## Why it is not a small change
+
+All fleet members run in ONE JVM, and the correctness checks depend on that: `totalConsumed`,
+`totalStarted`, `allConsumed` and `KeyOrderLedger`'s history are in-memory structures every instance
+writes to directly. Killing a process therefore means the ledger loses exactly the records that
+process handled - which is the evidence a crash scenario exists to examine.
+
+An in-JVM approximation - stop an instance heartbeating without closing it, and let the coordinator
+evict it - models the group's view but not the process's: threads stay alive, sockets stay open, and
+in-flight work keeps running against a consumer nobody owns. That last part is not merely lower
+fidelity, it is a DIFFERENT scenario, and one that can produce failures no real crash could.
+
+## The approach to take when this is picked up
+
+Antony's suggestion, and it is the one that makes the rest tractable: **separate JVMs that report
+through the filesystem**. Each instance appends its deliveries and counters to its own file; a
+central chaos admin tails them and assembles the same ledger the in-memory version builds today.
+`kill -9` then models a crash exactly, and the killed instance's evidence survives it, because what
+it wrote is already on disk.
+
+Two things to get right, both learned the hard way this week:
+
+- **The files must not live on `/tmp` on the dev box.** It is a 32GB tmpfs shared by every agent
+  session, and chaos logs filled it to 99% on 2026-08-19 - truncating a run's log mid-quiet-phase,
+  which read as a test ending early and cost real diagnosis time.
+- **Flush per record, and write the ledger line before the work is acknowledged.** A crash that
+  loses the last buffered writes makes the ledger under-report exactly the records a crash scenario
+  is asking about.
+
+## Why it is parked rather than queued
+
+The suite's open question is a Class 2 stall that no scenario has reproduced in 9 seeds, and the
+evidence so far points at detector calibration rather than a defect
+(`test-857-revoke-under-work-sightings.md`). Building a multi-JVM harness is a large piece of work
+to aim at a hypothesis that is currently losing. It becomes worth doing when a crash-shaped stall is
+suspected on its own evidence, or when the fork wants a fidelity claim it cannot currently make.
+
+## Related
+
+- `docs/inflight/test-857-revoke-under-work-sightings.md` - the replays and the recovery experiment
+- `docs/testing.md` - the chaos suite's shape and lanes
+<!-- file-refs: N/A - the sightings ledger arrives with astubbs/parallel-consumer#29, which this branch was split out of; it resolves once that merges -->

--- a/docs/inflight/test-chaos-phase2.md
+++ b/docs/inflight/test-chaos-phase2.md
@@ -10,9 +10,16 @@
   legit-window), and the cooperative-sticky W4 variant was green on both arms (sticky drops revoke
   events ~6x, refuting the more-revokes hypothesis; eager-calibrated Class 1 bounds do not transfer to
   cooperative). GREEN-side validated on both assignors; the RED side awaits a real occurrence or a new
-  trigger idea. Unexplored levers, most promising first: KEY-ordered processing to concentrate commit
-  contention per shard; sub-second commit intervals; EoS/transactional mode; `confluentinc#909`
-  stale-container restart patterns.
+  trigger idea. Unexplored levers, most promising first: sub-second commit intervals;
+  EoS/transactional mode; `confluentinc#909` stale-container restart patterns.
+- **KEY-ordered processing: tried as W5, and it did NOT concentrate contention into a stall.**
+  `ChaosKeyOrderIT` runs the lever previously ranked first on the list above. Its calibrated shape is
+  green with a 22s lag-stagnation peak against the 150s bound, so as a Class 2 trigger this lever is
+  spent; it landed instead as the ordering half of the correctness ledger. What it did surface is that
+  a KEY-ordered workload turns two ordinary sizing mistakes into something indistinguishable from a
+  Class 2 stall - a heavy tail collapsing onto one shard, and a dwell longer than the gap between
+  rebalances chaining forever - both now checked or measured in the scenario. Anyone still hunting
+  Class 2 under KEY ordering should start from W5's constants, not W1's.
 - **Thin margin.** W4's legit lag-stagnation peaks (117-123s) sit only ~1.25x under the 150s Class 2
   bound. Fine for a non-gating suite; widen it (shorter storm or dwell) if it ever flakes.
   **It has flaked, and the cause was measured** - see

--- a/docs/inflight/test-class2-probe-asserts-timing-not-correctness.md
+++ b/docs/inflight/test-class2-probe-asserts-timing-not-correctness.md
@@ -1,0 +1,61 @@
+# `CLASS2_STALL` gates on a TIMING bound in a CORRECTNESS suite
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+## The critique
+
+The chaos suite exists to establish correctness: no record lost, duplicates bounded, ordering held,
+work completes. `ProgressProbe`'s Class 2 detector instead asserts **"no partition's committed offset
+may be still for 150 seconds"** - a performance claim, used as a proxy for the liveness property
+actually wanted, which is *"it is not wedged forever"*.
+
+**If the system recovers, it is correct.** Slow recovery is an optimisation question, and an
+optimisation question does not belong in a gate. Raised by Antony on 2026-08-19, after four
+measurement arms had been spent arguing about whether the legitimate window was 100s, 150s or 281s -
+arithmetic that only matters because the assertion is aimed at the wrong property.
+
+## What the proxy costs, measured
+
+Seed `4734674029169027864`, four arms, all recorded in
+`test-857-revoke-under-work-sightings.md`. Every arm **completed**: no loss, bounded duplicates,
+`done=true`. By the correctness criterion all four pass. By the 150s bound, three of four fail.
+
+The false-positive mechanism is not subtle once the counters are on both ends of the user function:
+a committed offset is SILENT while a long record runs, so a busy fleet and a wedged one look
+identical to a watermark-stagnation detector. The diagnostic mode's `inFlight` counter shows the
+eager arm holding 20-29 records in flight continuously, with `consumed` advancing on every poll,
+throughout the window the probe was calling it stalled.
+
+## What to replace it with
+
+**Gate on progress; report timing.**
+
+- **Gate**: the run completes, nothing is lost, duplicates stay bounded, ordering holds - and a real
+  liveness check, e.g. in-flight work never sits at zero while a backlog exists. That detects a
+  genuine wedge and *cannot* fire on slowness, which is the whole property the bound fails to have.
+- **Report, do not gate**: recovery time, stagnation peaks, throughput. A regression there is worth
+  seeing and is not a correctness failure. Put it in the run output where it is visible, not in an
+  assertion that fails the build.
+
+Read that way, the four arms are one sentence: all four are correct; eager takes 281s and
+cooperative 104s, so eager is slower, which is an optimisation matter.
+
+## Why this is not just "raise the bound"
+
+Raising it keeps a timing assertion in a correctness gate and buys time until a slower box or a
+denser workload crosses the new line. The July recalibration already did this once - 90s/45s retuned
+to 60s/20s so `60+20+20=100s` sat under 150s - and the arithmetic assumed ONE restart of an in-flight
+heavy record. Measured reality with several restarts is 281s. A third retune would be the same move
+a third time.
+
+## Related
+
+- `docs/inflight/test-857-revoke-under-work-sightings.md` - the four arms and their numbers
+- `docs/inflight/test-truth-probes-for-internal-state.md` - the same shape of question for internal state
+- `docs/testing.md` - the chaos suite and its probes
+- `docs/inflight/bug-857-family.md` - the sighting ledger. Its **twelfth sighting** is the live test
+  of this critique: the new drain control arm fired `CLASS2_STALL` twice on 2026-08-20, and whether
+  that is a stall or the slowness this note describes is decided by one
+  `-Dchaos.diagnoseStallRecovery=true` replay, which nobody has run yet
+<!-- file-refs: N/A - the sightings ledger arrives with astubbs/parallel-consumer#29, which this branch was split out of; it resolves once that merges -->

--- a/docs/inflight/test-key-order-cells-duplicate-their-accessors.md
+++ b/docs/inflight/test-key-order-cells-duplicate-their-accessors.md
@@ -1,0 +1,32 @@
+# The two key-ordered chaos cells implement the same four hooks, and the same guard test
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: refactor -->
+<!-- inflight-state: deferred - the fix changes a base class every chaos scenario extends, and it is not worth destabilising the suite for boilerplate the gate already passes -->
+
+`ChaosKeyOrderIT` and `ChaosRevokeUnderWorkKeyOrderIT` each override `orderRecorder()`, `keyFor()`,
+`identityFor()` and `identityOf()` with identical bodies, and each carries its own verbatim copy of
+the `heavyRecordsMustNotAllShareOneKey` guard. The duplication detector reports 41 lines - most of it
+javadoc, since the tool runs with `only_code: false`.
+
+## The fix, and why it is not done yet
+
+`ChaosScenarioBase` already provides defaults for all four hooks. The clean shape is a `keySpace()`
+hook there - zero meaning "not key-ordered", preserving today's behaviour for every other cell - with
+the base supplying the key-ordered variants when it is set. Both cells then override one method
+instead of four and drop their copies of the guard.
+
+That is a change to the class **every** chaos scenario extends, and the chaos suite is the thing this
+work exists to make trustworthy. Doing it immediately after the suite got its first ordering
+assertions would put a base-class refactor underneath findings that have not yet been reproduced
+twice. The duplication is boilerplate, it is below the 80% gate, and it costs a reader nothing that a
+cross-reference does not fix.
+
+## What would change the answer
+
+A third key-ordered cell. Two copies is duplication; three is a pattern nobody will keep in sync, and
+at that point the hook is cheaper than the drift.
+
+## Related
+
+- `docs/inflight/test-chaos-phase2.md` - owns the chaos suite and its lanes

--- a/docs/inflight/test-truth-probes-for-internal-state.md
+++ b/docs/inflight/test-truth-probes-for-internal-state.md
@@ -1,0 +1,48 @@
+# Truth probes: tests that can tell internal state from reality
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: test-debt -->
+Candidate work, unowned. Ranked here rather than in `docs/refactoring.md` because it is a testing
+capability rather than a code refactor.
+
+## The gap
+
+Nothing in this repo could distinguish *"the counter says 0"* from *"there are 0 records in flight"*
+until 2026-08-18, when one had to be built to settle a question. That absence is what let a fix be
+written in April 2026 for counter drift **that does not exist** - and the fix itself then drove the
+counter to -20 while records were genuinely in flight. Two independent defects, both from reasoning
+about a symptom with no instrument to check the premise.
+
+The two that now exist, and are the model:
+
+- `OutForProcessingCounterDriftProbeTest` - runs the real engine on a `MockConsumer`, gates the user
+  function so records are genuinely out with the pool, drives a revoke through the engine's own
+  listener, waits for quiescence, then compares `numberRecordsOutForProcessing` against ground truth.
+- `Rebalance857CommitSyncDeadlockProbeIT` - forces the revoke-during-commit overlap deterministically
+  rather than waiting for a rebalance to draw it.
+
+Both share the shape worth generalising: **arrange the state deliberately, then assert the internal
+view against an independently computed truth** - not against itself, and not against "did it stall".
+
+## Candidates, roughly by how much they gate behaviour
+
+1. **Shard and queue depth** - `getNumberOfWorkQueuedInShardsAwaitingSelection()` feeds
+   `isSufficientlyLoaded()` alongside the counter that already drifted. Same failure mode available.
+2. **Incomplete-offset tracking** - the offset map decides what gets committed and therefore what is
+   redelivered. Truth is derivable from what the harness produced and what the user function saw.
+3. **Paused-partition state** - now derived from the consumer rather than mirrored, so a probe would
+   pin that it stays derived; the mirror it replaced desynced silently under cooperative rebalancing.
+4. **Epoch fencing** - that records from a revoked assignment are dropped and *their new owner
+   receives them*, rather than merely "dropped".
+
+## Why this is not just "more tests"
+
+The existing suite asserts outcomes - records processed, offsets committed. A truth probe asserts
+that PC's own *bookkeeping* matches reality, which is the thing that silently degrades: every
+confluentinc#857-family stall is a stall with no error, and every one of them was visible in some
+internal number before it was visible in behaviour.
+
+Background:
+`docs/solutions/workflow-issues/prove-the-problem-exists-before-writing-the-fix.md`,
+`docs/solutions/architecture-patterns/two-threads-one-consumer-why-the-commit-seam-keeps-deadlocking.md`.
+<!-- file-refs: N/A - both write-ups arrive with astubbs/parallel-consumer#29, which this branch was split out of; they resolve once it merges -->

--- a/docs/solutions/test-flakiness/uber-stall-experiment-results-2026-07-30.md
+++ b/docs/solutions/test-flakiness/uber-stall-experiment-results-2026-07-30.md
@@ -138,6 +138,8 @@ drain.
 - fork16 binary verdicts were unusable; the per-test decomposition above is the salvage.
 - `ManagedPCInstanceLifecycleTest` flakiness under fork16 is astubbs#29's own test under load - not triaged here.
 
+  > **Citation repair, 2026-08-20:** `ManagedPCInstanceLifecycleTest` was DELETED in astubbs/parallel-consumer#325. A mutation matrix over the four `ManagedPCInstance` guards showed it killed none of them, while `ManagedPCInstanceLifecycleIT` - which now lives at `integrationTests/ManagedPCInstanceLifecycleIT.java` - killed both real mutants deterministically, without a broker, in a tenth of the time. The claim above is left unchanged: the flakiness it records was real when measured.
+
 ## Addendum (2026-07-30, post nudge-race fix): full-stack composition check
 
 After the nudge-race harness fix landed on PR astubbs#80, its full tip (drain fix + nudge fix + all guards and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -91,11 +91,52 @@ with `bin/quarantined-test.sh`.
 ## Chaos Pain Suite (on-demand bug detector - never gates)
 
 A seeded, calibrated chaos suite (`integrationTests.chaostests`: `ChaosConductor`, `ProgressProbe`,
-`ChaosScenarioBase`, plus scenarios `ChaosChurnStormIT` W1 and `ChaosRevokeUnderWorkIT` W4) that
-hunts the "alive but not progressing" bug class: rebalance-dwell zombies, protocol-invisible
-per-partition lag stagnation (Class 2, W4's prey), drain overruns, and record loss or duplication.
-Tagged `@Tag("chaos")` and excluded from all default and gating suites via `pom.xml`'s
+`ChaosScenarioBase`) that hunts the "alive but not progressing" bug class: rebalance-dwell zombies,
+protocol-invisible per-partition lag stagnation (Class 2), drain overruns, and record loss or
+duplication. Tagged `@Tag("chaos")` and excluded from all default and gating suites via `pom.xml`'s
 `excluded.groups` default.
+
+**What it can assert, so you know whether a question is already answerable.** Reach for an existing
+capability before building one - the calibration behind each of these is the expensive part, not the
+code:
+
+| Capability | Where | What it catches |
+|---|---|---|
+| Loss and bounded duplication | `ProgressProbe`'s ledger | a record never arrives, or arrives more often than a disturbance explains |
+| **Per-key ORDERING and concurrency** | `KeyOrderLedger` | a key's offsets going backwards, or two deliveries of one key in flight at once |
+| **A stalled instance** | `InstanceStallProbeIT`, `ProgressProbe` | a member present and heartbeating while making no progress |
+| Lag stagnation (Class 2) | `ProgressProbe` | a committed offset frozen while lag grows, group STABLE |
+| **Watching a stall instead of killing it** | `-Dchaos.diagnoseStallRecovery=true` | keeps a stalled run alive so its state can be read |
+
+**Recorded but not yet analysed - reach for this before adding instrumentation.** The ledger is an
+event register: it writes down facts and lets the end-of-run assessment decide what they mean. So
+some questions need only a new *analysis*, not new *recording*. Every `KeyOrderLedger.Delivery`
+already carries `incarnationId`, `partition`, `epoch`, `key`, `offset`, `startSeq` and `endSeq`
+(`null` while still running), and the full history is retained - the per-window grouping is a choice
+`check()` makes, not a limit on what was captured.
+
+The worked example is cross-epoch comparison. Nothing today compares deliveries across an epoch
+boundary, but the data to do it is present: a delivery with `endSeq == null` in one epoch, against a
+delivery of the same key and partition in a later epoch whose `startSeq` falls after it. **If a test
+needs that, write the comparison - do not add instrumentation for it.** The work is the calibration,
+not the capture: a revoked owner finishing its in-flight record is legitimate, so such a check needs a
+defensible bound on how long an old-epoch delivery may still run before it counts as a violation.
+
+Scenario cells, each isolating one disturbance shape: `ChaosChurnStormIT` (W1, continuous churn),
+`ChaosRevokeUnderWorkIT` (W4, revoke while work is in flight), `ChaosKeyOrderIT` (key-ordered
+processing under churn), `ChaosRevokeUnderWorkKeyOrderIT` (key order under revoke), and
+`ChaosRevokeUnderWorkDrainIT` / `ChaosRevokeUnderWorkCooperativeDrainIT` - a 2x2 control arm over
+assignor and stop-mode, whose weights are shared through `drainOnlyChaosWeights()` so the two cannot
+drift apart.
+
+**Two limits worth knowing before you trust a verdict.** `KeyOrderLedger` compares only within one
+incarnation, partition, epoch and key - so a **cross-epoch overlap** (an old owner still running past
+a revoke while the new owner takes the same key) lands in two windows and is not reported. It is
+**not** unanswerable, though: every delivery records its epoch and incarnation and the full history is
+kept, so the check is a function nobody has written rather than data nobody has. What it would need is
+a calibrated bound on how long a revoked owner may legitimately still be finishing - see the class
+javadoc. That shape is a real defect this repo has already fixed once (astubbs#80). And `CLASS2_STALL` gates on a timing bound, so a red proves the bound was crossed, not
+that the backlog never drained - see `docs/inflight/test-class2-probe-asserts-timing-not-correctness.md`.
 
 - **Run locally** (requires Docker; ~5-6 min):
   `./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true -Dincluded.groups=chaos -Dexcluded.groups=`

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/ManagedPCInstanceLifecycleIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/ManagedPCInstanceLifecycleIT.java
@@ -1,9 +1,13 @@
-package bz.stub.parallelconsumer.integrationTests.utils;
+package bz.stub.parallelconsumer.integrationTests;
 
 /*-
  * Copyright (C) 2026 Antony Stubbs and contributors
  */
 
+import bz.stub.parallelconsumer.integrationTests.utils.BrokerlessInstances;
+import bz.stub.parallelconsumer.integrationTests.utils.KafkaClientUtils;
+import bz.stub.parallelconsumer.integrationTests.utils.ManagedPCInstance;
+import bz.stub.parallelconsumer.integrationTests.utils.RecordingExecutor;
 import bz.stub.parallelconsumer.ParallelEoSStreamProcessor;
 import org.junit.jupiter.api.Test;
 

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/AbstractRevokeUnderWorkScenario.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/AbstractRevokeUnderWorkScenario.java
@@ -13,6 +13,8 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
@@ -24,8 +26,8 @@ import static org.awaitility.Awaitility.await;
  * The shared two-phase "revoke under work" driver behind the W4 scenario family - see
  * {@link ChaosRevokeUnderWorkIT} (eager assignor; the original, with the full design + calibration
  * javadoc) and {@link ChaosRevokeUnderWorkCooperativeIT} (cooperative-sticky). Variants differ only by
- * the two abstract methods below; the storm/quiet mechanics, probe configuration, and ledger are
- * identical so the assignor is the single experimental variable.
+ * the abstract and overridable hooks below; the storm/quiet mechanics, probe configuration, and
+ * ledger are identical so each variant changes exactly one experimental variable.
  * <p>
  * The {@code protected static final} constants are SHARED fixed calibration values, not per-variant
  * knobs: static field references in the inherited driver resolve at compile time to this class, so a
@@ -57,6 +59,43 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
     /** Quiet-phase cap: must exceed LAG_STAGNATION_BOUND (150s) by margin so a stall wedged late in the
      * storm still has time to trip the Class 2 probe before the await gives up. */
     protected static final Duration QUIET_CAP = Duration.ofMinutes(5);
+
+    /**
+     * <b>Diagnostic only - never a way to make this test pass.</b> Set {@code -Dchaos.diagnoseStallRecovery=true}
+     * to answer the one question the gating configuration structurally cannot: when a Class 2 stall
+     * fires, does the frozen partition <b>ever</b> recover, or is it wedged forever?
+     * <p>
+     * The scenario's own arithmetic above asserts that "a REAL Class 2 stall is unbounded", and the
+     * probe's javadoc records RED calibration as still open. Neither has been tested, because the
+     * gating run destroys the evidence at the moment of detection: {@code failFast} aborts the wait on
+     * the first violation and {@code QUIET_CAP} gives up at 5 minutes, so every observation to date
+     * ends the instant the stall is confirmed. Unbounded and merely-slow are indistinguishable from
+     * that data.
+     * <p>
+     * In this mode the quiet phase does not bail on a violation and waits {@link #DIAGNOSTIC_QUIET_CAP}
+     * instead, logging consumption progress each poll. The discriminator is which way the wait ends:
+     * the backlog drains (the stall was bounded - a starvation or fairness defect) or it times out with
+     * consumption flat (unbounded - lost state, a partition paused and never resumed, or a lost wakeup).
+     * <p>
+     * <b>It cannot turn a red run green.</b> {@code assertScenarioSlos} still asserts the probe's
+     * violations are empty after the wait, whichever way the wait ended, so a run that trips the probe
+     * still fails - it just fails having recorded what happened next. Off by default; the gating
+     * configuration is byte-for-byte unchanged when the property is absent.
+     */
+    private static final boolean DIAGNOSE_STALL_RECOVERY = Boolean.getBoolean("chaos.diagnoseStallRecovery");
+
+    /**
+     * Quiet cap in {@link #DIAGNOSE_STALL_RECOVERY} mode - long enough that "never recovered" means
+     * something. Override with {@code -Dchaos.diagnosticQuietCapMinutes=<n>}.
+     * <p>
+     * <b>The scenario class's {@code @Timeout} is the real ceiling, and it wins silently.</b> Those
+     * are 600s today, so a quiet cap above about six minutes cannot be reached - JUnit kills the
+     * test first, mid-observation, and the run then looks like one that stopped for its own reasons
+     * rather than one that was cut off. Raise the annotation if you genuinely need a longer watch;
+     * do not just raise this number and believe the result.
+     */
+    private static final Duration DIAGNOSTIC_QUIET_CAP =
+            Duration.ofMinutes(Integer.getInteger("chaos.diagnosticQuietCapMinutes", 20));
     /** Low eviction horizon: a storm-wedged (deadlocked) member stops polling and gets evicted ~30s
      * later, letting pending rebalances resolve and the group re-stabilize for the quiet phase. */
     protected static final int MAX_POLL_INTERVAL_MS = 30_000;
@@ -76,6 +115,79 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
     /** Short label for topic names and log lines (e.g. "w4" / "w4coop"). */
     protected abstract String scenarioLabel();
 
+    /**
+     * The processing order - {@link ProcessingOrder#UNORDERED} for the assignor/stop-mode matrix
+     * cells, which make no ordering claim (and produce a unique key per record, so a KEY override
+     * without the {@code ChaosScenarioBase} identity-trio overrides would assert nothing). Promoted
+     * to an accessor - per this class's constants rule above - for
+     * {@link ChaosRevokeUnderWorkKeyOrderIT}, the cell that exists to make the ordering claim.
+     */
+    protected ProcessingOrder processingOrder() {
+        return ProcessingOrder.UNORDERED;
+    }
+
+    /**
+     * The heavy-tail dwell - {@link #HEAVY_SLEEP} (20s) for the matrix cells, whose legit-freeze
+     * arithmetic above depends on it. Promoted to an accessor because a KEY-ordered cell CANNOT run
+     * 20s dwells: a dwell longer than the gap between storm rebalances chains indefinitely under
+     * at-least-once, and KEY ordering pins the whole shard behind it -
+     * {@code ChaosKeyOrderIT}'s {@code HEAVY_SLEEP} carries the measurement (a 154s stagnation at a 10s dwell).
+     */
+    protected Duration heavySleep() {
+        return HEAVY_SLEEP;
+    }
+
+    /**
+     * Storm tick range - 300-1000ms for the matrix cells (more rebalances per run = more
+     * revoke-under-work collisions, the class javadoc's calibration). Promoted for the KEY cell,
+     * which CANNOT run that fast under the eager assignor: {@code ChaosKeyOrderIT}'s
+     * {@code minTick} javadoc records that membership changes arriving faster than an eager
+     * rebalance completes keep the group permanently unstable, which both accrues the Class 1 dwell
+     * clock artificially AND splits every key's sequence into single-delivery assignment-epoch
+     * windows - and a window with one delivery asserts nothing, so the ordering ledger it exists for
+     * would go vacuous ({@code LEDGER_ORDER_VACUOUS}).
+     */
+    protected Duration minTick() {
+        return Duration.ofMillis(300);
+    }
+
+    /** See {@link #minTick}. */
+    protected Duration maxTick() {
+        return Duration.ofMillis(1000);
+    }
+
+    /**
+     * The conductor's action mix. Defaults to {@link ChaosConductor#defaultW4Weights()} - <b>no drain
+     * stops at all</b>, because a drain opens the Class 1 zombie window and would mask the Class 2
+     * mechanism this scenario exists to isolate.
+     * <p>
+     * A subclass overrides this only to run a deliberate CONTROL ARM against that choice, and owes
+     * the reader why in its own javadoc: inverting it changes which failure class the scenario can
+     * see, so a variant that overrides this is answering a different question, not running the same
+     * test more gently.
+     */
+    protected Map<ChaosConductor.ChaosAction, Integer> chaosWeights() {
+        return ChaosConductor.defaultW4Weights();
+    }
+
+    /**
+     * The drain-only action mix, shared by this family's CONTROL ARMS
+     * ({@link ChaosRevokeUnderWorkDrainIT} and {@link ChaosRevokeUnderWorkCooperativeDrainIT}) so the
+     * two cells cannot drift apart and silently stop being the same control.
+     * <p>
+     * {@code STOP_DRAIN} takes the weight {@link ChaosConductor#defaultW4Weights()} gives
+     * {@code STOP_NO_DRAIN}; RESTART and JOIN_NEW keep theirs, so the membership churn RATE is
+     * comparable and only the MANNER of leaving changes. That is what keeps a control arm a control
+     * arm rather than a different workload.
+     */
+    protected Map<ChaosConductor.ChaosAction, Integer> drainOnlyChaosWeights() {
+        Map<ChaosConductor.ChaosAction, Integer> weights = new EnumMap<>(ChaosConductor.ChaosAction.class);
+        weights.put(ChaosConductor.ChaosAction.STOP_DRAIN, 3); // was STOP_NO_DRAIN at 3
+        weights.put(ChaosConductor.ChaosAction.RESTART, 3);
+        weights.put(ChaosConductor.ChaosAction.JOIN_NEW, 2);
+        return weights;
+    }
+
     protected void runRevokeUnderWorkScenario() throws Exception {
         ChaosSeed seed = resolveSeed();
         log.info("=== CHAOS {} revoke-under-work (cooperative={}): seed={} (replay: {}) ===",
@@ -89,7 +201,7 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
         ManagedPCInstance.Config pcConfig = ManagedPCInstance.Config.builder()
                 // sync commits sharpen revoke-vs-commit lock contention - the confluentinc#857 deadlock recipe
                 .commitMode(CommitMode.PERIODIC_CONSUMER_SYNC)
-                .order(ProcessingOrder.UNORDERED)
+                .order(processingOrder())
                 .inputTopic(topic)
                 .pollDelayMs(1)
                 .maxConcurrency(10)
@@ -98,8 +210,9 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
                 .build();
 
         FleetBootstrap fleet = bootstrapFleet(topic, pcConfig, EXPECTED_MESSAGES, PRE_PRODUCE_FRACTION,
-                INITIAL_FLEET, HEAVY_EVERY, HEAVY_SLEEP);
+                INITIAL_FLEET, HEAVY_EVERY, heavySleep());
         AtomicLong totalConsumed = fleet.getTotalConsumed();
+        AtomicLong totalStarted = fleet.getTotalStarted();
         Queue<String> allConsumed = fleet.getAllConsumed();
         Set<String> expectedKeys = fleet.getExpectedKeys();
         ProgressProbe probe = fleet.getProbe()
@@ -110,13 +223,17 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
                 // eviction horizon (all of it, under the eager assignor); widen the watermark beyond it
                 .withNoProgressWindow(Duration.ofSeconds(60));
 
-        ChaosConductor conductor = conductorFor(fleet, pcConfig, HEAVY_EVERY, HEAVY_SLEEP, MAX_FLEET)
+        ChaosConductor conductor = conductorFor(fleet, pcConfig, HEAVY_EVERY, heavySleep(), MAX_FLEET)
                 .seed(seed.getValue())
-                // faster ticks than W1: more rebalances per run = more revoke-under-work collisions
-                .minTick(Duration.ofMillis(300))
-                .maxTick(Duration.ofMillis(1000))
-                .weights(ChaosConductor.defaultW4Weights()) // NO drain stops - see scenario javadoc
-                .joinAfterDrainBias(0) // no drains to bias after
+                // matrix cells: faster ticks than W1 - more rebalances per run = more
+                // revoke-under-work collisions (the KEY cell overrides - see minTick())
+                .minTick(minTick())
+                .maxTick(maxTick())
+                .weights(chaosWeights())
+                // 0 in every cell, for different reasons: the matrix cells have no drains to bias
+                // after, and the drain control arms deliberately keep the unbiased join schedule so
+                // only the MANNER of leaving changes against their no-drain counterparts
+                .joinAfterDrainBias(0)
                 .build();
 
         startRun(probe, conductor);
@@ -133,12 +250,46 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
 
             // Phase 2 - quiet observation: group must settle, evict any storm-wedged member, and FINISH.
             // The only defect signal that can fire here is the protocol-invisible kind - exactly Class 2.
-            await().alias("backlog drained after the storm settles (quiet phase)")
-                    .atMost(QUIET_CAP)
-                    .pollInterval(Duration.ofSeconds(2))
-                    .failFast("probe violation", probe::hasViolations)
-                    .until(() -> totalConsumed.get() >= EXPECTED_MESSAGES
-                            && allConsumedCovers(expectedKeys, allConsumed));
+            org.awaitility.core.ConditionFactory quiet =
+                    await().alias("backlog drained after the storm settles (quiet phase)")
+                            .pollInterval(Duration.ofSeconds(2));
+            if (DIAGNOSE_STALL_RECOVERY) {
+                // Deliberately no failFast: the whole point is to keep watching AFTER the violation.
+                log.warn("=== chaos.diagnoseStallRecovery ACTIVE - quiet cap {} and no fail-fast. " +
+                        "This is a DIAGNOSTIC run: violations are still asserted at the end, so this " +
+                        "cannot make the test pass. ===", DIAGNOSTIC_QUIET_CAP);
+                // The prior art nobody greps, delivered at the moment it is about to be repeated: the
+                // six prior-art checks in AGENTS.md search docs, PRs and issues, and none of them
+                // reaches a class javadoc. This exact experiment was run once before at the 90s/45s
+                // shape and is recorded there, and was re-derived in August 2026 by someone who had
+                // done the documented checks correctly.
+                log.warn("=== BEFORE INTERPRETING THIS RUN, read the scenario class's 'Calibration " +
+                        "status' javadoc. A recovery diagnostic has been run on this family before " +
+                        "and already established that the freeze RESOLVES and the backlog completes " +
+                        "at the pre-2026-07-30 shape. If your result is 'it recovers', you have " +
+                        "reproduced a known result - the NEW question is whether it still recovers " +
+                        "at the current shape, and how long it takes against the {} bound. ===",
+                        ProgressProbe.LAG_STAGNATION_BOUND);
+                quiet = quiet.atMost(DIAGNOSTIC_QUIET_CAP);
+            } else {
+                quiet = quiet.atMost(QUIET_CAP).failFast("probe violation", probe::hasViolations);
+            }
+            quiet.until(() -> {
+                boolean done = totalConsumed.get() >= EXPECTED_MESSAGES
+                        && allConsumedCovers(expectedKeys, allConsumed);
+                if (DIAGNOSE_STALL_RECOVERY) {
+                    // Both ends of the user function, because a completion counter alone cannot tell
+                    // "nothing is finishing" from "nothing is happening": a fleet all sitting inside
+                    // HEAVY_SLEEP reads as a flat line while it is fully busy. inFlight is the
+                    // difference, and it is what makes a flat consumed count interpretable.
+                    long started = totalStarted.get();
+                    long consumed = totalConsumed.get();
+                    log.info("[diagnose] quiet phase: consumed={}/{} started={} inFlight={} violations={} done={}",
+                            consumed, EXPECTED_MESSAGES, started, started - consumed,
+                            probe.getViolations().size(), done);
+                }
+                return done;
+            });
         } finally {
             settleRun(conductor, probe, fleet.getProducerThread(), fleet.getPcExecutor(), totalConsumed);
         }

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosKeyOrderIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosKeyOrderIT.java
@@ -1,0 +1,217 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions.CommitMode;
+import bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder;
+import bz.stub.parallelconsumer.PollContext;
+import bz.stub.parallelconsumer.integrationTests.utils.ManagedPCInstance;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Chaos Pain Suite - W5 "key order under churn": the only scenario that puts PC's <b>headline</b>
+ * guarantee - key concurrency <em>without</em> losing per-key order - under the suite's membership
+ * churn, and asserts it. W1 and W4 hunt liveness classes and run {@link ProcessingOrder#UNORDERED},
+ * where PC promises nothing about order; this one runs {@link ProcessingOrder#KEY} over a REPEATED key
+ * space, so there is an order to keep and a ledger that fails when it is not kept
+ * ({@link KeyOrderLedger}, which owns the guarantee's exact window and why each part of it is there).
+ *
+ * <h2>Two things about the workload are load-bearing, not incidental</h2>
+ * <ul>
+ *   <li><b>Keys repeat.</b> {@link #KEY_SPACE} keys carry {@link #EXPECTED_MESSAGES} records, so every
+ *   key is a shard with a real sequence in it. W1/W4 produce a unique key per record, which makes ANY
+ *   per-key ordering assertion vacuous by construction - {@link KeyOrderLedger#check} says so out loud
+ *   rather than passing quietly.</li>
+ *   <li><b>The ledger's record IDENTITY moves into the value.</b> With keys repeating, the key no
+ *   longer identifies a record, so the loss/duplicate half of the ledger would read a second record of
+ *   a key as a duplicate delivery of the first. The value carries the unique identity instead
+ *   ({@link #identityFor} / {@link #identityOf}), leaving {@link ProgressProbe#ledger} asserting
+ *   exactly what it asserts everywhere else.</li>
+ * </ul>
+ *
+ * <h2>Calibration</h2>
+ * Both calibration constants are set by how KEY ordering changes the LEGITIMATE commit-freeze window
+ * that {@link ProgressProbe}'s Class 2 lag probe tolerates, and both were moved by measurement rather
+ * than by argument - each carries its measured evidence:
+ * <ul>
+ *   <li>{@link #HEAVY_SLEEP} - a dwell longer than the gap between rebalances chains indefinitely under
+ *   at-least-once, pinning a partition's commit watermark for the whole run.</li>
+ *   <li>{@link #KEY_SPACE} - coprime with {@link #HEAVY_EVERY}, or the entire heavy tail serialises onto
+ *   one key's shard; {@link #heavyRecordsMustNotAllShareOneKey} is the check, not a comment.</li>
+ * </ul>
+ * Volume is sized per instance, for the reason on {@link #EXPECTED_MESSAGES}.
+ *
+ * <h2>The ledger is calibrated RED as well as GREEN</h2>
+ * The control arm is this scenario with one character changed - {@link ProcessingOrder#UNORDERED}
+ * instead of {@code KEY}, everything else identical - which removes the guarantee while leaving the
+ * workload, the fleet and the churn alone. Measured 2026-08-18 at 90k:
+ * <ul>
+ *   <li><b>KEY (this scenario)</b>: {@code orderRegressions=0 overlaps=0} over 90,401 deliveries, of
+ *   which 85,433 were compared against a predecessor in their own window. GREEN.</li>
+ *   <li><b>UNORDERED (control)</b>: {@code orderRegressions=1 overlaps=857} over 90,530 deliveries.
+ *   RED - and the shape of the RED is informative: PC still hands out a partition's records in
+ *   ascending offset order, so an ORDER regression is rare; what UNORDERED actually loses is the
+ *   serialisation, which is why {@code LEDGER_KEY_CONCURRENCY} exists. An offset-order-only detector
+ *   would have called this arm green 857 times over.</li>
+ * </ul>
+ * <p>
+ * Seed protocol: {@code -Dchaos.seed=<long>} replays a schedule; unset = random seed, always logged.
+ * Excluded from default suites via {@code @Tag("chaos")}; run with {@code -Dincluded.groups=chaos}.
+ */
+@Tag("chaos")
+@Timeout(600)
+@Testcontainers
+@Slf4j
+class ChaosKeyOrderIT extends ChaosScenarioBase {
+
+    private static final int PARTITIONS = 80;
+    /**
+     * Sized so the run lasts long enough to be CHURNED, which is the constraint here - not throughput
+     * and not the cap. At 24k the calibrated shape drained in 14s, which at a 500-1500ms tick is barely
+     * twenty disturbances and about two assignment epochs per key: green, but asserting almost nothing
+     * about order under rebalance. Measured on this axis: 24k = 14s; 60k = 26s, 16 disturbances,
+     * lag-stagnation peak 11s; 90k = 42s, 20 disturbances, peak 22s; 120k = 88s, 39 disturbances, peak
+     * 77s. The peak tracks run
+     * length and the Class 2 bound is 150s, so volume buys churn against margin - and CI runs the chaos
+     * lane with {@code -DforkCount=4}, where everything here is slower than these single-fork numbers.
+     * This is the constant to cut first if that probe ever comes close.
+     */
+    private static final int EXPECTED_MESSAGES = 90_000;
+    /**
+     * ~40 records per key, so a key's shard holds a real sequence for the ordering ledger to be able to
+     * fail on. Also >> the fleet's total worker slots ({@code MAX_FLEET x maxConcurrency} = 100), so
+     * per-key serialisation does not starve the run of parallelism and turn it into a throughput test.
+     * <p>
+     * COPRIME with {@link #HEAVY_EVERY}, and asserted so at the top of the run - see
+     * {@link #heavyRecordsMustNotAllShareOneKey}.
+     */
+    private static final int KEY_SPACE = 2_251;
+    private static final int INITIAL_FLEET = 8;
+    private static final int MAX_FLEET = 10;
+    private static final double PRE_PRODUCE_FRACTION = 0.3;
+    private static final Duration RUN_CAP = Duration.ofMinutes(5);
+    private static final int HEAVY_EVERY = 2_000;
+    /**
+     * 3s, far below W1's 45s, because a dwell interacts with churn differently under KEY ordering. A
+     * revoke fences a record's completion, and at-least-once re-runs it FRESH on the next owner - so a
+     * dwell longer than the gap between rebalances (measured here: one per instance every ~10s) chains
+     * indefinitely, and the record's partition commit watermark is pinned for the whole run. At 10s that
+     * chain never terminated: three runs measured a lag-stagnation peak of 154s against
+     * {@link ProgressProbe#LAG_STAGNATION_BOUND}'s 150s. 3s completes inside the gap, so the chain is
+     * short and the legitimate freeze window stays far under the bound - while still being ~3000x a
+     * normal record, which is what makes revokes catch real in-flight work.
+     */
+    private static final Duration HEAVY_SLEEP = Duration.ofSeconds(3);
+
+    /** One recorder for the whole fleet and the whole run - see {@link ChaosScenarioBase#orderRecorder}. */
+    private final KeyOrderLedger.Recorder recorder = new KeyOrderLedger.Recorder();
+
+    @Override
+    protected KeyOrderLedger.Recorder orderRecorder() {
+        return recorder;
+    }
+
+    /** Repeated keys: this is the shard, and so the unit PC promises order within. */
+    @Override
+    protected String keyFor(int i) {
+        return "k-" + (i % KEY_SPACE);
+    }
+
+    /** The unique record identity - matches the value {@code produceRange} sends ({@code "v-" + i}). */
+    @Override
+    protected String identityFor(int i) {
+        return "v-" + i;
+    }
+
+    @Override
+    protected String identityOf(PollContext<String, String> context) {
+        return context.value();
+    }
+
+    /**
+     * The heavy tail is spaced on the record identity, so which KEYS carry it is decided by
+     * {@code HEAVY_EVERY mod KEY_SPACE} - and when {@link #KEY_SPACE} divides {@link #HEAVY_EVERY},
+     * EVERY heavy record lands on key {@code k-0}. KEY ordering then serialises the whole heavy tail
+     * onto one shard on one partition, pinning that partition's commit watermark until the run ends:
+     * measured at {@code KEY_SPACE=400, HEAVY_EVERY=2000} as a 154s lag stagnation on exactly one
+     * partition, whose blocking record was {@code o:40:k:k-0}. That reads as a Class 2 stall and is a
+     * workload artifact, so it is checked rather than commented.
+     */
+    @Test
+    void heavyRecordsMustNotAllShareOneKey() {
+        assertWithMessage("KEY_SPACE and HEAVY_EVERY must be coprime, or the whole heavy tail serialises "
+                + "onto one key's shard and pins its partition's commit watermark for the run")
+                .that(BigInteger.valueOf(KEY_SPACE).gcd(BigInteger.valueOf(HEAVY_EVERY)).intValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    void perKeyOrderSurvivesChurn() throws Exception {
+        ChaosSeed seed = resolveSeed();
+        String replayCmd = seed.replayCommand();
+        log.info("=== CHAOS W5 key order: seed={} (replay: {}) ===", seed.getValue(), replayCmd);
+
+        String topic = getClass().getSimpleName() + "-w5-" + RandomUtils.nextInt();
+        ensureTopic(topic, PARTITIONS);
+
+        ManagedPCInstance.Config pcConfig = ManagedPCInstance.Config.builder()
+                .commitMode(CommitMode.PERIODIC_CONSUMER_ASYNCHRONOUS)
+                // the whole point of this scenario - the other two run UNORDERED
+                .order(ProcessingOrder.KEY)
+                .inputTopic(topic)
+                .pollDelayMs(1)
+                .maxConcurrency(10)
+                .build();
+
+        FleetBootstrap fleet = bootstrapFleet(topic, pcConfig, EXPECTED_MESSAGES, PRE_PRODUCE_FRACTION,
+                INITIAL_FLEET, HEAVY_EVERY, HEAVY_SLEEP);
+        AtomicLong totalConsumed = fleet.getTotalConsumed();
+        Queue<String> allConsumed = fleet.getAllConsumed();
+        Set<String> expectedKeys = fleet.getExpectedKeys();
+        ProgressProbe probe = fleet.getProbe();
+
+        ChaosConductor conductor = conductorFor(fleet, pcConfig, HEAVY_EVERY, HEAVY_SLEEP, MAX_FLEET)
+                .seed(seed.getValue())
+                // slower than W1's 500-1500ms, and the ONE thing that has to be different about this
+                // scenario's churn: at W1's rate membership changes arrive faster than an EAGER rebalance
+                // can complete, so the group never returns to Stable and ProgressProbe's CONTINUOUS
+                // rebalance-dwell clock accrues past its 15s bound with no member actually being a zombie
+                // (measured 15.5s). It is also what this ledger needs - a group that never stabilises
+                // splits every key's sequence into windows of one delivery, which assert nothing
+                .minTick(Duration.ofMillis(1_000))
+                .maxTick(Duration.ofMillis(2_500))
+                .joinAfterDrainBias(0.9)
+                .build();
+
+        startRun(probe, conductor);
+
+        try {
+            await().alias("all messages consumed under churn, in key order")
+                    .atMost(RUN_CAP)
+                    .pollInterval(Duration.ofSeconds(2))
+                    .failFast("probe violation during run", probe::hasViolations)
+                    .until(() -> totalConsumed.get() >= EXPECTED_MESSAGES
+                            && allConsumedCovers(expectedKeys, allConsumed));
+        } finally {
+            settleRun(conductor, probe, fleet.getProducerThread(), fleet.getPcExecutor(), totalConsumed);
+        }
+
+        assertScenarioSlos(probe, conductor, replayCmd, expectedKeys, allConsumed);
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosRevokeUnderWorkCooperativeDrainIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosRevokeUnderWorkCooperativeDrainIT.java
@@ -1,0 +1,73 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+
+/**
+ * The fourth cell of the assignor x stop-mode matrix: COOPERATIVE assignor, DRAINING stops.
+ * <p>
+ * The other three were measured on seed 4734674029169027864 on 2026-08-19, and they show the
+ * assignor doing nearly all the work: eager/no-drain gave 53 violations and 2421 duplicates,
+ * eager/drain 45 and 2007, cooperative/no-drain 0 and 405. Draining moved almost nothing while
+ * changing the assignor moved everything, because eager revokes ALL partitions from ALL members on
+ * any membership change, so the in-flight work that gets abandoned was never the departing member's
+ * to drain.
+ * <p>
+ * This cell exists to complete the matrix rather than to test a hypothesis, and that is the point:
+ * with three cells measured, the fourth is where an unexpected interaction would show up. The
+ * prediction is boring - cooperative/drain should look like cooperative/no-drain, at or near zero
+ * violations, with duplicates at or below 405, because the only work left to abandon belongs to the
+ * member that is leaving and draining is exactly what saves it. A result far from that would mean
+ * the two variables interact, which nothing so far suggests.
+ * <p>
+ * <b>The control-arm reasoning is not repeated here.</b> Why a draining stop should break the
+ * abandoned-heavy-work chain, what each outcome would mean, why the duplicate count is the same
+ * measurement taken from the other side, and why this deliberately INVERTS
+ * {@link ChaosRevokeUnderWorkIT}'s central design choice rather than softening it - all of that is in
+ * {@link ChaosRevokeUnderWorkDrainIT}'s javadoc and applies unchanged to this cell. Read that one
+ * first; this file records only what swapping the assignor adds, and the same warning carries over:
+ * a GREEN here is never evidence about the no-drain arm's Class 2 hunt.
+ * <p>
+ * Seed protocol and lane are inherited: {@code -Dchaos.seed=<long>} replays a schedule, and
+ * {@code @Tag("chaos")} keeps it out of the default suites.
+ */
+@Tag("chaos")
+@Timeout(600)
+@Testcontainers
+@Slf4j
+class ChaosRevokeUnderWorkCooperativeDrainIT extends AbstractRevokeUnderWorkScenario {
+
+    @Override
+    protected boolean useCooperativeAssignor() {
+        return true;
+    }
+
+    @Override
+    protected String scenarioLabel() {
+        return "w4coopdrain";
+    }
+
+    /**
+     * Drain-only stops - the single variable against {@link ChaosRevokeUnderWorkIT}. The mix itself is
+     * {@link AbstractRevokeUnderWorkScenario#drainOnlyChaosWeights()}, shared with the eager
+     * control arm ({@link ChaosRevokeUnderWorkDrainIT}) so the two cannot drift apart.
+     */
+    @Override
+    protected Map<ChaosConductor.ChaosAction, Integer> chaosWeights() {
+        return drainOnlyChaosWeights();
+    }
+
+    @Test
+    void revokeUnderDrainingStopsWithCooperativeAssignorStaysProtocolHonest() throws Exception {
+        runRevokeUnderWorkScenario();
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosRevokeUnderWorkDrainIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosRevokeUnderWorkDrainIT.java
@@ -1,0 +1,79 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+
+/**
+ * CONTROL ARM for {@link ChaosRevokeUnderWorkIT}: the same scenario, but every stop DRAINS.
+ * <p>
+ * It exists to test a mechanism rather than to hunt a defect. The eager scenario's stops are
+ * {@code close()}, which is {@code closeDontDrainFirst()} - in-flight work is abandoned without being
+ * committed, so at-least-once redelivers it to the next assignee. A record that takes
+ * {@link AbstractRevokeUnderWorkScenario#HEAVY_SLEEP} to process therefore costs that dwell AGAIN
+ * each time a storm tick catches it in flight, and a partition's commit watermark cannot advance past
+ * it. Chain enough of those and the watermark is legitimately pinned past
+ * {@link ProgressProbe#LAG_STAGNATION_BOUND} with nothing wrong - which is the leading explanation for
+ * the {@code CLASS2_STALL/LAG_STAGNATION} sightings this family has collected.
+ * <p>
+ * A draining stop lets the in-flight heavy FINISH and commit before the member leaves, so the chain
+ * cannot form. The prediction is therefore sharp, and either outcome is informative:
+ * <ul>
+ *   <li><b>Drain arm clean, no-drain arm red</b> - the stagnation is redelivery of abandoned heavy
+ *   work, an artifact of the workload against the bound, not a PC defect.</li>
+ *   <li><b>Drain arm ALSO red</b> - the abandoned-work explanation is wrong and something else pins
+ *   the watermark. That would be the first real lead on a Class 2 mechanism in this family.</li>
+ * </ul>
+ * <b>Duplicates are the same measurement from the other side.</b> A draining close should produce
+ * few or none, where the no-drain arm measured ~1% (2,421 of 250,000). If this arm still duplicates
+ * heavily, the drain is not doing what its name says, which is worth knowing on its own.
+ * <p>
+ * <b>This deliberately inverts {@link ChaosRevokeUnderWorkIT}'s central design choice, and is not a
+ * gentler version of it.</b> That scenario excludes drains precisely because a drain opens the
+ * Class 1 drain-zombie window, which can mask the Class 2 mechanism it isolates. So this arm can see
+ * a failure class that one cannot, and is blind to nothing it needs - but its GREEN must never be
+ * read as evidence about the no-drain arm's Class 2 hunt. It answers "does abandoning in-flight work
+ * cause the watermark pinning", and only that.
+ * <p>
+ * Seed protocol and lane are inherited: {@code -Dchaos.seed=<long>} replays a schedule, and
+ * {@code @Tag("chaos")} keeps it out of the default suites.
+ */
+@Tag("chaos")
+@Timeout(600)
+@Testcontainers
+@Slf4j
+class ChaosRevokeUnderWorkDrainIT extends AbstractRevokeUnderWorkScenario {
+
+    @Override
+    protected boolean useCooperativeAssignor() {
+        return false;
+    }
+
+    @Override
+    protected String scenarioLabel() {
+        return "w4drain";
+    }
+
+    /**
+     * Drain-only stops - the single variable against {@link ChaosRevokeUnderWorkIT}. The mix itself is
+     * {@link AbstractRevokeUnderWorkScenario#drainOnlyChaosWeights()}, shared with the cooperative
+     * control arm ({@link ChaosRevokeUnderWorkCooperativeDrainIT}) so the two cannot drift apart.
+     */
+    @Override
+    protected Map<ChaosConductor.ChaosAction, Integer> chaosWeights() {
+        return drainOnlyChaosWeights();
+    }
+
+    @Test
+    void revokeUnderDrainingStopsStaysProtocolHonest() throws Exception {
+        runRevokeUnderWorkScenario();
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosRevokeUnderWorkKeyOrderIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosRevokeUnderWorkKeyOrderIT.java
@@ -1,0 +1,169 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder;
+import bz.stub.parallelconsumer.PollContext;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigInteger;
+import java.time.Duration;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Chaos Pain Suite - W4's ORDERING cell: {@link ProcessingOrder#KEY} over repeated keys under the
+ * revoke-under-work storm, so {@link KeyOrderLedger} is exercised by the suite's most violent
+ * revocation shape (eager assignor, hard stops and joins, sync commits, heavy work in flight at
+ * every revoke). Closes the gap the 2026-08-19 assignor/stop-mode matrix left open: all four cells
+ * verified no-loss, bounded-duplicates and completion, but ran {@code UNORDERED} over a unique key
+ * per record - so none of them asserted anything about the guarantee PC exists for. {@code W5}
+ * ({@link ChaosKeyOrderIT}) asserts it under W1-style continuous churn; this cell asserts it under
+ * W4's storm-then-quiet revocation shape, where redelivery chains and assignment epochs are at
+ * their densest.
+ *
+ * <h2>Deliberately a NEW cell, not a change to the matrix</h2>
+ * The four {@code UNORDERED} cells stay exactly as measured: switching the shared driver to KEY
+ * would serialise per-key work and invalidate the matrix's four recorded measurements (and with the
+ * driver's unique-key workload it would also assert nothing -
+ * {@code KeyOrderLedger#check} calls such a history vacuous out loud). This cell overrides the
+ * driver's promoted hooks ({@code processingOrder()}, {@code heavySleep()}) plus
+ * {@link ChaosScenarioBase}'s identity trio, and changes nothing else - storm, weights, commit mode
+ * and fleet shape are inherited, so the ordering claim is added to the same disturbance the matrix
+ * measured.
+ *
+ * <h2>Three calibration traps - two already paid for in {@link ChaosKeyOrderIT}, one paid for here</h2>
+ * <ul>
+ *   <li><b>{@link #KEY_SPACE} must be coprime with {@code HEAVY_EVERY}</b> (2000): the heavy tail is
+ *   spaced on the record index, so a common factor lands the entire tail on few keys - in the worst
+ *   case one - and KEY ordering then serialises every dwell onto one shard, pinning its partition's
+ *   commit watermark into a measured 154s false Class 2 stall.
+ *   {@link #heavyRecordsMustNotAllShareOneKey} is the check, not a comment.</li>
+ *   <li><b>{@link #HEAVY_SLEEP_KEY} is 3s, not the matrix cells' 20s</b>: a revoke fences a heavy
+ *   record's completion and at-least-once re-runs it fresh on the next owner, so a dwell longer than
+ *   the gap between storm rebalances (300-1000ms ticks here) chains for the whole storm - under KEY
+ *   ordering with the whole shard queued behind it. 3s completes inside the post-storm gap, keeping
+ *   the legitimate freeze window (60s storm + short chains + commit slack, ~90s) well under the
+ *   150s Class 2 bound, while still ~3000x a normal record so revokes genuinely catch work in
+ *   flight.</li>
+ *   <li><b>Storm ticks are W5's 1000-2500ms, not the matrix cells' 300-1000ms</b> - eager rebalances
+ *   must COMPLETE between membership changes or every key's sequence splits into single-delivery
+ *   epoch windows and the ordering ledger asserts nothing; see {@link #STORM_TICK_MIN}, whose
+ *   javadoc carries the measured cost of getting this wrong.</li>
+ * </ul>
+ * <p>
+ * ~111 records per key ({@code EXPECTED_MESSAGES} 250k / 2251), so every key's shard holds a real
+ * sequence; {@link #KEY_SPACE} is also far above the fleet's ~140 worker slots
+ * ({@code MAX_FLEET x maxConcurrency}), so per-key serialisation does not starve the run of
+ * parallelism. The record IDENTITY moves into the VALUE ({@link #identityFor}/{@link #identityOf}),
+ * keeping the loss/duplicate ledger asserting exactly what it asserts in every other scenario.
+ * <p>
+ * Seed protocol: {@code -Dchaos.seed=<long>} replays a schedule; unset = random seed, always logged.
+ * Excluded from default suites via {@code @Tag("chaos")}; run with {@code -Dincluded.groups=chaos}.
+ */
+@Tag("chaos")
+@Timeout(600)
+@Testcontainers
+@Slf4j
+class ChaosRevokeUnderWorkKeyOrderIT extends AbstractRevokeUnderWorkScenario {
+
+    /**
+     * Prime (so coprime with any {@code HEAVY_EVERY}), sized like {@code ChaosKeyOrderIT}'s {@code KEY_SPACE}
+     * and for the same reasons - see the class javadoc's trap list.
+     */
+    static final int KEY_SPACE = 2_251;
+
+    /** See the class javadoc's trap list for why this is far below the matrix cells' 20s. */
+    private static final Duration HEAVY_SLEEP_KEY = Duration.ofSeconds(3);
+
+    /**
+     * W5's tick range (1000-2500ms), NOT the matrix cells' 300-1000ms - the third trap, and this one
+     * was rediscovered the expensive way before this override existed: at 300-1000ms the first run of
+     * this cell (2026-08-19, seed 4734674029169027864) had eager rebalances arriving faster than they
+     * complete, which under KEY ordering both shreds key sequences into single-delivery epoch windows
+     * (asserting nothing - the vacuity {@code KeyOrderLedger#check} exists to call out) and re-delivers
+     * every revoked shard's queue on each storm tick, pinning two partitions' commit watermarks to a
+     * 154s stagnation against the 150s Class 2 bound. The ordering claim needs windows a rebalance
+     * GAP long; the revoke-under-work collisions it also needs survive at this rate (the storm still
+     * lands ~40 membership actions on heavy in-flight work).
+     */
+    private static final Duration STORM_TICK_MIN = Duration.ofMillis(1_000);
+    private static final Duration STORM_TICK_MAX = Duration.ofMillis(2_500);
+
+    /** One recorder for the whole fleet and the whole run - see {@link ChaosScenarioBase#orderRecorder}. */
+    private final KeyOrderLedger.Recorder recorder = new KeyOrderLedger.Recorder();
+
+    @Override
+    protected boolean useCooperativeAssignor() {
+        // the eager arm: every membership change revokes ALL partitions from ALL members, which is
+        // the maximum redelivery/epoch churn available - the strongest test of the ordering window
+        return false;
+    }
+
+    @Override
+    protected String scenarioLabel() {
+        return "w4key";
+    }
+
+    @Override
+    protected ProcessingOrder processingOrder() {
+        return ProcessingOrder.KEY;
+    }
+
+    @Override
+    protected Duration heavySleep() {
+        return HEAVY_SLEEP_KEY;
+    }
+
+    @Override
+    protected Duration minTick() {
+        return STORM_TICK_MIN;
+    }
+
+    @Override
+    protected Duration maxTick() {
+        return STORM_TICK_MAX;
+    }
+
+    @Override
+    protected KeyOrderLedger.Recorder orderRecorder() {
+        return recorder;
+    }
+
+    /** Repeated keys: the shard, and so the unit PC promises order within. */
+    @Override
+    protected String keyFor(int i) {
+        return "k-" + (i % KEY_SPACE);
+    }
+
+    /** The unique record identity - matches the value {@code produceRange} sends ({@code "v-" + i}). */
+    @Override
+    protected String identityFor(int i) {
+        return "v-" + i;
+    }
+
+    @Override
+    protected String identityOf(PollContext<String, String> context) {
+        return context.value();
+    }
+
+    /** Same workload-artifact guard as {@code ChaosKeyOrderIT}'s {@code heavyRecordsMustNotAllShareOneKey}. */
+    @Test
+    void heavyRecordsMustNotAllShareOneKey() {
+        assertWithMessage("KEY_SPACE and HEAVY_EVERY must be coprime, or the whole heavy tail serialises "
+                + "onto one key's shard and pins its partition's commit watermark for the run")
+                .that(BigInteger.valueOf(KEY_SPACE).gcd(BigInteger.valueOf(HEAVY_EVERY)).intValue())
+                .isEqualTo(1);
+    }
+
+    @Test
+    void perKeyOrderSurvivesRevokeUnderWork() throws Exception {
+        runRevokeUnderWorkScenario();
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosScenarioBase.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosScenarioBase.java
@@ -4,6 +4,7 @@ package bz.stub.parallelconsumer.integrationTests.chaostests;
  * Copyright (C) 2026 Antony Stubbs and contributors
  */
 
+import bz.stub.parallelconsumer.PollContext;
 import bz.stub.parallelconsumer.integrationTests.BrokerIntegrationTest;
 import bz.stub.parallelconsumer.integrationTests.utils.ManagedPCInstance;
 import lombok.Getter;
@@ -25,14 +26,16 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 
 /**
- * Shared scaffolding for Chaos Pain Suite scenarios (W1 churn storm, W4 revoke-under-work, ...): the
- * keyed producer, the heavy-tailed NON-interruptible user function, coverage checks, and fleet settling.
+ * Shared scaffolding for Chaos Pain Suite scenarios (W1 churn storm, W4 revoke-under-work, W5 key
+ * order, ...): the keyed producer, the heavy-tailed NON-interruptible user function, coverage checks,
+ * and fleet settling.
  * Scenario classes own their chaos shape (conductor weights/ticks, fleet size, commit mode) - this base
  * owns the mechanics every scenario shares, so scenarios can't drift apart on them.
  */
@@ -48,32 +51,85 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
      */
     protected ManagedPCInstance newInstance(ManagedPCInstance.Config config,
                                             int heavyEvery, Duration heavySleep,
-                                            AtomicLong totalConsumed, Queue<String> allConsumed) {
-        return new ManagedPCInstance(config, getKcu(), key -> {
-            if (isHeavyKey(key, heavyEvery)) {
-                long deadline = System.currentTimeMillis() + heavySleep.toMillis();
-                boolean interrupted = false;
-                long left;
-                while ((left = deadline - System.currentTimeMillis()) > 0) {
-                    try {
-                        Thread.sleep(Math.min(left, 1_000));
-                    } catch (InterruptedException e) {
-                        interrupted = true; // note it, keep dwelling until the deadline
+                                            AtomicLong totalConsumed, AtomicLong totalStarted,
+                                            Queue<String> allConsumed) {
+        KeyOrderLedger.Recorder recorder = orderRecorder();
+        return new ManagedPCInstance(config, getKcu(), (incarnationId, context) -> {
+            // recorded FIRST and released LAST, so the bracket is the user function's real execution
+            // window - what KeyOrderLedger's overlap half is asserting about
+            KeyOrderLedger.Delivery delivery = recorder == null ? null : recorder.started(incarnationId, context);
+            // Counted at ENTRY, where totalConsumed is counted at exit. The pair is the measurement:
+            // a completion counter alone reads a fleet busy inside HEAVY_SLEEP as a flat line, which
+            // is indistinguishable from a fleet that is genuinely stuck. started-minus-consumed is
+            // work in flight, and it separates "nothing is finishing" from "nothing is happening".
+            totalStarted.incrementAndGet();
+            try {
+                String identity = identityOf(context);
+                if (isHeavyKey(identity, heavyEvery)) {
+                    long deadline = System.currentTimeMillis() + heavySleep.toMillis();
+                    boolean interrupted = false;
+                    long left;
+                    while ((left = deadline - System.currentTimeMillis()) > 0) {
+                        try {
+                            Thread.sleep(Math.min(left, 1_000));
+                        } catch (InterruptedException e) {
+                            interrupted = true; // note it, keep dwelling until the deadline
+                        }
+                    }
+                    if (interrupted) {
+                        Thread.currentThread().interrupt();
                     }
                 }
-                if (interrupted) {
-                    Thread.currentThread().interrupt();
+                totalConsumed.incrementAndGet();
+                allConsumed.add(identity);
+            } finally {
+                if (delivery != null) {
+                    recorder.finished(delivery);
                 }
             }
-            totalConsumed.incrementAndGet();
-            allConsumed.add(key);
         });
     }
 
-    /** key format is "key-N"; every heavyEvery-th record is heavy. */
+    /** identity format is "<prefix>-N"; every heavyEvery-th record is heavy. */
     protected static boolean isHeavyKey(String key, int heavyEvery) {
         int n = Integer.parseInt(key.substring(key.indexOf('-') + 1));
         return n > 0 && n % heavyEvery == 0;
+    }
+
+    /**
+     * The RECORD IDENTITY the correctness ledger tracks - unique per produced record, and the value the
+     * heavy tail is spaced on. It is the Kafka key by default because the shared scenarios produce a
+     * unique key per record; a scenario that repeats keys (which is what makes a per-key ordering claim
+     * testable at all) must move the identity into the value and override this trio together.
+     *
+     * @see #keyFor the Kafka record key, which for such a scenario is NOT the identity
+     * @see #identityFor the produce-side half of the same mapping
+     */
+    protected String identityOf(PollContext<String, String> context) {
+        return context.key();
+    }
+
+    /** The Kafka record key for produced record {@code i} - the shard, and so the ordering unit. */
+    protected String keyFor(int i) {
+        return "key-" + i;
+    }
+
+    /** The ledger identity of produced record {@code i} - must agree with {@link #identityOf}. */
+    protected String identityFor(int i) {
+        return keyFor(i);
+    }
+
+    /**
+     * The per-key ordering recorder for this scenario, or {@code null} when the scenario makes NO
+     * ordering claim - which is the correct answer for every {@code UNORDERED} scenario, where PC
+     * promises nothing about per-key order and recording would only produce a history
+     * {@link KeyOrderLedger#check} would rightly call vacuous.
+     * <p>
+     * An overriding scenario must return the SAME recorder every call (a field, not a fresh instance):
+     * every fleet member records into it, and {@link #assertScenarioSlos} replays the one history.
+     */
+    protected KeyOrderLedger.Recorder orderRecorder() {
+        return null;
     }
 
     /** Coverage check is expensive at scale - callers only evaluate once the counter says it's plausible. */
@@ -86,9 +142,8 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
         try (Producer<String, String> producer = getKcu().createNewProducer(false)) {
             List<Future<RecordMetadata>> sends = new ArrayList<>();
             for (int i = fromInclusive; i < toExclusive; i++) {
-                String key = "key-" + i;
-                expectedKeys.add(key);
-                sends.add(producer.send(new ProducerRecord<>(topic, key, "v-" + i)));
+                expectedKeys.add(identityFor(i));
+                sends.add(producer.send(new ProducerRecord<>(topic, keyFor(i), "v-" + i)));
             }
             for (Future<RecordMetadata> send : sends) {
                 send.get();
@@ -145,6 +200,8 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
     protected static class FleetBootstrap {
         ExecutorService pcExecutor;
         AtomicLong totalConsumed;
+        /** Incremented at user-function ENTRY - see {@link #newInstance} for why the pair is needed. */
+        AtomicLong totalStarted;
         Queue<String> allConsumed;
         Set<String> expectedKeys;
         Thread producerThread;
@@ -164,6 +221,7 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
                                             int initialFleetSize, int heavyEvery, Duration heavySleep) {
         // fleet-wide consumption tracking (the probe's watermark + the ledger's evidence)
         AtomicLong totalConsumed = new AtomicLong();
+        AtomicLong totalStarted = new AtomicLong();
         Queue<String> allConsumed = new ConcurrentLinkedQueue<>();
         ExecutorService pcExecutor = Executors.newWorkStealingPool();
 
@@ -174,7 +232,7 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
         produceRange(topic, 0, preProduce, expectedKeys);
 
         // protected first member - chaos never touches it, so the group always has a healthy survivor
-        ManagedPCInstance pc0 = newInstance(pcConfig, heavyEvery, heavySleep, totalConsumed, allConsumed);
+        ManagedPCInstance pc0 = newInstance(pcConfig, heavyEvery, heavySleep, totalConsumed, totalStarted, allConsumed);
         pc0.start(pcExecutor);
         await().atMost(30, SECONDS).until(() -> totalConsumed.get() > 100);
 
@@ -185,14 +243,14 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
         List<ManagedPCInstance> initialFleet = new ArrayList<>();
         initialFleet.add(pc0);
         for (int i = 1; i < initialFleetSize; i++) {
-            ManagedPCInstance pc = newInstance(pcConfig, heavyEvery, heavySleep, totalConsumed, allConsumed);
+            ManagedPCInstance pc = newInstance(pcConfig, heavyEvery, heavySleep, totalConsumed, totalStarted, allConsumed);
             initialFleet.add(pc);
             pc.start(pcExecutor);
         }
 
         ProgressProbe probe = new ProgressProbe(getKcu(), getKcu().getGroupId(), topic,
                 totalConsumed::get, expectedMessages);
-        return new FleetBootstrap(pcExecutor, totalConsumed, allConsumed, expectedKeys,
+        return new FleetBootstrap(pcExecutor, totalConsumed, totalStarted, allConsumed, expectedKeys,
                 producerThread, pc0, initialFleet, probe);
     }
 
@@ -209,14 +267,19 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
                 .maxFleetSize(maxFleetSize)
                 .pcExecutor(fleet.getPcExecutor())
                 .instanceFactory(() -> newInstance(pcConfig, heavyEvery, heavySleep,
-                        fleet.getTotalConsumed(), fleet.getAllConsumed()))
+                        fleet.getTotalConsumed(), fleet.getTotalStarted(), fleet.getAllConsumed()))
                 .protectedInstance(fleet.getPc0())
                 .initialFleet(fleet.getInitialFleet())
                 .observer(fleet.getProbe());
     }
 
-    /** Arm the probe, then unleash chaos. */
+    /** Arm the probe, then unleash chaos. Wired here (not per-scenario) so every scenario's probe
+     * watches per-instance progress ({@code INSTANCE_STALL/NO_WORK_COMPLETED}) over the conductor's
+     * LIVE fleet view - a supplier, because JOIN_NEW grows the fleet mid-run. */
     protected void startRun(ProgressProbe probe, ChaosConductor conductor) {
+        probe.withInstanceProgress(() -> conductor.getFleet().stream()
+                .map(ProgressProbe.InstanceProgressView::of)
+                .collect(Collectors.toList()));
         probe.start();
         conductor.start();
     }
@@ -238,8 +301,8 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
     /** The suite-wide verdict, identical for every scenario by design: probes must be violation-free
      * (each violation carries its own diagnosis), every instance's terminal failure cause must be
      * classified, and the correctness ledger must balance - no loss ever, duplicates bounded per
-     * disturbance. Every message carries the full replay command - a raw CI log must be
-     * self-sufficient to reproduce. */
+     * disturbance, and per-key order kept where the scenario claims it ({@link #orderRecorder}). Every
+     * message carries the full replay command - a raw CI log must be self-sufficient to reproduce. */
     protected void assertScenarioSlos(ProgressProbe probe, ChaosConductor conductor, String replayCmd,
                                       Set<String> expectedKeys, Queue<String> allConsumed) {
         assertWithMessage("chaos probes must be violation-free (each violation carries the diagnosis; " +
@@ -261,10 +324,12 @@ abstract class ChaosScenarioBase extends BrokerIntegrationTest<String, String> i
                 replayCmd)
                 .that(unexpectedFailures).isEmpty();
 
-        // correctness ledger: no loss ever; duplicates bounded per disturbance
+        // correctness ledger: no loss ever; duplicates bounded per disturbance; and - for a scenario that
+        // makes the claim - per-key order kept inside every instance+partition+epoch window
         int disturbances = conductor.getDisturbanceCount();
-        List<String> ledgerProblems = ProgressProbe.ledger(expectedKeys, allConsumed,
-                Math.max(disturbances, 1), /* perDisturbanceAllowance */ 5_000);
+        List<String> ledgerProblems = new ArrayList<>(ProgressProbe.ledger(expectedKeys, allConsumed,
+                Math.max(disturbances, 1), /* perDisturbanceAllowance */ 5_000));
+        ledgerProblems.addAll(KeyOrderLedger.checkIfRecording(orderRecorder()));
         assertWithMessage("correctness ledger must balance (replay: %s)", replayCmd)
                 .that(ledgerProblems).isEmpty();
     }

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/InstanceStallProbeIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/InstanceStallProbeIT.java
@@ -1,0 +1,217 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Non-vacuity regression for {@link ProgressProbe}'s instance-progress detector
+ * ({@code INSTANCE_STALL/NO_WORK_COMPLETED}, {@link ProgressProbe#INSTANCE_STALL_BOUND}) - in BOTH
+ * directions: a detector that cannot fire is decoration, and one that fires on healthy instances
+ * would be disabled within a week. Drives {@link ProgressProbe#sampleInstanceProgress} directly with
+ * constructed views and explicit instants - pure replay, no broker, no sampler thread - and is
+ * deliberately NOT tagged {@code chaos}, so it gates every default integration build (the
+ * {@link ProgressProbeLedgerIT} / {@link KeyOrderLedgerIT} pattern).
+ */
+class InstanceStallProbeIT {
+
+    private static final Duration BOUND = ProgressProbe.INSTANCE_STALL_BOUND;
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    /** Mutable scripted view - the test flips its fields between samples. */
+    private static final class FakeInstance implements ProgressProbe.InstanceProgressView {
+        final int id;
+        boolean live = true;
+        long queued;
+        long outForProcessing;
+        long workResultsReturned;
+        Object incarnation = new Object();
+
+        FakeInstance(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public int instanceId() {
+            return id;
+        }
+
+        @Override
+        public boolean isLive() {
+            return live;
+        }
+
+        @Override
+        public long queuedInShards() {
+            return queued;
+        }
+
+        @Override
+        public long outForProcessing() {
+            return outForProcessing;
+        }
+
+        @Override
+        public long workResultsReturned() {
+            return workResultsReturned;
+        }
+
+        @Override
+        public Object incarnationMarker() {
+            return incarnation;
+        }
+    }
+
+    /** A probe with only the instance-progress detector armed - the ctor's null kcu is legal because
+     * the sampler thread is never started. */
+    private static ProgressProbe probeWatching(FakeInstance... instances) {
+        List<ProgressProbe.InstanceProgressView> views = new ArrayList<>(Arrays.asList(instances));
+        return new ProgressProbe(null, "test-group", "test-topic", () -> 0L, 0)
+                .withInstanceProgress(() -> views);
+    }
+
+    private static Instant pastBound(Instant from) {
+        return from.plus(BOUND).plusSeconds(1);
+    }
+
+    @Test
+    void firesWhenWorkIsHeldAndNothingCompletesPastTheBound() {
+        FakeInstance instance = new FakeInstance(7);
+        instance.queued = 132;
+        instance.outForProcessing = 10;
+        instance.workResultsReturned = 5_000;
+        ProgressProbe probe = probeWatching(instance);
+
+        probe.sampleInstanceProgress(T0);
+        probe.sampleInstanceProgress(pastBound(T0));
+
+        List<String> violations = probe.getViolations();
+        assertWithMessage("held work + frozen completion count past the bound is the detector's whole prey")
+                .that(violations).hasSize(1);
+        assertThat(violations.get(0)).contains("INSTANCE_STALL/NO_WORK_COMPLETED");
+        assertThat(violations.get(0)).contains("instance 7");
+        assertThat(violations.get(0)).contains("queued=132");
+    }
+
+    @Test
+    void silentWhileCompletionsAdvance() {
+        FakeInstance instance = new FakeInstance(1);
+        instance.queued = 500;
+        instance.outForProcessing = 10;
+        ProgressProbe probe = probeWatching(instance);
+
+        // far more than one bound's worth of wall clock, but a result returns between samples every
+        // time - the slow-but-progressing case CLASS2_STALL false-positives on, and the exact case
+        // this detector must stay silent for
+        Instant now = T0;
+        for (int i = 0; i < 5; i++) {
+            probe.sampleInstanceProgress(now);
+            instance.workResultsReturned++;
+            now = now.plus(Duration.ofSeconds(100));
+        }
+        probe.sampleInstanceProgress(now);
+
+        assertWithMessage("an instance returning results is progressing, however slowly")
+                .that(probe.getViolations()).isEmpty();
+    }
+
+    @Test
+    void silentWhenNoWorkIsHeld() {
+        FakeInstance instance = new FakeInstance(2);
+        // nothing queued, nothing out: an idle instance's completion count legitimately never moves
+        ProgressProbe probe = probeWatching(instance);
+
+        probe.sampleInstanceProgress(T0);
+        probe.sampleInstanceProgress(pastBound(T0));
+        probe.sampleInstanceProgress(pastBound(pastBound(T0)));
+
+        assertWithMessage("an idle instance is not a stalled instance")
+                .that(probe.getViolations()).isEmpty();
+    }
+
+    @Test
+    void silentWhenTheInstanceIsStopped() {
+        FakeInstance instance = new FakeInstance(3);
+        instance.queued = 40; // a stopping PC can still hold state - it must not be reported
+        instance.live = false;
+        ProgressProbe probe = probeWatching(instance);
+
+        probe.sampleInstanceProgress(T0);
+        probe.sampleInstanceProgress(pastBound(T0));
+
+        assertWithMessage("the harness stops and restarts members constantly; a stopped instance is not a stall")
+                .that(probe.getViolations()).isEmpty();
+    }
+
+    @Test
+    void restartGrantsAFreshFullWindow() {
+        FakeInstance instance = new FakeInstance(4);
+        instance.queued = 40;
+        ProgressProbe probe = probeWatching(instance);
+
+        probe.sampleInstanceProgress(T0);
+        Instant restartAt = T0.plus(Duration.ofSeconds(100));
+        instance.incarnation = new Object(); // conductor restarted it: new PC, same instance id
+        probe.sampleInstanceProgress(restartAt);
+
+        // past the bound from T0, but only 51s into the new incarnation's window
+        probe.sampleInstanceProgress(pastBound(T0));
+        assertWithMessage("a fresh incarnation must not inherit the old PC's silence")
+                .that(probe.getViolations()).isEmpty();
+
+        // ...and the new incarnation is still covered: its own full window elapsing fires
+        probe.sampleInstanceProgress(pastBound(restartAt));
+        assertThat(probe.getViolations()).hasSize(1);
+    }
+
+    @Test
+    void reArmsAfterFiringInsteadOfFiringEverySample() {
+        FakeInstance instance = new FakeInstance(5);
+        instance.outForProcessing = 3;
+        ProgressProbe probe = probeWatching(instance);
+
+        probe.sampleInstanceProgress(T0);
+        Instant firstFire = pastBound(T0);
+        probe.sampleInstanceProgress(firstFire);
+        probe.sampleInstanceProgress(firstFire.plusSeconds(1)); // 1s later - must NOT double-report
+        assertWithMessage("one violation per stalled window, not one per 1s sample")
+                .that(probe.getViolations()).hasSize(1);
+
+        // a further full window with still nothing returned is a further violation
+        probe.sampleInstanceProgress(pastBound(firstFire));
+        assertThat(probe.getViolations()).hasSize(2);
+    }
+
+    @Test
+    void oneStalledInstanceIsNotHiddenByHealthySiblings() {
+        // the granularity claim itself: the fleet-wide NO_PROGRESS watermark cannot see one wedged
+        // member behind advancing siblings - this detector exists to
+        FakeInstance healthy = new FakeInstance(10);
+        healthy.queued = 100;
+        FakeInstance wedged = new FakeInstance(11);
+        wedged.queued = 100;
+        ProgressProbe probe = probeWatching(healthy, wedged);
+
+        Instant now = T0;
+        for (int i = 0; i < 4; i++) {
+            probe.sampleInstanceProgress(now);
+            healthy.workResultsReturned++; // only the healthy sibling advances
+            now = now.plus(Duration.ofSeconds(60));
+        }
+
+        List<String> violations = probe.getViolations();
+        assertThat(violations).hasSize(1);
+        assertThat(violations.get(0)).contains("instance 11");
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/KeyOrderLedger.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/KeyOrderLedger.java
@@ -1,0 +1,374 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.PollContext;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/**
+ * The per-key ORDERING half of the chaos correctness ledger - the guarantee the library exists for
+ * ("key concurrency without losing per-key order"), asserted under the same churn the loss/duplicate
+ * half of the ledger ({@link ProgressProbe#ledger}) runs under.
+ *
+ * <h2>The guarantee this asserts, and the window it holds in</h2>
+ * <p>
+ * <b>Within one PC incarnation, one partition, one partition-assignment epoch and one record key, the
+ * records of that key are executed strictly one at a time, in ascending offset order.</b> Two
+ * violations follow from that, and this class reports exactly those two:
+ * <ul>
+ *   <li>{@code LEDGER_KEY_ORDER} - a later-started delivery has a LOWER offset than one already started
+ *   in the same window (an out-of-order regression).</li>
+ *   <li>{@code LEDGER_KEY_CONCURRENCY} - two deliveries of the same window overlapped in flight (the
+ *   serialisation half of the same promise; an ordering bug can show up as either).</li>
+ * </ul>
+ * <p>
+ * The window is not decoration - it is the whole difficulty, because a NAIVE "offsets per key must
+ * increase" fires on correct behaviour. Each of the four components excludes one class of legitimate
+ * re-processing that at-least-once delivery under churn produces on purpose:
+ * <ul>
+ *   <li><b>key</b> - PC orders per key ONLY; two different keys share no order (that is the
+ *   concurrency). {@code ShardKey.KeyOrderedKey} is the shard identity in
+ *   {@link bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder#KEY} mode.</li>
+ *   <li><b>partition</b> - {@code ShardKey.KeyOrderedKey} carries the record's {@code TopicPartition},
+ *   not just the topic, so the shard (and therefore the order) is per key PER PARTITION.</li>
+ *   <li><b>epoch</b> - the assignment generation, incremented per partition on BOTH revoke and assign
+ *   ({@code PartitionStateManager.incrementPartitionAssignmentEpoch}). When an assignment moves,
+ *   uncommitted work is redelivered from the last commit, so an earlier offset is legitimately
+ *   processed after a later one. That opens a NEW window; it does not violate the old one. The epoch
+ *   is read off the record's own {@code WorkContainer}, so a heavy record still in flight when its
+ *   partition is revoked keeps the OLD epoch - it cannot be mistaken for the new window's work.</li>
+ *   <li><b>incarnation</b> - a chaos restart builds a fresh {@code ParallelEoSStreamProcessor}, whose
+ *   epoch counter starts again at zero. Scoping to the (stable) chaos instance id would collide epoch
+ *   0 of two unrelated PC lifetimes and report the second one's legitimate redelivery as a regression.</li>
+ * </ul>
+ * <p>
+ * Everything the window excludes is excluded in the SAFE direction: a delivery that cannot be placed in
+ * a window is skipped, so a mis-scoped observation loses a detection rather than inventing one. (A
+ * delivery with no recorded end is NOT such a case: {@code finished} is finally-guaranteed, so a missing
+ * end means still-running, and {@link #check} treats it as an open interval that any later same-window
+ * start certainly overlaps.) A detector that fires on correct behaviour would be disabled within a week, and
+ * the suite's whole value is that a RED means something.
+ *
+ * <h2>Why this cannot silently become vacuous</h2>
+ * A window holding one delivery asserts nothing, and a workload with a unique key per record (which is
+ * what the other chaos scenarios produce) is nothing BUT such windows. {@link #check} therefore reports
+ * {@code LEDGER_ORDER_VACUOUS} when no window held two deliveries - the check going quiet is itself a
+ * failure. Scenarios that make no ordering claim (UNORDERED processing) must not record at all rather
+ * than record a history this would call vacuous. The same failure shape - an assertion silently losing
+ * its precondition and going green - is the subject of
+ * {@code docs/solutions/test-flakiness/vacuous-counting-assertion-loop-changed-its-own-precondition-2026-08-18.md}.
+ *
+ * <h2>Prior art, and why it is not extended</h2>
+ * The one existing per-key ordering assertion in the repo is
+ * {@code KafkaTestUtils.checkExactOrdering}, called only by
+ * {@code ParallelEoSStreamProcessorTest.lessKeysThanThreads}. It has NO window, because it cannot need
+ * one: a {@code MockConsumer}, one instance, no rebalance, drained before the check - so no record can
+ * be redelivered. In that world it can assert something strictly stronger than this class does (a
+ * gapless {@code +1} value sequence of exactly the produced size), which doubles as a loss/duplicate
+ * check. Scoping it to a window would weaken it for its own caller, and it fails on the first duplicate
+ * under churn, so the two are kept separate and cross-referenced rather than merged. The unit-level
+ * assertions in {@code WorkManagerTest} ({@code orderedByKeyParallel},
+ * {@code testOrderedInFlightShouldBlockQueue}) check the same guarantee one layer down - that a shard
+ * hands out one record at a time in offset order - also with no epochs in play.
+ *
+ * <h2>What this does NOT assert</h2>
+ *
+ * "Asserts ordering under churn" is easy to read as "no two owners ever concurrently touch a key
+ * across a revoke", and it does not mean that. Overlap and order are compared only WITHIN a window,
+ * so a <b>cross-epoch overlap</b> - an old-epoch delivery still executing on a stopped-but-not-drained
+ * owner while the new owner processes the same key in a new epoch - falls into two different windows
+ * and is not raised as {@code LEDGER_KEY_CONCURRENCY}. That is the window doing its job:
+ * a new epoch legitimately opens a new window, which is what keeps at-least-once redelivery after a
+ * revoke from reading as a violation.
+ *
+ * <p><b>The data to close that gap is already here.</b> Nothing is discarded: every {@link Delivery}
+ * carries its {@code epoch} and {@code incarnationId}, and the whole history is retained - the window
+ * is a grouping the ANALYSIS chooses, not a limit on what was recorded. So a cross-epoch check is a
+ * function nobody has written yet rather than a question this ledger cannot answer. It would look
+ * for a delivery with {@code endSeq == null} in one epoch, and a delivery of the same key and
+ * partition in a LATER epoch whose {@code startSeq} falls after it - which is an overlap on the same
+ * evidence the within-window check already uses. What makes it a separate piece of work is not the
+ * data but the calibration: a revoked owner finishing its in-flight record is legitimate, so such a
+ * check needs a defensible bound on how long an old-epoch delivery may still be running before it
+ * counts as a violation, and picking that number is the whole job.
+ *
+ * <p>It is worth stating explicitly because that gap is the shape of a product bug this repo has
+ * already found once - the drain-path zombie in
+ * {@code docs/solutions/test-flakiness/pc-silent-stall-under-contention-2026-07-29.md}, fixed in
+ * astubbs#80 - so a reader could reasonably assume this ledger now covers it. It does not, and it is
+ * not trying to: {@code AbstractRevokeUnderWorkScenario} names the same boundary from the scenario
+ * side ("a drain opens the Class 1 drain-zombie window, which can mask the Class 2 mechanism it
+ * isolates"). Detecting cross-epoch overlap needs an instrument that outlives an epoch, which is a
+ * different tool from this one.
+ *
+ * <h2>It is an event register: record facts, decide meaning at the end</h2>
+ *
+ * The recorder writes down what happened - key, offset, start, end - and nothing else. Interpretation
+ * belongs to {@link #check}, which runs once, with the whole run in front of it. Keeping those two
+ * jobs apart is not tidiness; it is the reason the ledger can be trusted, because a fact discarded
+ * while the run is still going cannot be reconsidered once the run is over.
+ *
+ * <p><b>The analysis pass must not throw information away either, and that is where this went
+ * wrong.</b> A delivery with no end time is a FACT - the worker never finished. The first version
+ * read that fact, concluded "end unknown", and deleted the window's running end, so the next
+ * delivery had nothing to compare against. It had turned a recorded fact into a forgotten one, and
+ * the detector reported green because it had stopped looking rather than because nothing was wrong.
+ * The information was always there; only the analysis discarded it.
+ *
+ * <p>So the rule for anything added here: <b>never delete, only interpret</b>. A missing end means
+ * still running, which makes every later start in that window a certain overlap - no guess, and no
+ * data thrown away to reach it.
+ *
+ * <p><b>Which is why absence is {@code null} here and never a sentinel.</b> A sentinel is
+ * type-compatible with the arithmetic: {@code Long.MAX_VALUE} slides into {@code Math::max}, into a
+ * {@code >} comparison, into a subtraction, and the calculation simply happens - silently, on a
+ * number the run never produced. A {@code null Long} cannot. It will not compile into arithmetic,
+ * and at runtime it throws rather than returning a plausible answer, so the compiler is what forces
+ * every site touching the value to decide what "we do not know" means there. That is the difference
+ * between a rule written down and a rule enforced.
+ *
+ * <p>This is not hypothetical: the first fix for the discarded-end bug used {@code Long.MAX_VALUE}
+ * as the open-interval marker and reintroduced the same class of error one layer down - a max
+ * computed over a fabricated value, which then leaked into the overlap report as "ended at seq
+ * 9223372036854775807". <b>Do not take shortcuts in capturing reality</b>: record what happened, and
+ * let the type system carry the fact that sometimes nothing did.
+ *
+ * <p><b>And the reason the rule is absolute rather than a preference: a check that does not hold all
+ * the information its decision needs cannot be testing what it claims to test.</b> Not testing it
+ * weakly - not testing it. Once the end time was discarded, no amount of care in the comparison that
+ * followed could recover the answer, because the input to that comparison was gone. That is why this
+ * failed silently instead of loudly: a check starved of its inputs does not error, it returns
+ * "nothing found", which is indistinguishable from a healthy run. Any future change here should be
+ * read against that test - after it, does the assessment still hold everything it needs to decide?
+ *
+ * @see ProgressProbe#ledger the loss / bounded-duplicate half of the same end-of-run ledger
+ */
+@Slf4j
+public final class KeyOrderLedger {
+
+    /** Reported problems are capped: a systemic break produces thousands of identical lines. */
+    static final int MAX_REPORTED_PER_KIND = 5;
+
+    private KeyOrderLedger() {
+    }
+
+    /**
+     * One execution of the user function, bracketed. {@code startSeq}/{@code endSeq} come from a single
+     * shared counter, so they order events across every worker thread in the fleet - the observation
+     * order the check replays. {@code endSeq} stays {@code null} for a delivery still running when the
+     * run was torn down - the absence of an end, never a value standing in for one.
+     */
+    @Getter
+    public static class Delivery {
+
+        private final String incarnationId;
+        private final int partition;
+        private final long epoch;
+        private final String key;
+        private final long offset;
+        private final long startSeq;
+        /** {@code null} until {@link #finished} runs - absence of an end, not a value standing in for one. */
+        private volatile Long endSeq;
+
+        public Delivery(String incarnationId, int partition, long epoch, String key, long offset,
+                        long startSeq, Long endSeq) {
+            this.incarnationId = incarnationId;
+            this.partition = partition;
+            this.epoch = epoch;
+            this.key = key;
+            this.offset = offset;
+            this.startSeq = startSeq;
+            this.endSeq = endSeq;
+        }
+
+        /** The ordering window this delivery belongs to - see the class javadoc for why each part is in it. */
+        String window() {
+            return incarnationId + "|p" + partition + "|e" + epoch + "|" + key;
+        }
+
+        @Override
+        public String toString() {
+            return "offset " + offset + " of key '" + key + "' [" + window() + "]";
+        }
+    }
+
+    /**
+     * Live recorder handed to a scenario's user function. Allocation is one {@link Delivery} per record
+     * (not per event), so a 60k-record run holds 60k objects - the history has to survive to the end of
+     * the run because {@link #check} is a pure replay, which is what makes it unit-testable against
+     * constructed histories instead of only against live chaos.
+     */
+    public static class Recorder {
+
+        private final AtomicLong sequence = new AtomicLong();
+        @Getter
+        private final Queue<Delivery> history = new ConcurrentLinkedQueue<>();
+
+        /**
+         * Call as the FIRST thing the user function does, and pass the returned handle to
+         * {@link #finished} in a {@code finally}.
+         */
+        public Delivery started(String incarnationId, PollContext<String, String> context) {
+            var record = context.getSingleConsumerRecord();
+            long epoch = epochOf(context);
+            var delivery = new Delivery(incarnationId, record.partition(), epoch, record.key(),
+                    record.offset(), sequence.incrementAndGet(), null);
+            history.add(delivery);
+            return delivery;
+        }
+
+        public void finished(Delivery delivery) {
+            delivery.endSeq = sequence.incrementAndGet();
+        }
+
+        /**
+         * PC's own per-partition assignment epoch, carried ON the record rather than read from a
+         * counter at execution time. That is what makes the window race-free: a record taken as work
+         * in epoch N and started on a worker thread after a rebalance bumped the partition to N+1
+         * still reports N, so it lands in the window it was actually taken from.
+         * <p>
+         * {@code PollContext#streamInternal} and {@code RecordContextInternal#getWorkContainer} are both
+         * public API, so this needs no production change and no same-package accessor.
+         */
+        private static long epochOf(PollContext<String, String> context) {
+            return context.streamInternal()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("poll context held no record: " + context))
+                    .getWorkContainer()
+                    .getEpoch();
+        }
+    }
+
+    /**
+     * Replays a delivery history and returns the ordering violations (empty = the ordering ledger
+     * balances). Pure function - the history may be live-recorded or constructed, which is how the
+     * boundary is pinned deterministically in {@code KeyOrderLedgerIT} rather than only by chaos runs.
+     * <p>
+     * The history is sorted by {@code startSeq} rather than trusted in iteration order: the sequence is
+     * claimed atomically but the append that follows it is not, so two worker threads can enqueue in
+     * the opposite order to the one they started in.
+     *
+     * @param history every {@link Delivery} of the run, in any order
+     * @return list of ledger violations (empty = balanced)
+     */
+    public static List<String> check(Collection<Delivery> history) {
+        List<String> orderProblems = new ArrayList<>();
+        List<String> overlapProblems = new ArrayList<>();
+        long orderCount = 0;
+        long overlapCount = 0;
+        long comparedCount = 0;
+
+        var byStartSeq = history.stream()
+                .sorted(Comparator.comparingLong(Delivery::getStartSeq))
+                .collect(Collectors.toList());
+
+        Map<String, Long> highestOffsetStarted = new HashMap<>();
+        Map<String, Long> latestEndSeq = new HashMap<>();
+        // A window with a delivery that never ended. Kept as its own FACT rather than folded into
+        // latestEndSeq as Long.MAX_VALUE: that sentinel is a real, valid end value standing in for
+        // "no end", so it fabricates information the run never produced - and it leaked, printing
+        // "ended at seq 9223372036854775807" in the very report meant to explain the overlap.
+        Set<String> windowsWithOpenDelivery = new HashSet<>();
+        Set<String> assertingWindows = new HashSet<>();
+        Set<String> keysSeen = new HashSet<>();
+
+        for (Delivery delivery : byStartSeq) {
+            String window = delivery.window();
+            keysSeen.add(delivery.getKey());
+
+            Long previousOffset = highestOffsetStarted.get(window);
+            if (previousOffset == null) {
+                highestOffsetStarted.put(window, delivery.getOffset());
+            } else {
+                assertingWindows.add(window);
+                comparedCount++;
+                if (delivery.getOffset() < previousOffset) {
+                    // strictly LOWER only: an equal offset is a redelivery of the same record, which is
+                    // the duplicate ledger's business, not an ordering regression
+                    orderCount++;
+                    if (orderProblems.size() < MAX_REPORTED_PER_KIND) {
+                        orderProblems.add(delivery + " was started after offset " + previousOffset
+                                + " of the same key, in the SAME assignment epoch on the SAME instance");
+                    }
+                } else {
+                    highestOffsetStarted.put(window, delivery.getOffset());
+                }
+
+                Long previousEnd = latestEndSeq.get(window);
+                boolean openDeliveryHere = windowsWithOpenDelivery.contains(window);
+                if (openDeliveryHere || (previousEnd != null && previousEnd > delivery.getStartSeq())) {
+                    overlapCount++;
+                    if (overlapProblems.size() < MAX_REPORTED_PER_KIND) {
+                        overlapProblems.add(delivery + " started at seq " + delivery.getStartSeq()
+                                + " while an earlier delivery of the same key was still in flight ("
+                                + (openDeliveryHere ? "that delivery never finished" : "it ended at seq " + previousEnd)
+                                + ")");
+                    }
+                }
+            }
+
+            if (delivery.getEndSeq() != null) {
+                latestEndSeq.merge(window, delivery.getEndSeq(), Math::max);
+            } else {
+                // No end recorded is a FACT, and it is recorded as one. finished() is
+                // finally-guaranteed ({@code ChaosScenarioBase#newInstance}), so no end means the
+                // delivery is genuinely still running - which makes any later start in the same
+                // window a CERTAIN overlap, with no guess and no invented end value involved.
+                // Legitimate redelivery of a wedged record opens a NEW window (epoch bump on
+                // revoke+assign, or a new incarnation), so this cannot fire on correct behaviour.
+                // Deleting the window's end here instead was the original bug: it silently disabled
+                // the overlap half for exactly the confluentinc#857 wedge shape this detector exists
+                // to catch.
+                windowsWithOpenDelivery.add(window);
+            }
+        }
+
+        List<String> problems = new ArrayList<>();
+        if (!orderProblems.isEmpty()) {
+            problems.add("LEDGER_KEY_ORDER: " + orderCount + " per-key ordering regression(s) - "
+                    + "records of one key ran out of offset order within one instance+partition+epoch, which "
+                    + "is the guarantee PC exists to keep (sample: " + orderProblems + ")");
+        }
+        if (!overlapProblems.isEmpty()) {
+            problems.add("LEDGER_KEY_CONCURRENCY: " + overlapCount + " overlapping delivery pair(s) - "
+                    + "two records of one key were in flight at once within one instance+partition+epoch, so "
+                    + "per-key order was not merely reordered but abandoned (sample: " + overlapProblems + ")");
+        }
+        if (assertingWindows.isEmpty()) {
+            problems.add("LEDGER_ORDER_VACUOUS: no key was delivered twice inside one instance+partition+epoch, "
+                    + "so the ordering ledger asserted NOTHING over " + byStartSeq.size() + " deliveries across "
+                    + keysSeen.size() + " keys - the workload must repeat keys (and process them in KEY order) "
+                    + "for this check to mean anything");
+        }
+
+        // comparedDeliveries is the "how much did this assert" number: a delivery only counts once it has
+        // a predecessor in its own window, so heavy churn (short windows) shows up here as a smaller
+        // number rather than as a quietly weaker check
+        log.info("[chaos-ledger] ordering: deliveries={} comparedDeliveries={} keys={} windows={} "
+                        + "assertingWindows={} orderRegressions={} overlaps={}",
+                byStartSeq.size(), comparedCount, keysSeen.size(), highestOffsetStarted.size(),
+                assertingWindows.size(), orderCount, overlapCount);
+        return problems;
+    }
+
+    /** Null-tolerant convenience for scenarios that make no ordering claim - see {@code ChaosScenarioBase}. */
+    public static List<String> checkIfRecording(Recorder recorder) {
+        return recorder == null ? new ArrayList<>() : check(recorder.getHistory());
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/KeyOrderLedgerIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/KeyOrderLedgerIT.java
@@ -1,0 +1,329 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static pl.tlinkowski.unij.api.UniLists.of;
+
+/**
+ * Boundary regression for {@link KeyOrderLedger#check} - the per-key ordering half of the end-of-run
+ * correctness ledger, pinned against CONSTRUCTED histories rather than only against live chaos.
+ * <p>
+ * Both directions are the point, and the second one is the one that decides whether the check survives
+ * contact with the suite:
+ * <ul>
+ *   <li>a genuine ordering violation must be caught - a bound that cannot fire is decoration;</li>
+ *   <li>the LEGITIMATE at-least-once redelivery that churn produces on purpose (an assignment moves, a
+ *   revoked partition's uncommitted work is re-run from the last commit, so an earlier offset follows a
+ *   later one) must NOT be caught. A detector that fires on correct behaviour gets disabled within a
+ *   week, and takes the suite's credibility with it.</li>
+ * </ul>
+ * Pure function, no broker - and deliberately NOT tagged {@code chaos}, so it gates every default
+ * integration build, exactly like its sibling {@link ProgressProbeLedgerIT}.
+ */
+class KeyOrderLedgerIT {
+
+    private static final String PC_A = "PC-1#1";
+    private static final String PC_B = "PC-2#1";
+    private static final int P0 = 0;
+
+    /** A delivery that ran to completion between {@code startSeq} and {@code endSeq}. */
+    /**
+     * Builds a delivery that FINISHED. Overloaded so the fixtures can keep writing plain integer
+     * literals. Java widens {@code int -> long} or boxes {@code long -> Long}, never both in one
+     * step, so without this every end value would need an {@code L} suffix - 34 call sites edited to
+     * satisfy a signature rather than to say anything.
+     */
+    private static KeyOrderLedger.Delivery delivery(String incarnation, int partition, long epoch, String key,
+                                             long offset, long startSeq, int endSeq) {
+        return delivery(incarnation, partition, epoch, key, offset, startSeq, Long.valueOf(endSeq));
+    }
+
+    /**
+     * The real one. {@code endSeq} is {@code null} for a delivery that never finished - the absence
+     * of an end, not a value standing in for one. {@code null} is not applicable to the {@code int}
+     * overload above, so it resolves here unambiguously.
+     */
+    private static KeyOrderLedger.Delivery delivery(String incarnation, int partition, long epoch, String key,
+                                             long offset, long startSeq, Long endSeq) {
+        return new KeyOrderLedger.Delivery(incarnation, partition, epoch, key, offset, startSeq, endSeq);
+    }
+
+    /** A sequential, non-overlapping run of offsets in one window, starting at sequence {@code fromSeq}. */
+    private static List<KeyOrderLedger.Delivery> sequential(String incarnation, long epoch, String key,
+                                                            long fromSeq, long... offsets) {
+        List<KeyOrderLedger.Delivery> deliveries = new ArrayList<>();
+        long seq = fromSeq;
+        for (long offset : offsets) {
+            deliveries.add(delivery(incarnation, P0, epoch, key, offset, seq, seq + 1));
+            seq += 2;
+        }
+        return deliveries;
+    }
+
+    // --- the check must be able to fire ---
+
+    @Test
+    void outOfOrderInsideOneWindowIsCaught() {
+        // one instance, one partition, one epoch, one key: 10, then 12, then 11 - a real regression
+        List<KeyOrderLedger.Delivery> history = of(
+                delivery(PC_A, P0, 4, "k-1", 10, 1, 2L),
+                delivery(PC_A, P0, 4, "k-1", 12, 3, 4L),
+                delivery(PC_A, P0, 4, "k-1", 11, 5, 6L));
+
+        List<String> problems = KeyOrderLedger.check(history);
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0)).contains("LEDGER_KEY_ORDER");
+        assertThat(problems.get(0)).contains("1 per-key ordering regression");
+        assertThat(problems.get(0)).contains("offset 11 of key 'k-1'");
+    }
+
+    @Test
+    void twoDeliveriesOfOneKeyInFlightAtOnceIsCaught() {
+        // offsets ascend, so the order check is happy - but the two executions OVERLAP (offset 11 starts
+        // at seq 2, before offset 10 ends at seq 4), which abandons per-key order rather than reordering it
+        List<KeyOrderLedger.Delivery> history = of(
+                delivery(PC_A, P0, 4, "k-1", 10, 1, 4L),
+                delivery(PC_A, P0, 4, "k-1", 11, 2, 3L));
+
+        List<String> problems = KeyOrderLedger.check(history);
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0)).contains("LEDGER_KEY_CONCURRENCY");
+        assertThat(problems.get(0)).contains("1 overlapping delivery pair");
+    }
+
+    @Test
+    void aRegressionIsFoundEvenWhenTheHistoryArrivesOutOfOrder() {
+        // the live recorder claims its sequence atomically but appends after, so two worker threads can
+        // enqueue in the opposite order to the one they started in - check() sorts by startSeq, and this
+        // is what proves it does
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>(of(
+                delivery(PC_A, P0, 4, "k-1", 10, 1, 2L),
+                delivery(PC_A, P0, 4, "k-1", 12, 3, 4L),
+                delivery(PC_A, P0, 4, "k-1", 11, 5, 6L)));
+        Collections.shuffle(history, new Random(42));
+
+        assertThat(KeyOrderLedger.check(history).get(0)).contains("LEDGER_KEY_ORDER");
+    }
+
+    @Test
+    void everyRegressionIsCountedButOnlyASampleIsPrinted() {
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>();
+        history.add(delivery(PC_A, P0, 4, "k-1", 1_000, 1, 2L));
+        long seq = 3;
+        for (int offset = 0; offset < KeyOrderLedger.MAX_REPORTED_PER_KIND + 3; offset++) {
+            history.add(delivery(PC_A, P0, 4, "k-1", offset, seq, seq + 1));
+            seq += 2;
+        }
+
+        List<String> problems = KeyOrderLedger.check(history);
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0)).contains((KeyOrderLedger.MAX_REPORTED_PER_KIND + 3) + " per-key ordering regression");
+        // the sample is capped: a systemic break must not print thousands of identical lines
+        assertThat(problems.get(0)).doesNotContain("offset " + (KeyOrderLedger.MAX_REPORTED_PER_KIND + 2) + " of key");
+    }
+
+    @Test
+    void everyOverlapIsCountedButOnlyASampleIsPrinted() {
+        // sibling of the regression-cap test above, for the LEDGER_KEY_CONCURRENCY kind: one long
+        // delivery spans the window, every later one overlaps it, offsets ascend so order stays quiet
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>();
+        history.add(delivery(PC_A, P0, 4, "k-1", 10, 1, 1_000));
+        long seq = 2;
+        int overlapping = KeyOrderLedger.MAX_REPORTED_PER_KIND + 3;
+        for (int i = 1; i <= overlapping; i++) {
+            history.add(delivery(PC_A, P0, 4, "k-1", 10 + i, seq, seq + 1));
+            seq += 2;
+        }
+
+        List<String> problems = KeyOrderLedger.check(history);
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0)).contains(overlapping + " overlapping delivery pair");
+        // the sample is capped: a systemic break must not print thousands of identical lines
+        assertThat(problems.get(0)).doesNotContain("offset " + (10 + overlapping) + " of key");
+    }
+
+    // --- and must NOT fire on the legitimate redelivery churn produces on purpose ---
+
+    @Test
+    void redeliveryAfterARevokeOpensANewWindow() {
+        // THE false-positive case: epoch 4 processed 10,11,12; the partition was revoked and reassigned
+        // (epoch 5), so uncommitted work is legitimately re-run from the last commit - 10 after 12
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>();
+        history.addAll(sequential(PC_A, 4, "k-1", 1, 10, 11, 12));
+        history.addAll(sequential(PC_A, 5, "k-1", 7, 10, 11, 12));
+
+        assertWithMessage("redelivery after a revoke is the contract working, not a violation")
+                .that(KeyOrderLedger.check(history)).isEmpty();
+    }
+
+    @Test
+    void redeliveryToAnotherInstanceIsNotAViolation() {
+        // the assignment moved to a different member, which re-runs from the last commit
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>();
+        history.addAll(sequential(PC_A, 4, "k-1", 1, 10, 11, 12));
+        history.addAll(sequential(PC_B, 0, "k-1", 7, 10, 11, 12));
+
+        assertThat(KeyOrderLedger.check(history)).isEmpty();
+    }
+
+    @Test
+    void aRestartOfTheSameInstanceIsNotAViolation() {
+        // a chaos restart builds a fresh PC whose epoch counter starts again at zero - keying the window
+        // on the chaos instance id instead of the INCARNATION would collide these two lifetimes and call
+        // the second one's legitimate redelivery a regression
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>();
+        history.addAll(sequential("PC-3#1", 0, "k-1", 1, 10, 11, 12));
+        history.addAll(sequential("PC-3#2", 0, "k-1", 7, 10, 11, 12));
+
+        assertThat(KeyOrderLedger.check(history)).isEmpty();
+    }
+
+    @Test
+    void aHeavyRecordStillRunningWhenItsPartitionIsRevokedIsNotAnOverlap() {
+        // offset 10 of epoch 4 is a heavy record: PC does not interrupt in-flight work on revoke, so it
+        // is still running (ends at seq 9) while epoch 5's redelivery of 10 and 11 runs. Different
+        // windows - the epoch is read off the record's own WorkContainer, so the straggler keeps epoch 4
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>(of(
+                delivery(PC_A, P0, 4, "k-1", 9, 1, 2L),
+                delivery(PC_A, P0, 4, "k-1", 10, 3, 9L),
+                delivery(PC_A, P0, 5, "k-1", 10, 4, 6L),
+                delivery(PC_A, P0, 5, "k-1", 11, 7, 8L)));
+
+        assertThat(KeyOrderLedger.check(history)).isEmpty();
+    }
+
+    @Test
+    void thePartitionIsPartOfTheWindow() {
+        // the KEY shard carries the record's TopicPartition, so the same key on two partitions is two
+        // independent orders (only reachable with a non-default partitioner, but the window says so)
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>(of(
+                delivery(PC_A, 0, 4, "k-1", 10, 1, 2L),
+                delivery(PC_A, 0, 4, "k-1", 11, 3, 4L),
+                delivery(PC_A, 7, 4, "k-1", 5, 5, 6L),
+                delivery(PC_A, 7, 4, "k-1", 6, 7, 8L)));
+
+        assertThat(KeyOrderLedger.check(history)).isEmpty();
+    }
+
+    @Test
+    void differentKeysAreIndependentOfEachOther() {
+        // the concurrency PC exists to give: k-2's whole sequence runs interleaved with, and out of
+        // offset order relative to, k-1's - which is not an order anyone promised
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>(of(
+                delivery(PC_A, P0, 4, "k-1", 40, 1, 4L),
+                delivery(PC_A, P0, 4, "k-2", 5, 2, 3L),
+                delivery(PC_A, P0, 4, "k-2", 6, 5, 6L),
+                delivery(PC_A, P0, 4, "k-1", 41, 7, 8L)));
+
+        assertThat(KeyOrderLedger.check(history)).isEmpty();
+    }
+
+    @Test
+    void theSameOffsetTwiceIsTheDuplicateLedgersBusiness() {
+        // a redelivery of the SAME record is a duplicate, bounded by ProgressProbe#ledger - it is not an
+        // out-of-order execution, and reporting it here would double-count one event as two defects
+        List<KeyOrderLedger.Delivery> history = sequential(PC_A, 4, "k-1", 1, 10, 10, 11);
+
+        assertThat(KeyOrderLedger.check(history)).isEmpty();
+    }
+
+    @Test
+    void aWedgedDeliveryStillOverlapsLaterStartsInItsWindow() {
+        // THE confluentinc#857 wedge shape: offset 10 never finishes (a stuck worker holds the shard),
+        // yet PC hands offset 11 of the SAME window to another worker. Offsets ascend, so the order
+        // half is silent - only the overlap half can see this, and a never-finished delivery overlaps
+        // every later start in its window BY CONSTRUCTION (finished() is finally-guaranteed, so
+        // UNFINISHED means genuinely still running, not instrumentation noise)
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>(of(
+                delivery(PC_A, P0, 4, "k-1", 10, 1, null),
+                delivery(PC_A, P0, 4, "k-1", 11, 2, 3L)));
+
+        List<String> problems = KeyOrderLedger.check(history);
+
+        assertWithMessage("a wedged delivery is in flight for the rest of the run - a later same-window "
+                + "start is a certain overlap, not an unknowable one")
+                .that(problems).hasSize(1);
+        assertThat(problems.get(0)).contains("LEDGER_KEY_CONCURRENCY");
+    }
+
+    @Test
+    void anUnfinishedDeliveryReportsBothTheRegressionAndTheOverlap() {
+        // still running at teardown: the ordering regression (11 after 12) is reported, AND the
+        // never-finished 12 is an open interval, so 11 starting inside it is also a certain overlap
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>(of(
+                delivery(PC_A, P0, 4, "k-1", 12, 1, null),
+                delivery(PC_A, P0, 4, "k-1", 11, 2, 3L)));
+
+        List<String> problems = KeyOrderLedger.check(history);
+
+        assertThat(problems).hasSize(2);
+        assertThat(problems.get(0)).contains("LEDGER_KEY_ORDER");
+        assertThat(problems.get(1)).contains("LEDGER_KEY_CONCURRENCY");
+    }
+
+    @Test
+    void aFinishedEndIsNotForgottenWhenAnUnfinishedDeliveryFollowsIt() {
+        // d1 ends at seq 10; d2 (unfinished) is caught overlapping d1; d3 starts at seq 4, inside
+        // BOTH d1's known interval and d2's open one - the known end must survive d2, not be wiped
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>(of(
+                delivery(PC_A, P0, 4, "k-1", 20, 1, 10L),
+                delivery(PC_A, P0, 4, "k-1", 21, 2, null),
+                delivery(PC_A, P0, 4, "k-1", 22, 4, 5L)));
+
+        List<String> problems = KeyOrderLedger.check(history);
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0)).contains("LEDGER_KEY_CONCURRENCY");
+        assertThat(problems.get(0)).contains("2 overlapping delivery pair");
+    }
+
+    @Test
+    void anOrderedRunIsClean() {
+        assertThat(KeyOrderLedger.check(sequential(PC_A, 4, "k-1", 1, 10, 11, 12, 13))).isEmpty();
+    }
+
+    // --- and must say so when it asserted nothing ---
+
+    @Test
+    void aUniqueKeyPerRecordIsReportedAsVacuous() {
+        // exactly what W1/W4 produce: every window holds one delivery, so nothing is ever compared. The
+        // check going quiet must be a failure, not a pass
+        List<KeyOrderLedger.Delivery> history = new ArrayList<>(of(
+                delivery(PC_A, P0, 4, "key-1", 10, 1, 2L),
+                delivery(PC_A, P0, 4, "key-2", 11, 3, 4L),
+                delivery(PC_A, P0, 4, "key-3", 12, 5, 6L)));
+
+        List<String> problems = KeyOrderLedger.check(history);
+
+        assertThat(problems).hasSize(1);
+        assertThat(problems.get(0)).contains("LEDGER_ORDER_VACUOUS");
+        assertThat(problems.get(0)).contains("3 deliveries across 3 keys");
+    }
+
+    @Test
+    void anEmptyHistoryIsVacuous() {
+        assertThat(KeyOrderLedger.check(of()).get(0)).contains("LEDGER_ORDER_VACUOUS");
+    }
+
+    @Test
+    void aScenarioThatMakesNoOrderingClaimRecordsNothingAndIsNotJudged() {
+        // the UNORDERED scenarios pass no recorder at all, which must be silence rather than a vacuity
+        // complaint about a history they never had
+        assertThat(KeyOrderLedger.checkIfRecording(null)).isEmpty();
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
@@ -5,6 +5,7 @@ package bz.stub.parallelconsumer.integrationTests.chaostests;
  */
 
 import bz.stub.parallelconsumer.integrationTests.utils.KafkaClientUtils;
+import bz.stub.parallelconsumer.integrationTests.utils.ManagedPCInstance;
 import lombok.Getter;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,12 @@ import static pl.tlinkowski.unij.api.UniLists.of;
  * <ul>
  *   <li><b>Progress watermark</b>: while work remains, fleet-wide consumed count must advance within
  *   {@link #NO_PROGRESS_WINDOW} (generalises the confluentinc#857 investigation's "no progress for 11s" check).</li>
+ *   <li><b>Instance progress</b> ({@code INSTANCE_STALL/NO_WORK_COMPLETED}): the same shape one
+ *   granularity finer - for each LIVE fleet member that holds work (queued in shards or out for
+ *   processing, read from PC's own {@code WorkManager}), a work result must be returned within
+ *   {@link #INSTANCE_STALL_BOUND}. Wired per-run via {@link #withInstanceProgress}; inactive (like
+ *   the watermark) in ambient mode. See the bound's javadoc for why this is instance-level rather
+ *   than shard-level, and why it cannot fire on a merely-busy instance.</li>
  *   <li><b>Zombie-member / rebalance dwell</b>: the group must not dwell in
  *   {@code PREPARING_REBALANCE}/{@code COMPLETING_REBALANCE} beyond {@link #REBALANCE_DWELL_BOUND}.
  *   Keyed on protocol-unresponsiveness, NOT on "member holds partitions with zero consumption" - a
@@ -92,8 +99,54 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
      * artifact-free but has not yet reproduced a true unbounded Class 2 stall on master (the confluentinc#857
      * root-cause stall is probabilistic); the probe ships GREEN-calibrated with peaks measured. */
     public static final Duration LAG_STAGNATION_BOUND = Duration.ofSeconds(150);
+    /**
+     * Appended to every Class 2 violation so the interpretation arrives WITH the failure, not in a
+     * document the reader must first decide to open. The gap it closes cost a measured day: three of
+     * four 2026-08-19 arms failed this check while progressing normally, because the natural reading
+     * of the bare message - "the library has stalled" - is wrong.
+     */
+    static final String CLASS2_INTERPRETATION =
+            "NOTE: this bound is a TIMING measurement, not a correctness verdict - a partition's "
+                    + "committed offset cannot advance past one incomplete record, so a slow or "
+                    + "repeatedly-redelivered record pins the watermark while the shard behind it "
+                    + "completes work normally, and exceeding the bound does NOT mean the consumer is "
+                    + "stalled or incorrect. Before concluding a defect, re-run with "
+                    + "-Dchaos.diagnoseStallRecovery=true (keeps the run observing instead of aborting) "
+                    + "and check whether the backlog drains: on seed 4734674029169027864 the eager arm "
+                    + "trips this bound 53 times and still drains completely - see "
+                    + "docs/inflight/test-class2-probe-asserts-timing-not-correctness.md";
     /** Ignore trivial tails - the Class 2 signature is real backlog going nowhere. */
     public static final long LAG_STAGNATION_MIN_LAG = 50;
+    /**
+     * INSTANCE-progress probe: no live instance may hold work while returning no work result for
+     * longer than this. The liveness claim it makes is the one the Class 2 lag bound only
+     * approximates: {@code CLASS2_STALL} watches a partition's COMMITTED offset, which one incomplete
+     * record legitimately pins while the shard behind it completes work continuously - so a busy
+     * fleet and a wedged fleet look identical to it (measured 2026-08-19, seed 4734674029169027864:
+     * four arms all drained fully, three of four still tripped the 150s bound). This probe instead
+     * watches COMPLETIONS: any returned work result re-arms it, so it structurally cannot fire on an
+     * instance that is slow-but-progressing - only on one that is holding work and finishing nothing.
+     * <p>
+     * <b>Granularity is per INSTANCE, not per shard, and that is a reachability constraint, not the
+     * ideal.</b> The owner's formulation is per shard ("no shard should go {@code INSTANCE_STALL_BOUND}
+     * without returning a work result"), but "which shards hold queued work" lives in
+     * {@code ShardManager}'s private {@code processingShards} map with no public accessor, and this
+     * suite does not add main-code accessors for a probe. Per instance is still the confluentinc#857
+     * wedge signature exactly: work results are counted where {@code WorkManager#onSuccessResult}
+     * runs - PC's CONTROL thread - so a deadlocked control loop freezes the count even while worker
+     * threads finish records and heartbeats keep flowing. What per-instance cannot see is one wedged
+     * shard on an instance whose other shards keep completing; that case remains
+     * {@code CLASS2_STALL}'s, false positives and all.
+     * <p>
+     * Bound arithmetic (why 150s cannot fire legitimately): a completion arrives at the end of every
+     * user-function execution, so the longest legitimate GAP is one heaviest record - W1's 45s dwell,
+     * 3.3x under the bound. The other legitimate quiet stretch is an eager storm, where completions
+     * of revoked in-flight work are dropped as stale (no listener fire): storm (60s) plus one
+     * eviction horizon (30s) is 90s, still 60s under. Sharing {@link #LAG_STAGNATION_BOUND}'s 150s
+     * figure is deliberate - it keeps the two detectors' verdicts comparable on the same run: a run
+     * where Class 2 fires and this stays silent is measured slow-but-progressing, not wedged.
+     */
+    public static final Duration INSTANCE_STALL_BOUND = Duration.ofSeconds(150);
     private static final Duration SAMPLE_INTERVAL = Duration.ofSeconds(1);
     /** A probe that cannot sample is a probe silently passing - after this many consecutive sampling
      * failures the degradation itself becomes a violation (false-GREEN guard), instead of the run
@@ -130,6 +183,95 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
     /** Chaos mode's fleet consumed-count; null in {@link Mode#AMBIENT_OBSERVER} (progress watermark inactive). */
     private final LongSupplier totalConsumed;
     private final long expectedTotal;
+    /**
+     * What the instance-progress probe samples from one fleet member. An interface rather than
+     * {@code ManagedPCInstance} directly so the detector's decision logic is broker-free testable
+     * against fake views ({@code InstanceStallProbeIT}) - the same pure-replay pattern as
+     * {@link #ledger} and {@code KeyOrderLedger#check}.
+     */
+    public interface InstanceProgressView {
+        int instanceId();
+
+        /**
+         * Started, not mid-stop/restart, and its PC is up and not failed. The chaos harness stops and
+         * restarts members constantly; a stopped or restarting instance holds torn-down state and must
+         * never be reported as stalled.
+         */
+        boolean isLive();
+
+        /** Work queued in this instance's shards awaiting selection ({@code WorkManager}'s own count). */
+        long queuedInShards();
+
+        /** Records this instance currently has out for processing ({@code WorkManager}'s own count). */
+        long outForProcessing();
+
+        /** Monotone count of work results returned - see {@code ManagedPCInstance#workResultsReturned}. */
+        long workResultsReturned();
+
+        /**
+         * Identity that changes when the instance brings up a NEW PC (a restart). A fresh incarnation
+         * gets a fresh full bound-window rather than inheriting the old PC's silence.
+         */
+        Object incarnationMarker();
+
+        /** The live adapter over a real fleet member, reading PC's own {@code WorkManager} state. */
+        static InstanceProgressView of(ManagedPCInstance pc) {
+            return new InstanceProgressView() {
+                @Override
+                public int instanceId() {
+                    return pc.getInstanceId();
+                }
+
+                @Override
+                public boolean isLive() {
+                    var parallelConsumer = pc.getParallelConsumer();
+                    return pc.isStarted() && !pc.isClosePending()
+                            && parallelConsumer != null && !parallelConsumer.isClosedOrFailed();
+                }
+
+                @Override
+                public long queuedInShards() {
+                    var parallelConsumer = pc.getParallelConsumer();
+                    // the count can be transiently negative by its own javadoc (counter races) - floor it
+                    return parallelConsumer == null ? 0
+                            : Math.max(0, parallelConsumer.getWm().getNumberOfWorkQueuedInShardsAwaitingSelection());
+                }
+
+                @Override
+                public long outForProcessing() {
+                    var parallelConsumer = pc.getParallelConsumer();
+                    return parallelConsumer == null ? 0
+                            : Math.max(0, parallelConsumer.getWm().getNumberRecordsOutForProcessing());
+                }
+
+                @Override
+                public long workResultsReturned() {
+                    return pc.getWorkResultsReturnedCount();
+                }
+
+                @Override
+                public Object incarnationMarker() {
+                    return pc.getParallelConsumer();
+                }
+            };
+        }
+    }
+
+    /** Instance-progress bookkeeping: the completion count last seen, which PC it was seen on, and
+     * since when it has not advanced. */
+    @Value
+    private static class InstanceProgressMark {
+        long workResultsReturned;
+        Object incarnation;
+        Instant since;
+    }
+
+    /** Fleet supplier for the instance-progress probe; null (ambient mode, or not wired) = inactive. */
+    private volatile Supplier<List<InstanceProgressView>> instanceProgressSupplier;
+    private final Map<Integer, InstanceProgressMark> instanceProgressMarks = new ConcurrentHashMap<>();
+    @Getter
+    private volatile long peakInstanceStallMs = 0;
+
     /** per-partition committed-offset watermarks for the Class 2 (lag stagnation) probe */
     private final Map<TopicPartition, Long> lastCommitted = new ConcurrentHashMap<>();
     private final Map<TopicPartition, Instant> lastCommittedMove = new ConcurrentHashMap<>();
@@ -173,6 +315,17 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
      * (an eager rebalance revokes every member's partitions) longer than the W1 default tolerates. */
     public ProgressProbe withNoProgressWindow(Duration window) {
         this.noProgressWindow = window;
+        return this;
+    }
+
+    /**
+     * Arms the instance-progress probe ({@code INSTANCE_STALL/NO_WORK_COMPLETED} - see
+     * {@link #INSTANCE_STALL_BOUND}) with a live view of the fleet. A supplier because the fleet
+     * GROWS during a run (JOIN_NEW); {@code ChaosScenarioBase#startRun} wires it from the conductor
+     * for every chaos scenario. Never wired in ambient mode, which has no fleet to watch.
+     */
+    public ProgressProbe withInstanceProgress(Supplier<List<InstanceProgressView>> fleetSupplier) {
+        this.instanceProgressSupplier = fleetSupplier;
         return this;
     }
 
@@ -234,11 +387,11 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
         }
         if (isObserverMode()) {
             // quiet flight recorder: the extension owns end-of-test reporting (autopsy / DEBUG one-liner)
-            log.debug("[{}] peaks: maxRebalanceDwell={}ms maxDrainDuration={}ms maxLagStagnation={}ms",
-                    mode.logTag, peakRebalanceDwellMs, peakDrainDurationMs, peakLagStagnationMs);
+            log.debug("[{}] peaks: maxRebalanceDwell={}ms maxDrainDuration={}ms maxLagStagnation={}ms maxInstanceStall={}ms",
+                    mode.logTag, peakRebalanceDwellMs, peakDrainDurationMs, peakLagStagnationMs, peakInstanceStallMs);
         } else {
-            log.info("[{}] peaks: maxRebalanceDwell={}ms maxDrainDuration={}ms maxLagStagnation={}ms",
-                    mode.logTag, peakRebalanceDwellMs, peakDrainDurationMs, peakLagStagnationMs);
+            log.info("[{}] peaks: maxRebalanceDwell={}ms maxDrainDuration={}ms maxLagStagnation={}ms maxInstanceStall={}ms",
+                    mode.logTag, peakRebalanceDwellMs, peakDrainDurationMs, peakLagStagnationMs, peakInstanceStallMs);
         }
         return getViolations();
     }
@@ -272,6 +425,7 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
                 Thread.sleep(SAMPLE_INTERVAL.toMillis());
                 if (!isObserverMode()) {
                     sampleProgress();
+                    sampleInstanceProgress(Instant.now());
                 }
                 sampleRebalanceDwell();
                 sampleDrains();
@@ -310,6 +464,55 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
             violate("NO_PROGRESS: fleet consumed count stuck at " + now + "/" + expectedTotal
                     + " for " + stalled.getSeconds() + "s (bound " + noProgressWindow.getSeconds() + "s)");
             lastAdvance = Instant.now(); // re-arm so a genuine stall reports once per window, not per sample
+        }
+    }
+
+    /**
+     * INSTANCE-progress detector - see {@link #INSTANCE_STALL_BOUND} for the property it asserts and
+     * the granularity reasoning. Per live instance: if it holds work (queued in shards, or records out
+     * for processing) and its returned-work-result count has not advanced within the bound, that is a
+     * violation. The clock re-arms on ANY of: a result returned, the instance going idle (nothing
+     * held), a restart (new PC incarnation), or the instance leaving the live set - so only a
+     * continuous hold-work-return-nothing stretch can accumulate.
+     * <p>
+     * Package-private and taking {@code now} explicitly so {@code InstanceStallProbeIT} can drive it
+     * deterministically, broker-free, in both directions - the sampler thread calls it with
+     * {@code Instant.now()}.
+     */
+    void sampleInstanceProgress(Instant now) {
+        var supplier = instanceProgressSupplier;
+        if (supplier == null) return; // not wired (ambient mode, or a scenario predating the probe)
+        for (InstanceProgressView view : supplier.get()) {
+            int id = view.instanceId();
+            if (!view.isLive()) {
+                // stopped or mid-restart: torn-down state must never read as a stall
+                instanceProgressMarks.remove(id);
+                continue;
+            }
+            long returned = view.workResultsReturned();
+            Object incarnation = view.incarnationMarker();
+            InstanceProgressMark mark = instanceProgressMarks.get(id);
+            boolean advanced = mark == null
+                    || mark.getWorkResultsReturned() != returned
+                    || mark.getIncarnation() != incarnation;
+            long queued = view.queuedInShards();
+            long outForProcessing = view.outForProcessing();
+            boolean holdsWork = queued > 0 || outForProcessing > 0;
+            if (advanced || !holdsWork) {
+                instanceProgressMarks.put(id, new InstanceProgressMark(returned, incarnation, now));
+                continue;
+            }
+            long stalledMs = Duration.between(mark.getSince(), now).toMillis();
+            if (stalledMs > peakInstanceStallMs) peakInstanceStallMs = stalledMs;
+            if (stalledMs > INSTANCE_STALL_BOUND.toMillis()) {
+                violate("INSTANCE_STALL/NO_WORK_COMPLETED: instance " + id + " holds work (queued="
+                        + queued + ", outForProcessing=" + outForProcessing
+                        + ") but has returned no work result for " + (stalledMs / 1000) + "s (bound "
+                        + INSTANCE_STALL_BOUND.getSeconds() + "s) at " + returned
+                        + " results returned - completions are counted on PC's control thread, so this "
+                        + "instance's control loop is holding work and finishing nothing");
+                instanceProgressMarks.put(id, new InstanceProgressMark(returned, incarnation, now)); // re-arm
+            }
         }
     }
 
@@ -386,7 +589,8 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
                 violate("CLASS2_STALL/LAG_STAGNATION: partition " + tp + " lag=" + lag
                         + " with committed offset stagnant at " + committed + " for " + (stagnantMs / 1000)
                         + "s (bound " + LAG_STAGNATION_BOUND.getSeconds() + "s) - protocol-invisible stall: "
-                        + "group STABLE + heartbeats flowing, yet this partition's backlog is going nowhere");
+                        + "group STABLE + heartbeats flowing, yet this partition's backlog is going nowhere. "
+                        + CLASS2_INTERPRETATION);
                 lastCommittedMove.put(tp, now); // re-arm
             }
         }

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/utils/ManagedPCInstance.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/utils/ManagedPCInstance.java
@@ -6,6 +6,7 @@ package bz.stub.parallelconsumer.integrationTests.utils;
  */
 
 import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import bz.stub.parallelconsumer.PollContext;
 import bz.stub.parallelconsumer.ParallelConsumerOptions.CommitMode;
 import bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder;
 import bz.stub.parallelconsumer.ParallelEoSStreamProcessor;
@@ -31,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import static bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor.MDC_INSTANCE_ID;
@@ -102,11 +104,59 @@ public class ManagedPCInstance implements Runnable {
     @ToString.Exclude
     private final Queue<String> consumedKeys = new ConcurrentLinkedQueue<>();
 
+    /**
+     * Work results this instance's PCs have returned, counted by PC's OWN bookkeeping: a
+     * {@code WorkManager.successfulWorkListeners} listener registered on every incarnation (the same
+     * public testing hook {@code AbstractParallelEoSStreamProcessorTestBase} uses). Monotone across
+     * restarts - never reset, so an observer needs only "did it advance", not incarnation arithmetic.
+     * <p>
+     * Deliberately NOT another count of the test's user-function exits: the listener fires in
+     * {@code WorkManager#onSuccessResult}, which runs on PC's control thread as it processes returned
+     * futures - so a wedged control thread (the confluentinc#857 deadlock family) freezes this counter
+     * even while worker threads keep finishing records. That is the signal
+     * {@code ProgressProbe}'s instance-progress detector samples; a harness-side counter would keep
+     * advancing straight through the exact wedge being hunted.
+     */
+    @Getter(AccessLevel.NONE) // mutable guard - callers get the count via getWorkResultsReturnedCount()
+    @ToString.Exclude
+    private final AtomicLong workResultsReturned = new AtomicLong();
+
+    /** Snapshot of {@link #workResultsReturned} - see its javadoc for what a "work result" is here. */
+    public long getWorkResultsReturnedCount() {
+        return workResultsReturned.get();
+    }
+
+    /**
+     * The test's user function. Receives the full {@link PollContext} plus the id of the PC
+     * <em>incarnation</em> running it - see {@link #incarnations} for why the instance id alone is not
+     * enough for anything that must not span two PC lifetimes.
+     */
+    @FunctionalInterface
+    public interface RecordListener {
+        void onRecord(String incarnationId, PollContext<String, String> context);
+    }
+
     /** Callback invoked for each consumed record — lets the test track overall progress */
     @ToString.Exclude
-    private final Consumer<String> onConsumed;
+    private final RecordListener onConsumed;
 
+    /**
+     * Counts the PCs this instance has brought up. A restart builds a <em>new</em>
+     * {@link ParallelEoSStreamProcessor} with a new consumer and, critically, a new partition-assignment
+     * epoch counter starting again at zero - so any test state keyed on "which PC produced this
+     * observation" must key on the incarnation, not on {@link #instanceId}, or two unrelated lifetimes
+     * collide. {@code KeyOrderLedger} is the caller that depends on this.
+     */
+    @ToString.Exclude
+    @Getter(AccessLevel.NONE)
+    private final AtomicInteger incarnations = new AtomicInteger();
+
+    /** Convenience for the common case: a listener that only wants the record's key. */
     public ManagedPCInstance(Config config, KafkaClientUtils kcu, Consumer<String> onConsumed) {
+        this(config, kcu, (incarnationId, context) -> onConsumed.accept(context.key()));
+    }
+
+    public ManagedPCInstance(Config config, KafkaClientUtils kcu, RecordListener onConsumed) {
         this.config = config;
         this.kcu = kcu;
         this.onConsumed = onConsumed;
@@ -171,6 +221,11 @@ public class ManagedPCInstance implements Runnable {
                     .maxConcurrency(config.maxConcurrency)
                     .build());
 
+            // every incarnation gets its own fresh WorkManager, so this never double-registers; the
+            // instance-level counter deliberately spans incarnations (see workResultsReturned)
+            this.parallelConsumer.getWm().getSuccessfulWorkListeners()
+                    .add(wc -> workResultsReturned.incrementAndGet());
+
             this.parallelConsumer.setTimeBetweenCommits(Duration.ofSeconds(1));
             this.parallelConsumer.setMyId(Optional.of("PC-" + instanceId));
             this.parallelConsumer.subscribe(of(config.inputTopic));
@@ -188,6 +243,7 @@ public class ManagedPCInstance implements Runnable {
                 return;
             }
 
+            String incarnationId = "PC-" + instanceId + "#" + incarnations.incrementAndGet();
             parallelConsumer.poll(record -> {
                 if (config.pollDelayMs > 0) {
                     try {
@@ -197,7 +253,7 @@ public class ManagedPCInstance implements Runnable {
                     }
                 }
                 consumedKeys.add(record.key());
-                onConsumed.accept(record.key());
+                onConsumed.onRecord(incarnationId, record);
             });
         } finally {
             // release the start window - a further start() may now submit (see startInFlight)
@@ -357,8 +413,14 @@ public class ManagedPCInstance implements Runnable {
     /**
      * Test hook: seed the PC without bringing one up, so the close-path guards can be exercised
      * without a broker. Production callers get their PC from {@link #run()}.
+     * <p>
+     * Public rather than package-private only so its test can live with the other integration tests
+     * instead of in this helpers package. Package-private was keeping
+     * {@code ManagedPCInstanceLifecycleIT} here - the sole test among six helpers with no test
+     * methods - which is a filing decision made by a modifier rather than by where the test belongs.
+     * This whole source root is test-only, so nothing is published by widening it.
      */
-    void setParallelConsumerForTest(ParallelEoSStreamProcessor<String, String> pc) {
+    public void setParallelConsumerForTest(ParallelEoSStreamProcessor<String, String> pc) {
         this.parallelConsumer = pc;
     }
 


### PR DESCRIPTION
depends on astubbs/parallel-consumer#324

Third in the agreed merge order (323, 324, 325, 57, 322, 267, 29); astubbs/parallel-consumer#323
merged on 2026-08-20 as `a80f2bbd1`. The dependency is real rather than bookkeeping: astubbs#324
lands the inflight-tag and citation gates that the notes this PR adds are judged by. The line was
missing, so `Check PR Dependencies` was passing and nothing mechanically held the order.

## Description

Chaos-suite instrumentation, extracted from astubbs/parallel-consumer#29 so it can be reviewed on
its own terms. "Are these checks non-vacuous and correctly windowed?" is a different question from
"is this locking correct?", and one reviewer switching between the two mid-diff is where things get
waved through.

**No main-code change.** It compiles and runs against master untouched, which is also the evidence
that the chaos work never depended on astubbs#29's product fixes.

### 1. The CHAOS suite asserts ordering under churn, for the first time

**To be clear about scope: ordering is asserted throughout the existing test suite** - the integration
tests cover it extensively, and it is the guarantee this library exists for. What had never been
checked under churn was ordering in the **chaos** suite specifically, whose correctness ledger
verified that no record is lost and that duplicates stay bounded, but not their order. That gap
mattered because chaos is the only lane that reorders the world underneath the consumer - repeated
rebalances, revocations and restarts mid-flight - so it is the one place a re-ordering bug could hide
from every other test.

`KeyOrderLedger` asserts it within one PC **incarnation**, one **partition**, one assignment
**epoch** and one **key**. Each component excludes a class of legitimate re-processing, and the
window is the whole difficulty: a naive "offsets per key must increase" fires on *correct*
behaviour, because at-least-once redelivery after a revoke is the contract working. The epoch is
read off the record's own `WorkContainer` through public API, so a heavy record still in flight when
its partition is revoked keeps the old epoch and cannot be mistaken for the new window's work.

Two violation kinds, and the second is not decoration - the `UNORDERED` control arm produced **857
overlaps against one order regression**, so an offset-order-only detector would have called that arm
green 857 times.

**Vacuity is reported, not hoped for**: `check` returns `LEDGER_ORDER_VACUOUS` when no window held
two deliveries, and logs `comparedDeliveries` - 244,022 of 250,608 on the live run, so ~97% of
deliveries were genuinely compared against a predecessor.

### 2. `INSTANCE_STALL/NO_WORK_COMPLETED` - the liveness check at a granularity that can see a wedge

The existing `NO_PROGRESS` probe has the right *shape* - while work remains, completions must advance
- but is **fleet-wide**, so one wedged instance hides behind healthy siblings.

This adds the same idea per instance, read from PC's own state (`pc.getWm()`) rather than inferred
from committed offsets read externally. Completions are counted through a listener that fires on
PC's **control thread** - the thread an AB-BA cycle freezes - so a wedged control loop stops the
counter even while workers finish and heartbeats flow. It re-arms on any result, idle, restart or
leaving the live set, so it **cannot fire on slow-but-progressing**.

Granularity is per-instance rather than per-shard, and the javadoc says so: `processingShards` is
`@Getter(PRIVATE)` and adding a main-code accessor for a probe was not worth it.

### 3. A diagnostic mode, because the gating run destroys its own evidence

`-Dchaos.diagnoseStallRecovery=true` keeps the quiet phase watching after a violation instead of
aborting at the first one. Without it a wedged partition and a merely slow one are indistinguishable,
because every observation ends at the moment of detection.

It **cannot turn a red run green** - violations are still asserted afterwards - and it prints the
prior art on startup, since a recovery diagnostic on this family had already been run once and was
repeated because nothing led anyone to that record.

### 4. `CLASS2_STALL` now explains itself where it fires

Its message carries the interpretation: a timing bound is not a correctness verdict, the mechanism is
a commit watermark pinned by one incomplete record while the shard behind it progresses, and the next
step is the diagnostic flag rather than "investigate". Three of four measurement arms failed this
check while progressing normally, and the natural reading of it is wrong.

The bound's value and its gating are **unchanged** here - the open question is recorded in
`docs/inflight/test-class2-probe-asserts-timing-not-correctness.md`.

### 5. Four scenario cells

Drain, cooperative-drain and KEY-ordered arms complete an assignor x stop-mode matrix. Existing cells
are untouched; the shared driver gained hooks with byte-identical defaults.

## Notes for the reviewer

- **This does not remove the code from astubbs/parallel-consumer#29.** That branch keeps its copy
  deliberately and depends on this one; the duplication resolves when it merges master.
- Three doc paragraphs cite records that arrive with astubbs/parallel-consumer#29 and are marked
  `file-refs: N/A` until it merges.
- The chaos lane is `@Tag("chaos")` and never gates. What gates from this PR is the broker-free
  ledger and probe logic: `KeyOrderLedgerIT` (19), `InstanceStallProbeIT` (7).

## Verification

- Compiles against master with no main-code change
- Broker-free gating tests: **36/36**, all deterministic, 2.4s combined - `KeyOrderLedgerIT` 19, `InstanceStallProbeIT` 7, `ProgressProbeLedgerIT` 5, `ManagedPCInstanceLifecycleIT` 5.
  (Previously stated as 33/33 while counting `ManagedPCInstanceLifecycleTest`, which was broker-BACKED - so the claim was wrong twice. Round 3 caught the miscount; that test has since been deleted after a mutation matrix showed it killed none of the four `ManagedPCInstance` guards, while the deterministic IT killed both real ones.)
- `INSTANCE_STALL` verified **silent** on the eager arm (seed `4734674029169027864`), which trips the
  older `CLASS2_STALL` bound 53 times on that same seed while draining completely - the case it must
  not fire on
- Ordering ledger verified in both directions: catches synthetic violations, and correctly ignores
  redelivery after revoke, restart of the same instance, a straggler crossing an epoch boundary, and
  the same key on two partitions

## Checklist

- [x] Docs updated - the probes' contract, the Class 2 bound's open calibration question, the chaos
      harness's inability to model a crash, and a feature record for seeded replay
- [x] User-facing feature documentation data added under `docs/features/` - `seeded-chaos-replay.yaml`
- [x] Tests added/updated - this PR is tests; `KeyOrderLedgerIT` and `InstanceStallProbeIT` prove the
      new checks fire and stay silent in both directions
- [x] Title & body reflect the final content of this PR





