### PR TITLE
test(arch): forbid one-character method names, close the ArchUnit module gap, and gate inflight notes that describe their own PR

### DIFF
--- a/.github/scripts/issue-ref-gate.js
+++ b/.github/scripts/issue-ref-gate.js
@@ -27,6 +27,11 @@
 
 // Below this, a reference is ambiguous and must name its repo. At or above it, only this fork has
 // such a number, so a bare `#NNNN` is unambiguous.
+// Read by bin/check-branch-self-reference.sh as well, which is NOT obvious from here: that gate
+// matches a bare `#NNN` self-reference precisely because this constant cannot be relied on to force
+// qualification forever. Lowering it, or fork PR numbers passing it, changes what that gate sees.
+// The dependency is one-way and deliberate - nothing here should read that gate - but a change to
+// this number is worth a glance at it.
 const QUALIFY_BELOW = 1000;
 
 // Files where a bare #NN legitimately means upstream, so the rule must NOT fire.

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -79,6 +79,20 @@ jobs:
       - name: Inflight notes carry valid tags
         run: bash bin/check-inflight-tags.sh
 
+      - name: "Self-test the branch self-reference gate"
+        run: bash bin/test-check-branch-self-reference.sh
+
+      # PR_NUMBER is not a convenience here - without it the gate checks HALF of what it claims and
+      # still exits 0. `gh` on a runner is unauthenticated (no GH_TOKEN in this workflow, by design -
+      # nothing else here needs one), so the script's `gh pr list` fallback exits 4, `2>/dev/null ||
+      # true` swallows it, and the `#NNN` / `/pull/NNN` arm is skipped entirely. That arm is the
+      # gate's own motivating incident: a note citing astubbs#1 by number, with no branch name in it.
+      # The event payload already carries the number, so this costs nothing and needs no token.
+      - name: "A doc that mentions this branch must read correctly after the merge"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: bash bin/check-branch-self-reference.sh
+
       # Self-test only. check-pr-ready.sh reads a live PR, so running the gate itself in CI would be
       # a network call with an answer that changes by the minute; what must not rot is its refusal to
       # ever conclude "ready".

--- a/bin/check-branch-self-reference.sh
+++ b/bin/check-branch-self-reference.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Fails when a note in docs/inflight/ mentions THIS branch or THIS PR, unless the mention has been
+# written in post-merge terms and says so.
+#
+# WHY IT EXISTS, and why only here. An inflight note is a claim about NOW - the directory's contract
+# is transient cross-branch state, and a note is deleted when its work lands. So a sentence in one
+# describing your own open PR is a claim your merge falsifies: accurate when written, accurate at
+# review, wrong seconds after the merge button - by which time the person who could cheaply fix it has
+# moved on, and the fix is too small to justify its own PR, so it rots.
+#
+# It happened in exactly this directory, and then it happened AGAIN while this gate was being written.
+# `branch-package-rename-sweep.md` is a live 38-branch worklist. It told readers astubbs#1 was excluded
+# from the sweep "until its branch was reset onto renamed master and repurposed as documentation" -
+# written while astubbs#1 was open. astubbs#1 merged and its branch was deleted, leaving a live
+# worklist asserting an arrangement that had ended.
+#
+# The recurrence is the better evidence. That sentence was repaired - and then astubbs#1's own merge
+# commit put an equivalent one back, in the present tense, in the same paragraph of the same file, on
+# the day this gate was in review. Grep it: `grep -n "reset onto renamed master"
+# docs/inflight/branch-package-rename-sweep.md` resolves TODAY, and the claim is once again about a
+# branch that no longer exists. A rule stated in prose did not survive one merge cycle in the file
+# that motivated it, which is the whole argument for making it a gate.
+#
+# This gate would have caught it, on the branch where it was cheap: the sentence names astubbs#1, and
+# it was added by astubbs#1. It deliberately does NOT fire now - it only ever looks at YOUR branch and
+# YOUR PR, because only yours is about to change state. Somebody else's stale tense is not your merge.
+#
+# **The PR did not stop existing - PRs are permanent, and citing one is fine forever.** What rotted is
+# the BRANCH (deleted) and the TENSE (a present-state claim about an arrangement that ended). That is
+# also why this looks nowhere else: in docs/solutions/, dated docs/plans/ or CHANGELOG.adoc, a branch
+# or PR reference records what already happened and stays correct forever. Demanding a marker there
+# would be a tax on writing history correctly.
+#
+# **After the merge is too late, so this fires before it.** The rule it enforces is not "do not
+# mention your own PR" - cross-referencing is often exactly right - but "write the mention as it will
+# read AFTER this lands." A sweep table should say a branch is excluded because it carries no Java,
+# not because a PR that will be closed by then is currently repurposing it.
+#
+# HOW TO SATISFY IT. Rewrite the sentence in post-merge terms, then mark the line so this gate knows
+# a human made that judgement:
+#
+#     <!-- post-merge: checked -->        markdown / HTML, on or above the line
+#     # post-merge: checked               shell, yaml
+#     // post-merge: checked              java, js
+#
+# A rewritten sentence usually spans several lines, so a paragraph takes the block form - the same
+# shape `check-issue-refs.sh` already uses, so there is one convention to remember rather than two:
+#
+#     <!-- post-merge: checked-begin -->
+#     ...the rewritten paragraph...
+#     <!-- post-merge: checked-end -->
+#
+# A whole file that legitimately discusses in-flight state - a PR note in docs/inflight/ named for
+# this very PR - takes `post-merge: exempt-file` anywhere in it. The marker travels with the file, so
+# it keeps holding on later branches and local runs.
+#
+# Two verbs, deliberately, and they are not interchangeable: `checked` is an ATTESTATION (a human read
+# this line and judged it post-merge-correct), `exempt-file` is a SCOPE OPT-OUT (do not look here at
+# all). `check-issue-refs.sh` spells all four of its markers `exempt`, so the habit transfers wrongly;
+# a line marked `post-merge: exempt` would otherwise match nothing and be silently ignored, which is
+# the failure this gate exists to prevent. It is therefore a hard error - see UNKNOWN MARKER below.
+#
+# WHAT IT DOES NOT DO. It cannot tell whether your rewritten sentence is actually true after the
+# merge; no grep can. It forces a human to look at every self-reference at the one moment fixing it is
+# cheap, and records that they did. It also does not care about OTHER branches or PRs - only your own,
+# because only your own is about to change state.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# CI checks out a detached HEAD, so the branch name must come from the event, not from Git.
+branch="${GITHUB_HEAD_REF:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')}"
+if [ -z "$branch" ] || [ "$branch" = "HEAD" ] || [ "$branch" = "master" ]; then
+    echo "check-branch-self-reference: no feature branch to check (branch='${branch:-none}')"
+    exit 0
+fi
+
+# The PR number is optional: this runs locally before a PR exists, where the branch name alone is
+# still worth checking. Never `gh pr view` without -R here; a bare gh resolves to confluentinc.
+pr="${PR_NUMBER:-}"
+if [ -z "$pr" ] && command -v gh >/dev/null 2>&1; then
+    pr="$(gh pr list -R astubbs/parallel-consumer --head "$branch" --json number --jq '.[0].number' 2>/dev/null || true)"
+fi
+
+# Escaped for ERE use below. A branch name may legally contain `.` and `+`.
+branch_re="$(sed 's/[][\\.^$*+?(){}|]/\\&/g' <<<"$branch")"
+
+problems=0
+note() { printf 'SELF-REF: %s\n' "$1" >&2; problems=$((problems + 1)); }
+
+# MENTION IS NOT USE. Every marker test runs on this backtick-stripped view: a marker quoted in a code
+# span is documentation, not an instruction. Without it, a note explaining the convention - the
+# directory's own rules doc, a solution write-up, this gate's own PR description pasted into a note -
+# silences itself just by naming the marker. `.github/scripts/issue-ref-gate.js` records that exact
+# incident for its own markers: "this PR's own docs made five files - including the convention's
+# defining doc - permanently self-exempt, and a doc line quoting the block markers opened a real,
+# unclosed block." This gate copied that convention's SPELLING without its guard, and reproduced the
+# bug. An UNQUOTED prose mention still matches, because nothing can tell it from use - write marker
+# names in backticks when writing about them, as this comment does.
+#
+# Only MARKERS use the stripped view. A branch name or PR number inside backticks is still a real
+# mention, and the search arms below read the original file.
+strip_spans() { sed 's/`[^`]*`/ /g' "$1"; }
+
+# docs/inflight/ ONLY, and the scope is the whole point. That directory's contract is "currently
+# true" - AGENTS.md calls it transient cross-branch state, and a note is deleted when its work lands.
+# Everywhere else (docs/solutions/, dated docs/plans/, CHANGELOG.adoc) records what ALREADY HAPPENED,
+# where a branch reference stays correct forever and demanding a marker would be pure tax.
+# The glob DOES recurse - a git pathspec `*` matches `/` too, so `docs/inflight/sub/note.md` is
+# covered. (An earlier comment here claimed the opposite and called the flatness load-bearing; it was
+# wrong in the safe direction, but wrong.) The directory is flat anyway - docs/inflight/AGENTS.md
+# mandates one file per item and bin/check-inflight-tags.sh fails on any subdirectory - so the
+# recursion is belt-and-braces rather than something the scope depends on.
+#
+# UNTRACKED FILES COUNT. `git ls-files` alone reads the index, so a note you just wrote about your own
+# branch - the single commonest way to trip this gate - was invisible until you staged it, and the
+# local run this header advertises reported green on the exact case it exists for.
+mapfile -t candidates < <(
+    {
+        git ls-files -- 'docs/inflight/*.md' || true
+        git ls-files --others --exclude-standard -- 'docs/inflight/*.md' || true
+    } | sort -u
+)
+[ "${#candidates[@]}" -gt 0 ] || { echo "check-branch-self-reference: no documents to check"; exit 0; }
+
+for f in "${candidates[@]}"; do
+    [ -f "$f" ] || continue
+    # AGENTS.md and CLAUDE.md are this directory's RULES, not notes - the same exclusion
+    # bin/check-inflight-tags.sh already makes. They cite PR numbers permanently and correctly (the
+    # rules doc for the tag gate names astubbs#324 as settled history), so without this the gate
+    # fires on the document that explains it.
+    case "$(basename "$f")" in AGENTS.md|CLAUDE.md) continue ;; esac
+
+    # Line-for-line with the original, so line numbers below still address the real file.
+    markers="$(strip_spans "$f")"
+    grep -q 'post-merge: exempt-file' <<<"$markers" && continue
+
+    # UNKNOWN MARKER. `exempt` is the sibling gate's word for all four of its markers, so it arrives
+    # here by muscle memory - and an unrecognised marker is not a no-op, it is a line the author
+    # believes is handled. Fail loudly rather than ignore it. `-[^f]` catches `exempt-begin`/`-end`
+    # while leaving the one real spelling, `exempt-file`, already handled above.
+    if grep -qE 'post-merge: exempt([^-]|$|-[^f])' <<<"$markers"; then
+        note "$f uses an unrecognised 'post-merge: exempt...' marker. This gate has exactly two: 'post-merge: checked' on or above a line (or checked-begin/checked-end around a paragraph), and 'post-merge: exempt-file' for a whole file."
+    fi
+
+    # Line ranges covered by a checked-begin/end block.
+    blocks=""
+    if grep -q 'post-merge: checked-begin' <<<"$markers"; then
+        blocks="$(awk '/post-merge: checked-begin/{s=NR} /post-merge: checked-end/{if(s){print s":"NR; s=0}}' <<<"$markers")"
+    fi
+
+    while IFS=: read -r lineno text; do
+        [ -n "$lineno" ] || continue
+        # A marker on the line itself, or on the line above it, is the human's acknowledgement.
+        prev=$((lineno - 1))
+        # Herestrings, not `printf | grep -q`: the reader exits on first match, the writer takes
+        # EPIPE, and pipefail makes that the pipeline status - so the check would FAIL when it FOUND
+        # the marker. bin/AGENTS.md, "Scripts that guard other scripts".
+        # `checked([^-]|$)` not a bare `checked`: `checked-end` CONTAINS `checked`, so a loose match
+        # let a block's END marker clear the line beneath it - silencing exactly the mentions that
+        # fall outside the block. Caught by the near-miss self-test, not by any of the red controls.
+        if grep -qE 'post-merge: checked([^-]|$)' <<<"$(sed -n "${lineno}p" <<<"$markers")"; then continue; fi
+        if [ "$prev" -ge 1 ] && grep -qE 'post-merge: checked([^-]|$)' <<<"$(sed -n "${prev}p" <<<"$markers")"; then continue; fi
+        covered=""
+        for range in $blocks; do
+            start="${range%%:*}"; end="${range##*:}"
+            if [ "$lineno" -ge "$start" ] && [ "$lineno" -le "$end" ]; then covered=1; break; fi
+        done
+        [ -n "$covered" ] && continue
+        note "$f:$lineno mentions this branch or PR - rewrite it as it will read AFTER this merges, then add 'post-merge: checked'. Line: ${text:0:100}"
+    done < <(
+        {
+            # BOUNDED, not a substring. `grep -F "$branch"` matched any line CONTAINING the name, so
+            # on `fix/909` a note mentioning `builds/fix/9090/output.log` failed the gate, and on
+            # `feat/857-fix` so did `feat/857-fix-followup`. This repo's branch convention is
+            # `bugs/857-...`/`fix/909-...`, so short names nest inside longer ones by design and the
+            # false positive blocks an unrelated PR. The PR-number arm below was given boundaries for
+            # exactly this reason; the branch arm was not.
+            #
+            # The trailing class excludes `/` and `-` (a longer branch, or a deeper path, is a
+            # DIFFERENT branch); the leading one does not, so a mention as a URL or a path
+            # (`.../tree/feat/my-branch`) still counts. Metacharacters in the name are escaped rather
+            # than relying on -F, which cannot carry boundaries.
+            grep -nE "(^|[^0-9A-Za-z_])${branch_re}([^0-9A-Za-z_/-]|$)" "$f" || true
+            # Bare `#NNN` counts too. Requiring the `astubbs` prefix left a silent hole, masked only
+            # by accident: `.github/scripts/issue-ref-gate.js` sets QUALIFY_BELOW=1000, so today's
+            # three-digit PR numbers must be qualified anyway and a bare one never survives to reach
+            # here. Nothing ties the two gates together though - once fork PR numbers pass 1000, or
+            # that constant drops, a bare self-reference becomes legal AND undetected. Matching it
+            # here removes the coupling rather than documenting it.
+            # The URL form counts as much as the `#NNN` one - it is what `gh` prints and what a
+            # paste carries, and it is already live in this very directory (deps-cve-backlog.md
+            # cites PRs as .../pull/NNN). The `#`-anchored regex above cannot see it.
+            [ -n "$pr" ] && {
+                grep -nE "(^|[^0-9A-Za-z_/])(astubbs(/parallel-consumer)?)?#${pr}([^0-9]|$)" "$f" || true
+                grep -nE "/pull/${pr}([^0-9]|$)" "$f" || true
+            }
+        } | sort -t: -k1,1n -u
+    )
+done
+
+if [ "$problems" -gt 0 ]; then
+    echo "check-branch-self-reference: $problems self-reference(s) not confirmed post-merge-correct." >&2
+    echo "After the merge is too late - this branch and its PR stop existing when it lands." >&2
+    exit 1
+fi
+if [ -n "$pr" ]; then
+    echo "check-branch-self-reference: no unconfirmed self-references (branch '$branch', PR #$pr)"
+else
+    # NOT the same statement as a clean full run, and it must not read like one. Before the PR exists
+    # this is normal; in CI it means PR_NUMBER was not passed and `gh` could not answer, so the whole
+    # PR-number arm - the gate's own motivating incident, a note citing astubbs#1 by NUMBER with no
+    # branch name in it - was never searched. Three of the four red self-test cases cover that arm.
+    echo "check-branch-self-reference: branch name only - NO PR NUMBER RESOLVED, so #NNN and /pull/NNN mentions were NOT checked (branch '$branch')"
+fi

--- a/bin/test-check-branch-self-reference.sh
+++ b/bin/test-check-branch-self-reference.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Self-test for bin/check-branch-self-reference.sh.
+#
+# Carries the ADJACENT cases as well as the red ones, per docs/agent-harness.md rule 3: a red control
+# proves the gate can fire, never that it is looking at the right thing. Every gate that misbehaved in
+# this repo failed on SCOPE while passing its red control - so the near-misses that must stay GREEN
+# (a different branch, a longer PR number sharing the prefix, a marked line) are the half that matters.
+#
+# THIS SUITE HAS BEEN WRONG THREE TIMES, ALL THE SAME SHAPE, so read the shape before adding a case.
+# Each time the gate stopped looking at the right thing and every case still passed:
+#   1. `checked-end` contains `checked`, so a block's END marker cleared the line beneath it.
+#   2. The fixtures inherited GITHUB_HEAD_REF from CI, so every branch-name case tested a name that
+#      was not in the fixture at all.
+#   3. Unsetting those variables (the fix for 2) deleted all coverage of the branch resolution CI
+#      actually uses - deleting the GITHUB_HEAD_REF preference from the gate passed 17/17, while on a
+#      detached HEAD the mutant exits 0 forever, checking nothing.
+# The root cause of all three is that a case asserted only an EXIT CODE. A gate that crashed on every
+# input scored four `ok`s. So `assert` now requires a red case to actually SAY what it caught, and the
+# CI branch-resolution path has its own cases below.
+#
+# THE BAR IS A MUTATION MATRIX, NOT A GREEN RUN. Green proves nothing here - it was green all three
+# times. Before changing the gate, break it on purpose and confirm this suite goes red. The thirteen
+# mutants it is known to kill: dropping the GITHUB_HEAD_REF preference; the branch match reverting to
+# an unanchored `grep -F`; each of the four marker tests (file, block, line, line-above) reading the
+# raw file instead of the code-span-stripped view; dropping the untracked-file arm; dropping the
+# `/pull/NNN` arm; the gate crashing outright; removing the unknown-marker diagnosis; widening the
+# marker-above window to two lines; widening the AGENTS.md exclusion to every file; and widening the
+# scope past docs/inflight/. A new case earns its place by killing a mutant none of the others do.
+
+set -uo pipefail
+
+pass=0; fail=0
+GATE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/bin/check-branch-self-reference.sh"
+
+# Builds a fixture repo on branch feat/my-branch, runs the gate, and checks BOTH the exit code and
+# that a failure named the file it was supposed to catch.
+#   <name> <expected: pass|fail|pass_elsewhere|pass_rules|fail_untracked> <file-body>
+assert() {
+    local name="$1" expected="$2" body="$3" want="${4:-}" tmp rc got target out stage=1
+    target="docs/inflight/note.md"
+    case "$expected" in
+        pass_elsewhere) target="docs/solutions/note.md"; expected=pass ;;
+        pass_rules)     target="docs/inflight/AGENTS.md"; expected=pass ;;
+        fail_untracked) stage=0; expected=fail ;;
+    esac
+    tmp="$(mktemp -d)"
+    out="$(
+        cd "$tmp" || exit 1
+        git init -q .
+        git checkout -q -b feat/my-branch 2>/dev/null || git branch -q -m feat/my-branch
+        mkdir -p "$(dirname "$target")" docs/inflight
+        # A scope control that lands outside docs/inflight/ must still find the directory populated,
+        # or it passes through the `no documents to check` early exit and tests nothing at all.
+        printf 'unrelated placeholder\n' > docs/inflight/other.md
+        # The untracked case must exist ONLY after the commit: git ls-files reads the index, and a
+        # note you have written but not staged is the commonest way to trip this gate locally.
+        # Writing it on both sides of the commit would leave it tracked, testing nothing.
+        [ "$stage" = 1 ] && printf '%b' "$body" > "$target"
+        git add -A
+        git -c user.email=t@e.invalid -c user.name=t commit -qm x
+        [ "$stage" = 0 ] && printf '%b' "$body" > "$target"
+        # UNSET the CI variables, or the fixture is not isolated: on a real PR, Actions sets
+        # GITHUB_HEAD_REF to the actual branch, the gate prefers it over the fixture's checkout, and
+        # every branch-name case silently tests the wrong name. Green on a developer machine where
+        # the variable is absent, red only in CI - which is the worst place to learn it.
+        # assert_ci below covers the path this unset removes.
+        unset GITHUB_HEAD_REF GITHUB_REF GITHUB_REF_NAME
+        PR_NUMBER=326 bash "$GATE" 2>&1
+    )"
+    rc=$?
+    [ "$rc" -eq 0 ] && got=pass || got=fail
+    # A non-zero exit is not evidence the gate FIRED - a crash is also non-zero. Require the report.
+    if [ "$got" = fail ] && ! grep -q 'SELF-REF:' <<<"$out"; then
+        printf 'FAIL: %s (exited non-zero without reporting a self-reference: %s)\n' "$name" "${out%%$'\n'*}"
+        fail=$((fail + 1)); rm -rf "$tmp"; return
+    fi
+    # Some cases are about WHAT the gate said, not merely that it said something. Without this, a
+    # mutation that deletes a specific diagnosis still passes on the back of an unrelated mention in
+    # the same fixture.
+    if [ -n "$want" ] && ! grep -q "$want" <<<"$out"; then
+        printf 'FAIL: %s (output did not contain %s)\n' "$name" "$want"; fail=$((fail + 1)); rm -rf "$tmp"; return
+    fi
+    if [ "$got" = "$expected" ]; then
+        printf 'ok:   %s\n' "$name"; pass=$((pass + 1))
+    else
+        printf 'FAIL: %s (expected %s, got %s) %s\n' "$name" "$expected" "$got" "${out%%$'\n'*}"; fail=$((fail + 1))
+    fi
+    rm -rf "$tmp"
+}
+
+# The branch resolution CI actually uses: a DETACHED HEAD plus GITHUB_HEAD_REF, which is what
+# actions/checkout produces on a pull_request event. Without these two cases, deleting the
+# GITHUB_HEAD_REF preference from the gate leaves every other case green while the gate exits 0 on
+# every PR forever.
+#   <name> <expected: pass|fail> <head-ref> <file-body>
+assert_ci() {
+    local name="$1" expected="$2" head_ref="$3" body="$4" tmp rc got out
+    tmp="$(mktemp -d)"
+    out="$(
+        cd "$tmp" || exit 1
+        git init -q .
+        git checkout -q -b some-other-local-name 2>/dev/null || git branch -q -m some-other-local-name
+        mkdir -p docs/inflight
+        printf '%b' "$body" > docs/inflight/note.md
+        git add -A
+        git -c user.email=t@e.invalid -c user.name=t commit -qm x
+        git checkout -q --detach
+        unset GITHUB_REF GITHUB_REF_NAME
+        GITHUB_HEAD_REF="$head_ref" PR_NUMBER=326 bash "$GATE" 2>&1
+    )"
+    rc=$?
+    [ "$rc" -eq 0 ] && got=pass || got=fail
+    if [ "$got" = fail ] && ! grep -q 'SELF-REF:' <<<"$out"; then
+        printf 'FAIL: %s (exited non-zero without reporting a self-reference)\n' "$name"
+        fail=$((fail + 1)); rm -rf "$tmp"; return
+    fi
+    if [ "$got" = "$expected" ]; then
+        printf 'ok:   %s\n' "$name"; pass=$((pass + 1))
+    else
+        printf 'FAIL: %s (expected %s, got %s) %s\n' "$name" "$expected" "$got" "${out%%$'\n'*}"; fail=$((fail + 1))
+    fi
+    rm -rf "$tmp"
+}
+
+# --- RED: the gate must fire ---
+assert "an unmarked branch-name mention fails"  fail 'work continues on feat/my-branch for now\n'
+assert "an unmarked PR-number mention fails"    fail 'see astubbs#326 for the fix\n'
+assert "the fully qualified PR form fails too"  fail 'see astubbs/parallel-consumer#326\n'
+# A BARE `#NNN` counts. It was invisible until review: the regex demanded the `astubbs` prefix, and
+# the hole was masked only by the issue-refs gate's QUALIFY_BELOW=1000 forcing qualification today.
+# The bare number IS the fixture here; qualifying it would test the opposite thing, so the line
+# carries the `issue-refs` line-scope opt-out. Note the two gates meeting: check-issue-refs.sh blocked
+# this line on first commit, which is the QUALIFY_BELOW coupling the gate's own comment describes,
+# demonstrated rather than argued. (Marker names appear in backticks throughout this file on purpose -
+# both gates strip code spans before reading markers, so writing ABOUT one does not invoke it.)
+# issue-refs: exempt-begin
+assert "a bare #NNN mention fails"              fail 'see #326 for the fix\n'
+# issue-refs: exempt-end
+# The URL form is what `gh` prints and what a paste carries, and it is already live in this directory.
+assert "a PR cited by URL fails"                fail 'tracked in https://github.com/astubbs/parallel-consumer/pull/326\n'
+# git ls-files reads the INDEX, so an unstaged note was invisible - the commonest local case.
+assert "an untracked note is still checked"     fail_untracked 'work continues on feat/my-branch\n'
+# MENTION IS NOT USE. A note explaining the convention must not exempt itself by naming the marker.
+assert "a quoted exempt-file does not exempt"   fail 'write `post-merge: exempt-file` to skip a file\nastubbs#326 is unmarked here\n'
+assert "a quoted checked-begin opens nothing"   fail 'use `post-merge: checked-begin` to open a block\nastubbs#326 is unmarked here\n'
+# A quoted PAIR is the one that matters: unclosed, awk emits no range and the mutant survives. Closed,
+# reading the raw file wraps the mention in a real block and silences it.
+assert "a quoted begin/end pair covers nothing" fail 'write `post-merge: checked-begin` first\nastubbs#326 is unmarked here\nthen `post-merge: checked-end`\n'
+# The LINE and ABOVE marker tests need the same guard as the file and block ones - a sentence that
+# tells the reader which marker to type must not thereby type it.
+assert "a quoted marker on the line clears nothing"  fail 'on feat/my-branch, write `post-merge: checked` to clear it\n'
+assert "a quoted marker above clears nothing"        fail 'write `post-merge: checked` above the line\non feat/my-branch\n'
+# An unrecognised marker is not a no-op - the author believes the line is handled.
+assert "an unknown exempt marker is an error"   fail 'post-merge: exempt\nastubbs#326 all over\n' 'unrecognised'
+
+# --- GREEN: near-misses, each one character from something it must catch ---
+assert "a DIFFERENT branch name is ignored"     pass 'work continues on feat/other-branch\n'
+assert "a DIFFERENT PR number is ignored"       pass 'see astubbs#32 for that\n'
+assert "a longer number sharing the prefix"     pass 'see astubbs#3266 for that\n'
+# Scope controls for the bare form: a longer number, and a digit-adjacent one, must NOT match.
+assert "a bare longer number is ignored"        pass 'see #3266 for that\n'
+assert "a number embedded in a word is ignored" pass 'ref abc#326x and v1#3260\n'
+assert "a longer PR URL number is ignored"      pass 'see .../parallel-consumer/pull/3266 there\n'
+# Branch names NEST by convention here (bugs/857-..., fix/909-...), so a substring match on the name
+# blocks unrelated PRs. These are the two cases that actually reproduced.
+assert "a longer branch sharing the prefix"     pass 'follow-up lives on feat/my-branch-followup\n'
+assert "a deeper path under the branch name"    pass 'log at builds/feat/my-branch2/output.log\n'
+# The directory's RULES docs are not notes - they cite PRs permanently and correctly.
+assert "AGENTS.md in the directory is ignored"  pass_rules 'the tag gate shipped in astubbs#326\n'
+assert "an unrelated document is ignored"       pass 'nothing self-referential here at all\n'
+# Scope control: the SAME sentence outside docs/inflight/ is history, not a live claim, and must pass.
+assert "a mention outside docs/inflight is fine" pass_elsewhere 'landed via feat/my-branch, see astubbs#326\n'
+assert "a marker on the same line clears it"    pass 'on feat/my-branch <!-- post-merge: checked -->\n'
+assert "a marker on the line above clears it"   pass '<!-- post-merge: checked -->\non feat/my-branch\n'
+assert "a marker two lines above does NOT"      fail '<!-- post-merge: checked -->\nfiller line\non feat/my-branch\n'
+assert "a checked block clears its range"       pass '<!-- post-merge: checked-begin -->\nastubbs#326 did the thing\nand feat/my-branch too\n<!-- post-merge: checked-end -->\n'
+assert "exempt-file clears the whole file"      pass 'post-merge: exempt-file\nastubbs#326 all over\nfeat/my-branch again\n'
+# A block that CLOSED before the mention must not cover it - otherwise one block anywhere in a file
+# silences everything after it, which is the failure mode this gate is itself about.
+assert "a closed block does not cover later"    fail '<!-- post-merge: checked-begin -->\nx\n<!-- post-merge: checked-end -->\nastubbs#326 unmarked here\n'
+
+# --- The CI branch-resolution path: detached HEAD, name from the event ---
+assert_ci "the event branch name is preferred"  fail feat/my-branch 'work continues on feat/my-branch\n'
+assert_ci "the local detached name is not used" pass feat/my-branch 'work continues on some-other-local-name\n'
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1
+echo "All check-branch-self-reference self-tests passed"

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -282,9 +282,24 @@ one is a case in that file, and the suite goes red against the old parser.
    gate. To bind humans too -> git hook or CI, never `.claude/`.
 2. **Prefer the cheapest layer that actually fires.** A nested `CLAUDE.md` costs nothing and loads at
    exactly the right moment.
-3. **Give it a negative control.** This repo's standing rule: a check that has never failed proves
-   nothing. Make it go red on purpose before you trust it - `bin/AGENTS.md` says the same about
-   `test-check-*.sh`.
+3. **Give it a negative control - and an ADJACENT case it must ignore.** This repo's standing rule:
+   a check that has never failed proves nothing. Make it go red on purpose before you trust it -
+   `bin/AGENTS.md` says the same about `test-check-*.sh`.
+
+   **The red control alone is not enough, and a session's worth of evidence says so.** Every gate
+   that misbehaved on 2026-08-19/20 failed on **scope**, never on logic: `pre-commit-gate.sh` fired
+   on read-only commands that were not commits; `check-pr-ready.sh` read only the first matching
+   `pr-<n>-*.md` when two existed; the inflight `inflight-state` regex was greedy, so the gate and
+   the session index disagreed about the same note; `chaos-test.sh`'s EXIT trap swallowed the exit
+   code and would have rendered a real chaos RED as green. **Not one was wrong about what to check.**
+   A red control proves the gate CAN fire; it says nothing about whether it is looking at the right
+   thing.
+
+   So pair every red control with a **near-miss that must stay green** - the thing one character away
+   from what you are catching. `bin/test-check-agent-hooks.sh` already does this where it was learned
+   the hard way (`a commit MESSAGE mentioning push does not fire`, `gh pr comment --body "run gh pr
+   merge later"`), and those cases exist because the first drafts matched substrings and blocked
+   them. Write the near-miss when the gate is new, not after it has been routed around.
 4. **Keep pre-commit under a couple of seconds.** A slow hook gets `--no-verify`'d by habit and then
    protects nothing. Slower checks belong in CI only.
 5. **Write down what you verified**, especially harness behaviour - the auto-load table above was

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -646,3 +646,31 @@ a one-off.
 passed all seven chaos scenarios. Two adjacent commits, a prose-only diff between them, red then
 green: whatever draws this signature is drawn per seed, and no tree-content explanation survives that
 pair. Every prior entry asserts seed-dependence from branch subject matter; this one measures it.
+
+**Thirteenth sighting, 2026-08-20 - the first chaos run with the new detectors, and none of them
+fired.** `Chaos Pain Suite` on astubbs/parallel-consumer#325's merged head `283202eb5`
+([run 32334089543](https://github.com/astubbs/parallel-consumer/actions/runs/32334089543)), 8 of 9
+chaos ITs green, `ChaosRevokeUnderWorkDrainIT.revokeUnderDrainingStopsStaysProtocolHonest` red at
+173s. **21 violations, all one kind**: `CLASS2_STALL/LAG_STAGNATION`, committed offset stagnant
+~153s against the 150s bound, group STABLE and heartbeats flowing.
+`peaks: rebalanceDwell=9935ms lagStagnation=153984ms`.
+
+**Seed `2801529966526445415`** - recorded because the artifact expires and, by this ledger's own
+argument, the seed is the asset:
+
+    ./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true \
+      -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=2801529966526445415
+
+**What makes this entry worth more than another tally mark: zero `INSTANCE_STALL`, zero
+`LEDGER_KEY_ORDER`, zero `LEDGER_KEY_CONCURRENCY`.** This was the first full chaos storm run against
+the ordering ledger and the stall probe astubbs#325 added, and neither produced a single finding. A
+new detector's most likely failure is crying wolf; on this evidence they do not. The red is entirely
+the pre-existing `CLASS2_STALL` timing bound, whose value and gating that PR deliberately left alone.
+
+**Contention is a hypothesis here, not the finding.** `Performance (optional)` ran 05:02:53-05:05:42
+on the same self-hosted box, overlapping the chaos job's opening minutes, and this ledger already
+records that pairing as a prior cause. But the discriminator is an uncontended replay of *this* seed,
+and per the table in
+[`test-chaos-class2-red-was-runner-contention.md`](test-chaos-class2-red-was-runner-contention.md)
+the GREEN side needs two or three replays before it settles anything. **Nobody has replayed it.**
+Recorded as unresolved.

--- a/docs/inflight/ci-dup-similarity-cannot-accept-known-duplication.md
+++ b/docs/inflight/ci-dup-similarity-cannot-accept-known-duplication.md
@@ -10,11 +10,15 @@ baseline, no glob. `ignore_directories` is the only exclusion and it takes direc
 ## Why that is a defect rather than a missing nicety
 
 Its only baseline is **the base branch, computed live**. So identical files are accepted or rejected
-purely by which side of a merge they sit on. Concretely, on astubbs/parallel-consumer#326: the four
-existing `TestConventionsArchTest` wrappers (core, vertx, reactor, mutiny) are ~84% similar to each
-other on master and the check is green, because they are not an *increase*. The three identical
-wrappers that PR adds for the example modules fail at 84.3%. Same files, same similarity, opposite
-verdicts.
+purely by which side of a merge they sit on.
+
+<!-- post-merge: checked-begin -->
+The worked example: when astubbs/parallel-consumer#326 added `TestConventionsArchTest` wrappers to
+three example modules, they failed at 84.3% while the four already on master (core, vertx, reactor,
+mutiny) passed at ~84% - because those four were not an *increase*. Same files, same similarity,
+opposite verdicts. Once astubbs#326 landed, its three joined the baseline and stopped being flagged,
+which is the whole problem: nothing about the code changed, only which side of the merge it sat on.
+<!-- post-merge: checked-end -->
 
 ArchUnit opts a module in **only** through its own two-line wrapper pointing `@AnalyzeClasses` at
 that module's packages, so every wrapper in the repo is near-identical by construction. There is no
@@ -22,6 +26,7 @@ way to write one that is not. This recurs on **every new module**.
 
 ## Why the obvious workarounds are all wrong
 
+<!-- post-merge: checked -->
 - **Exclude the example modules** - tried on astubbs#326 and reverted. Each wrapper shares its
   directory with that module's real app test (`CoreAppTest`, `VertxAppTest`, `ReactorAppTest`), and
   those five example apps solve the same problem five ways, so they are the *most* likely place for

--- a/docs/inflight/ci-dup-similarity-cannot-accept-known-duplication.md
+++ b/docs/inflight/ci-dup-similarity-cannot-accept-known-duplication.md
@@ -1,0 +1,56 @@
+# The similarity engine has no way to accept duplication that is correct
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+`dups: similarity` (`astubbs/duplicate-code-detection-tool`, pinned in `maven.yml`) compares whole
+files pairwise and fails above 80%. It has **no allowlist**: no `ignore_files`, no accepted-pairs
+baseline, no glob. `ignore_directories` is the only exclusion and it takes directories.
+
+## Why that is a defect rather than a missing nicety
+
+Its only baseline is **the base branch, computed live**. So identical files are accepted or rejected
+purely by which side of a merge they sit on. Concretely, on astubbs/parallel-consumer#326: the four
+existing `TestConventionsArchTest` wrappers (core, vertx, reactor, mutiny) are ~84% similar to each
+other on master and the check is green, because they are not an *increase*. The three identical
+wrappers that PR adds for the example modules fail at 84.3%. Same files, same similarity, opposite
+verdicts.
+
+ArchUnit opts a module in **only** through its own two-line wrapper pointing `@AnalyzeClasses` at
+that module's packages, so every wrapper in the repo is near-identical by construction. There is no
+way to write one that is not. This recurs on **every new module**.
+
+## Why the obvious workarounds are all wrong
+
+- **Exclude the example modules** - tried on astubbs#326 and reverted. Each wrapper shares its
+  directory with that module's real app test (`CoreAppTest`, `VertxAppTest`, `ReactorAppTest`), and
+  those five example apps solve the same problem five ways, so they are the *most* likely place for
+  genuine duplication. The exclusion blinds the metric to the one thing in examples worth measuring.
+- **`only_code: true`** (strip comments before analysis) makes it WORSE: the wrappers' *code* is what
+  is identical, so removing the differing javadoc raises their similarity.
+- **Lower `fail_above`** - blinds the metric everywhere to fix one file class.
+- **Make it advisory** - it has a demonstrated catch. On astubbs#325 this same engine flagged 83%
+  between the two drain control arms; the fix stopped two controls drifting apart. `dups: clones` is
+  density-based and would not have caught it: two near-identical 40-line files barely move a 0.13%
+  figure. Downgrading a check that works, because it lacks an allowlist, treats a missing feature as
+  a reason to stop enforcing.
+
+## The fix
+
+Add an accepted-duplication input to the tool - `ignore_files` taking paths or globs, or a checked-in
+accepted-pairs baseline. **The action is `astubbs/duplicate-code-detection-tool`, this project's own
+fork**, so this is available rather than blocked on a third party.
+
+An accepted-pairs baseline is the better shape: it records *which* duplication was reviewed and
+accepted, so a NEW pair between the same files still fails. A path ignore silences the file forever,
+including duplication nobody has looked at.
+
+## Related
+
+- `.github/workflows/maven.yml` - the job, whose own comment already makes this argument about
+  `bin/`: check/test-check twins are similar by design, and flagging them "yields findings that are
+  all correct and all unactionable, which is how a check gets ignored."
+
+## Delete when
+
+The tool can express accepted duplication and `maven.yml` uses it.

--- a/docs/inflight/process-compounding-candidates-2026-08-20.md
+++ b/docs/inflight/process-compounding-candidates-2026-08-20.md
@@ -1,0 +1,67 @@
+# Compounding candidates mined from the 2026-08-19/20 session
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: process -->
+
+A long session produced more lessons than were worth acting on at once. The two cheapest landed with
+this note; the rest are recorded so the analysis is not re-derived. **Ranked by enforceable ×
+frequency**, each with the incident that motivates it - a proposal without one is speculation.
+
+## Already covered - checked, not proposed
+
+`check-history-rewrite.sh`, `check-merge-outstanding-work.sh`, `check-pr-ready.sh`,
+`check-inflight-tags.sh`, the `pre-commit-gate.sh` scope fix, the mutation-lane skip note, the
+`included.groups` trap, and the duplicate-code thread churn (fixed upstream). Listing them is the
+point: it stops the same thing being proposed a third time.
+
+## Open candidates
+
+1. **Zero tests selected is a failure, not a pass.** Three consecutive false-green soak runs in ten
+   minutes on 2026-08-18: `nohup &` returned 0 over a `BUILD FAILURE`; a run died in 2.7s on the
+   parent module, which has no tests; and an empty `included.groups` selected nothing.
+   `bin/chaos-test.sh` already implements exactly this check locally ("ZERO chaos tests selected -
+   this run measured NOTHING"), so generalising it into `bin/lib/` is proven, not invented. Small.
+2. **An inflight filename prefix must name an AREA, never a state.** `docs/inflight/AGENTS.md` says
+   so in bold and nothing enforces it; `next-`/`parked-` names survived into two PRs, and a
+   rename-plus-edit merge left two copies of one note. ~15 lines in `check-inflight-tags.sh`, which
+   already reads every one of those files in a job that already runs. Small.
+3. **Reconcile required status checks against what actually reports.** A sibling repo's PR was
+   permanently unmergeable because a required CodeQL workflow had been auto-disabled for inactivity -
+   and the message reads as transient. Also collapses four prose copies of "the job name is an API
+   for the ruleset" into one enforced rule. **The only candidate here that DELETES documentation.**
+   Medium; the networked half cannot use the `check-` prefix (see `bin/AGENTS.md`).
+4. **Refuse to cut a branch from a stale local base.** The astubbs#322 split was built against a
+   local master 40 commits behind and had to be discarded and rebuilt. `docs/merge-checklist.md`
+   already says "fetch first, every time" - but it is injected on merge-prep-shaped prompts, and this
+   was a split, so the rule existed and did not reach the moment. Medium.
+5. **Two Maven runs must not share one worktree's `target/`.** An A/B soak was rendered worthless by
+   two overlapping runs sharing one `target/`, both writing the same log and both starting Kafka
+   containers. `bin/worktree-status.sh` reports holders; nothing consults it. Medium.
+6. **`check-pr-ready.sh` should print the commit subjects and count.** A rebase-merge was recommended
+   for a branch of 39 commits that were "a record of me changing my mind". Five lines, and it fits
+   the script's charter exactly: give the claim a testable referent, never conclude. Tiny.
+7. **The no-loss proof for a SPLIT, as a named method.** Merging all split branches back together and
+   diffing against a pre-split backup tag must be empty. `docs/merge-checklist.md` has the
+   single-branch analogue and no split one. Prose only, so it fires only when opened.
+8. **When corrected on behaviour, suspect the injected doc.** The squash-message instruction produced
+   the same wrong move three times because the fix belonged in the injected document, not the
+   instance. The set of injected docs is small and enumerable, so a corrected agent has a short
+   suspect list. Tiny.
+
+## The pattern worth more than the list
+
+**Enforcement here is concentrated at commit time and merge time, and this session's failures
+concentrated in claims made in chat** - "MERGEABLE/CLEAN" reported as readiness, a merge strategy
+recommended without reading the commits, a fabricated user-report narrative. None passed through a
+tool call, so no gate could have fired. `bin/check-pr-ready.sh` is the only existing answer to that
+class, and its design move - give the claim a testable referent and refuse to conclude - generalises
+further than it is currently used. Candidate 6 is the cheapest next instance.
+
+**A rule that lands only in an unmerged PR does not bind, and nobody can tell.** Both operator and
+agent believed the squash-message instruction had been fixed; a sweep of every open branch found it
+had never been touched anywhere. With seven PRs open at once, "we already fixed that" is
+unverifiable without a scripted sweep.
+
+## Delete when
+
+The list is empty, or the remaining items have moved to `docs/refactoring.md` as ordinary backlog.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -88,6 +88,43 @@ Rules:
 A non-empty lane blocks releases - see [`docs/releasing.md`](releasing.md). Run the lane locally
 with `bin/quarantined-test.sh`.
 
+## Does a test earn its place? Mutate a guard and see who notices (optional)
+
+**Reach for this when a test's value is disputed** - two reviewers wanting opposite things, or a
+slow/flaky test somebody wants to keep on the grounds that it "covers" something. It is not a routine
+step; it costs a few builds, and most tests never need it.
+
+The method, which settles the argument instead of continuing it:
+
+1. Name the guards in the code under test - the specific conditionals or flags the test claims to
+   protect.
+2. **Break ONE at a time**, in main code, locally, never committed.
+3. Run every candidate test against each mutant.
+4. Tabulate which tests go red for which break. A test that kills no mutant another test does not
+   already kill is **redundant for the guards you mutated** - which is not the same as covering nothing.
+   A finite, hand-picked mutant set cannot show that: the test may uniquely assert an output, an ordering
+   property, or a race that none of your mutations disturbs. So the table is evidence for a deletion
+   argument, never the whole of one - read the test and say what else it could be asserting before you
+   remove it.
+
+**Worked example, and why it was worth the builds.** `ManagedPCInstanceLifecycleTest` existed to catch
+the astubbs#292 double-submission race. Four reviewers flagged it and split between "delete it" and
+"harden it", so nobody acted. Three mutants over the four guards in `ManagedPCInstance` settled it:
+the test killed **none** - including the scenario its own javadoc named - while the older
+`ManagedPCInstanceLifecycleIT` killed both real mutants deterministically, broker-free, in a hundredth
+of the time. Deleted, with the table in the commit message.
+
+Two things that make the result trustworthy:
+
+- **Fix the test's own bugs before measuring**, or you measure a broken test. That one bypassed the
+  guard it was verifying in its own setup, and had to be corrected first.
+- **Watch for equivalent mutants.** A mutant that changes no observable behaviour is not evidence
+  about anything - one of the three above was probably equivalent, and the write-up says so rather
+  than counting it.
+
+A `@RepeatedTest` is the shape to look at hardest: repetition is what you reach for when you cannot
+force a race and hope to draw it, so it is often a hope-based test sitting in a gating lane.
+
 ## Chaos Pain Suite (on-demand bug detector - never gates)
 
 A seeded, calibrated chaos suite (`integrationTests.chaostests`: `ChaosConductor`, `ProgressProbe`,

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/EveryModuleWiresUpArchUnitTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/EveryModuleWiresUpArchUnitTest.java
@@ -1,0 +1,123 @@
+package bz.stub.parallelconsumer;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * ArchUnit only sees a module that opts in: {@code TestConventionRules} holds the rules, but each module needs its
+ * own thin {@code TestConventionsArchTest} to point {@code @AnalyzeClasses} at its packages. Nothing made that
+ * opt-in visible, so a module without one was not reported as unprotected - it was reported as nothing at all,
+ * which reads exactly like passing.
+ *
+ * <p>It had already happened. Three of the five example modules - core, vertx and reactor - had test sources and no
+ * ArchUnit at all, found only because someone asked whether coverage was complete. This test converts that question
+ * into a build failure, and covers modules that do not exist yet, which is the half a one-time audit cannot reach.
+ *
+ * <p>Why not inherit it from the root pom instead: surefire's {@code dependenciesToScan} can pull a shared test
+ * class into every module, but it pulls the WHOLE test-jar, so core's 54 test classes would run in all five
+ * modules. Scoping that back needs global {@code <includes>}, which then constrains normal test selection
+ * everywhere. A two-line file per module plus this check buys the same guarantee without that blast radius.
+ */
+@Slf4j
+class EveryModuleWiresUpArchUnitTest {
+
+    private static final String ARCH_TEST = "TestConventionsArchTest.java";
+
+    @Test
+    void everyModuleWithTestSourcesWiresUpArchUnit() throws IOException {
+        Path repoRoot = repoRoot();
+        List<Path> unprotected;
+        try (Stream<Path> paths = Files.walk(repoRoot)) {
+            unprotected = paths
+                    .filter(p -> p.endsWith(Paths.get("src", "test", "java")))
+                    .filter(Files::isDirectory)
+                    .filter(p -> !p.toString().contains("/target/"))
+                    .filter(EveryModuleWiresUpArchUnitTest::hasJavaSources)
+                    .filter(p -> !containsArchTest(p))
+                    .map(repoRoot::relativize)
+                    .collect(Collectors.toList());
+        }
+
+        assertWithMessage("every module with test sources needs its own %s - it is two lines pointing "
+                        + "@AnalyzeClasses at that module's packages, and without it ArchUnit silently "
+                        + "does not run there at all. Copy any existing one and change the package. "
+                        + "Unprotected", ARCH_TEST)
+                .that(unprotected)
+                .isEmpty();
+    }
+
+    private static boolean hasJavaSources(Path testJavaDir) {
+        try (Stream<Path> paths = Files.walk(testJavaDir)) {
+            return paths.anyMatch(p -> p.getFileName().toString().endsWith(".java"));
+        } catch (IOException e) {
+            throw new IllegalStateException("cannot read " + testJavaDir, e);
+        }
+    }
+
+    /**
+     * Accepts a module only when its wrapper is actually WIRED, never merely present. Matching the filename
+     * alone would let a placeholder - or a file accidentally stripped of its annotation - satisfy this check
+     * while ArchUnit discovers nothing there, which is the exact silent opt-out this test exists to prevent.
+     * Found by Codex review of astubbs/parallel-consumer#326, and it is an instance of the rule that same PR
+     * adds to docs/agent-harness.md: a check can be right about WHAT to look for and wrong about its scope.
+     */
+    private static boolean containsArchTest(Path testJavaDir) {
+        try (Stream<Path> paths = Files.walk(testJavaDir)) {
+            return paths.filter(p -> p.getFileName().toString().equals(ARCH_TEST))
+                    .anyMatch(EveryModuleWiresUpArchUnitTest::isWired);
+        } catch (IOException e) {
+            throw new IllegalStateException("cannot read " + testJavaDir, e);
+        }
+    }
+
+    /** The wrapper must both point ArchUnit at packages and pull in the shared rules; either alone runs nothing. */
+    private static boolean isWired(Path wrapper) {
+        try {
+            String body = new String(Files.readAllBytes(wrapper), java.nio.charset.StandardCharsets.UTF_8);
+            return body.contains("@AnalyzeClasses") && body.contains("ArchTests.in(TestConventionRules.class)");
+        } catch (IOException e) {
+            throw new IllegalStateException("cannot read " + wrapper, e);
+        }
+    }
+
+    /** Walks up from the module the test runs in - surefire's working directory - to the reactor root. */
+    private static Path repoRoot() {
+        Path candidate = Paths.get("").toAbsolutePath();
+        // Located by BUILD content - the aggregator pom that declares <module> entries - not by Git metadata.
+        // Requiring `.git` fails outright in a source archive or exported tree, where the build is otherwise
+        // perfectly runnable and this test would abort before checking any module (Codex review of
+        // astubbs/parallel-consumer#326). It also sidesteps the trap that a git WORKTREE stores `.git` as a
+        // FILE, so an isDirectory check would walk past the worktree root onto the main checkout entirely.
+        while (candidate != null && !isReactorRoot(candidate)) {
+            candidate = candidate.getParent();
+        }
+        assertWithMessage("could not find the reactor root by walking up from %s looking for an aggregator pom",
+                Paths.get("").toAbsolutePath()).that(candidate).isNotNull();
+        return candidate;
+    }
+
+    private static boolean isReactorRoot(Path dir) {
+        Path pom = dir.resolve("pom.xml");
+        if (!Files.isRegularFile(pom)) {
+            return false;
+        }
+        try {
+            return new String(Files.readAllBytes(pom), java.nio.charset.StandardCharsets.UTF_8).contains("<module>");
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/TestConventionRules.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/TestConventionRules.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 /**
@@ -143,6 +144,33 @@ public class TestConventionRules {
                     // integrationTests packages (exempted above, since failsafe selects those by package), so
                     // this rule evaluates against an empty set there. That is a pass, not a violation -
                     // without this, ArchUnit's verifyNoEmptyShouldIfEnabled fails those modules.
+                    .allowEmptyShould(true);
+
+    /**
+     * A single-character method name tells a reader nothing, and it is nearly always a fixture builder -
+     * the identifier a test file repeats more than any other. The codebase had exactly ONE
+     * ({@code d(...)} in {@code KeyOrderLedgerIT}, since renamed to {@code delivery(...)}), so this rule
+     * costs nothing and forecloses the whole class.
+     *
+     * <p>It is here rather than in a {@code bin/check-*.sh} gate because ArchUnit already runs in every
+     * module's normal test suite - no new script, no new CI job, and the failure arrives at the
+     * developer who wrote it. SpotBugs was the other candidate and is the wrong tool: it detects bugs,
+     * not naming.
+     *
+     * <p>Worth recording WHY a rule this trivial is worth having. That {@code d(...)} survived three
+     * Claude review rounds and a Fable simplify-and-review pass whose maintainability reviewer returned
+     * findings on that exact file. It was found by a human, reading. Naming is precisely the class of
+     * defect automated review is weakest at - and precisely the class a cheap mechanical rule catches
+     * perfectly.
+     */
+    @ArchTest
+    static final ArchRule test_methods_must_have_names_longer_than_one_character =
+            methods()
+                    .should().haveNameNotMatching("^.$")
+                    .because("a one-character method name says nothing, and the identifier a fixture "
+                            + "builder is called by is the most-read name in a test file")
+                    // Modules whose tests live only in integrationTests packages import no classes here,
+                    // so the rule evaluates against an empty set - a pass, not a violation.
                     .allowEmptyShould(true);
 
 }

--- a/parallel-consumer-examples/parallel-consumer-example-core/src/test/java/bz/stub/parallelconsumer/examples/core/TestConventionsArchTest.java
+++ b/parallel-consumer-examples/parallel-consumer-example-core/src/test/java/bz/stub/parallelconsumer/examples/core/TestConventionsArchTest.java
@@ -1,0 +1,21 @@
+package bz.stub.parallelconsumer.examples.core;
+/*-
+ * Copyright (C) 2020-2026 Antony Stubbs and contributors
+ */
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import bz.stub.parallelconsumer.TestConventionRules;
+
+/**
+ * Applies the shared {@link TestConventionRules} to this module's test classes - the rule logic lives once in
+ * {@link TestConventionRules} (core test-jar); this only points ArchUnit at this module's packages.
+ */
+@AnalyzeClasses(packages = "bz.stub.parallelconsumer.examples.core", importOptions = ImportOption.OnlyIncludeTests.class)
+class TestConventionsArchTest {
+
+    @ArchTest
+    static final ArchTests conventions = ArchTests.in(TestConventionRules.class);
+}

--- a/parallel-consumer-examples/parallel-consumer-example-reactor/src/test/java/bz/stub/parallelconsumer/examples/reactor/TestConventionsArchTest.java
+++ b/parallel-consumer-examples/parallel-consumer-example-reactor/src/test/java/bz/stub/parallelconsumer/examples/reactor/TestConventionsArchTest.java
@@ -1,0 +1,21 @@
+package bz.stub.parallelconsumer.examples.reactor;
+/*-
+ * Copyright (C) 2020-2026 Antony Stubbs and contributors
+ */
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import bz.stub.parallelconsumer.TestConventionRules;
+
+/**
+ * Applies the shared {@link TestConventionRules} to this module's test classes - the rule logic lives once in
+ * {@link TestConventionRules} (core test-jar); this only points ArchUnit at this module's packages.
+ */
+@AnalyzeClasses(packages = "bz.stub.parallelconsumer.examples.reactor", importOptions = ImportOption.OnlyIncludeTests.class)
+class TestConventionsArchTest {
+
+    @ArchTest
+    static final ArchTests conventions = ArchTests.in(TestConventionRules.class);
+}

--- a/parallel-consumer-examples/parallel-consumer-example-vertx/src/test/java/bz/stub/parallelconsumer/examples/vertx/TestConventionsArchTest.java
+++ b/parallel-consumer-examples/parallel-consumer-example-vertx/src/test/java/bz/stub/parallelconsumer/examples/vertx/TestConventionsArchTest.java
@@ -1,0 +1,21 @@
+package bz.stub.parallelconsumer.examples.vertx;
+/*-
+ * Copyright (C) 2020-2026 Antony Stubbs and contributors
+ */
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import bz.stub.parallelconsumer.TestConventionRules;
+
+/**
+ * Applies the shared {@link TestConventionRules} to this module's test classes - the rule logic lives once in
+ * {@link TestConventionRules} (core test-jar); this only points ArchUnit at this module's packages.
+ */
+@AnalyzeClasses(packages = "bz.stub.parallelconsumer.examples.vertx", importOptions = ImportOption.OnlyIncludeTests.class)
+class TestConventionsArchTest {
+
+    @ArchTest
+    static final ArchTests conventions = ArchTests.in(TestConventionRules.class);
+}


### PR DESCRIPTION
## Description

**Things this repo learned the hard way, turned into mechanism** — plus the review and dependency work that landing it turned up. Each commit is independent and separately revertable; merge strategy is rebase-merge.

### The mechanism

**1. One-character method names are now an ArchUnit rule, and no module can silently opt out.** `d(...)` in `KeyOrderLedgerIT` was the only single-letter method in the codebase — the identifier every fixture in that file was built from. It survived three Claude review rounds and a Fable simplify-and-review pass whose maintainability reviewer returned findings on that exact file. A human reading the code found it.

Wiring it up exposed a second gap: **three of the five example modules had no ArchUnit at all.** `example-core`, `example-vertx` and `example-reactor` all have test sources and no `TestConventionsArchTest`, so every shared rule silently did not run there. A module that opts out isn't reported as unprotected — it's reported as nothing, which reads exactly like passing. Files added, plus `EveryModuleWiresUpArchUnitTest`, which fails the build when a module with test sources lacks one — covering modules that don't exist yet.

Root-pom inheritance was the obvious alternative and is worse: surefire's `dependenciesToScan` pulls the whole test-jar, so core's 54 test classes would run in all five modules. That reasoning is recorded on the test.

**2. A red control proves a gate can fire, not that it is looking at the right thing.** Every gate that misbehaved during this work failed on **scope**, never on logic — a pre-commit gate firing on non-commit commands, a checker reading only the first of two matching notes, a greedy regex, an EXIT trap swallowing a real failure. Not one was wrong about *what* to check, and every one passed its negative control. `docs/agent-harness.md` rule 3 now also asks for the **near-miss that must stay green**.

**3. How to settle whether a test earns its place** — optional, for when it's disputed. Four reviewers deadlocked on one test, two wanting it deleted and two wanting it hardened, and nobody acted. Three mutants over the guards it claimed to protect settled it. `docs/testing.md` had nothing on the technique.

**4. The thirteenth confluentinc#857 sighting, with its seed.** Recorded because CI artifacts expire and, by that ledger's own argument, the seed is the asset. It earns its place beyond the tally: this was the first full chaos storm run against the ordering ledger and stall probe added in astubbs/parallel-consumer#325, and **none of them fired** — zero `INSTANCE_STALL`, zero `LEDGER_KEY_ORDER`, zero `LEDGER_KEY_CONCURRENCY`. A new detector's likeliest failure is crying wolf; this is the first evidence these two do not. Marked **unresolved**, not contention — nobody has run the discriminating replay.

### What review and CI added

**5. Three Codex findings, all P2, all valid** — and the first is an instance of the rule commit 2 adds. `EveryModuleWiresUpArchUnitTest` accepted a wrapper **by filename**, so a placeholder or annotation-stripped file satisfied it while ArchUnit discovered nothing there — preserving the exact silent opt-out the test exists to prevent. It now requires `@AnalyzeClasses` *and* `ArchTests.in(TestConventionRules.class)`. A check right about *what* and wrong about *scope*, whose red control passed throughout, written two commits before a reviewer caught it.

Also: root detection required `.git`, which aborts the test in a source archive — it now locates the reactor by the aggregator pom's `<module>` entries, which also keeps the property that a git *worktree* stores `.git` as a file. And the mutation-matrix write-up overclaimed: a hand-picked mutant set shows redundancy *for those guards*, not that a test covers nothing.

**6. `reactor-core` 3.8.6 -> 3.8.7 landed separately and is no longer part of this PR.** It was cherry-picked to master while this was open (`0e21b903d`), so the rebase onto master dropped this branch's identical commit as already-upstream. Recorded here because the description claimed it as a commit of this PR; it is now inherited, not contributed.

**7. A gate for inflight notes that describe their own open PR.** `bin/check-branch-self-reference.sh` fails when a `docs/inflight/` note mentions the current branch or PR without being written as it will read *after* the merge, marked `post-merge: checked`. The rule is not "do not cite your own PR" - it is that the tense has to survive the merge button. It happened here: `branch-package-rename-sweep.md` described astubbs#1's branch as currently repurposed, then astubbs#1 merged and the branch was deleted, leaving a live worklist asserting an arrangement that had ended. Scoped to `docs/inflight/` only, because everywhere else a branch reference records what already happened and stays correct.

A six-lens review of it found the gate was **passing in CI having checked half of what it claimed**: no `PR_NUMBER` in the workflow, so `gh` on the runner was unauthenticated, the failure was swallowed, and the whole `#NNN` arm was skipped - disabling the gate's own motivating incident, which is a note citing a PR by *number*. Also fixed: prose quoting a marker invoked it (the bug `.github/scripts/issue-ref-gate.js` already records for its own markers), an unanchored branch match that fired on `fix/9090` when the branch was `fix/909`, a PR cited by URL being invisible, and unstaged notes being invisible to the local run. The self-test's bar is now a **mutation matrix** rather than a green run - it was green while blind four times - with 31 cases and the thirteen mutants they kill named in the header.

**8. `dups: similarity` fails, and it is the only red check.** The three new ArchUnit wrappers flag at 84.3% against core's. Excluding the example modules was tried here and **reverted**: each wrapper shares a directory with that module's real app test, and the five example apps solve one problem five ways, so examples are the *most* likely place for genuine duplication. The engine's only baseline is the base branch computed live, so the four wrappers already on master pass at ~84% while three identical new ones fail - same code, opposite verdicts, decided by merge timing. Recorded as a `bug`/`misdirection` note with all four workarounds and why each is wrong; the named fix is an accepted-pairs baseline in the tool, which is this project's own fork. **This needs a merge decision, not a code change.**

## Checklist

- [x] Docs updated — `docs/testing.md`, `docs/agent-harness.md`, `docs/inflight/bug-857-family.md`, plus a candidates register
- [x] User-facing feature documentation data added under `docs/features/` — `N/A - no user-facing behaviour; test-only rules, docs, a ledger entry, and a test-scope dependency bump`
- [x] Tests added/updated — one ArchUnit rule and one coverage test, each proven red against a deliberate control that names the offender by file and line
- [x] Title & body reflect the final content of this PR — rewritten after review, the CVE bump, and the self-reference gate

**Verified locally:** all `bin/check-*.sh` gates, the new gate's 31-case self-test and its 13-mutant matrix (all killed), `test-check-agent-hooks.sh`, `test-check-inflight-tags.sh`, the ArchUnit rules in all nine modules, negative controls for both new rules including an unwired-wrapper control, and the OSS Index audit against the bumped reactor tree.


