### PR TITLE
docs(inflight): triage ten untriaged upstream mirrors, give the fork's branches one validated accounting, and index every issue so grep reaches the tracker

### DIFF
--- a/bin/check-upstream-map.sh
+++ b/bin/check-upstream-map.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Validate src/docs/development/upstream-map.yaml against its declared schema.
+#
+# WHY THIS EXISTS
+#
+# `scripts/upstream-map.py validate` has existed for a long time and was run by nobody: no workflow,
+# no gate, no hook. The manifest is the source of truth for the fork<->upstream mapping and is
+# hand-edited at every lifecycle transition, so a typo in a status or a state is exactly the kind of
+# error that passes review and then quietly misroutes the next sweep.
+#
+# The second half of the same failure is what prompted this: astubbs#327 added a whole new
+# `branch_accounting` section and `validate` read only `entries`, so a bogus state validated clean
+# while the run printed a reassuring count of the section it HAD looked at. A gate reporting success
+# about something it never inspected is worse than no gate.
+#
+# This wrapper is deliberately thin - the schema knowledge stays in the Python, which is also the
+# renderer, so the two cannot disagree about what a field means. It reads files only and touches no
+# network, which is what keeps the `check-` prefix honest under bin/AGENTS.md.
+#
+# Exit 0 valid, 1 schema errors, 2 cannot run (no Python or no PyYAML - never a pass).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MANIFEST="src/docs/development/upstream-map.yaml"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "check-upstream-map: $MANIFEST does not exist" >&2
+  exit 2
+fi
+
+PY=""
+for c in python3 python; do
+  if command -v "$c" >/dev/null 2>&1 && "$c" -c '' >/dev/null 2>&1; then PY="$c"; break; fi
+done
+if [ -z "$PY" ]; then
+  echo "check-upstream-map: no working Python 3 on PATH" >&2
+  exit 2
+fi
+
+if ! "$PY" -c 'import yaml' >/dev/null 2>&1; then
+  echo "check-upstream-map: PyYAML is not installed. Install it with: $PY -m pip install pyyaml" >&2
+  exit 2
+fi
+
+# Distinguish "the manifest is invalid" (exit 1) from "the validator itself blew up" (exit 2).
+# Without this an unparseable YAML file and a broken script are indistinguishable, and the repo's
+# standing rule is that a skip must never read as a pass.
+set +e
+out="$("$PY" scripts/upstream-map.py validate 2>&1)"
+rc=$?
+set -e
+
+printf '%s\n' "$out"
+
+if [ "$rc" -eq 0 ]; then
+  exit 0
+fi
+
+# Herestring, not a pipe: `printf | grep -q` takes EPIPE under pipefail and turns a MATCH into a
+# failure. bin/check-shell-sigpipe.sh enforces this across the directory.
+if grep -q '^INVALID:' <<<"$out"; then
+  echo "check-upstream-map: $MANIFEST does not satisfy its schema" >&2
+  exit 1
+fi
+
+echo "check-upstream-map: the validator failed to run (exit $rc), so nothing was checked" >&2
+exit 2

--- a/bin/issue-index.sh
+++ b/bin/issue-index.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Regenerate docs/inflight/issue-index.md - one line per GitHub issue in this fork, so an agent can
+# GREP for issues instead of remembering to query GitHub.
+#
+# Usage:
+#   bin/issue-index.sh          # rewrite docs/inflight/issue-index.md
+#
+# WHY THIS EXISTS, given "never write down what a command can answer".
+#
+# It breaks that rule deliberately, and the reason is discovery rather than storage. The rule exists
+# to stop a SECOND TRACKER forming - a copy that is believed, drifts, and is indistinguishable from
+# the truth. This file is not believed: every row says which day it was read, and the header sends
+# you to `gh issue view` before acting. What it buys is that `grep -ri 'offset encoding' docs/`
+# now reaches the issue tracker, which no amount of discipline was achieving - `gh issue list
+# --state all` is, by AGENTS.md's own admission, the most-skipped of the six prior-art checks,
+# because an agent has to think of it first. Grep is what agents already do.
+#
+# The precedent is `.claude/hooks/inject-recorded-knowledge.sh`, which injects the TITLES of every
+# `docs/solutions/` write-up at session start for exactly this reason: "so you know what exists;
+# grep the ones that look close". Issues were the one knowledge surface with no such index.
+#
+# WHY NO `--check` GATE, unlike bin/todo-index.sh.
+#
+# That script regenerates from the tracked tree, so staleness is decidable offline and a gate is
+# free. This one cannot be: deciding whether the index matches reality means asking GitHub, which
+# needs the network and a token. A gate like that is skipped for fork PRs and dies on a token
+# expiry - the exact failure `bin/check-cve-exclusions.sh`'s header describes, where an unwatched
+# list rots precisely when the check that guards it cannot run. So staleness is handled by SAYING
+# so, in the file, with a date - not by a check that reports "could not run" and gets read as a
+# pass.
+#
+# THE EXEMPT-FILE MARKER IS EMITTED HERE TOO, and for the same reason as the tags below. Every row
+# is a bare `#NN`, so `bin/check-issue-refs.sh` sees a file entirely composed of unqualified
+# references - correctly, since qualifying 122 of them would be noise. The header qualifies them
+# ONCE, by saying the numbers are this fork's. Note the gate only saw this after the file was first
+# COMMITTED: it enumerates via `git diff --name-only`, so an untracked file is invisible to it and a
+# local run reports a green that asserted nothing.
+#
+# THE INFLIGHT TAGS ARE EMITTED HERE, not added to the file by hand. This file is rewritten
+# wholesale on every run, so a hand-added `inflight-type` would be silently dropped by the next
+# regeneration and `bin/check-inflight-tags.sh` would fail on a file nobody remembered editing.
+# `register` is the type because the index is consulted, never completed - it has no done state.
+#
+# NOT NAMED `check-*`, deliberately. That prefix grants a script to the review agent by pattern
+# (bin/AGENTS.md), and the grant is meant for read-only tree gates. This one reaches the network,
+# so it must stay outside it.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+OUT="docs/inflight/issue-index.md"
+REPO="astubbs/parallel-consumer"
+
+# Strict, for the reason bin/todo-index.sh's header records: a permissive parser silently accepted
+# anything it did not recognise and fell through to the rewrite path. Exit 2 is a usage error.
+if [ "$#" -ne 0 ]; then
+    printf 'usage: %s   (no arguments)\n' "bin/issue-index.sh" >&2
+    exit 2
+fi
+
+command -v gh >/dev/null 2>&1 || { echo "issue-index: gh is not on PATH" >&2; exit 2; }
+
+# `-R` is not optional here. This fork's `gh` resolves to confluentinc when nothing says otherwise,
+# and an index silently built from UPSTREAM's issues would be worse than no index at all - the
+# numbers overlap, so every row would look plausible. AGENTS.md opens with this trap.
+raw=$(gh issue list -R "$REPO" --state all --limit 1000 \
+        --json number,title,state,labels,updatedAt) \
+  || { echo "issue-index: could not read issues from $REPO" >&2; exit 2; }
+
+count=$(printf '%s' "$raw" | jq 'length')
+[ "$count" -gt 0 ] || { echo "issue-index: read zero issues - refusing to write an empty index" >&2; exit 2; }
+
+# The date is when the data was READ, which is the only thing this file can honestly assert.
+today=$(date -u +%Y-%m-%d)
+
+{
+cat <<HEADER
+# Issue index - a discovery aid, NOT a source of truth
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: blind-spot -->
+<!-- issue-refs: exempt-file - every row IS a bare fork issue number; that is what the file is. The
+     header states the numbers are this fork's, which is the qualification the gate wants, once. -->
+
+**Data read from GitHub on ${today}.** Regenerate with \`bin/issue-index.sh\`.
+
+**Every row here goes stale silently.** An issue can be closed, retitled or relabelled the minute
+after this file is written, and nothing in the repository will notice. So: use this to FIND issues,
+never to decide anything about one. \`gh issue view <n> -R ${REPO}\` before you act.
+
+## Why this exists, and why it does not break "never write down what a command can answer"
+
+It is here for **discovery**, not storage. That rule exists to stop a second tracker forming - a
+copy that gets believed and drifts apart from the truth. This one is not believed: it is dated, it
+says so twice, and it sends you elsewhere before acting.
+
+What it buys is reach. \`gh issue list --state all\` is the most-skipped of the six prior-art checks
+in [\`AGENTS.md\`](../../AGENTS.md), because an agent has to think of querying GitHub before it can
+do it. Grep is what agents do anyway - so a keyword sweep of \`docs/\` now surfaces the tracker
+too. The same argument already justifies the \`docs/solutions/\` title index that
+\`.claude/hooks/inject-recorded-knowledge.sh\` injects at session start.
+
+**Numbers here are this fork's.** Upstream's range overlaps ours, so a bare number is ambiguous
+everywhere else - see [\`docs/issue-references.md\`](../issue-references.md). A row whose title
+begins \`confluentinc#NN:\` is a mirror of that upstream issue; read the upstream original rather
+than the mirror's summary.
+
+| # | State | Title | Labels |
+|---|---|---|---|
+HEADER
+
+printf '%s' "$raw" | jq -r '
+  sort_by(.number) | .[] |
+  # A pipe in a title would break the table row, so escape it rather than dropping the row.
+  [ "#\(.number)",
+    (.state | ascii_upcase),
+    (.title | gsub("\\|"; "\\\\|")),
+    ([.labels[].name] | join(", "))
+  ] | "| " + join(" | ") + " |"'
+} > "$OUT"
+
+echo "issue-index: wrote $OUT ($count issue(s), read $today)"

--- a/bin/test-check-upstream-map.sh
+++ b/bin/test-check-upstream-map.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Self-test for bin/check-upstream-map.sh.
+#
+# The arms that matter are the CONTROLS: each mutation below passed clean against the validator as
+# it existed before astubbs#327, because `validate` read only `entries` and never looked at
+# `branch_accounting` at all. A regression test that has never failed proves nothing, so every arm
+# here was run against the old code first and observed to pass wrongly.
+#
+# Fixtures are built in a throwaway directory holding a COPY of the real manifest, so the real
+# repository cannot make an arm pass by accident.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+REPO="$PWD"
+MANIFEST="src/docs/development/upstream-map.yaml"
+
+PY=""
+for c in python3 python; do
+  if command -v "$c" >/dev/null 2>&1 && "$c" -c '' >/dev/null 2>&1; then PY="$c"; break; fi
+done
+if [ -z "$PY" ] || ! "$PY" -c 'import yaml' >/dev/null 2>&1; then
+  echo "test-check-upstream-map: no Python 3 with PyYAML, cannot self-test" >&2
+  exit 2
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+# Run the gate against a mutated copy of the tree and assert its exit code.
+# `sed` is deliberately avoided for the mutation: these are YAML flow mappings on one long line and
+# an anchored Python replace says exactly what changed.
+arm() {
+  local name="$1" want="$2" mutation="$3"
+  local work="$TMP/$RANDOM$RANDOM"
+  mkdir -p "$work/bin" "$work/scripts" "$work/src/docs/development"
+  cp "$REPO/bin/check-upstream-map.sh" "$work/bin/"
+  cp "$REPO/scripts/upstream-map.py" "$work/scripts/"
+  cp "$REPO/$MANIFEST" "$work/$MANIFEST"
+
+  if [ -n "$mutation" ]; then
+    MUT="$mutation" MANIFEST="$MANIFEST" "$PY" - "$work" <<'PYTHON'
+import os, pathlib, sys
+work = pathlib.Path(sys.argv[1])
+p = work / os.environ["MANIFEST"]
+old, new = os.environ["MUT"].split("=>", 1)
+s = p.read_text()
+if old not in s:
+    sys.exit(f"fixture anchor not found: {old!r}")
+p.write_text(s.replace(old, new, 1))
+PYTHON
+  fi
+
+  set +e
+  ( cd "$work" && bash bin/check-upstream-map.sh >/dev/null 2>&1 )
+  local got=$?
+  set -e
+
+  if [ "$got" -eq "$want" ]; then
+    echo "  ok    $name (exit $got)"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL  $name: wanted exit $want, got $got"
+    fail=$((fail + 1))
+  fi
+}
+
+echo "test-check-upstream-map:"
+
+# The real manifest must be valid, or every negative arm below is meaningless.
+arm "unmutated manifest is valid" 0 ""
+
+# --- controls: each of these validated CLEAN before branch_accounting was covered -------------
+arm "bogus branch state is rejected" 1 \
+  "state: mirrored=>state: TYPO_NOT_A_STATE"
+arm "deleted branch with no date is rejected" 1 \
+  "state: deleted, deleted: 2026-08-20=>state: deleted"
+arm "non-ISO deleted date is rejected" 1 \
+  "deleted: 2026-08-20=>deleted: last tuesday"
+arm "duplicate ref is rejected" 1 \
+  "- {ref: upstream/master,=>- {ref: upstream/pyallel-consumer,"
+arm "'see' as a bare string is rejected" 1 \
+  'see: [confluentinc#539],=>see: "confluentinc#539",'
+
+# A tip that YAML parses as an integer never string-compares equal to `git rev-parse` output, so it
+# is silently useless rather than absent. This one bit for real, in review on astubbs#327.
+arm "integer tip is rejected" 1 \
+  "tip: 4533f6d8d,=>tip: 255916684,"
+
+# A tip is required only where nothing else can recover it. A live branch is one `git rev-parse`
+# away, and this section's rule is "nothing a command answers" - so the pair below is the point:
+# the same omission is a finding for a deleted branch and legitimate for a live one.
+arm "deleted branch with no tip is rejected" 1 \
+  "tip: 9a25939d7, state: deleted=>state: deleted"
+arm "live branch with no tip is accepted" 0 \
+  "- {ref: presentation, state: ours,=>- {ref: presentation, state: ours, extra_note: fine,"
+
+# `archived` is the other half of the same rule and has no entry in the real manifest, so without
+# this arm the tuple could regress to just ("deleted",) and nothing - data or test - would notice.
+arm "archived branch with no tip is rejected" 1 \
+  "- {ref: presentation, state: ours,=>- {ref: presentation, state: archived,"
+arm "archived branch WITH a tip is accepted" 0 \
+  "- {ref: presentation, state: ours,=>- {ref: presentation, tip: deadbeef1, state: archived,"
+
+# --- the gate must not launder "could not run" into a pass ------------------------------------
+arm "unparseable manifest is not a pass" 2 \
+  "branch_accounting:=>branch_accounting: [unclosed"
+
+echo "test-check-upstream-map: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/docs/inflight/AGENTS.md
+++ b/docs/inflight/AGENTS.md
@@ -129,9 +129,19 @@ existing number by its prefix and check it; write new ones the way this section 
 
   Record what no command knows: why something is parked, what blocks it, which decision is pending,
   what collides.
-- **No committed index.** An index file would be edited by every PR, which is the problem this
-  directory exists to solve. `ls docs/inflight/` and `grep -r` are the index. (`docs/todo-index.md` is
-  the cautionary case: committed, generated, and stale until a reviewer caught it on astubbs#110.)
+- **No committed index OF THESE NOTES.** An index of the notes would be edited by every PR, which is
+  the problem this directory exists to solve. `ls docs/inflight/` and `grep -r` are the index.
+  (`docs/todo-index.md` is the cautionary case: committed, generated, and stale until a reviewer
+  caught it on astubbs#110.)
+
+  **[`issue-index.md`](issue-index.md) is not that**, and is here on purpose - do not delete it
+  citing the rule above. It indexes GITHUB ISSUES, not notes, so no PR edits it except one that
+  regenerates it deliberately, and the churn the rule guards against cannot arise. It exists because
+  `gh issue list --state all` is the most-skipped of the root `AGENTS.md` prior-art checks - an agent
+  must think of querying GitHub, whereas it greps by reflex. It is dated, it says twice that it goes
+  stale silently, and it sends the reader to `gh issue view` before acting, which is what keeps it a
+  discovery aid rather than the second tracker "never write down what a command can answer" forbids.
+  Regenerate with `bin/issue-index.sh`; the script's header records why it has no `--check` gate.
 - **If you are given new guidance about how these notes are written, update this file too**, so other
   sessions inherit the rule instead of rediscovering it.
 

--- a/docs/inflight/AGENTS.md
+++ b/docs/inflight/AGENTS.md
@@ -79,6 +79,30 @@ ranking. Where a note sits is `inflight-state`'s job; what it is ranked against 
 New prefixes are fine when something genuinely does not fit **and names an area, not a status**. Do
 not add subdirectories - the prefix is the grouping.
 
+### The number, when a note has one
+
+A note that maps to exactly one issue puts that number between the area and the slug -
+`<area>-<NNN>-<slug>.md`, as in `core-139-public-api-thread-safety-contract.md`. It is optional; the
+slug alone is fine for notes that belong to no single issue, and the population-level and register
+notes carry none.
+
+**The number is always this fork's**, never confluentinc's. Two reasons, and the second is the
+binding one: it is the number `gh issue view` resolves without `-R`, and it is the only one that
+always exists - every upstream issue is mirrored here, but plenty of fork issues have no upstream
+counterpart, so upstream numbering cannot name the whole directory.
+
+This is a rule because a filename cannot be qualified. Prose has
+[`docs/issue-references.md`](../issue-references.md) and a gate behind it, precisely because a bare
+number below the threshold is a coin flip between two repos that both have one. A filename is bare by
+construction, so the convention is the only thing standing between a reader and the wrong issue.
+
+**Older names predate this and disagree** - `bug-857-family.md` and `branch-912-vertx-leak.md` carry
+confluentinc numbers, `perf-192-followups.md` carries a fork one. They are left alone rather than
+swept, because renaming a note breaks every citation of it for no gain in what the note says. Read an
+existing number by its prefix and check it; write new ones the way this section says.
+
+`pr-` is the deliberate exception: its number is a fork **PR**, which is what that prefix is for.
+
 ## Rules
 
 - **Track only what is currently OPEN**, plus cross-branch context a future branch should inherit.

--- a/docs/inflight/branch-audit-orphans.md
+++ b/docs/inflight/branch-audit-orphans.md
@@ -13,7 +13,9 @@ in `sweep-2023-async-produce`, was already known wrong and is fixed alongside th
 
 Upstream-tip preservation is DONE, not open: every non-bot `upstream/*` branch tip is now reachable
 from an origin branch or pinned under `archive/upstream-branch/*` /
-`archive/upstream-pr-*` tags. `preserved_branch_tips` in upstream-map.yaml owns the tag/SHA record;
+`archive/upstream-pr-*` tags - and since 2026-08-20 every upstream branch is also mirrored on this
+fork under `upstream/*`. `branch_accounting` in upstream-map.yaml owns the tag/SHA record, having
+absorbed the former `preserved_branch_tips` and `preserved_heads`;
 docs/upstream.md owns the method, including the trap that the 2026-08-14 containment command
 (`git branch -r --contains`) cannot see tags, so re-running it verbatim reports already-preserved
 heads as lost.
@@ -40,8 +42,9 @@ Defect / correctness cohort:
   against the bug-857 family before any new work there
 - `bugs/issue-184-reproduce-using-cfacade` and `bugs/issue-184-reproduce-w-cf-reverted` -
   reproduction pair for confluentinc#184
-- `bugs/prod-tx-manager-retries` - plausibly belongs to `sweep-2023-tx-failure-taxonomy`
-  (confluentinc#144); verify before attaching
+- `bugs/prod-tx-manager-retries` - **attached.** It belongs to `sweep-2023-tx-failure-taxonomy`
+  (confluentinc#144), and is the prototype to start from rather than the older `tx-commit-failure`
+  branch; see `docs/inflight/core-241-tx-commit-failure-taxonomy.md`
 - `features/partial-batch-failure`
 - `tests/less-keys-than-threads-broker-test`
 
@@ -77,6 +80,6 @@ stayed invisible for three years. Two audit modes wanted:
 
 - branch-audit: origin branches vs manifest `fork.branches` + refactoring.md, with an explicit junk
   allowlist, so untracked work cannot silently regrow
-- containment re-check: every `preserved_heads` / `preserved_branch_tips` SHA still reachable on
-  origin (branch OR tag - see the docs/upstream.md trap above); docs/upstream.md already records
-  this as manual-only, tracked in astubbs#300
+- containment re-check: every `branch_accounting` tip still reachable on origin (branch OR tag - see
+  the docs/upstream.md trap above); docs/upstream.md already records this as manual-only, tracked in
+  astubbs#300

--- a/docs/inflight/bug-162-offset-state-truncation.md
+++ b/docs/inflight/bug-162-offset-state-truncation.md
@@ -1,0 +1,96 @@
+# "Truncating state" warns when there is no state to truncate
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+[astubbs#162](https://github.com/astubbs/parallel-consumer/issues/162), mirroring
+[confluentinc issue #546](https://github.com/confluentinc/parallel-consumer/issues/546). That thread
+holds three distinct defects behind one warning string. One is fixed here by inheritance; the other
+two are live at HEAD and neither has a test.
+
+## Fixed: the RunLength "expected 1" decode
+
+`857c384af` (confluentinc#563, upstream 0.5.2.6) is in this fork's history, and its guard is
+`long highestSeenOffset = (baseOffset > 0)` in `offsets/OffsetRunLength.java`, with a comment naming
+confluentinc#546. A no-progress commit used to decode back as base offset 0, so bootstrap expected
+offset 1 and truncated. That form of the message cannot occur now.
+
+## Live: absent commit data reports as "expected 0 from loaded commit data"
+
+`maybeTruncateBelowOrAbove` in `state/PartitionState.java` takes its expectation from
+`long expectedBootstrapRecordOffset = getOffsetToCommit()` and never asks whether commit data
+existed. When it did not, the partition came from the `PartitionState<K, V> defaultEntry` branch in
+`offsets/OffsetMapCodecManager.java`, so `offsetHighestSucceeded` is `KAFKA_OFFSET_ABSENCE` and the
+expectation computes to 0. The comparison is strict (`bootstrapPolledOffset >
+expectedBootstrapRecordOffset`), so a first poll at offset 0 does not qualify - but a first poll at
+any offset above 0 takes the above-expected branch and logs `Truncating state - removing records
+lower than`, while pruning nothing, because the incompletes map is empty. The message is false in both halves: no commit data was loaded, and no state was
+removed.
+
+That is the shape reported upstream on **0.5.2.7**, after the RunLength fix shipped, alongside a
+broker CLI screenshot showing an empty CURRENT-OFFSET for exactly those partitions. Established by
+reading the code, not by running it.
+
+The same default entry is reached from `catch (OffsetDecodingError offsetDecodingError)` in the same
+file, so the foreign-metadata recovery landed by astubbs#217 routes its partitions into this false
+warning rather than the crash it replaced.
+
+## Live and never diagnosed: the below-expected branch resets and replays
+
+The thread's second warning, `Bootstrap polled offset has been reset to an earlier offset`, survived
+the 0.5.2.6 snapshot for the original reporter and was never explained upstream. Its branch discards
+all loaded state and replays, so the cost is duplicate processing, not loss. Reported gaps were small
+and were seen on already-running instances taking on new partitions, which points at handoff rather
+than retention.
+
+**Untested hypothesis, stated so it can be refuted:** PC issues its own `consumer.committed()` in
+`loadPartitionStateForAssignment`, separate from the consumer's own position resolution for a newly
+assigned partition. If the previous owner's commit lands between those two reads, PC's expectation is
+one commit newer than the position the fetcher starts from. The control arm is a test that delays the
+old owner's commit past assignment, predicting the warning appears in that arm only.
+
+## Neither case is tested, and the open offset PRs do not touch them
+
+`PartitionStateCommittedOffsetIT` covers deliberate truncation only - compaction, committed offset
+moved higher or lower, no reset policy on startup. No test in the surefire or failsafe suites references the
+warning or `maybeTruncateBelowOrAbove` - the other references are javadoc in
+`state/PartitionStateManager.java` and `state/PartitionState.java`, plus a jcstress probe in
+`jcstress-poc/` that models the same branch but is not part of the test suite - so a partition with
+no commit data is never asserted to start quietly. A test wants both cases: first offset 0, and first offset
+above 0.
+
+astubbs#106 (stop walking every offset), astubbs#306 (encoding density) and astubbs#207
+(`invalidOffsetMetadataPolicy` reachability) all touch this area and address neither case. The mirror
+body implies astubbs#106 might; it does not.
+
+## Draft replacement for the mirror's `## Fork status` (NOT posted)
+
+Text a maintainer can paste over the existing section, which is stale in the ways above. Fully
+qualified because it is destined for GitHub, where `astubbs#NN` renders as plain text.
+
+> **Partially fixed.** confluentinc/parallel-consumer#563, which upstream shipped in 0.5.2.6, is in
+> this fork by inheritance (`857c384af`); its guard sits in `OffsetRunLength` and it ends the
+> "expected 1" form of the warning.
+>
+> It does not close this issue. The same warning was reported upstream on **0.5.2.7**, after that fix
+> shipped, in a different form - "expected 0 from loaded commit data", on partitions the broker shows
+> with no committed offset at all. That is a second defect, still present here:
+> `PartitionState#maybeTruncateBelowOrAbove` never checks whether commit data existed, so absence
+> computes to an expectation of 0 and the warning fires having truncated nothing.
+>
+> A third path, the "reset to an earlier offset" branch, was never diagnosed upstream and is also
+> still open. It causes replay, not loss.
+>
+> `PartitionStateCommittedOffsetIT` covers deliberate truncation only; neither remaining case is
+> tested. The open offset-encoding work (astubbs/parallel-consumer#106,
+> astubbs/parallel-consumer#306, astubbs/parallel-consumer#207) addresses none of it.
+
+## The decision to make
+
+Whether absent commit data should warn at all. It is the normal state of a new group or an expired
+offset, so the honest handling is a distinct message at a lower level and no truncation branch - but
+that is a behaviour change to a log line operators alert on.
+
+## Delete when
+
+Both live cases are closed, or the maintainer rules the warning acceptable as it stands.

--- a/docs/inflight/core-139-public-api-thread-safety-contract.md
+++ b/docs/inflight/core-139-public-api-thread-safety-contract.md
@@ -1,0 +1,102 @@
+# The public API has no thread-safety contract, so nothing can clear the 1.0 blocker
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: reliability -->
+<!-- inflight-labels: concurrency -->
+
+
+astubbs#139 (mirroring confluentinc#186) is labelled *blocker* and *1.0*, and has been since 2022,
+but it names no method, no thread and no check. **That is the thing to fix first.** Below is the
+audit it was missing, so the label can either be cleared or, for the first time, be actionable.
+
+## What the mirror body gets wrong now
+
+- Its `## Fork status` cites `file:line`, and every one of those numbers has drifted. The reasoning
+  around them still holds; the coordinates do not. Anything quoting them should re-grep.
+- **"Thread-safe here only by convention" is too generous.** `subscribe` is the *safest* of the
+  cross-thread methods, because a pre-start subscribe genuinely is single-threaded. The unsafe
+  surface is the run-state machine, and the body does not mention it.
+- It frames the whole issue as needing the astubbs#142 thread-model rework. Most of the audit below
+  is fixable without it.
+
+## The audit - what a user may call off the constructing thread, and what happens
+
+Verified against the tree, not inferred. The field at the centre of it is
+`AbstractParallelEoSStreamProcessor`'s `private State state = State.UNUSED`, which is **not**
+volatile on master.
+
+| Surface | Verdict |
+|---|---|
+| `pauseIfRunning` / `resumeIfPaused` | **Unsafe twice.** Non-volatile read, and a check-then-set that is not atomic - a `pause` racing a `close` can write `PAUSED` over `CLOSING` and resurrect a consumer that was shutting down |
+| `close*` (six overloads on `DrainingCloseable`) | Same field. `waitForClose` spins on `while (!state.equals(CLOSED))` and the control task loops on `while (state != CLOSED)`, both non-volatile |
+| `isClosedOrFailed` | Reads the same field plus a non-volatile `controlThreadFuture` |
+| `subscribe` x4 | Safe before `poll*`, unsafe after - `consumer.subscribe(topics, this)` runs on the caller's thread while the poll thread owns the `KafkaConsumer`. This is the half confluentinc#346 addressed |
+| `addLoopEndCallBack` | Registers onto `controlLoopHooks`, a plain `ArrayList` walked by `this.controlLoopHooks.forEach(Runnable::run)` every control pass. **astubbs#267 fixes this** |
+| `setLongPollTimeout` | An instance method writing `BrokerPollSystem`'s `private static Duration longPollTimeout` - one PC changes every PC in the JVM |
+| `getFailureCause` | **Safe** - `failureReason` is volatile, and the comment above it says why |
+| `workRemaining` | **Safe.** Predicted unsafe and refuted: `PartitionStateManager.partitionStates` is a `ConcurrentHashMap` and `PartitionState.incompleteOffsets` a `ConcurrentSkipListMap` |
+| `getPausedPartitionSize` | **Safe** - `ConsumerManager.pausedPartitionSizeCache` is volatile |
+| `requestCommitAsap`, `notifySomethingToDo` | Guarded already |
+
+Two more sites are the same defect and already have owners: `PCMetrics.registeredMeters` and
+`WorkManager.successfulWorkListeners`, both in
+[`bug-shared-collections-across-the-poll-boundary.md`](bug-shared-collections-across-the-poll-boundary.md).
+
+**`RetryQueue` was the sharpest example and has since been FIXED**, which is why it is kept here
+rather than deleted: it is the worked case for why a javadoc claim is not a contract. Its class
+javadoc said "Implementation is thread safe and uses ReadWriteLock" while `removeAll`'s fast path
+read `unique.isEmpty()` with no lock held, so the JMM permitted a stale `true` and the method could
+return having removed nothing - leaving a container in the retry queue while it was also in flight.
+astubbs#268 found it independently and had to forbid its own snapshot source from calling the
+accessors. Fixed by `d2e00faf0`; every read now takes the read lock, and the method carries a comment
+explaining why the guard is on the caller's list instead.
+
+**Checked at HEAD before writing this**, because an earlier revision of this note asserted the bug in
+the present tense after the fix had already landed via a master merge on the same branch - grep
+`GUARD ON THE CALLER'S OWN LIST` to see the current state. One stale copy of the old claim survives
+in `parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md` ("`size()` reads the map
+under no lock at all"), which is master's file and out of scope here.
+
+## Definition of done, so the label means something
+
+1. Every method on `ParallelConsumer`, `ParallelStreamProcessor` and `DrainingCloseable` carries a
+   javadoc sentence saying which threads may call it. Not a blanket claim - a per-method one, since
+   `subscribe` and `pauseIfRunning` genuinely have different answers.
+2. The run-state machine survives a concurrent `pause`/`resume`/`close` without losing a transition.
+   Volatile is necessary and not sufficient - the check-then-set needs to be atomic.
+3. No public method claims thread safety it does not have (`RetryQueue`).
+4. A test that drives the surface in step 1 concurrently against a live instance and asserts no
+   exception and no lost transition. Without step 4 there is nothing to say the blocker is cleared.
+
+## Is it still a 1.0 blocker
+
+**Yes, but for a smaller reason than the label implies.** The full confluentinc#346 ambition -
+exposing *all* `Consumer` APIs safely - is a feature, and belongs with astubbs#158 rather than on a
+blocker. Steps 1-4 are the blocking part: they stop the published contract from being a guess, and a
+contract cannot be corrected after a 1.0 without breaking someone.
+
+## What has already moved, and what it collides with
+
+- **astubbs#226** makes `state` and `controlThreadFuture` volatile and documents the four threads
+  that touch the field. It closes the visibility half of the state defect and *not* the atomicity
+  half - `pauseIfRunning` and `resumeIfPaused` are unchanged there.
+- **astubbs#267** closes the listener-registration half.
+- **astubbs#268** is the worked example of the design rule this issue needs: it marshals every read
+  onto the control thread via the loop-end callback, and its `DirectStateSource` javadoc enumerates
+  what may never be read from another thread, with a reason each. Whoever writes step 1 should start
+  from that list rather than re-deriving it.
+- **astubbs#51** (a copy of confluentinc#908) rewrites `synchronized` blocks in the same class as
+  `ReentrantLock` to avoid virtual-thread pinning. It is still on pre-rename packages, and it touches
+  `AbstractParallelEoSStreamProcessor` and `PCMetrics`, so it collides with all three above. Any
+  atomicity fix wants to know which lock primitive wins before it picks one.
+- confluentinc#346 itself is closed unmerged, on pre-rename packages, and predates the fork's actor
+  work. Treat it as a design reference for the `subscribe` half only, not a cherry-pick.
+
+[`docs/refactoring.md`](../refactoring.md) carries the same issue under "Thread-safe public API
+surface", plus the SpotBugs `AT_*` findings that overlap it; this note is the audit and the
+done-definition it points at.
+
+## Delete when
+
+The four steps above are done, or the surface audit moves into published javadoc and this note has
+nothing left that the code does not say.

--- a/docs/inflight/core-163-poll-path-has-no-error-seam.md
+++ b/docs/inflight/core-163-poll-path-has-no-error-seam.md
@@ -1,0 +1,111 @@
+# No poll-path exception handler: the answer to astubbs#163, and the premise it corrects
+
+<!-- inflight-type: feature -->
+<!-- inflight-impact: crash -->
+
+[astubbs#163](https://github.com/astubbs/parallel-consumer/issues/163) (confluentinc#550) asks whether
+PC has an exception handler, and then asks the question that was never answered: *"is there a plan to
+add error handler processing, or do we need to customize it?"*
+
+Below is a draft reply, written to be postable as-is. Under it are the two things the reply depends on
+that no command can tell you, one of which is currently wrong in live requirements work.
+
+## Draft answer (not yet posted)
+
+> No, there is no handler for a deserialization failure thrown out of `consumer.poll()`, and that
+> is still true today. The poll path does catch two specific exceptions - a bounded
+> `SaslAuthenticationException` retry, and `WakeupException` as control flow - but nothing catches
+> yours. You need to customize it, and there is a plan, but no date. Here is the whole picture.
+>
+> **Your stack trace is the poll path, not the processing path, and that distinction is the answer.**
+> PC's documented error handling - retry with a delay, skip by returning normally - all lives on the
+> processing path and operates on a record PC has already deserialized and queued. A
+> `RecordDeserializationException` is thrown by `consumer.poll()` before any of that exists, so none of
+> it can apply.
+>
+> **What happens today:** the exception propagates out of the broker-poll thread, which dies. PC then
+> closes the whole instance and stores the cause, reachable through `getFailureCause()` after the fact.
+> So a single undeserializable record stops consumption for that instance, and the cause arrives
+> wrapped in generic exception types rather than something you can usefully switch on.
+>
+> **The workaround that works today**, and the one we would recommend: consume as `byte[]/byte[]`,
+> deserialize inside your processing function, and handle the failure there. That moves the failure
+> onto the processing path, where you can log and skip it, divert it to a topic of your own, or rethrow
+> to retry it.
+>
+> **One thing to know before you rely on that:** on the processing path every exception is treated as
+> retriable and a record is retried indefinitely - there is no max-retry ceiling and no terminal state.
+> "Give up on this record" means catching it yourself and returning normally, which PC records as a
+> success so the offset advances. There is no built-in dead-letter queue yet.
+>
+> **The plan.** Two issues track this, and they are deliberately different sizes:
+> [astubbs/parallel-consumer#148](https://github.com/astubbs/parallel-consumer/issues/148)
+> (confluentinc/parallel-consumer#304) is the contained step - stop a bad record from killing the poll
+> thread - and
+> [astubbs/parallel-consumer#153](https://github.com/astubbs/parallel-consumer/issues/153)
+> (confluentinc/parallel-consumer#391) is the full handler/policy API, along the lines of the Kafka
+> Streams handler suggested on the original thread. The dead-letter-queue and max-retries work
+> ([astubbs/parallel-consumer#149](https://github.com/astubbs/parallel-consumer/issues/149),
+> [astubbs/parallel-consumer#141](https://github.com/astubbs/parallel-consumer/issues/141)) is a
+> separate track and would *not* cover your case: a record that fails to deserialize never enters the
+> retry system at all, so nothing that triggers on retry exhaustion can ever fire on it.
+>
+> Note that the Confluent-hosted repository is no longer maintained. This fork is where the work
+> happens, so discussion belongs here.
+
+## What the answer depends on that is not in the issue
+
+**The poll is not unguarded, and the issue body's claim that it is has gone stale.** The body quotes a
+blanket `catch (Exception e)` as the only handling. In fact `internal/ConsumerManager.java` has
+`catch (SaslAuthenticationException`, which retries against a bounded budget, and a `WakeupException`
+arm that returns an empty result (grep `correctPollWakeups++`; `WakeupException` itself is not unique
+in that file). A **typed per-exception poll-error seam already exists and is load-bearing** -
+a deserialization policy would be a third arm of it rather than new architecture. That makes
+astubbs#148 materially cheaper than the mirror bodies suggest, and nothing else records it.
+
+**The quoted catch block has also changed.** astubbs#204 added
+`committer.ifPresent(c -> c.notifyPollerDied(e))` to the `log.error("Unknown error", e)` catch in
+`internal/BrokerPollSystem.java`, before the rethrow,
+so a control thread blocked in `ConsumerOffsetCommitter#commitAndWait` is released by an event instead
+of waiting out `offsetCommitTimeout`. The thread still dies and PC still closes; only the reporting
+improved.
+
+**The death is wrapped twice** - `void supervise()` in `internal/BrokerPollSystem.java` into
+`InternalRuntimeException`, then `failureReason = new RuntimeException` in
+`internal/AbstractParallelEoSStreamProcessor.java` into a bare one. That is the complaint in
+`core-exception-hierarchy-cleanup.md` reaching a user-facing path, and it is why the draft says the
+cause is not something you can switch on.
+
+## The collision, and it is a wrong premise in live work
+
+The DLQ prior-art report on astubbs#313 files astubbs#163 under "adjacent demand, same nerve", and its
+**open question 6** asks whether deserialization failures ride along with the DLQ work. **On the
+mechanism they cannot.** A record that fails to deserialize never becomes a `WorkContainer`, so
+`numberOfFailedAttempts` never increments and no terminal-exception, max-retry or DLQ trigger can ever
+fire on it. Answering question 6 "rides along" would settle requirements on a false premise.
+
+For the same reason `bug-max-failure-history-is-inert.md` is unrelated here, being per-`WorkContainer`
+too, and `OffsetCommitBudgetExceededException` (astubbs#204) does not collide either, being the commit
+path.
+
+What genuinely should be shared is the *shape* of the answer. astubbs#317
+(`core-commit-failure-seam.md`) is the same request on a different path: hand the application a
+decision instead of PC terminating for it. Whatever decision type astubbs#317 settles on should be
+reused here rather than invented twice.
+
+## The decision only the maintainer can make
+
+Whether PC's contract is "an undeserializable record kills the instance" - which is Kafka's own
+consumer behaviour, and defensible - or whether PC offers skip / divert / shut-down like Kafka Streams'
+handler. That choice, not the code, is what has kept astubbs#148 and astubbs#153 open for years. The
+cheap half is independent of it: the `byte[]` route is **absent from the README**, whose Retries and
+Skipping Records sections describe only the processing path.
+
+Recommended disposition for astubbs#163 itself: post the answer, correct the stale poll-is-unguarded
+claim in the body, then close it as a duplicate of astubbs#153 with astubbs#148 as the contained step.
+Answering before closing matters - the reporter asked in 2023 and has never had a fork answer.
+
+## Delete this file when
+
+The answer is posted and the poll-path policy is decided - either implemented, or recorded as
+deliberately-not-offered in `docs/refactoring.md` with the README documenting the `byte[]` route.

--- a/docs/inflight/core-178-key-order-across-a-rebalance.md
+++ b/docs/inflight/core-178-key-order-across-a-rebalance.md
@@ -1,0 +1,102 @@
+# Key ordering across a rebalance - the one route to "same record, two threads at once"
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: reliability -->
+<!-- inflight-labels: concurrency -->
+
+Triage of [astubbs#178](https://github.com/astubbs/parallel-consumer/issues/178), the fork mirror of
+[confluentinc issue #843](https://github.com/confluentinc/parallel-consumer/issues/843): one record
+run by two `pc-pool-1-thread-*` threads in one pod, 70ms apart, on 0.5.3.0.
+
+## confluentinc#909 is NOT the cause - prediction refuted
+
+`src/docs/development/upstream-pr-analysis.adoc` carries "PR #909 likely root cause" for <!-- issue-refs: exempt -->
+confluentinc#843, unverified since it was written. It is wrong on both terms:
+
+- **Wrong consequence.** The confluentinc#909 defect *drops* the fresh container and wedges the
+  offset - anchor `already exists in shard queue, dropping record` in `ProcessingShard.java`. Loss and
+  stall, not duplication. astubbs#322's reproduction counts lost records, never a duplicate.
+- **Wrong precondition.** It needs a rebalance inside the registration loop. The reporter states there
+  was none, no retry and no load peak.
+
+Same for confluentinc#893, which is offset accuracy on assignment - also rebalance-gated.
+
+## The only inspected route that produces the symptom
+
+Not the reporter's scenario, but it is the one mechanism in the tree that puts the same key on two
+worker threads at once *within one instance*, and nothing names it yet:
+
+1. A container is taken as work (`onQueueingForExecution` in `WorkContainer.java`) and stays resident
+   in its shard; a worker is inside the user function.
+2. A revoke bumps the epoch and sweeps - anchor `removeStaleWorkContainersFromShard` in
+   `ProcessingShard.java`, reached via `ShardManager.removeStaleContainers()`, which
+   `PartitionStateManager.java` calls on both assign and remove. (Do not anchor on the comment
+   `remove stale work containers after partition epoch changed` - it occurs twice in that file,
+   so it does not identify a site.) That method tests staleness only and **never asks whether the container is in flight**. The worker keeps
+   running: `onPartitionsRevoked` in `AbstractParallelEoSStreamProcessor.java` commits and truncates,
+   it does not drain.
+3. The partition comes back to the same consumer. The offset was never committed, so it re-delivers,
+   the shard slot is now free, and the fresh container is takeable - the key-ordering restriction only
+   consults `entries`, and the old container is no longer in it.
+4. Both run. `handleFutureResult` discards the old result (anchor `Dropping work from revoked
+   partition` in `WorkManager.java`), so PC's *bookkeeping* stays correct while the user function has
+   already executed twice, concurrently, on one key.
+
+The sweep route is in 0.5.3.0 (`git tag --contains bab2c6b7a`), so it is not fork-introduced.
+astubbs#31 added a second way into the same state: the `Replacing stale entry (epoch {})` path frees
+the slot even when the sweep missed it.
+
+**README promises "strong ordering by key".** Whether an undrained old-epoch delivery is a violation
+or legitimate at-least-once is a maintainer call, and it is the blocker here.
+`KeyOrderLedger.java`'s javadoc reaches the same fork - it says choosing the bound on how long an
+old-epoch delivery may still run before it counts as a violation is "the whole job" (grep
+`picking that number is the whole job`).
+
+## Next step, and what it is not
+
+The detector is an **analysis**, not instrumentation. `KeyOrderLedger` already asserts
+`LEDGER_KEY_CONCURRENCY`, but its window key includes the epoch (`"|e" + epoch`), so a cross-epoch
+overlap falls into two windows and passes. Every `Delivery` already carries what a cross-epoch check
+needs and the full history is retained - see the "Recorded but not yet analysed" section of
+`docs/testing.md`. `ChaosRevokeUnderWorkKeyOrderIT` is the scenario cell to run it under. Cost: the
+comparison is small, the bound is the decision above.
+
+**That still would not settle confluentinc#843**, which had no rebalance. Nothing was ever supplied
+that could: the reporter never logged partition or offset at pickup, said detailed logging was added,
+and has not returned since 2025-03. Their own uniqueness key is `groupId`+`taskId` while the Kafka key
+is the item id, so two records at different offsets carrying one logical task remain unexcluded.
+Cannot reproduce - not "did not happen".
+
+## The information request, ready to post
+
+The issue is `wait for info` and the ask was never made precisely, so here it is. Post to
+`astubbs/parallel-consumer#178`, and cross-post to confluentinc#843 only if the reporter is still
+watching there. Not posted by triage.
+
+> Re-reading this with fresh eyes, the analysis above still holds - work selection is single-threaded
+> and the in-flight flag is written and read by that one thread - so a duplicate dispatch with no
+> rebalance is not reachable by reading the code. There is exactly one route we can find that puts one
+> key on two threads in a single instance, and it needs a rebalance. Four things would separate them,
+> and the detailed logging you added should already carry the first two:
+>
+> 1. **Partition and offset for both pickups.** If both threads logged the same partition and offset,
+>    it is one record dispatched twice and we have a real bug. If they differ, it is two records
+>    carrying one logical task, and the trail moves to your producer.
+> 2. **Consumer-group events for that pod in a wider window** - the minutes either side, not just the
+>    second the two log lines span. `Revoke previously assigned partitions`,
+>    `Successfully joined group with generation N`, or a heartbeat failure is enough. A rebalance
+>    shortly *before* the first pickup would fit the mechanism we found; a rebalance inside the 70ms
+>    gap would not.
+> 3. **Your key vs your identity.** You partition by item id but identify a task by `groupId`+`taskId`,
+>    so two records with different keys can carry one task and key ordering would not serialise them.
+>    Worth confirming the two log lines came from the same key.
+> 4. **The exact Parallel Consumer version**, and, if you can reproduce, DEBUG on
+>    `io.confluent.parallelconsumer.state` (`bz.stub.parallelconsumer.state` on this fork). The lines
+>    that matter are the stale-container removals and `Replacing stale entry`.
+>
+> If (1) shows the same partition and offset with no rebalance anywhere near, that is a new mechanism
+> and we will build a reproduction for it directly.
+
+If nothing arrives, do not close as "not a bug" - close as **not actionable without a reproduction**,
+citing the two exclusions above. The mechanism this note records is separate and stays open either
+way.

--- a/docs/inflight/core-189-batch-failure-granularity.md
+++ b/docs/inflight/core-189-batch-failure-granularity.md
@@ -1,0 +1,97 @@
+# One poison record starves its batch companions permanently - astubbs/parallel-consumer#189
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: stall -->
+
+
+Mirror of [confluentinc issue #887](https://github.com/confluentinc/parallel-consumer/issues/887).
+The design work is already done and ranked: the **poison-isolation ladder** in
+[`docs/ideation/2026-08-17-batching-enhancements-ideation.html`](../ideation/2026-08-17-batching-enhancements-ideation.html)
+- jitter, then batch bisection, then a per-record failure manifest. This note exists because that
+ideation is filed under *batch composition* in
+[`core-batching-enhancements.md`](core-batching-enhancements.md), whose deferral is gated on the
+`confluentinc#915` composition-API decision - and **the first rung is not gated on it**. Separating
+the two is the point.
+
+## Verified at HEAD
+
+The reporter's reading is correct, and the consequence is worse than "surprising". Four mechanisms
+compose, all under `parallel-consumer-core/src/main`:
+
+- `AbstractParallelEoSStreamProcessor.java`, the `for (var wc : workContainerBatch)` loop in the
+  `catch` around `runUserFunctionInternal` - one thrown exception calls `onUserFunctionFailure` on
+  **every** container. The user function is invoked before anything is marked succeeded, so no
+  innocent record is ever distinguishable from the poison one.
+- `WorkContainer.java`, `updateFailureHistory` - the retry due time is
+  `lastFailedAt.get().plus(retryDelay)`, and `ParallelConsumerOptions.java`'s
+  `DEFAULT_STATIC_RETRY_DELAY` is a flat `Duration.ofSeconds(1)` with no randomisation. The whole
+  batch becomes due at the same instant.
+- `AbstractParallelEoSStreamProcessor.java`, `makeBatches` - a plain fixed-size `partition` over the
+  shard scan, and `ProcessingShard.getWorkIfAvailable` walks `entries` in offset order. The failed
+  records hold the lowest available offsets in their shard, so the identical batch re-forms.
+- **There is no retry ceiling** - the same finding astubbs#149 records as the DLQ's prerequisite - so
+  it never ends. The innocent records' side effects re-execute once a second, unbounded, past what
+  at-least-once implies.
+
+The line the reporter quotes, "There is no guarantee that the messages will be retried again in the
+same batch" (`src/docs/README_TEMPLATE.adoc`, and the generated `README.adoc`), is literally true and
+practically inverted: in steady state it is always the same batch.
+
+Nothing merged since the mirror was written has changed this. The merged PRs touching
+`AbstractParallelEoSStreamProcessor.java` or `WorkContainer.java` are the package rename, the
+issue-reference sweep, astubbs#177's commit-error reporting and astubbs#209's pool hardening.
+
+## The seam is already half-built
+
+`runUserFunctionInternal` declares `intermediateResults`, comments *"capture each result, against the
+input record"*, never populates it, and returns it empty. Per-record result correlation was started
+and abandoned, so **batch atomicity is an unfinished feature, not a design invariant** - which is what
+makes the manifest rung "finish a seam" rather than hot-path surgery.
+
+## Pending decision, maintainer-only
+
+**Does the default retry delay get jitter?** Small change, and the existing per-record
+`retryDelayProvider` (`WorkContainer.java`, `getRetryDelayConfig`) is both the workaround to give the
+reporter today and the proof that desynchronising breaks the lockstep. But it changes retry timing
+for every existing deployment, so it wants a go/no-go rather than silent shipping. Nothing else in
+the ladder waits on that answer.
+
+## Draft answer to the reporter, ready to post
+
+astubbs#189 stays open - the ladder is real work - but the reporter has been waiting since 2025-08
+and the workaround exists today. Post something like:
+
+> Your reading is right, and it is not bad luck. On a batch failure every record in the batch is
+> marked failed, the retry delay is a flat one second with no randomisation, and batches are cut as
+> fixed-size runs over the shard's records in offset order. So the three records fail together,
+> become due together, sit adjacently, and re-form the same batch - and because there is no retry
+> ceiling, that repeats indefinitely. The README's "no guarantee they will be retried in the same
+> batch" is literally true, but it reads as though re-batching were random when in steady state it
+> is not, so you were right to expect otherwise.
+>
+> **What unblocks you now:** set a `retryDelayProvider` on `ParallelConsumerOptions`. It is invoked
+> per record with a `RecordContext`, so returning a jittered or attempt-scaled delay (for example a
+> base delay plus a random component, or one scaled by `getNumberOfFailedAttempts()`) desynchronises
+> the three records. Only the due records are eligible when a batch is formed, so the good ones get
+> taken alone and commit, and the poison record ends up retrying by itself.
+>
+> **What we intend to do about it:** ship default-on jitter, then bisect a failed batch to isolate
+> the poison record in a bounded number of rounds, then let a batch function report which records
+> failed so only those re-enter retry. Tracked here.
+
+Nothing above is a promise about dates. Do not claim the manifest is close; only the first rung is.
+
+## Overlaps to hold together
+
+- **DLQ (astubbs#149, brainstorm astubbs#313, draft astubbs#8).** Both want a terminal disposition
+  for a record that cannot succeed. A DLQ needs the retry *ceiling*; this needs failure
+  *attribution*, and the per-record manifest is the natural place a DLQ hand-off fires from. Scope
+  the contract once rather than twice.
+- **`confluentinc#915` batch construction strategy.** It changes what a batch contains on first
+  construction; bisection and the manifest change what it contains on retry, and bisection has to
+  respect shard boundaries. The two collide at ordering. Jitter touches neither.
+
+## Delete when
+
+The jitter go/no-go is recorded, its rung has shipped or been declined, and astubbs#189 carries the
+answer to the reporter.

--- a/docs/inflight/core-241-tx-commit-failure-taxonomy.md
+++ b/docs/inflight/core-241-tx-commit-failure-taxonomy.md
@@ -1,0 +1,90 @@
+# Transaction commit failures: the record says "undifferentiated", the code has not been since 2022
+
+<!-- inflight-type: feature -->
+<!-- inflight-impact: reliability -->
+
+
+astubbs#241 (confluentinc#144). **The premise both the mirror body and the manifest entry
+`sweep-2023-tx-failure-taxonomy` rest on is false at HEAD**, and correcting it is the point of this
+note - a future session reading either would design against code that stopped existing in 2022.
+
+## What the record claims, and what the code does
+
+The claim is "one generic retry loop"; the loop's own `catch` clause is
+`catch (TimeoutException | InterruptException e)` in
+`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java`, sitting
+under a comment block that classifies every exception `KafkaProducer#commitTransaction` documents and
+ends `Only catch and retry the retriable ones, others fail fast the control thread`. `IllegalState`,
+`UnsupportedVersion`, `Authorization`, `KafkaException` and `InvalidProducerEpoch` are therefore not
+retried at all - they propagate on first occurrence. A coarse taxonomy already exists.
+
+It arrived in confluentinc#355 (2022-09-29), which replaced `catch (Exception e)` outright. The issue
+predates it by more than a year and nobody re-read the code afterwards.
+
+## What is actually still open
+
+- **The retry set contradicts Kafka's own taxonomy, in both directions.** `TimeoutException extends
+  RetriableException`; `InterruptException extends KafkaException` directly and is *not* retriable by
+  Kafka's marker. PC retries the interrupt anyway, without honouring or restoring the interrupt.
+  Whether to key off `RetriableException` instead of an enumerated list is the first design question.
+- **`arbitrarilyChosenLimitForArbitraryErrorSituation` is a count, not a budget.** Each attempt blocks
+  up to `max.block.ms`, so the worst case is that many multiples of it. astubbs#204 gave the *consumer*
+  path a whole-operation budget, but `offsetCommitTimeout` is read only by `ConsumerManager` /
+  `ConsumerOffsetCommitter`, and its javadoc says so - "Only relevant if using
+  `PERIODIC_CONSUMER_SYNC`". Transactional mode has no user-visible commit budget at all. That
+  asymmetry is the obvious fix shape.
+- **The retry arm can report success without committing.** On a retry it calls `commitTransaction()`
+  only when `isTransactionCompleting()`; the other branch merely logs, then `committed = true` is set
+  unconditionally. Probably unreachable, because a timed-out commit leaves the manager COMMITTING -
+  but nothing establishes that, which is the next bullet.
+- **Nothing tests any of it.** No test in either source tree names `InterruptException`,
+  `Retired too many times` or the retry limit. This is unasserted behaviour, not verified behaviour.
+- **Fencing arrives by two different routes with two different types**: wrapped in
+  `InternalRuntimeException` from `sendOffsetsToTransaction`, raw from `commitTransaction`.
+  `core-recoverable-producer-fencing.md` and astubbs#225 describe only the first.
+
+## Start from the better prototype, not the one the manifest names
+
+The manifest points at `origin/tx-commit-failure`, a single 2021 WIP commit that retried
+`IllegalStateException` and predates confluentinc#355 entirely.
+
+`origin/bugs/prod-tx-manager-retries` (2022-11) is the one to read: it deletes the arbitrary constant
+for a `RetrySettings` option (`FailureReaction` of `FAIL_FAST` or `RETRY_UP_TO_MAX_RETRIES`), adds
+retry around `sendOffsetsToTransaction`, and introduces `PCCommitFailedException` and
+`PCTimeoutException`. Not cherry-pickable - it calls `commitTransaction()` twice on the retry path and
+dereferences the saved error before its own null check - but it is a design, not a sketch. **This
+settles the open question in `branch-audit-orphans.md`**, which lists that branch as "plausibly
+belongs to `sweep-2023-tx-failure-taxonomy`; verify before attaching": it does. Its exception types
+are unrecorded input to `core-exception-hierarchy-cleanup.md`.
+
+## What to put on the issue
+
+Keep it open - the taxonomy question survives even though its stated premise does not - but the body
+is what a future reader trusts, so replace `## Fork status` with something like:
+
+> **Partly overtaken by events.** The "one generic retry loop" this issue describes was replaced in
+> confluentinc/parallel-consumer#355 (2022-09-29): `commitOffsets` now retries only `TimeoutException` and
+> `InterruptException` and fails fast on everything else. What remains is narrower. The retry set does
+> not match Kafka's own marker in either direction - `TimeoutException` *is* a `RetriableException`,
+> `InterruptException` is not and is retried anyway without honouring the interrupt. The limit is a
+> count rather than a time budget, and `offsetCommitTimeout` covers only the consumer path, so
+> transactional mode has no commit budget a user can set. None of it is covered by a test.
+
+Relabel `bug` to `feature`: no defect is demonstrated here, and what is left is a policy design.
+
+## Collisions
+
+`ProducerManager` is contended. astubbs#262 and the `fix/transactional-produce-callback-abort` branch
+both carry the produce-callback change that astubbs#261 already landed on master, so both need
+reconciling against master before anything else touches the file; astubbs#257 does not go near
+`commitOffsets`. None of them changes the commit retry loop, so a taxonomy change conflicts textually
+at worst - but it must not land before astubbs#262, whose own notes record two further produce-path
+mishandlings that belong in the same design.
+
+Co-design partners, all three: astubbs#225 (fencing should abort and rejoin), astubbs#317 /
+`core-commit-failure-seam.md` (let the application decide when a commit fails), and this. They are one
+question - what PC does when a commit fails - and answering them separately will produce three
+policies.
+
+`docs/refactoring.md` carries a one-line `brute-force transaction-commit retry` triage item for the
+same code; fold it into this note when the work starts.

--- a/docs/inflight/deps-181-java-24-compatibility.md
+++ b/docs/inflight/deps-181-java-24-compatibility.md
@@ -1,0 +1,63 @@
+# astubbs#181 - Java 24: what actually broke, and why this tree no longer hits it
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: test-debt -->
+
+[astubbs#181](https://github.com/astubbs/parallel-consumer/issues/181), mirroring
+[confluentinc issue #862](https://github.com/confluentinc/parallel-consumer/issues/862). **Verified
+on a workstation, never in CI** - that gap is the whole of the remaining work.
+
+## The mechanism, confirmed rather than assumed
+
+The break was never in Parallel Consumer's code. kafka-clients up to 3.9.0 calls
+`Subject.getSubject(AccessController.getContext())` from its SASL callback handlers
+(`SaslClientCallbackHandler`, `OAuthBearerSaslClientCallbackHandler`). JDK 23 already makes that
+throw `UnsupportedOperationException` - "supported only if a security manager is allowed", so
+`-Djava.security.manager=allow` was still an escape hatch - and JDK 24 removes the hatch, which is
+why the reporter drew the line at 24 rather than 23. kafka-clients 3.9.1 (KAFKA-19024) routes the
+same calls through `org.apache.kafka.common.internals.SecurityManagerCompatibility`, which selects
+`Subject.current()` / `callAs` when the JDK has them.
+
+Two predictions were refuted and are worth recording, because both are believable and both are wrong:
+
+- **`Subject.doAs` is not the failing call.** It still returns normally on JDK 26. Only `getSubject`
+  throws, so the broken surface is the authentication callback path, not every Kafka client. A
+  PLAINTEXT client on kafka-clients 3.7.1 processed records to completion on JDK 26 in the same
+  harness.
+- **confluentinc PR #908 cannot resolve confluentinc#862**, contrary to the ranking in
+  `src/docs/development/upstream-pr-analysis.adoc` (grep `Virtual Threads support`). That PR migrates
+  `synchronized` to `ReentrantLock` for virtual-thread pinning, and JDK 24 removed pinning anyway.
+  Different mechanism. Fork PR astubbs#51 is a copy of it and neither blocks nor closes this issue.
+
+## Where this tree stands
+
+`pom.xml` carries `<kafka.version>3.9.2</kafka.version>`, past the fix. No main-code reference to
+`SecurityManager`, `AccessController`, `doPrivileged` or `sun.misc.Unsafe` exists in any module. The
+reflective access that does exist -
+`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java`
+(grep `getDeclaredField("delegate")`) and
+`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerWrapper.java` (grep
+`transactionManager`) - targets kafka-clients classes on the classpath, not JDK-internal modules, so
+strong encapsulation never applies to it.
+
+Evidence, run locally: the built core jar is class file version 52 (Java 8 bytecode), and an
+end-to-end `ParallelStreamProcessor` run over a `MockConsumer` (KEY ordering,
+`PERIODIC_CONSUMER_SYNC`, 50 records) completed identically on JDK 17 and JDK 26. JDK 26 is strictly
+harsher than 24. **The caveat matters: a `MockConsumer` cannot exercise SASL, which is the one path
+that ever broke.** A real SASL client on a modern JDK remains untested here.
+
+## What is left, and the decision that is not mine
+
+Nothing in CI runs above `java-version: '17'`, and the Kafka-version axis is switched off in
+`.github/workflows/maven.yml` (grep `test-kafka-compat`). That gap is astubbs#128
+(mirroring confluentinc#103), and until a lane exists "runs on Java 24" is a local observation, not
+a claim the project can publish.
+
+**Maintainer's call:** close astubbs#181 on the rationale above - the concrete ask (stop being pinned
+to kafka-clients 3.7.1) is satisfied by 3.9.2, and the mechanism it was pinned on is gone - and let
+astubbs#128 carry the CI proof; or hold it open until that lane exists. The reporter should be told
+which kafka-clients version settles it, not just that it is fixed.
+
+This is **not** 0.7.x work, so do not fold it into `docs/inflight/pr-53-java-baseline-kafka4.md`:
+that note is about the *build and compile* baseline needed for Kafka 4, a different question from
+what the shipped Java 8 jar can run on. The two only look alike because both say "Java".

--- a/docs/inflight/deps-renovate-instead-of-dependabot.md
+++ b/docs/inflight/deps-renovate-instead-of-dependabot.md
@@ -1,0 +1,72 @@
+# Should the dependency bot be Renovate rather than Dependabot
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: deps-debt -->
+
+**Leaning: no, on current evidence.** This note began as a case *for* switching and the case did not
+survive checking. It is kept rather than deleted because the reasoning is the useful part - the next
+person to have this idea should meet the counter-evidence, not re-derive it.
+
+## The original argument, and why it was wrong
+
+The claim was that [`deps-deferred-majors.md`](deps-deferred-majors.md) is a register of held-back
+upgrades that the bot cannot read, so it keeps proposing them and a human keeps re-deciding, and that
+Renovate's `packageRules` would fix that by holding the decision and its reason together in config.
+
+**Every part of that is already true of the Dependabot config we have.** `.github/dependabot.yml`
+carries scoped `ignore` entries, each with its reason in a comment, and they line up with the
+register's rows:
+
+```yaml
+- dependency-name: "org.apache.kafka:*"          # Kafka 4 (needs Java 11 baseline)
+- dependency-name: "org.junit.jupiter:*"         # JUnit 6 (needs Java 17 + ArchUnit engine)
+- dependency-name: "org.testcontainers:*"        # Testcontainers 2.x
+- dependency-name: "io.vertx:*"                  # Vert.x 5
+```
+
+It also already batches by risk class - a `maven-non-major` group covering minor and patch updates -
+which was the other half of the argument.
+
+**And the duplication it complained about is deliberate, in the right direction.** The config's own
+comment says declaring ignores there is better than `@dependabot ignore` PR comments, "whose ignore
+conditions live invisibly in Dependabot's state and give future maintainers no clue why a dependency
+silently stopped updating", and then points at the register: "Full rationale for each:
+docs/inflight/deps-deferred-majors.md." A short reason at the rule plus a pointer to the long one is
+the pattern this repository wants, not the drift the original note accused it of. That work landed in
+astubbs#78 (the earlier draft of this note mis-cited astubbs#76, which is an unrelated closed bump).
+
+## What would actually still have to be true to justify a switch
+
+A real gap, not a general preference. Candidates, none of them established:
+
+- **A release-age delay.** Not proposing a version until it has been public for some days is cheap
+  insurance against a bad or withdrawn release. Renovate has `minimumReleaseAge`. **Whether
+  Dependabot's own cooldown setting covers this is unchecked** - check before using it as an argument.
+- **Grouping by Maven property rather than by artifact pattern.** This POM drives versions through
+  properties (`<kafka.version>`, `<vertx.version>`), and upstream's Renovate branch names show it
+  bumping those properties directly. Our `patterns`-based groups reach a similar result by a different
+  route; nobody has shown a case where the difference bites.
+- **A concrete instance of the bot proposing something the ignore list should have caught**, which
+  would mean the current mechanism is failing rather than merely being unfashionable.
+
+Against any of that: Renovate is a third-party app where Dependabot is native and already configured,
+its config surface can produce more noise than it removes, and the migration work is real - every
+ignore and group would have to be re-expressed and the register repointed.
+
+## How this note got it wrong, which is the transferable part
+
+The original was written from the branch names upstream left behind, plus the register, without
+opening `.github/dependabot.yml`. Every claim it made about "what Dependabot cannot do" was a claim
+about a config file that was sitting in the repository, unread. It was caught by a review pass on the
+same branch, a few hours later.
+
+That is precisely the failure this branch documents in
+[`upstream-mirror-bodies-are-stale.md`](upstream-mirror-bodies-are-stale.md): a confident record
+written from adjacent evidence rather than from the thing itself, which then reads as settled. Worth
+keeping visible here, because a note arguing for a tooling change is exactly the kind that gets
+believed later without anyone re-checking its premise.
+
+## Delete when
+
+A concrete gap above is established and acted on, or someone decides the question is closed and says
+so in [`deps-deferred-majors.md`](deps-deferred-majors.md) so it is not re-proposed from scratch.

--- a/docs/inflight/handoff-fork-branch-audit.md
+++ b/docs/inflight/handoff-fork-branch-audit.md
@@ -1,0 +1,162 @@
+---
+artifact_contract: "ce-handoff/v1"
+created_at: "2026-08-20T11:34:33Z"
+title: "Fork branch audit - findings landed, the check itself unbuilt"
+summary: "109 of the fork's own branches are accounted for by no inventory; the finding and its method are committed, the recurring check that would keep the answer true is not written."
+keywords: ["branch-audit", "archaeology", "orphan-branches", "upstream-map", "inflight", "presentation-branch", "pyallel-consumer"]
+cwd: "/Users/astubbs/github/parallel-consumer/.claude/worktrees/fork-branch-archaeology"
+resume_focus: "Build the branch-accounting check, and correct the upstream.md entry that over-claims"
+repository: "astubbs/parallel-consumer"
+repo_root_sha: "713c7468d5ecda55a2190d38e698cda017e91259"
+branch: "docs/fork-branch-archaeology"
+head: "854ee239c1b49ad23a44fc009e6a1b59453e3e8f"
+worktree_path: "/Users/astubbs/github/parallel-consumer/.claude/worktrees/fork-branch-archaeology"
+---
+
+# Fork branch audit - what is established, and what is not built
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: stranded-work -->
+
+## Objective
+
+A branch carrying the code behind the project's most-linked artifact turned out to be named in no
+ledger. The owner's question was the useful one - not "rescue that file", but *"How can a branch be
+invisible to every inventory we keep, and what else have we missed?"* This branch answers the
+question and records the method. **It does not build the thing that would keep the answer true.**
+
+The owner's stated intent for this branch: hand it on so a fresh session can pick it up.
+
+## Current state
+
+**Complete and committed** (`854ee239c`, one commit ahead of `origin/master`, **not pushed**):
+
+- `docs/inflight/process-fork-branch-archaeology.md` - the whole finding. Read this first; everything
+  below is orientation for it, not a substitute.
+
+**Not started:** the recurring check, and the `docs/upstream.md` correction. Both are named in that
+file's "What this wants" section.
+
+Nothing else on this branch. No code, no scripts, no CI wiring.
+
+## What is established, and how
+
+Counts as of 2026-08-20, on `origin` (= `astubbs/parallel-consumer`; `upstream` is
+`confluentinc/parallel-consumer`):
+
+The counts, and the commands that re-derive them, are in
+[`process-fork-branch-archaeology.md`](process-fork-branch-archaeology.md) and are not repeated here -
+that file owns them, and a second copy would drift from it.
+
+**The benign explanation was tested and does not hold.** "Not merged" is computed by ancestry and
+squash-merges break ancestry, so these could have been branches whose content landed years ago. A
+per-branch tree comparison against master by file basename says otherwise: after subtracting the nine
+files common to more than half the branches (the baseline master deleted wholesale - `Jenkinsfile`,
+`RELEASE.adoc`, `EnumCartesianProductTestSets.java`, `JavaEnvTest.java`, `StringTestUtils.java` and
+four more), **all 109 still carry branch-specific classes present nowhere on master**.
+
+**The claim is deliberately narrow: "109 branches nobody has an account for", not "109 lost
+treasures."** Two caveats are stated in the committed file and should not be dropped when the finding
+is repeated - basename matching over-counts renames, and much of this was tried and abandoned
+deliberately, which is a perfectly good account that simply nobody wrote down.
+
+## The mechanism, which is the transferable part
+
+Four inventories exist. Three were correctly scoped to something that excluded the branch:
+`src/docs/development/upstream-map.yaml` maps fork↔**upstream** issues and PRs and this branch has
+neither; `docs/inflight/branch-package-rename-sweep.md` enumerated from `gh pr list` because its job
+was keeping open PRs mergeable; `docs/inflight/branch-stale-and-diagnostic.md` is a hand-written
+list, not an enumeration.
+
+The fourth is the near miss and the reason this is worth a check rather than a one-off sweep:
+**`docs/upstream.md` line 344 carries an entry titled "Orphan branches never attached to a PR"** -
+exactly the right check, pointed at the wrong remote. It swept `upstream`; the trigger branch exists
+only on `origin`. It reads as covering orphan branches generally while covering five branches on one
+of two remotes, which is worse than not having looked, because it closes the question.
+
+Common shape: **every audit was seeded from a list of interesting things and worked outward; none
+started from the complete set of refs and worked inward.** Same defect as searching only
+`--state open`.
+
+## What the next session would build
+
+From the committed file's "What this wants":
+
+1. **A check, not a sweep.** Enumerate `origin` and `upstream` refs and require every one to be
+   accounted for by exactly one of: merged, has a PR of any state, named in a document, or tagged as
+   archived. Report the unaccounted set, and make absence fail loudly rather than read as coverage.
+2. **Correct `docs/upstream.md` line 344** so it says which remote it covered.
+
+The repo already has the pattern to copy: `bin/check-*.sh` is a family of exactly this kind of gate,
+and **`bin/check-file-refs.sh` is the closest model** - read its header comment, which explains why
+a documentation-integrity check exists at all and why it delegates to the same module CI uses rather
+than reimplementing the rule. `.github/workflows/maven.yml` is where such checks are wired.
+`scripts/upstream-sweep.sh` and `scripts/upstream-map.py` are the existing upstream-facing tooling
+and are the natural place for the `upstream` half.
+
+Design question left open deliberately, because it is a judgement call and not a detail: an archive
+tag is one of the four proposed accounting routes, and no tag convention exists yet. The owner has
+separately decided that `origin/presentation` will be archived under an `archive/` tag prefix and
+then deleted - see the related work below. Whoever builds the check should settle whether that
+prefix is the convention it recognises.
+
+## Already surfaced, unread, and directly relevant to live work
+
+**`upstream/pyallel-consumer` is a prior Python client** - `confluentinc#443` (Robbie-Palmer,
+"feature: Python Support", CLOSED unmerged) plus `confluentinc#539` ("Automatically Publish Python
+Package to PyPi", MERGED). confluentinc#443 **is** tracked in `upstream-map.yaml` under the `sweep-2023-long-tail`
+entry, characterised in a single line as having "attacked the same goal from the client side" - but
+**the branch itself has not been read**, while a Python client is being written right now on
+`feats/proxy-requirements` (astubbs#293, astubbs#242). confluentinc#539 appears in no document at all.
+
+This is prior art in the strongest sense and it is the highest-value single follow-up on this branch,
+independent of whether the check ever gets built.
+
+Also unverified: `upstream` has 41 branches and the ruled-out entry accounted for 5 as orphans,
+implying the other ~36 each had a PR. Nobody has confirmed that implication.
+
+## Related work, deliberately not stacked here
+
+`feats/classic-vertx-demo` (worktree `.claude/worktrees/classic-vertx-demo`, one unpushed commit
+`4babb1414`, off `feats/proxy-requirements`) is where this was found. It carries
+`docs/inflight/branch-classic-comparison-demo.md` - the design ledger for a per-language comparison
+demo, and the plan to rescue `Demo.java` from `origin/presentation` @ `ffda9c6a3`.
+<!-- file-refs: N/A - that path lands on feats/classic-vertx-demo, deliberately not on this branch; the paragraph below records why the split is kept -->
+
+**The split is intentional and should be preserved:** the audit is a repo-wide concern with nothing
+to do with the language proxy, and stacking it would gate a master-level finding behind an unrelated
+feature PR. The two entries reference each other by filename rather than by markdown link, precisely
+because they land on master through different branches.
+
+## Fragile local state - machine-local, not committed
+
+Both worktrees hold **unpushed** commits and neither branch exists on the remote. Nothing has been
+pushed at any point in this session; the owner gates the first push of any branch.
+
+The scratch data behind the counts lives under
+`/private/tmp/claude-501/-Users-astubbs-github-parallel-consumer/9c564e47-960b-4208-b88c-6ba27ef6cd34/scratchpad`
+(`origin-branches.txt`, `pr-heads.txt`, `merged.txt`, `old-undocumented.txt`, `master-files.txt`).
+It is regenerable from the commands above and should be treated as disposable, not as evidence.
+
+## Failed approaches - do not retry these shapes
+
+- **The interactive shell here is not bash**, despite the tool name. `time`/error output came back in
+  zsh form (`(eval):5: command not found: timeout`), `timeout` is absent, and three separate
+  shell-loop scans produced **zero output and no error** before this was noticed - roughly 25 minutes
+  lost. The successful scans are Python driving `git` through `subprocess`. Do that.
+- **`comm -23 - file`** reading the left operand from stdin is the specific construct that hung.
+- **Whole-path comparison against master is too noisy to mean anything.** The package rename
+  (`io/confluent` -> `bz/stub`) and years of restructuring make ~45-80 paths per branch read as
+  "absent". Basename comparison plus subtracting the shared baseline is what produced signal; the
+  intermediate whole-path numbers are in the transcript and are worthless.
+
+## Verification performed
+
+The counts and the content check were run and are reproducible by the commands above.
+`docs/upstream.md:344` was read directly rather than recalled. `confluentinc#443` and
+`confluentinc#539` were confirmed through `gh pr list` against `confluentinc/parallel-consumer`, and
+confluentinc#443's presence in `upstream-map.yaml` was confirmed by reading the `sweep-2023-long-tail` entry.
+
+**Not verified:** that the ~36 non-orphan upstream branches each had a PR; the contents of
+`upstream/pyallel-consumer`; and whether any of the 109 branches' work is genuinely worth recovering
+- that question was explicitly not asked.

--- a/docs/inflight/issue-index.md
+++ b/docs/inflight/issue-index.md
@@ -1,0 +1,154 @@
+# Issue index - a discovery aid, NOT a source of truth
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: blind-spot -->
+<!-- issue-refs: exempt-file - every row IS a bare fork issue number; that is what the file is. The
+     header states the numbers are this fork's, which is the qualification the gate wants, once. -->
+
+**Data read from GitHub on 2026-08-26.** Regenerate with `bin/issue-index.sh`.
+
+**Every row here goes stale silently.** An issue can be closed, retitled or relabelled the minute
+after this file is written, and nothing in the repository will notice. So: use this to FIND issues,
+never to decide anything about one. `gh issue view <n> -R astubbs/parallel-consumer` before you act.
+
+## Why this exists, and why it does not break "never write down what a command can answer"
+
+It is here for **discovery**, not storage. That rule exists to stop a second tracker forming - a
+copy that gets believed and drifts apart from the truth. This one is not believed: it is dated, it
+says so twice, and it sends you elsewhere before acting.
+
+What it buys is reach. `gh issue list --state all` is the most-skipped of the six prior-art checks
+in [`AGENTS.md`](../../AGENTS.md), because an agent has to think of querying GitHub before it can
+do it. Grep is what agents do anyway - so a keyword sweep of `docs/` now surfaces the tracker
+too. The same argument already justifies the `docs/solutions/` title index that
+`.claude/hooks/inject-recorded-knowledge.sh` injects at session start.
+
+**Numbers here are this fork's.** Upstream's range overlaps ours, so a bare number is ambiguous
+everywhere else - see [`docs/issue-references.md`](../issue-references.md). A row whose title
+begins `confluentinc#NN:` is a mirror of that upstream issue; read the upstream original rather
+than the mirror's summary.
+
+| # | State | Title | Labels |
+|---|---|---|---|
+| #39 | CLOSED | PIT baseline timeout: SASL + PCMetrics tests incompatible |  |
+| #40 | CLOSED | Reduce duplication in MockConsumer* test classes | 0.6.0.0 |
+| #41 | OPEN | Run PIT mutation testing on self-hosted performance runner |  |
+| #44 | OPEN | confluentinc#803: Transactional Producer instance gets timeout getting commit lock while second instance starts | bug, 0.6.0.0, upstream-mirror, area/reliability |
+| #52 | OPEN | When will the first stable fork release be published to Maven Central? | 0.6.0.0 |
+| #117 | OPEN | confluentinc#233: Refactor OffsetMapCodecManager.java | upstream-mirror, area/internals, chore |
+| #118 | CLOSED | confluentinc#326: "Unexpected magic" - offset metadata PC did not write crashes the consumer on assignment | bug, upstream-mirror, area/reliability, partially-fixed-in/0.5.2.6 |
+| #119 | OPEN | confluentinc#857: Paused consumption across multiple consumers | bug, upstream-mirror, area/reliability, partially-fixed-in/0.5.3.3, pr-available |
+| #120 | OPEN | confluentinc#859: Memory leak in PCMetrics class | bug, 0.6.0.0, upstream-mirror, area/reliability, pr-available |
+| #121 | OPEN | confluentinc#894: Offset reset when frequent rebalancing | bug, 0.6.0.0, upstream-mirror, area/reliability, pr-available |
+| #122 | OPEN | confluentinc#912: Memory Leak from JStreamVertxParallelStreamProcessor | bug, documentation, upstream-mirror, area/reliability, area/api, verified bug, pr-available |
+| #125 | CLOSED | confluentinc#27: Micrometer metrics | feature, upstream-mirror, area/observability, fixed-in/0.5.2.6 |
+| #126 | OPEN | confluentinc#71: Health-checks | feature, good first issue, 0.6.0.0, upstream-mirror, area/observability, pr-available, next-breaking-release |
+| #127 | OPEN | confluentinc#78: Allow customization of the ThreadPoolExecutor | feature, upstream-mirror, area/api, next-feature-release |
+| #128 | OPEN | confluentinc#103: Matrix test against multiple AK and JDK versions in GH | 0.6.0.0, upstream-mirror, chore, area/build-test |
+| #129 | OPEN | confluentinc#109: Review serialisation versioning strategy with ks and core team | upstream-mirror, chore, area/docs |
+| #130 | OPEN | confluentinc#115: javadoc: Clarify how to return tombstone messages from the consume / produce loops | upstream-mirror, chore, area/docs |
+| #131 | OPEN | confluentinc#130: Remove static state manipulation in tests | upstream-mirror, chore, area/build-test |
+| #132 | OPEN | confluentinc#162: mvn compile fails if test-jar of parallel-consumer-core was not previously installed / deployed. | bug, upstream-mirror, area/build-test |
+| #133 | OPEN | confluentinc#170: Add support for JDK's CompletableFuture into the API as part of the Reactor.io API, add docs | feature, upstream-mirror, area/api, next-feature-release |
+| #134 | OPEN | confluentinc#171: Spring boot example | feature, upstream-mirror, area/docs, next-feature-release |
+| #135 | OPEN | confluentinc#172: Release train for 1.0 | upstream-mirror, chore, area/release-health, 1.0, next-breaking-release |
+| #136 | OPEN | confluentinc#177: Investigate using Release Drafter | upstream-mirror, chore, area/release-health |
+| #137 | OPEN | confluentinc#178: How to take a single message, and distribute it to several http end points in parallel, with DLQ for failure | question, upstream-mirror, area/docs, next-feature-release |
+| #138 | OPEN | confluentinc#180: vertxHttpReqInfo only supports GET (Unable to call HTTP POST or PUT etc) | help wanted, question, upstream-mirror, area/modules, next-feature-release |
+| #139 | OPEN | confluentinc#186: Ensure all PC API's are thread safe | bug, upstream-mirror, area/api, blocker, 1.0, pr-available, next-breaking-release |
+| #140 | CLOSED | confluentinc#192: Feature Request: Unique thread names for PC instances for logging | feature, upstream-mirror, area/observability, fixed-in/0.5.2.6 |
+| #141 | OPEN | confluentinc#196: Provide option for max retires, and a call back when reached (potential DLQ) | feature, upstream-mirror, area/error-handling, pr-available, next-feature-release |
+| #142 | OPEN | confluentinc#200: Refactor: Consider a shared nothing architecture, to reduce thread complexity | upstream-mirror, area/internals, chore, pr-available, next-breaking-release |
+| #143 | OPEN | confluentinc#241: Try refactoring WC type from String to Enum | upstream-mirror, area/internals, chore, next-feature-release |
+| #144 | OPEN | confluentinc#259: Consider adopting error prone and checker | upstream-mirror, chore, area/build-test |
+| #145 | OPEN | confluentinc#266: feature: Option for batch to only contain messages of the same key | feature, good first issue, upstream-mirror, area/batching-ordering, next-feature-release |
+| #146 | OPEN | confluentinc#290: Refactor test base | upstream-mirror, chore, area/build-test |
+| #147 | OPEN | confluentinc#299: POC for project Loom integration for light weight threads (higher concurrency without Vert.x or Reactor) | feature, upstream-mirror, area/compat, pr-available, next-breaking-release |
+| #148 | OPEN | confluentinc#304: Handle deserialization exceptions thrown from the deserialiser | feature, upstream-mirror, area/error-handling, next-feature-release |
+| #149 | OPEN | confluentinc#310: Add a dead letter queue (DQL) implementation | feature, upstream-mirror, area/error-handling, pr-available, next-feature-release |
+| #150 | OPEN | confluentinc#314: With KEY ordering, option to combine queues from different partitions or topics | feature, 0.6.0.0, upstream-mirror, area/batching-ordering, pr-available |
+| #151 | OPEN | confluentinc#321: Transparent large message chunking and reconstruction | feature, upstream-mirror, area/batching-ordering |
+| #152 | OPEN | confluentinc#322: Disk backed Produce queue | feature, upstream-mirror, area/performance |
+| #153 | OPEN | confluentinc#391: Serialization error handling / flexibility | feature, upstream-mirror, area/error-handling, next-breaking-release |
+| #154 | OPEN | confluentinc#394: feature: Option to have Producer send records to least loaded broker | feature, upstream-mirror, area/performance, pr-available |
+| #155 | OPEN | confluentinc#402: Max loading factor steps reached: 100/100 | bug, 0.6.0.0, upstream-mirror, area/reliability |
+| #156 | OPEN | confluentinc#480: Question: Is it possible to produce events using reactor?  | question, upstream-mirror, area/modules, not-a-bug, next-feature-release |
+| #157 | OPEN | confluentinc#484: Question: Does Parallel-consumer have state that we can read from? | question, upstream-mirror, area/modules, next-breaking-release |
+| #158 | OPEN | confluentinc#520: major: Safe User API exposure of ALL Consumer APIs (seek, end offsets etc) | feature, upstream-mirror, area/api, pr-available, next-breaking-release |
+| #159 | OPEN | confluentinc#526: Move LongPollingMockConsumer to main artefact | 0.6.0.0, upstream-mirror, chore, area/build-test |
+| #160 | OPEN | confluentinc#540: Apply backpressure per partition instead of the entire assignment  | feature, upstream-mirror, area/performance, next-breaking-release |
+| #161 | OPEN | confluentinc#543: Why use of Scheduler if the processing has been proven NON blocking please? | question, 0.6.0.0, upstream-mirror, area/modules |
+| #162 | OPEN | confluentinc#546: Truncating state | bug, upstream-mirror, area/reliability, affects/0.5.2.4, partially-fixed-in/0.5.2.6 |
+| #163 | OPEN | confluentinc#550: Is There Any Exception Handler? | question, upstream-mirror, area/error-handling, next-breaking-release |
+| #164 | OPEN | confluentinc#551: Batching not working as expected | bug, 0.6.0.0, upstream-mirror, area/batching-ordering |
+| #165 | OPEN | confluentinc#560: Feature suggestion: Minimum batch size + batch max wait time | feature, upstream-mirror, area/batching-ordering, next-feature-release |
+| #166 | CLOSED | confluentinc#597: When parallel consumer does not close kafka consumer if commmit fails during close | bug, upstream-mirror, area/reliability, fixed-in/0.5.3.1 |
+| #167 | CLOSED | confluentinc#622: Wrong multiplier value in retry delay function example | bug, good first issue, 0.6.0.0, upstream-mirror, area/docs, pr-available |
+| #168 | OPEN | confluentinc#629: Missing topic and offset infos when login error in ConsumerOffsetCommitter | feature, good first issue, 0.6.0.0, upstream-mirror, area/observability |
+| #169 | OPEN | confluentinc#631: Warning log to verbose in RemovedPartitionState | feature, good first issue, 0.6.0.0, upstream-mirror, area/observability |
+| #170 | OPEN | confluentinc#640: Error log to verbose in AbstractParallelEoSStreamProcessor | feature, good first issue, 0.6.0.0, upstream-mirror, area/observability |
+| #171 | CLOSED | confluentinc#642: Add explanation of close modes to documentation | 0.6.0.0, upstream-mirror, chore, area/docs |
+| #172 | OPEN | confluentinc#718: Missing feature to terminate processing | feature, upstream-mirror, area/error-handling, next-breaking-release |
+| #173 | OPEN | confluentinc#777: Handling Partition Revocation in Parallel-Consumer Leading to Duplicate Event Processing | bug, upstream-mirror, area/reliability |
+| #174 | OPEN | confluentinc#782: Seeking to a specific offset for a partition | feature, upstream-mirror, area/api, next-breaking-release |
+| #175 | OPEN | confluentinc#809: Sporadic timeouts from ConsumerOffsetCommitter.CommitRequest | bug, upstream-mirror, area/reliability, partially-fixed-in/0.5.3.1 |
+| #176 | CLOSED | confluentinc#825: `checkAutoCommitIsDisabled` fails with kafka-clients < 3.7.0 when using consumer inherited from `KafkaConsumer` | bug, upstream-mirror, area/compat, fixed-in/0.5.3.0 |
+| #177 | OPEN | confluentinc#833: ParallelConsumer would run for a while and then exit due to InternalRuntimeException(Timeout) | bug, 0.6.0.0, upstream-mirror, area/reliability, affects/0.5.3.1 |
+| #178 | OPEN | confluentinc#843: Record being picked up by multiple threads simultaneously | bug, upstream-mirror, area/reliability, wait for info, affects/0.5.3.0 |
+| #179 | OPEN | confluentinc#860: Accept instance params for `managedExecutorService` and `managedThreadFactory` as an alternative to JNDI implementation | feature, upstream-mirror, area/api |
+| #180 | OPEN | confluentinc#861: Error running tests: io.confluent.parallelconsumer.ManagedTruth.assertThat not found | bug, 0.6.0.0, upstream-mirror, area/build-test |
+| #181 | OPEN | confluentinc#862: Parallel Consumer cannot run on Java 24 | bug, 0.6.0.0, upstream-mirror, area/compat |
+| #182 | CLOSED | confluentinc#874: Apache-client 3.9.1 (used in spring 3.5.0) not compatible with 0.5.3.2 of parallelConsumer | bug, 0.6.0.0, upstream-mirror, area/compat, affects/0.5.3.2, fixed-in/0.5.3.3 |
+| #183 | OPEN | confluentinc#875: Missing message in consumption and eventually pauses all consmption | bug, upstream-mirror, area/reliability, affects/0.5.3.1 |
+| #184 | CLOSED | confluentinc#878: Migration from java 8 to 21, from springboot 2.7 to 3.5 | question, 0.6.0.0, upstream-mirror, area/compat, affects/0.5.3.2, fixed-in/0.5.3.3 |
+| #185 | OPEN | confluentinc#879: Introduce no commit option | feature, upstream-mirror, area/api |
+| #186 | OPEN | confluentinc#880: Please release new version after important security updates | question, 0.6.0.0, upstream-mirror, area/release-health |
+| #187 | OPEN | confluentinc#884: Parallel Consumer is 30 times slower than Normal Consumer | bug, 0.6.0.0, upstream-mirror, area/performance |
+| #188 | CLOSED | confluentinc#885: How to get the latest version 0.5.3.3 of 'parallel-consumer-core' ? | question, 0.6.0.0, upstream-mirror, area/release-health, fixed-in/0.5.3.3 |
+| #189 | OPEN | confluentinc#887: Parellel-consumer does not behave expectedly when  a bad record cause failure for the whole batch | question, upstream-mirror, area/error-handling, next-feature-release |
+| #190 | OPEN | confluentinc#896: Add support for virtual threads | feature, upstream-mirror, area/compat, pr-available, next-breaking-release |
+| #191 | OPEN | confluentinc#902: Always process the freshest record when ordered by key | feature, upstream-mirror, area/batching-ordering, next-feature-release |
+| #192 | OPEN | confluentinc#903: Runlength and bitarray implementation | feature, upstream-mirror, area/internals, next-feature-release |
+| #193 | OPEN | confluentinc#904: support for Kafka 4.0.x | question, upstream-mirror, area/compat, next-breaking-release |
+| #194 | CLOSED | confluentinc#906: Mismatch between release.version in pom.xml and dependencies | bug, 0.6.0.0, upstream-mirror, area/release-health |
+| #195 | OPEN | confluentinc#907: Is the project still actively maintained? | question, 0.6.0.0, upstream-mirror, area/release-health |
+| #197 | OPEN | Release 0.6.0.0 - the fork's first release | 0.6.0.0, chore, area/release-health |
+| #208 | OPEN | Publish the docs as a versioned documentation site, not one 1578-line README | documentation, feature, help wanted, good first issue, chore, area/docs, next-feature-release |
+| #209 | CLOSED | chaos: poll control thread submits to an already-terminated executor during cooperative revoke | bug, 0.6.0.0, area/reliability |
+| #212 | OPEN | CI: our three forked actions are pinned to unreleased commits, not releases | chore, area/build-test, next-patch-release |
+| #215 | OPEN | Web GUI: show what a running Parallel Consumer instance is actually doing | feature, 0.6.0.0, area/observability, pr-available |
+| #216 | OPEN | Metrics: expose the buffers that have no upper bound (starting with the JStream result backlog) | feature, area/observability |
+| #222 | OPEN | Metrics: expose what PC delivers - head-of-line blocking avoided, end-to-end record latency, per-shard queue depth | feature, area/observability |
+| #225 | OPEN | Producer fencing kills the instance; it should abort and rejoin, like Kafka Streams' TaskMigratedException | feature, area/reliability |
+| #227 | OPEN | confluentinc#21: Dynamic concurrency control with flow control or tcp congestion control theory | feature, upstream-mirror, area/performance, pr-available, next-feature-release, upstream-admin-closed |
+| #228 | OPEN | confluentinc#24: Add distributed rate limiting support | feature, upstream-mirror, area/api, upstream-admin-closed |
+| #229 | OPEN | confluentinc#28: Opentracing support | feature, upstream-mirror, area/observability, upstream-admin-closed |
+| #230 | OPEN | confluentinc#29: performance: Support asynchronous sending of result messages | feature, upstream-mirror, area/performance, pr-available, upstream-admin-closed |
+| #231 | OPEN | confluentinc#34: Monitor for progress and optionally shutdown (leave consumer group), skip message or send to DLQ | feature, upstream-mirror, area/error-handling, upstream-admin-closed |
+| #232 | OPEN | confluentinc#40: Feature: Transactional mode for individual consume producer loop instead of periodic batch | feature, upstream-mirror, area/api, upstream-admin-closed |
+| #233 | CLOSED | confluentinc#41: Performance: FindCompletedEligibleOffsetsAndRemove method try replacing with cache of incomplete offsets | upstream-mirror, chore, area/performance, upstream-admin-closed |
+| #234 | OPEN | confluentinc#48: Support scheduled message processing (scheduled retry) | feature, upstream-mirror, area/error-handling, upstream-admin-closed |
+| #235 | OPEN | confluentinc#49: Feature: Run mode where transition to plain offset committing (no encoded offsets needed) | feature, upstream-mirror, area/internals, upstream-admin-closed |
+| #236 | OPEN | confluentinc#50: Feature: When subscribing to multiple topics, have the ability to priorities topics over others | feature, upstream-mirror, area/batching-ordering, pr-available, upstream-admin-closed |
+| #237 | OPEN | confluentinc#53: Exact continuous offset encoding for precise offset payload size back pressure | feature, upstream-mirror, area/internals, pr-available, upstream-admin-closed |
+| #238 | OPEN | confluentinc#57: Reduce debug log output | upstream-mirror, chore, area/observability, upstream-admin-closed |
+| #239 | OPEN | confluentinc#65: Enhanced retry epic | feature, upstream-mirror, area/error-handling, pr-available, upstream-admin-closed |
+| #240 | OPEN | confluentinc#119: Integration with Kafka Connect | feature, 0.6.0.0, upstream-mirror, area/modules, pr-available, upstream-admin-closed |
+| #241 | OPEN | confluentinc#144: ProducerManager should handle different types of transaction failures appropriately | bug, upstream-mirror, area/reliability, upstream-admin-closed |
+| #242 | OPEN | confluentinc#154: Integrate into a Proxy so can support any language and a server side queue implementation | feature, upstream-mirror, area/modules, upstream-admin-closed |
+| #243 | OPEN | confluentinc#175: Ability use different consume and produce types for the key and value | feature, upstream-mirror, area/api, next-breaking-release, upstream-admin-closed |
+| #244 | OPEN | confluentinc#183: Feature: Allow unordered processing of messages without a key in 'KEY' ordering mode | bug, upstream-mirror, area/batching-ordering, upstream-admin-closed |
+| #245 | OPEN | confluentinc#187: Enable changing of topic subscription before or after PC has started | feature, upstream-mirror, area/api, pr-available, upstream-admin-closed |
+| #246 | OPEN | confluentinc#191: Need ability to seek to the beginning of a partition | feature, good first issue, upstream-mirror, area/api, pr-available, upstream-admin-closed |
+| #247 | OPEN | confluentinc#199: Dynamic reason support for failfast in awaitility | upstream-mirror, chore, area/build-test, upstream-admin-closed |
+| #248 | OPEN | confluentinc#203: Bug: ConsumerOffsetCommitter goes into failure state after broker downtime | bug, upstream-mirror, area/reliability, wait for info, upstream-admin-closed |
+| #249 | OPEN | confluentinc#205: vert.x: Run user funtions in a Vertical instead of Java thread pool | feature, upstream-mirror, area/modules, pr-available, upstream-admin-closed |
+| #250 | OPEN | confluentinc#246: Consider turning on code sorting in the formatter | upstream-mirror, chore, area/build-test, not-a-bug, upstream-admin-closed |
+| #251 | OPEN | confluentinc#267: docs: Comparison to Spring Cloud Stream Kafka binder | documentation, help wanted, upstream-mirror, area/docs, upstream-admin-closed |
+| #252 | CLOSED | confluentinc#319: Error during shutdown - ConcurrentModificationException | bug, upstream-mirror, area/reliability, upstream-admin-closed |
+| #253 | OPEN | confluentinc#320: Extend parallel consumer to be able to include multiple consumers/producers of different clusters | feature, upstream-mirror, area/modules, upstream-admin-closed |
+| #254 | OPEN | confluentinc#372: Have processing functions attached to topics instead of a global one for all subscribed topics | feature, upstream-mirror, area/api, pr-available, upstream-admin-closed |
+| #255 | OPEN | Kafka Streams: give a Streams topology PC's per-key parallelism | feature, 0.6.0.0, area/internals, area/performance, pr-available |
+| #300 | OPEN | Upstream closure follow-up: the decisions nobody has made yet |  |
+| #311 | OPEN | Batching requests a full extra in-flight target of work, and batchSize is unvalidated | bug, 0.6.0.0, area/batching-ordering, verified bug |
+| #317 | OPEN | feat(core): a commit-failure seam, so the application decides instead of PC always terminating | feature |

--- a/docs/inflight/pr-mirror-fixes-and-what-they-close.md
+++ b/docs/inflight/pr-mirror-fixes-and-what-they-close.md
@@ -1,0 +1,53 @@
+# The mirror fixes in flight, and whether they close their issues
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: coordination -->
+
+Four of the mirrors swept in the 2026-08-20 triage already had a fix, so they were checked for a
+different thing than the other ten: does the PR actually close the issue, and if it deliberately does
+not, is that reasoning anywhere a reader will find it? Two need an edit. The companion note for the
+ten without fixes is [`upstream-mirror-bodies-are-stale.md`](upstream-mirror-bodies-are-stale.md).
+
+## astubbs#201 should close astubbs#155, and does not say so
+
+The PR carries no closing reference, and its body describes itself as fixing "the log-noise half" of
+astubbs#155. That framing implies a remainder, and there is not one.
+
+Both the issue's own `## Fork status` and this PR's body say the other half - the stall - was already
+fixed by confluentinc#547 and confluentinc#606, and further by the confluentinc#857 family here
+(astubbs#119), with "nothing in this PR touches it". So once astubbs#201 lands, astubbs#155 has
+nothing open left in it.
+
+**Add `Fixes astubbs/parallel-consumer#155` to the body before merge.** Without it the issue outlives
+its own fix, and the next person to read it inherits the "half" framing and goes looking for the
+missing half.
+
+## astubbs#203 closes astubbs#169 and astubbs#170, in a form the convention forbids
+
+The links resolve, so GitHub will close both. But the body writes `Closes #169. Closes #170.` -
+bare - and [`docs/issue-references.md`](../issue-references.md) requires the fully qualified
+`owner/parallel-consumer#NN` for anything posted to GitHub, because that is the only form that both
+names the repo and auto-links. confluentinc#169 and confluentinc#170 both exist and mean other
+things, so a reader of that body is guessing.
+
+Cosmetic against the gate, which passes, and not cosmetic against a human. Worth correcting while the
+PR is open.
+
+## astubbs#204 deliberately does not close astubbs#177, and that is right
+
+Merged with no closing reference, on purpose. Its body has a section headed "What this closes, and
+what it does not", reading confluentinc#833 as one symptom sitting on three independent defects:
+astubbs#100 and astubbs#80 landed, astubbs#204 took the reporting and the retry budget, and the third
+- an AB-BA deadlock between the poll and control threads on the commit path - is astubbs#29, still a
+draft whose fix has never been observed working.
+
+No change needed to the PR. **The gap is on the issue**, which has no comments at all, so the
+reasoning for why it survived its own fix exists only inside a merged PR body. Anyone scanning the
+tracker sees an open issue whose fix merged and draws the obvious wrong conclusion. The remaining
+scope is recorded here and in [`core-commit-failure-seam.md`](core-commit-failure-seam.md); it is
+not recorded where a reader of the issue will meet it.
+
+## Delete when
+
+astubbs#201 carries its closing reference, astubbs#203's is qualified, and astubbs#177 says on its
+own face what is left in it.

--- a/docs/inflight/process-fork-branch-archaeology.md
+++ b/docs/inflight/process-fork-branch-archaeology.md
@@ -1,0 +1,198 @@
+# Nothing has ever audited the fork's own branches
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: stranded-work -->
+
+Opened 2026-08-20 by the owner's question, on finding that the code behind the project's
+most-linked artifact sits on a branch named in no ledger: *"How can a branch be invisible to every
+inventory we keep? How the hell did we not find this in our archaeology hunts, and what else have we
+missed?"*
+
+The trigger is `origin/presentation`, found while scoping the per-language comparison demo on
+`feats/classic-vertx-demo` (its own entry, `branch-classic-comparison-demo.md`, lands with that
+branch). It carries `Demo.java`,
+the code that produced the asciinema cast embedded in `src/docs/README_TEMPLATE.adoc`. It was never
+merged, is 3 ahead / 631 behind, and has been untouched since 2021.
+
+## How it was missed: every audit was keyed on the tracker, never on the artifact store
+
+Four inventories exist. Each was scoped to something that structurally excluded this branch, and
+three of the four were correctly scoped - the gap is that nothing covers what falls between them.
+
+1. **[`upstream-map.yaml`](../../src/docs/development/upstream-map.yaml)** maps fork↔**upstream
+   issues and PRs**. `presentation` has neither. Never a candidate, and its header says so honestly.
+
+2. **[`docs/upstream.md`](../upstream.md), "Surfaces checked and ruled out"** carries an entry
+   literally titled **"Orphan branches never attached to a PR"**, naming five: `v0.6.x`, `v0.6.x-dev`,
+   `0.5.3.x`, `v0.5.2.x-dev`, `DP-12547`. That is exactly the right *shape* of check - and it was run
+   against **`upstream`** (confluentinc), not **`origin`** (astubbs). `presentation` does not exist on
+   upstream at all.
+
+   **This is the miss, and it is worse than a gap**, because the entry reads as "orphan branches:
+   ruled out, do not re-investigate". A reader takes it as covering orphan branches generally. It
+   covers five branches on one of two remotes.
+
+3. **[`branch-package-rename-sweep.md`](branch-package-rename-sweep.md)**, the 38-branch sweep,
+   enumerated from `gh pr list` - branches with **open PRs**. Thirty-eight PRs, not 198 branches. A
+   2021 branch with no PR was correctly out of scope: that sweep's job was keeping open PRs mergeable
+   across the rename.
+
+4. **[`branch-stale-and-diagnostic.md`](branch-stale-and-diagnostic.md)** is a hand-written
+   salvage-or-delete list of branches someone had already looked at. Not an enumeration.
+
+**No inventory has ever run `git ls-remote origin` and demanded an account for each ref.** Every
+audit started from a list of *interesting things* - PRs, upstream issues - and worked outward. None
+started from the *complete set of refs* and worked inward. That is the defect class, and it is the
+same shape as the recorded rule about searching only `--state open`: a search seeded from the tracker
+cannot find what the tracker never knew about.
+
+## What else is missing: the measured scale
+
+Counts as of 2026-08-20 (re-derive rather than trusting these; the commands are given so they can be):
+
+| | |
+|---|---|
+| Branches on `origin` | 198 |
+| Never had a PR of any state | 154 |
+| No PR **and** not merged into `master` | 150 |
+| ...of those, last commit predates 2026 | **112** |
+| ...of those, named in **no** document in the repo | **109** |
+
+`presentation` is one of 109, not a one-off. The pre-2026 tail is the 2020-2023 upstream-era
+development history that came across with the fork: `demo`, `features/*`, `improvements/*`,
+`refactor/*`, `continuous-encode`, `massive-refactor`, `predictive-offset-payloads` and so on.
+
+```sh
+git ls-remote --heads origin | awk '{print $2}' | sed 's|refs/heads/||' | sort
+gh pr list --repo astubbs/parallel-consumer --state all --limit 500 --json headRefName --jq '.[].headRefName' | sort -u
+git branch -r --merged origin/master
+```
+
+### The content check: all 109 carry code that exists nowhere on master
+
+"Not merged into master" is computed by ancestry, and squash-merges break ancestry - so the 109
+could in principle be branches whose content landed years ago under a different commit. It was
+checked rather than assumed: for each branch, which **file basenames** in its tree have no
+counterpart anywhere in master's tree.
+
+Nine files are common to more than half the branches - `Jenkinsfile`, `RELEASE.adoc`,
+`EnumCartesianProductTestSets.java`, `JavaEnvTest.java`, `StringTestUtils.java` and four more. That
+is the shared baseline master has since deleted or renamed, and it is subtracted as noise.
+
+**After subtracting it, all 109 still carry branch-specific classes that exist nowhere on master.**
+The largest: `features/consumer-interface` (27), `refactor/gpt3-central-queue-direct-pull` (26),
+`refactor/gpt3-queue-management-with-msg-push` (23), `massive-refactor` (23), `partition-state` (22),
+`continuous-encode` (18). The names are real design explorations, not scaffolding - `CentralQueue`,
+`ControlLoop`, `PCWorkerPool`, `ChaosBroker`, `AutoScalingProcessor`, `HealthCheck`,
+`ConnectExampleApp`, `ParallelJoin`, `BitSetFragment`, an `Actor`/`ActorRef` family across a dozen
+branches.
+
+**Read this as "109 branches nobody has an account for", not "109 lost treasures."** Two honest
+caveats: basename matching over-counts, because a class that was renamed on master reads as absent;
+and much of this is work that was deliberately tried and abandoned, which is a perfectly good account
+- it is just an account nobody has written down. The finding is the absence of the account, not a
+claim about the value of the code.
+
+## Already surfaced by the first pass
+
+- **`upstream/pyallel-consumer` is a prior Python client**, from `confluentinc#443` (Robbie-Palmer,
+  "feature: Python Support", CLOSED unmerged), plus `confluentinc#539` ("Automatically Publish Python
+  Package to PyPi", MERGED). `confluentinc#443` **is** tracked in `upstream-map.yaml` under `sweep-2023-long-tail`,
+  characterised in one line as having "attacked the same goal from the client side" - but the branch
+  itself has not been read, while a Python client is being written right now on
+  `feats/proxy-requirements` (astubbs#293, astubbs#242). This is prior art in the strongest sense:
+  someone already did this, and their code is sitting there. `confluentinc#539` appears in no
+  document.
+- **The ruled-out entry accounted for only a handful of upstream's branches as orphans**, implying
+  that nearly all the rest each had a PR. That implication has not been verified.
+  `git ls-remote --heads upstream` is the current total; the section below measures the gap and
+  dates it.
+
+## The other remote has the same hole, and it is not ours to lose
+
+Checked 2026-08-20, after this note was written. **34 of upstream's 42 branches exist on no branch of
+this fork.** The tempting reading is that we had them and deleted some. Tested and refuted: for 33 of
+the 34, *every commit on the branch* postdates this fork's creation, so they cannot have been ours to
+delete. The one exception, `features/dynamic-concurrency-control`, we do have - our copy diverged
+under our own work.
+
+The mechanism is worth writing down because it is invisible and permanent: **a fork receives
+branches once, when it is created, and never again.** This fork dates from 2020-11-11; upstream went
+on creating branches for years afterwards, and not one of them arrives. The older the fork, the wider
+the gap, and nothing reports it.
+
+**Closed 2026-08-20: all 42 upstream branches are now mirrored on this fork under `upstream/*`.**
+Tips verified identical to upstream's. The namespace is load-bearing rather than tidy - eight
+upstream branches share a name with one of ours carrying divergent work, `master` among them, so
+pushing them under their own names would have overwritten our history. Nothing of ours was touched.
+Re-derive rather than trusting a list: compare `git ls-remote --heads origin` against
+`--heads upstream` by name and tip.
+
+**Cleaned up the same day:** the 17 bot dependency branches among them were deleted again, and the
+deletion is recorded in `branch_accounting` rather than left as an absence. Sixteen were single-commit
+pom bumps against upstream's diverged tree and would not apply here. The seventeenth was not a bot
+branch at all despite its name - a maintainer had pushed CI, licence-header and gitignore commits onto
+`dependabot/maven/org.threeten-threeten-extra-1.8.0` - and it was read before being deleted, then
+recorded separately. **That is the argument for checking contents rather than prefixes**, and it is
+the same failure this note is about: a prefix sweep would have taken human commits with no trace that
+anyone had looked.
+
+What was in the gap is not all noise. `pyallel-consumer` and `python-cd-pipeline` are a prior Python
+client - prior art in the strongest sense while a Python client is being written on
+`feats/proxy-requirements` (astubbs#293, astubbs#242). `features/batching`, `docs/back-pressure`,
+`improvements/vertx-vertical` and the `v0.6.x` / `v0.5.2.x-dev` / `0.5.3.x` release lines are also
+absent. Upstream is unmaintained, so if that repository is ever archived or removed, none of it is
+preserved anywhere we control.
+
+## What the accounting must record, and why deletion is the case that matters
+
+The check this note asks for was framed as answering "is every branch accounted for". That is not
+sufficient on its own. **The record has to be permanent and per-branch, and it has to survive the
+branch.** The failure it prevents is specific: a branch is reviewed, judged worthless, deleted - and
+because the only trace was the branch itself, a later audit re-finds its absence, cannot tell a
+deliberate deletion from an accident, and re-does the work. That is the same shape as the mirror
+bodies this branch's sibling notes are about: the judgement existed, and nothing outlived the thing
+it was about.
+
+So the disposition belongs in
+[`upstream-map.yaml`](../../src/docs/development/upstream-map.yaml) - the file that already exists to
+cache judgements that were being re-derived every session - and it must record, per branch: which
+remote it came from, what was decided, why, and when. A deleted branch keeps its entry, with its tip
+SHA, so "we deleted this deliberately on this date for this reason" is a fact the next audit reads
+rather than a hole it rediscovers.
+
+**Settled 2026-08-20:** the manifest now carries a `branch_accounting` section, keyed by ref rather
+than by work item, seeded with the mirrored upstream branches and the two of ours that carry a
+decision the branch itself does not. `state: deleted` keeps its entry, with tip, date and reason -
+that case is the whole point.
+
+It is also now the ONLY branch record. Two others existed - `preserved_branch_tips` and, inside the
+2023 sweep entry, `preserved_heads` - and they recorded the same commits under different framings:
+every `preserved_heads` PR head is the tip of an upstream branch, so `pr: confluentinc#443` and the
+`pyallel-consumer` tip were two names for one SHA. Both are folded in, with `tag` and `pr` as fields
+on the branch entry.
+
+The rule that keeps it useful: **nothing a command answers.** Open PRs are `gh pr list`; merged-ness
+is `git branch --merged`. This records the judgement, not the state.
+
+## What this wants
+
+Not a sweep-by-hand. A **check**, so the answer stays true:
+
+- Enumerate `origin` and `upstream` refs, and require every one to be accounted for by exactly one
+  of: merged, has a PR (any state), named in a document, or tagged as archived.
+- Report the unaccounted set. Absence must fail loudly rather than read as coverage - the same
+  epistemology the conformance suite already applies to the wire.
+- Fix the `docs/upstream.md` "Orphan branches" entry, which currently over-claims: say which remote
+  it covered.
+
+## Related
+
+- `branch-classic-comparison-demo.md`, landing on `feats/classic-vertx-demo` - where this was
+  found, and the branch that rescues the artifact. This entry is deliberately **not** stacked on that
+  branch: the audit is a repo-wide concern with nothing to do with the language proxy, and stacking
+  it would gate a master-level finding behind an unrelated feature PR.
+- [`upstream-coverage-completeness.md`](upstream-coverage-completeness.md) - the sibling
+  obligation, pointed at upstream issues/PRs/discussions. Same "not sampled, not the interesting
+  ones" standard; different surface. That one is explicit that it is unfinished; this one nobody knew
+  was open.

--- a/docs/inflight/upstream-161-reactor-scheduler-rationale.md
+++ b/docs/inflight/upstream-161-reactor-scheduler-rationale.md
@@ -1,0 +1,95 @@
+# confluentinc#543 - the reactor Scheduler is answerable, but not from the mirror body
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: coordination -->
+
+astubbs#161 (mirror of confluentinc#543) asks why `ReactorProcessor` subscribes on a `Scheduler` when
+the user's pipeline is already non-blocking. There is no defect and no code work: the question has an
+answer, and the opt-out the reporter wants already exists in the API. What is recorded here is why
+the issue's own `## Fork status` section cannot be posted as that answer, and what the answer
+collides with.
+
+## The mirror body names the wrong thread
+
+`## Fork status` says the remaining `subscribeOn` moves the user function "off the PC control
+thread". It does not. `ExternalEngine` overrides `setupWorkerPool` to force a pool of one, so the
+user function was never on the control thread - it runs on this module's **single dispatch thread**.
+Upstream's own bug title for the defect that produced today's code says the same: confluentinc#793,
+"executes a user-provided function in a thread from the pc-pool rather than in the provided
+scheduler".
+
+That correction changes the answer rather than polishing it. With a dispatch pool of one, a function
+that blocks before returning its publisher serialises the dispatch of *all* in-flight work - a
+stronger reason to keep the hop than the mirror gives, and the reason `Schedulers::immediate` is a
+safe opt-out only when constructing the publisher is instantaneous.
+
+The rest of the section was checked against HEAD and holds: `publishOn` is gone (`ReactorProcessor`
+retains only `subscribeOn(getScheduler())`, removed by confluentinc#798 fixing confluentinc#793), the
+supplier is injectable via `defaultSchedulerSupplier`, and "scheduler" appears nowhere in
+`src/docs/README_TEMPLATE.adoc` near the `[[project-reactor]]` anchor.
+
+## The prescribed fix is already written, on astubbs#303
+
+The mirror prescribes "a short README subsection under Project Reactor". Open PR astubbs#303 adds a
+per-module reactor README already stating that subscription runs on a supplied `Scheduler` defaulting
+to `Schedulers::boundedElastic`, and that the module is pinned to a single dispatch thread that must
+never block. Writing the prescribed root-README subsection would state those facts a second time, in
+a file generated from a template. The one thing astubbs#303 omits is what confluentinc#543 actually
+asked - that `Schedulers::immediate` removes the hop. That sentence belongs in astubbs#303's file
+while it is open, not in the root README.
+<!-- file-refs: N/A - the per-module reactor README arrives with astubbs#303 and does not exist on this branch, which is the collision this paragraph records -->
+
+## Two code findings nothing else records
+
+- **The supplier is resolved per wrapped user-function invocation, not once.** `getScheduler()`
+  calls `schedulerSupplier.get()` inside the wrapper, once per invocation - which is once per
+  `PollContext`, so once per batch rather than once per record. A caller passing a factory rather
+  than an accessor gets a new `Scheduler`, and its threads, on every one - and nothing disposes them.
+  Safe by default only because `Schedulers::boundedElastic` returns a shared instance, and nothing
+  documents the requirement. `MutinyProcessor` already does this correctly, resolving
+  `newExecutorSupplier` once in its constructor. This is a defect in the very escape hatch the answer
+  below points users at; the fix is small and preserves default behaviour.
+- **The two-argument constructor has no test.** `ReactorUnitTestBase` builds
+  `new ReactorProcessor<>(build)` and no test in the tree passes a scheduler.
+
+## The answer to post, then close
+
+astubbs#161 is not on the 0.6.0.0 blocker register in
+[`release-0600-blockers.md`](release-0600-blockers.md); its `0.6.0.0` label groups it with the other
+question mirrors to answer around the release. Post this and close, keeping the existing labels:
+
+> Good question, and the answer changed after you filed this.
+>
+> The exact line you linked - `publishOn(getScheduler())` - is gone. It was removed in
+> confluentinc/parallel-consumer#798 (fixing confluentinc/parallel-consumer#793), first released in
+> 0.5.3.0, so there is now one
+> scheduler boundary rather than two.
+>
+> The remaining `.subscribeOn(getScheduler())` is deliberate, but not for the reason you might
+> expect. `ExternalEngine` overrides `setupWorkerPool` to pin the reactor module to a **single
+> dispatch thread** - that thread exists only to invoke your function, take the publisher it
+> returns, subscribe, and go back for more work. So a function that blocks *before* returning its
+> publisher does not just slow itself down; it serialises the dispatch of every other in-flight
+> record. Parallel Consumer cannot verify that a given function is non-blocking, so it cannot drop
+> that protection by default.
+>
+> But you are right that you should not have to pay for it, and you do not have to. The scheduler is
+> injectable:
+>
+> ```java
+> var pc = new ReactorProcessor<>(options, Schedulers::immediate);
+> ```
+>
+> With a BlockHound-clean pipeline, `Schedulers.immediate()` subscribes on the dispatch thread itself
+> and the extra hop disappears. The caveat is the one above: constructing the publisher must be
+> genuinely instantaneous, because anything spent there is spent on the single dispatch thread.
+>
+> One thing to watch if you pass your own - the supplier is invoked on every wrapped invocation, so pass an
+> accessor to a shared scheduler (`Schedulers::immediate`, `Schedulers::boundedElastic`, or
+> `() -> myScheduler`), never a factory such as `() -> Schedulers.newParallel(...)`, which would
+> create a scheduler and its threads for every batch.
+>
+> The real gap here was that none of this was discoverable - "scheduler" appears nowhere in the
+> README. That is being fixed in astubbs/parallel-consumer#303, which gives the reactor module its
+> own README covering the scheduler, its default, and the single-dispatch-thread constraint. Closing
+> this as answered; the documentation work is tracked there.

--- a/docs/inflight/upstream-173-revocation-duplicate-processing.md
+++ b/docs/inflight/upstream-173-revocation-duplicate-processing.md
@@ -1,0 +1,105 @@
+# confluentinc#777: revocation duplicates are the contract, and two records call them a bug
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+Mirror: [astubbs/parallel-consumer#173](https://github.com/astubbs/parallel-consumer/issues/173).
+Upstream: [confluentinc/parallel-consumer#777](https://github.com/confluentinc/parallel-consumer/issues/777).
+
+## The tracked claim is false, and it will close this issue for the wrong reason
+
+`src/docs/development/upstream-pr-analysis.adoc` ranks confluentinc#777 sixth and states, verbatim:
+
+> Fixed by merging PR #893 + #909 <!-- issue-refs: exempt - quoted from upstream-pr-analysis.adoc; requalifying a quote falsifies it -->
+
+with the verdict "Verify after cherry-pick". Verified 2026-08-20: **refuted**. The prediction was
+stated before checking, and it was that both halves would miss.
+
+confluentinc#909 is the testable half, because the fork already carries it (astubbs#31, merged). If
+it were the fix the behaviour would be gone. It is not: `WorkManager.handleFutureResult`
+(`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkManager.java`, grep
+`Dropping work from revoked partition`) still discards a result whose partition moved, which is
+verbatim the reporter's step 3. confluentinc#909 governs which container wins a *registration* race;
+it is silent about a result arriving after revocation.
+
+confluentinc#893 (carried in astubbs#337, split out of astubbs#57 on 2026-08-24) makes
+`getOffsetToCommit()` accurate so a commit cannot run
+*ahead* of completion. confluentinc#777 is the opposite shape: the offset committed at revocation is
+already correct, the in-flight record is correctly encoded as incomplete, and the redelivery follows
+from that correctness. Nothing is lost.
+
+**So merging the confluentinc#893 cherry-pick must not be read as closing confluentinc#777.**
+Correcting the adoc entry is the one change here with a deadline, because astubbs#337 is open now.
+
+## Draft answer - postable as-is once a maintainer agrees with the closing rationale
+
+> Your read of the mechanism is exactly right, including step 3, and the behaviour is deliberate
+> rather than an oversight - but the reason is worth stating, because it is not simply
+> "at-least-once, live with it".
+>
+> The divergence is over what PC treats as the unit of the delivery guarantee. You expected that
+> *starting* to process a record makes its completion durable. PC's guarantee is attached to
+> partition ownership: a completion can only be recorded by the instance that still owns the
+> partition when the result comes back. Once the partition is revoked, this instance has no standing
+> to record anything about it, so the result is dropped.
+>
+> That drop is load-bearing, not a gap. The new owner may already be processing that same offset. A
+> returning stale result that was allowed to write would remove the fresh work container that
+> replaced it - and *that* is a dropped record, which is strictly worse than a duplicated one. It is
+> the defect confluentinc/parallel-consumer#909 describes, and the guard in `handleFutureResult`
+> is what prevents it.
+> Honouring the completion of work on a revoked partition would reintroduce it.
+>
+> On mitigation, there is something concrete, and it is not the obvious thing. We measured the
+> assignor and stop-mode combinations against the same rebalance storm (250,000 records, one seed):
+> eager plus abrupt stop gave 2421 duplicates, eager plus draining stop 2007, and cooperative plus
+> abrupt stop 405. The cooperative-plus-draining cell has not been run. **The assignor accounts for
+> essentially all of it; draining is second-order.** That is what "duplicates are a product of revocation rather
+> than of departure" predicts: the eager assignor revokes every partition from every member on any
+> membership change, so most of the abandoned work never belonged to the member that left. Draining
+> on redeploy - your instinct, and the advice most people would give - buys almost nothing on its
+> own. Switching to `CooperativeStickyAssignor` is the change that moves the number.
+>
+> One correction to something you may have read here: EOS is not an escape hatch for this. Kafka
+> transactions give effectively-once *results in Kafka output topics*, not exactly-once processing,
+> and PC's own README says so. For non-idempotent work outside Kafka it does not help, so
+> idempotency really is the right call for your case.
+>
+> A revocation grace period (finish in-flight work for revoked partitions before releasing them) is
+> the feature that would reduce this further. It needs partition-scoped submission suppression plus
+> in-flight tracking, a crash still voids it, and nobody has built it. Tracked, not planned.
+
+## Also stale in the mirror body
+
+astubbs#173's `## Fork status` is otherwise sound - astubbs#29 is still open, `commitOffsetsThatAreReady`
+still takes the `synchronized (commitCommand)` monitor on master
+(`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java`,
+grep `Synchronizing on commitCommand` - the bare `synchronized (commitCommand)` appears four times in
+that file, so it is not an anchor), and the chaos suite really does assert bounded rather than zero
+duplicates. Two corrections:
+
+- *"Only the transactional (EOS) commit mode gives exactly-once"* contradicts our own README
+  (`src/docs/README_TEMPLATE.adoc`, grep `does not prevent _duplicate message replay_`; the template
+  is the source, `README.adoc` is generated). Offering it as the answer here is misleading.
+- astubbs#29 is named as the closest fork work, which is true, but its `tryCommitOffsetsOnRevoke()`
+  deliberately *skips* the revocation commit under lock contention, trading redelivery for killing
+  the deadlock. It moves this symptom the wrong way, and the mirror reads as though it helps.
+
+## Next
+
+The measurements are from the astubbs#57-family chaos work, seed `4734674029169027864`, recorded
+with the matrix in `parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosRevokeUnderWorkCooperativeDrainIT.java`.
+That javadoc records three cells and predicts the fourth rather than measuring it, so the
+cooperative-plus-draining figure must not be quoted until the cell is actually run. Nothing in
+`src/docs/README_TEMPLATE.adoc` tells a user any
+of it: the offset-map section states the replay caveat without saying what changes its magnitude,
+and there is no assignor guidance anywhere.
+
+1. README section on revocation redelivery, drawn from the draft above. The evidence exists; this is
+   writing, not investigation.
+2. Run the cooperative-plus-draining cell, so the fourth number can be stated rather than predicted.
+3. Post the answer, then close astubbs#173 and relabel it off `bug`.
+
+**Maintainer decision, and only theirs:** whether PC should offer a revocation grace period at all.
+Upstream declined it as complexity for a benefit a crash voids. If the answer is no, confluentinc#777
+is a documentation obligation rather than a defect, and step 3 above is unblocked.

--- a/docs/inflight/upstream-175-sporadic-commit-timeouts.md
+++ b/docs/inflight/upstream-175-sporadic-commit-timeouts.md
@@ -1,0 +1,56 @@
+# confluentinc#809: the sporadic commit timeouts, and the one strand still open
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: stranded-work -->
+
+
+Mirror: [astubbs/parallel-consumer#175](https://github.com/astubbs/parallel-consumer/issues/175).
+Upstream: [confluentinc/parallel-consumer#809](https://github.com/confluentinc/parallel-consumer/issues/809).
+
+**Read the upstream thread, not the mirror's summary.** The mirror describes the opening report
+(`InternalRuntimeException: Timeout waiting for commit response PT30S`, no diagnosis). The thread's
+substance is a *second* reporter, `gtassone`, who debugged it with JDWP, shipped a fix, and had it
+merged upstream. That work is already in this tree and the mirror does not say so.
+
+## It is not the same defect as confluentinc#833, though it shares the message
+
+confluentinc#833 / astubbs#177 is "PC runs a while and then **exits**". confluentinc#809 is "PC hits
+the same message and then **fails to exit**": `state == RUNNING`, `isClosedOrFailed()` false, both
+control threads dead, and a Kubernetes liveness probe with nothing to read. The headline stack is on
+the close path (`waitForClose` -> `doClose` -> `commitOffsetsThatAreReady`), not the control loop.
+Same symptom string, overlapping triggers, one extra defect that confluentinc#833 never had.
+
+## Where each strand stands at HEAD
+
+| Strand | State |
+|---|---|
+| Poll thread killed by a rebalance-time commit rejection | Fixed. In `internal/ConsumerOffsetCommitter.java`, `commitDeferringOnRebalance` catches both `RebalanceInProgressException` (astubbs#100) and `CommitFailedException` (astubbs#108) - grep `catch (CommitFailedException e)`, the only one in the tree. `CommitFailedException` is the exception in gtassone's own logs. |
+| Poll thread killed some other way, symptom names neither subsystem nor cause | Fixed by astubbs#204. `notifyPollerDied` (declared in the same file, called from `internal/BrokerPollSystem.java`) releases the waiter with the poller's exception at the moment of death. |
+| `commitSync` retrying a broker outage forever, stranding the poll thread | Fixed by astubbs#204 (per-call rather than per-attempt budget). This is the closest match to gtassone's trigger: connectivity blips on a large shared cluster, one-second commit interval. |
+| Close path aborting before the state transition, leaving an undetectable zombie | Fixed **upstream**, by confluentinc#818, and this tree carries it: in `internal/AbstractParallelEoSStreamProcessor.java`, `doClose` wraps `innerDoClose` and sets the state from a `finally` - grep `this.state = CLOSED`, the only one in the tree, and the comment above the `try` still names the issue. Not fork work, and not astubbs#204's. |
+| Poll thread **alive but wedged** - the AB-BA cycle | Still reachable. Owned by astubbs#29 (draft, fix never observed working) and `docs/solutions/runtime-errors/revoke-path-commit-deadlock-between-poll-and-control-threads.md`. |
+
+## What a future session should actually do with this
+
+**gtassone is a better wedge candidate than the one astubbs#204 nominated.** That PR flagged
+`dumontxiong` on confluentinc#833 as the possible AB-BA case. gtassone is stronger evidence: he posts
+his configuration, and it is `PERIODIC_CONSUMER_SYNC` - the only mode in which the cycle can close -
+with 128 partitions, concurrency 64 and a user function running from 100ms to minutes. Anyone picking
+up astubbs#29 should read his comments before building a reproducer.
+
+**The mirror's `## Fork status` is stale in three ways**, and it is what a future reader trusts:
+it credits astubbs#100 alone and predates astubbs#204; it treats the two 0.5.3.1 changes as upstream
+fixes that "did not finish the job" without recording that this tree *contains* both; and it never
+mentions the close-path hang, which is the half of confluentinc#809 that is genuinely distinct.
+
+**The resilience question this reopens.** confluentinc#809 is a transient-connectivity report, and
+astubbs#204 deliberately made PC give up where it previously hung. With the shipped default
+(`offsetCommitTimeout` 10s against the consumer's 60s `default.api.timeout.ms`) exactly one attempt is
+reachable, so a blip shorter than the outage now terminates the instance. gtassone said terminating
+was acceptable *to him* - the hang was his problem - but that is one user. The decision lives in
+`docs/inflight/bug-offset-commit-timeout-does-two-jobs.md` and astubbs#317; this issue is the demand
+signal for it, not a separate item.
+
+**No test locks in the close-state guarantee.** Nothing in the suite drives an exception through
+`innerDoClose` and asserts the instance still reaches `CLOSED`. It came in as an upstream patch with
+the behaviour in a `finally` block, and a later refactor could quietly lose it.

--- a/docs/inflight/upstream-mirror-bodies-are-stale.md
+++ b/docs/inflight/upstream-mirror-bodies-are-stale.md
@@ -1,0 +1,106 @@
+# The mirror bodies are wrong, and they are what people trust
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+Every open `upstream-mirror` issue carries a `## Fork status` section written when it was mirrored.
+That section, not
+[`upstream-map.yaml`](../../src/docs/development/upstream-map.yaml) and not
+[`upstream-pr-analysis.adoc`](../../src/docs/development/upstream-pr-analysis.adoc), is where the
+fork's only judgement about most upstream issues lives. A triage of ten of them checked those
+sections against the tree. Most had drifted and several were wrong on the mechanism.
+
+This matters more than a stale note usually would, because a mirror body is the artefact a reader
+trusts *instead of* investigating. It reads as settled, it carries citations, and nothing about it
+signals its age. An agent picking up one of these issues inherits its errors and builds on them.
+
+The corrected text for each is drafted and ready to post, in the per-issue notes linked below.
+**Nothing has been posted to any issue** - that is a separate, deliberate step.
+
+Four further mirrors from the same sweep already had a fix in flight and were checked for a different
+thing - whether the PR actually closes the issue. That is
+[`pr-mirror-fixes-and-what-they-close.md`](pr-mirror-fixes-and-what-they-close.md).
+
+## How they got this wrong
+
+Not carelessness, and worth understanding rather than just fixing, because four of the five causes
+will recur on the next mirror written.
+
+**A single rename falsified one layer of every body at once.** The bodies cite `file:line`. The
+`io.confluent` to `bz.stub` move changed every path and shifted every line in the tree, so every
+citation in every mirror broke in one commit, silently, while still reading as valid. One of them
+turned out to have been wrong from the day it was written - it named a method declaration rather
+than the statement it claimed to cite, and nobody could have noticed.
+[`docs/citations.md`](../citations.md) already forbids this form; the bodies predate the rule
+holding.
+
+**Nothing re-checks a body after it is written.** `upstream-map.yaml` carries a `last_checked` per
+entry and has a sweep script behind it. An issue body has neither, so it is accurate on the day it
+is written and decays untracked from then on. astubbs#175's body credits the correct PR for the day
+it was written and the wrong one a fortnight later, because astubbs#204 merged in between.
+
+**The summary was written from the summary.** The mirror header says "Summarised, not copied", which
+is the right call for the upstream thread. But the `## Fork status` beneath it was then reasoned
+from that summary rather than from the thread, and the discarded detail is exactly what a fork
+assessment needs. astubbs#162's body misses that reporters hit the same warning *after* the fix
+shipped, which is the single most important fact in its upstream thread and settles whether the
+issue is closed. astubbs#175's body misses the failure the reporter himself called the bigger
+problem.
+
+**Plausible adjacency got recorded as attribution.** astubbs#175 credits astubbs#100 with fixing the
+reporter's poll-thread death. astubbs#108 is the one that catches the exception in the reporter's
+own logs. Both are rebalance-time commit fixes, so the plausible one was written down. Nothing in
+the body's format distinguishes a claim that was verified from one that was inferred, so a guess and
+a check are indistinguishable to the next reader - and the guesses are what failed.
+
+**Upstream's own description was inherited as fact.** astubbs#241 restates upstream's account of
+`commitOffsets`, which confluentinc#355 falsified in 2022 - before the mirror was written. Mirroring
+carried the claim across without asking whether it was still true of our tree, or of any tree.
+
+Underneath all five: **the body was authored as a mirroring artefact and is now read as a maintained
+assessment.** It has no verified-on date, no separation of observed from inferred, and no trigger
+that fires when the code beneath it moves. The cohort's own note
+([`upstream-2023-sweep-manual-review.md`](upstream-2023-sweep-manual-review.md)) already admitted
+the related version of this: verification depth was uneven, and the interesting ones got dug into
+hardest.
+
+## What needs correcting, per mirror
+
+Each row's corrected text, with anchors and citations, is in the linked note.
+
+| Mirror | What is wrong in its `## Fork status` | Corrected text in |
+|---|---|---|
+| astubbs#241 | **Premise false.** Claims one generic retry loop treating every transaction failure identically. confluentinc#355 replaced that in 2022; a coarse taxonomy has existed since | [`core-241-tx-commit-failure-taxonomy.md`](core-241-tx-commit-failure-taxonomy.md) |
+| astubbs#189 | Understates it: omits that there is no retry ceiling, so innocent records re-run indefinitely rather than merely being delayed. Prescribes jitter as "the proper fix" when the real find is a half-built per-record seam. Predates the design that now exists | [`core-189-batch-failure-granularity.md`](core-189-batch-failure-granularity.md) |
+| astubbs#181 | Never names the mechanism, which was a kafka-clients SASL callback rather than anything in this project. "Untested on Java 24" is now too strong. Reads as though astubbs#53 blocks it, and astubbs#53 answers a different question | [`deps-181-java-24-compatibility.md`](deps-181-java-24-compatibility.md) |
+| astubbs#178 | "Not reproducible by inspection" is too broad - true only under the reporter's stated preconditions. The chaos-suite reasoning is stale: the suite does assert per-key concurrency now, and it is the epoch scoping that lets the case through | [`core-178-key-order-across-a-rebalance.md`](core-178-key-order-across-a-rebalance.md) |
+| astubbs#175 | **Credits the wrong PR** for the reporter's failure. Treats confluentinc#818 and confluentinc#819 as upstream-only when this tree carries both. Omits the close-path failure entirely | [`upstream-175-sporadic-commit-timeouts.md`](upstream-175-sporadic-commit-timeouts.md) |
+| astubbs#173 | **Contradicts our own README** on what the transactional mode guarantees. Names astubbs#29 as the closest fork work, when astubbs#29 skips the revocation commit by design and so moves this symptom the wrong way | [`upstream-173-revocation-duplicate-processing.md`](upstream-173-revocation-duplicate-processing.md) |
+| astubbs#163 | **False.** Says the poll is unguarded with only a blanket catch. A typed per-exception poll seam already exists and is load-bearing, which makes the fix far cheaper than the body implies. Quotes code that astubbs#204 has since changed | [`core-163-poll-path-has-no-error-seam.md`](core-163-poll-path-has-no-error-seam.md) |
+| astubbs#162 | **Misses the headline**: reporters hit the same warning after the fix shipped, proving it partial. Understates what this tree already carries. Cites an unrelated open PR as the thing reworking the area | [`bug-162-offset-state-truncation.md`](bug-162-offset-state-truncation.md) |
+| astubbs#161 | **Names the wrong thread.** Says the scheduler moves the user function off the control thread; it was never on the control thread. That changes the answer to the reporter's actual question | [`upstream-161-reactor-scheduler-rationale.md`](upstream-161-reactor-scheduler-rationale.md) |
+| astubbs#139 | Points at the wrong surface: treats `subscribe` as the problem when it is the safest of the cross-thread methods, and never mentions the run-state machine, which is the unsafe one. Frames the whole issue as gated on astubbs#142 when most of it is not | [`core-139-public-api-thread-safety-contract.md`](core-139-public-api-thread-safety-contract.md) |
+
+Line-number citations have drifted in every one of them. That is listed once here rather than ten
+times above.
+
+## What would stop it happening again
+
+Unresolved, and worth a decision before the next mirror is written. Correcting these ten bodies
+without this just resets the clock.
+
+- **Give the `## Fork status` section a verified-on date**, the way map entries have `last_checked`.
+  Without one there is no way to tell a fresh assessment from a three-year-old one, and no way for a
+  sweep to find the stale ones.
+- **Say which claims were checked against code and which were inferred.** The failures above are
+  concentrated entirely in the inferred half, and nothing marks it.
+- **Anchors, never line numbers**, per [`docs/citations.md`](../citations.md). This is the one cause
+  with a mechanical fix.
+- **A merged fork PR should mark every mirror it touches as needing a re-read.** astubbs#175 went
+  wrong precisely here. `scripts/upstream-sweep.sh` is the natural home, since it already reasons
+  about staleness.
+
+## Delete when
+
+The ten bodies above are corrected, and either the recurrence question has been decided and recorded
+where the next mirror author will see it, or it has been explicitly declined.

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -106,6 +106,24 @@ Rewriting history someone else may have pulled is not reversible from inside a P
   by name.
 - **Other instances of the same defect** - `AGENTS.md`, "PR Discipline", owns that rule; it belongs
   at merge prep, once the defect class is understood.
+- **Should this PR close an issue - and if only partly, which part?** Ask it explicitly at merge
+  prep, because nothing else will: the tracker is not in the diff, and a PR that finishes an issue
+  without saying so leaves it open for someone to rediscover. `docs/inflight/issue-index.md` is the
+  cheap way to look - grep it for the area the PR touches - but confirm with `gh issue view <n>`
+  before acting on any row, since it goes stale silently.
+
+  **A closing keyword needs the fully qualified form.** `Fixes astubbs#167` closes nothing; only
+  `Fixes astubbs/parallel-consumer#167` does. [`docs/issue-references.md`](issue-references.md)
+  owns that rule.
+
+  **Partly addressing an issue is the common case, and closing it then is the real damage** - the
+  remaining work goes with it. Say which part landed and leave it open. astubbs#41 is the worked
+  example: its reopening comment lists four remaining items, astubbs/parallel-consumer#366 did the
+  first, and closing on that would have taken the other three with it. Where the PR contradicts the
+  issue's own recommendation - as that one did, refuting a stated preference with a measurement -
+  record the disagreement on the issue, since the recommendation lives there and the evidence does
+  not.
+
 - **Does this PR advance a roadmap entry?** Then its `stage`/`stage_delivery` in
   `docs/data/roadmap.yaml` move in the same change - the `stages` block there owns the rule. The
   roadmap-stage gate enforces it when the entry's `pull_request` names this PR; entries carried by

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -284,7 +284,7 @@ annotated tags:
 | confluentinc#506 | astubbs | Fix chart links |
 
 Each is tagged `archive/upstream-pr-<n>`. **The tag name, target SHA and check date are deliberately
-not repeated here** - they live only in `sweep-2023-admin-closure.preserved_heads` in
+not repeated here** - they live only in `branch_accounting` in
 [`upstream-map.yaml`](../src/docs/development/upstream-map.yaml), this repo's owner of fork-upstream
 facts. A corrected SHA updated in one copy while the other still read as authoritative is exactly the
 drift this section exists to prevent; the table above carries only what does not change.
@@ -321,11 +321,18 @@ tags: the release-line branches (`0.5.3.x`, `v0.5.2.x-dev`, `v0.6.x`), upstream'
 `docs/back-pressure` (the swept confluentinc#508 head, out of the 2026-08-14 pass's scope),
 `features/batching`, `PL-176/DontDrainIssue` (content unassessed - flagged in
 `docs/inflight/branch-audit-orphans.md`), `python-cd-pipeline`, `correct-failing-license-check`,
-and `DP-12547` (already ruled out as content below; pinned so the ruling stays checkable). The 18
-dependabot/renovate/chore branches were deliberately not preserved - recreatable version bumps, not
-work. Tag names, SHAs and check date live only in `preserved_branch_tips` in
-[`upstream-map.yaml`](../src/docs/development/upstream-map.yaml), same contract as
-`preserved_heads`.
+and `DP-12547` (already ruled out as content below; pinned so the ruling stays checkable). The
+dependabot/renovate/chore branches were deliberately not tagged - recreatable version bumps, not
+work - though they are now mirrored with the rest.
+
+**Superseded 2026-08-20 by the branch mirror.** Every upstream branch, bot ones included, is now a
+branch on this fork under `upstream/*`, so tags are no longer the only copy. They are kept because an
+annotated tag is the more durable pin: a branch can be deleted or force-moved, a tag is the record
+that a specific commit was deliberately preserved. Tag names, SHAs, the PR each tip belongs to, and
+the check date now live in ONE place - `branch_accounting` in
+[`upstream-map.yaml`](../src/docs/development/upstream-map.yaml). The former
+`preserved_branch_tips` and `sweep-2023-admin-closure.preserved_heads` recorded the same commits
+under two framings and have been folded into it.
 
 **Re-running this is not yet automated.** Branches get deleted, so a head safe today can be orphaned
 tomorrow - but no script checks it: `--audit` covers tracking and mirroring, not reachability, and

--- a/docs/upstream.md
+++ b/docs/upstream.md
@@ -14,7 +14,9 @@ re-derived from scratch:
 - [**`src/docs/development/upstream-map.yaml`**](../src/docs/development/upstream-map.yaml) - the
   **state tracker**, and the **source of truth** for the *facts*: which fork branch/PR maps to
   which upstream issue/PR, its work group, and current status. Its header documents the schema.
-  Validate and render with `scripts/upstream-map.py {validate,table,refs}`. Design follows Debian
+  Validate and render with `scripts/upstream-map.py {validate,table,refs}`;
+  `bin/check-upstream-map.sh` runs that validation as a gate, so a schema error fails a PR rather
+  than waiting for someone to run the script by hand. Design follows Debian
   DEP-3, Yocto `Upstream-Status:` and OpenShift's `UPSTREAM:` fork conventions.
 - [**`src/docs/development/upstream-pr-analysis.adoc`**](../src/docs/development/upstream-pr-analysis.adoc) -
   the **plan**: *editorial* analysis with rankings, verdicts, and the recommended merge order. When
@@ -44,10 +46,12 @@ the mirrors move on.
 **When you start work that maps to an upstream PR, add or update its entry in `upstream-map.yaml`**
 - do not just note it in prose. And **it does not stop at "start work"**.
 
-Nothing automated checks the *fork* side: `upstream-map.py validate` only checks the schema, and
+Nothing automated checks the *fork* side, and the gate above does not change that:
+`upstream-map.py validate` checks the SHAPE of an entry, never whether its claims are true, and
 `upstream-sweep.sh` only watches upstream - so a manifest that says `prs: []` while a fork PR is
 open still passes every check, and the mapping quietly rots (a 2026-08-04 audit found five such
-entries). Update the entry **at every lifecycle transition of your own work, in the same commit that
+entries). Read a green gate as "this file parses and its states are spelled correctly", nothing
+more. Update the entry **at every lifecycle transition of your own work, in the same commit that
 causes it**: opening a PR (`prs:` + `status: pr-open`), finishing on a branch without a PR
 (`status: ready`), merging (`merged`), releasing (`released`), abandoning
 (`superseded`/`wontfix`).

--- a/scripts/upstream-map.py
+++ b/scripts/upstream-map.py
@@ -38,6 +38,11 @@ GROUPS = {"rebalance-stability", "metrics-observability", "vertx",
           "java-baseline-kafka4", "features", "deps-security", "deps-major",
           "deps-routine", "build-tooling", "logging-ux", "release", "governance"}
 
+# `branch_accounting` is the ONLY branch record (see the manifest header). It is a different shape
+# from `entries` - keyed by ref, not id - so it needs its own arm rather than reuse.
+BRANCH_STATES = {"mirrored", "ours", "archived", "deleted"}
+ISO_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
 
 def load():
     with open(MANIFEST) as fh:
@@ -64,6 +69,58 @@ def validate(d):
         grp = e.get("group")
         if grp not in GROUPS:
             errs.append(f"{eid}: bad group '{grp}' (allowed: {sorted(GROUPS)})")
+    errs.extend(validate_branches(d))
+    return errs
+
+
+def validate_branches(d):
+    """Check `branch_accounting`, which went unvalidated from the day it was added.
+
+    It arrived in astubbs#327 alongside a `validate` that read only `entries`, so a bogus `state`
+    passed silently while the run printed `OK: 39 entries` - a reassuring count of the OTHER
+    section. That is the shape this repo keeps rediscovering: not a gate that fails, a gate that
+    reports success about something it never looked at. The success line now names both sections
+    for the same reason.
+    """
+    errs = []
+    branches = d.get("branch_accounting") or []
+    if not isinstance(branches, list):
+        return [f"branch_accounting: should be a list, found {type(branches).__name__}"]
+    refs_seen = [b.get("ref") for b in branches if isinstance(b, dict)]
+    for dup in [k for k, v in collections.Counter(refs_seen).items() if v > 1]:
+        errs.append(f"branch_accounting: duplicate ref: {dup}")
+    for b in branches:
+        if not isinstance(b, dict):
+            errs.append(f"branch_accounting: entry is not a mapping: {b!r}")
+            continue
+        ref = b.get("ref") or "<no-ref>"
+        if not b.get("ref"):
+            errs.append(f"branch_accounting: entry missing 'ref': {b!r}")
+        st = b.get("state")
+        if st not in BRANCH_STATES:
+            errs.append(f"{ref}: bad state '{st}' (allowed: {sorted(BRANCH_STATES)})")
+        # A tip is REQUIRED only once the entry outlives the branch. For a live branch the SHA is
+        # one `git rev-parse` away, and this section's governing rule is "nothing a command
+        # answers" - so demanding it there would contradict the schema it validates. Once the
+        # branch is deleted or archived nothing can answer it, and an entry recording that we
+        # removed something without saying what is the exact failure the section exists to prevent.
+        tip = b.get("tip")
+        if tip is None:
+            if st in ("deleted", "archived"):
+                errs.append(f"{ref}: state '{st}' requires a 'tip' - nothing else can recover it")
+        elif not isinstance(tip, str):
+            # `tip: 255916684` is all digits, so YAML makes it an int and any string comparison
+            # against `git rev-parse` silently never matches. Already hit once, in review.
+            errs.append(f"{ref}: 'tip' parsed as {type(tip).__name__}, not str - quote it")
+        if st == "deleted":
+            when = b.get("deleted")
+            if when is None:
+                errs.append(f"{ref}: state 'deleted' requires a 'deleted' date")
+            elif not ISO_DATE.match(str(when)):
+                errs.append(f"{ref}: 'deleted' should be an ISO date (YYYY-MM-DD), found '{when}'")
+        see = b.get("see")
+        if see is not None and not isinstance(see, list):
+            errs.append(f"{ref}: 'see' should be a list, found {type(see).__name__}")
     return errs
 
 
@@ -153,7 +210,8 @@ def main():
             for e in errs:
                 print("  " + e)
             sys.exit(1)
-        print(f"OK: {len(d['entries'])} entries, no schema errors")
+        print(f"OK: {len(d['entries'])} entries, "
+              f"{len(d.get('branch_accounting') or [])} branch records, no schema errors")
     elif cmd == "table":
         table(d)
     elif cmd == "refs":

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -137,14 +137,14 @@ entries:
       branches: [test/177-commit-response-timeout]
       prs: [204]
       fork_issue: 177
-      status: pr-open
+      status: merged
     upstream:
       repo: confluentinc/parallel-consumer
       issues: [833]
       prs: []
       related: [857, 803, 809]
       status: open
-      last_checked: 2026-08-05
+      last_checked: 2026-08-20
     adoc_anchor: part3-cat1-stability
     notes: >
       ON RELEASE, say on the mirror that the reported message itself CHANGES: anyone
@@ -215,8 +215,8 @@ entries:
     group: rebalance-stability
     summary: Accurate committed offset on partition assignment (carried upstream PR)
     fork:
-      branches: [cherry-pick/893-offset-reset, upstream-pr-893]
-      prs: [57]
+      branches: [cherry-pick/893-offset-reset, upstream-pr-893, fix/121-offset-accuracy-on-assignment]
+      prs: [337]
       status: pr-open
     upstream:
       repo: confluentinc/parallel-consumer
@@ -280,7 +280,6 @@ entries:
     fork:
       branches: [feat/java-17-baseline]
       prs: [53]
-      fork_issue: 181
       status: in-progress
     upstream:
       repo: confluentinc/parallel-consumer
@@ -292,7 +291,10 @@ entries:
       0.7.x line. The only reason to move off Java 8 is Kafka 4 (kafka-clients
       4.x require Java 11 -- target baseline Java 11). PR #53 is a DRAFT holding
       a provisional Jabel-removed / release=17 state plus Kafka 4 research docs.
-      Addresses confluentinc#862 (cannot run on Java 24). confluentinc PR #866 bumps
+      Does NOT address confluentinc#862 (cannot run on Java 24) - that is a runtime
+      question about what the shipped Java 8 jar can run on, settled by kafka-clients
+      3.9.1, and it is owned by java-24-security-manager-removal. The two only look
+      alike because both say "Java". confluentinc PR #866 bumps
       Kafka to v4 (NOTE: .adoc previously said v7 -- stale). confluentinc PR #920
       (found by the 2026-07-28 sweep) documents the JDK 17 build requirement +
       Jabel Java 8 bytecode -- overlaps our Java-baseline framing; compare before
@@ -312,9 +314,15 @@ entries:
     group: features
     summary: Support Virtual Threads (JDK 21+); synchronized -> ReentrantLock
     fork: {branches: [], prs: [], status: none}
-    upstream: {repo: confluentinc/parallel-consumer, issues: [896, 862, 78], prs: [908], related: [299], status: open, last_checked: 2026-07-28}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [896, 78], prs: [908], related: [299, 862], status: open, last_checked: 2026-08-20}
     adoc_anchor: part1-group-b-features
-    notes: Sequence behind the Java baseline branch; ReentrantLock migration may also help #862.
+    notes: >
+      Sequence behind the Java baseline branch. The earlier claim that the ReentrantLock
+      migration may also help confluentinc#862 is REFUTED (2026-08-20): this PR removes
+      virtual-thread pinning on synchronized, JDK 24 removed pinning anyway, and
+      confluentinc#862 was a kafka-clients SASL callback calling a Subject API that the
+      JDK withdrew. Different mechanism entirely. Fork PR astubbs#51 carries this work and
+      neither blocks nor closes astubbs#181. See java-24-security-manager-removal.
 
   - id: upstream-pr-866-kafka-v4
     group: deps-major
@@ -621,18 +629,30 @@ entries:
 
   - id: sweep-2023-tx-failure-taxonomy
     group: rebalance-stability
-    summary: ProducerManager retries every transaction commit failure identically
-    fork: {branches: [tx-commit-failure], prs: [], fork_issues: [241], status: none}
-    upstream: {repo: confluentinc/parallel-consumer, issues: [144], prs: [], related: [112], status: closed, last_checked: 2026-08-07}
+    summary: Transaction commit failures are classified, but not by Kafka's own taxonomy and with no budget
+    fork: {branches: [bugs/prod-tx-manager-retries, tx-commit-failure], prs: [], fork_issues: [241], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [144], prs: [355], related: [112], status: closed, last_checked: 2026-08-20}
     adoc_anchor: null
     notes: >
-      commitOffsets still has one generic loop bounded by a constant literally named
-      arbitrarilyChosenLimitForArbitraryErrorSituation. ProducerFencedException is
-      singled out and rethrown; the rest (IllegalState, UnsupportedVersion,
-      Authorization, Kafka, Timeout, Interrupt) are undifferentiated despite having
-      different fatality. Design together with fork issue #225 (fencing should abort
-      and rejoin like Kafka Streams' TaskMigratedException) -- both are about giving
-      transaction failures a taxonomy. Upstream ideas on astubbs:tx-commit-failure.
+      SUPERSEDED PREMISE - both the issue and this entry's earlier note claimed one
+      generic retry loop treating every failure identically. That has been false since
+      confluentinc#355 (2022-09-29) replaced catch(Exception) with
+      catch(TimeoutException | InterruptException) plus a classifying comment block;
+      everything else now fails fast. What is genuinely open: the retry set contradicts
+      Kafka's own marker in both directions (TimeoutException IS a RetriableException,
+      InterruptException is NOT and is retried anyway without honouring the interrupt);
+      arbitrarilyChosenLimitForArbitraryErrorSituation is a count rather than a time
+      budget, and astubbs#204's offsetCommitTimeout covers only the consumer path, so
+      transactional mode has no user-visible commit budget; the retry arm can set
+      committed = true without having committed; and nothing tests any of it in any
+      module. Fencing also reaches the supervisor by two routes with two types - wrapped
+      InternalRuntimeException from sendOffsetsToTransaction but RAW from
+      commitTransaction - and astubbs#225 knows only the first. Start from
+      bugs/prod-tx-manager-retries (RetrySettings/FailureReaction, PCCommitFailedException,
+      PCTimeoutException), NOT tx-commit-failure, which is a 2021 WIP superseded by
+      confluentinc#355. That resolves the verify-before-attaching question in
+      docs/inflight/branch-audit-orphans.md: it attaches. Design with astubbs#225 and
+      astubbs#317. Detail in docs/inflight/core-241-tx-commit-failure-taxonomy.md.
 
   - id: sweep-2023-broker-disconnect-commit
     group: rebalance-stability

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -105,6 +105,12 @@ fork_repo: astubbs/parallel-consumer
 # specific commit was deliberately preserved. Verify without fetching:
 #   git ls-remote --tags origin 'archive/*'
 #
+# ENFORCED by `bin/check-upstream-map.sh` (via `scripts/upstream-map.py validate`): ref present and
+# unique, state in the closed set, a `deleted` entry carries an ISO date, and `tip` is a STRING - an
+# all-digit SHA otherwise parses as an integer and never compares equal to `git rev-parse` output.
+# The tip is required only for `deleted` and `archived`, because for a live branch it is one command
+# away and this section records nothing a command answers.
+#
 # A fork receives branches ONCE, at creation, and never again. This one dates
 # from 2020-11-11, so nothing upstream created afterwards ever arrived. That is
 # why the `upstream/*` mirror below exists rather than being redundant.

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -63,27 +63,104 @@ last_swept: 2026-08-06
 upstream_repo: confluentinc/parallel-consumer
 fork_repo: astubbs/parallel-consumer
 
-# Upstream BRANCH tips reachable from nothing on this fork (no origin branch, no tag),
-# pinned as annotated tags 2026-08-17 -- the branch-tip counterpart of
-# sweep-2023-admin-closure.preserved_heads, which covers swept PR heads. Same contract:
-# SHAs recorded here so the containment check can be redone without re-querying
-# upstream; a missing tag, or one no longer pointing at its SHA, means the copy is
-# gone. Re-verify with:
-#   git ls-remote --tags origin 'archive/upstream-branch/*'
-# Deliberately excluded: 18 dependabot/renovate/chore bot branches (recreatable
-# version bumps, not work) and upstream/HEAD (duplicates master).
-preserved_branch_tips:
-  - {branch: 0.5.3.x, sha: c097a3745, tag: archive/upstream-branch/0.5.3.x}
-  - {branch: DP-12547, sha: 87cdcf48c, tag: archive/upstream-branch/DP-12547}
-  - {branch: PL-176/DontDrainIssue, sha: 4869ccf65, tag: archive/upstream-branch/PL-176/DontDrainIssue}
-  - {branch: correct-failing-license-check, sha: e8c6ff5fa, tag: archive/upstream-branch/correct-failing-license-check}
-  - {branch: docs/back-pressure, sha: 50cd1cf01, tag: archive/upstream-branch/docs/back-pressure}
-  - {branch: features/batching, sha: 7e2607560, tag: archive/upstream-branch/features/batching}
-  - {branch: master, sha: 9b582c246, tag: archive/upstream-branch/master}
-  - {branch: python-cd-pipeline, sha: c3796a2fd, tag: archive/upstream-branch/python-cd-pipeline}
-  - {branch: v0.5.2.x-dev, sha: 5f5de9154, tag: archive/upstream-branch/v0.5.2.x-dev}
-  - {branch: v0.6.x, sha: 58159a0b9, tag: archive/upstream-branch/v0.6.x}
-preserved_branch_tips_checked: 2026-08-17
+# =============================================================================
+# BRANCH ACCOUNTING
+#
+# WHY THIS SECTION EXISTS
+#   This is the record of what we decided about a branch, and it must OUTLIVE the
+#   branch. It also carries the tag pinning each preserved tip, absorbing two
+#   earlier records (see below). The failure it
+#   prevents is specific - a branch is reviewed, judged worthless and deleted,
+#   its only trace was itself, and the next audit re-finds the absence, cannot
+#   tell a deliberate deletion from an accident, and redoes the work.
+#
+#   So a deleted branch KEEPS its entry, with its tip, its date and its reason.
+#   `state: deleted` is the case this section exists for.
+#
+# WHAT NOT TO PUT HERE
+#   Nothing a command answers. Open PRs are `gh pr list`; merged-ness is
+#   `git branch --merged`. Record the judgement, not the state.
+#
+# FIELDS
+#   ref    branch name as it exists on `fork_repo` (or `<remote>:<name>` if not ours)
+#   tip    short SHA at the time of the decision
+#   state  mirrored | ours | archived | deleted
+#   deleted  ISO date, required when state is `deleted`; the `note` carries the why
+#   tag    the annotated tag pinning that SHA, when one exists
+#   pr     the upstream PR this tip is the head of, when it is one
+#   see    where the reasoning lives - an inflight note, astubbs#NN, confluentinc#NN
+#   note   one line, only when it says something the fields do not
+#
+# THIS IS THE ONLY BRANCH RECORD, deliberately. Two others existed and recorded
+# the SAME COMMITS under different framings: `preserved_branch_tips` (branch tips
+# pinned as tags) and `sweep-2023-admin-closure.preserved_heads` (swept PR heads
+# pinned as tags). Every one of those PR heads is the tip of an upstream branch -
+# confluentinc#443 and the `pyallel-consumer` tip were two names for one SHA - so
+# they are folded in here as the `tag` and `pr` fields. Do not re-split them: a
+# corrected SHA fixed in one copy while another still reads as authoritative is
+# the drift this consolidation removes.
+#
+# Tags are kept alongside the mirrored branches rather than replaced by them. A
+# branch can be deleted or force-moved; an annotated tag is the record that a
+# specific commit was deliberately preserved. Verify without fetching:
+#   git ls-remote --tags origin 'archive/*'
+#
+# A fork receives branches ONCE, at creation, and never again. This one dates
+# from 2020-11-11, so nothing upstream created afterwards ever arrived. That is
+# why the `upstream/*` mirror below exists rather than being redundant.
+# =============================================================================
+
+branch_accounting_checked: 2026-08-20
+branch_accounting:
+
+  # --- upstream branches mirrored onto this fork 2026-08-20, tips verified ----
+  # Namespaced deliberately: eight share a name with one of ours carrying divergent
+  # work (master, 0.5.3.x, features/dynamic-concurrency-control, features/retry-exception,
+  # improvements/commit-command-actor, improvements/lambda-actor-bus,
+  # improvements/rebalance-messages, improvements/remove-static), so pushing under
+  # their own names would have overwritten our history. Re-derive rather than trusting
+  # the list: compare `git ls-remote --heads origin` against `--heads upstream` by name
+  # and tip.
+
+  - {ref: upstream/pyallel-consumer, tip: 4533f6d8d, state: mirrored, tag: archive/upstream-pr-443, pr: confluentinc#443, see: [confluentinc#443, confluentinc#539, astubbs#293, "docs/inflight/process-fork-branch-archaeology.md"],
+     note: "Prior Python client. The strongest prior art for the proxy work in astubbs#242, and unread. Its PR head is also pinned at archive/upstream-pr-443."}
+  - {ref: upstream/python-cd-pipeline, tip: c3796a2fd, state: mirrored, tag: archive/upstream-branch/python-cd-pipeline, see: [confluentinc#539],
+     note: "Publishing pipeline for the Python client above. Named in no document before this entry."}
+  - {ref: upstream/master, tip: 9b582c246, state: mirrored, tag: archive/upstream-branch/master, see: ["docs/inflight/process-fork-branch-archaeology.md"],
+     note: "Upstream master. Two commits we do not carry, both README notices - the maintenance notice and the link to this fork - so the divergence is benign."}
+  - {ref: upstream/features/dynamic-concurrency-control, tip: ba6b71f10, state: mirrored, tag: archive/upstream-pr-22, pr: confluentinc#22, see: [astubbs#227],
+     note: "The one upstream branch that predates our fork and is absent by name here only because OUR branch of the same name diverged under our own work. Not a deletion."}
+  - {ref: upstream/features/batching, tip: 7e2607560, state: mirrored, tag: archive/upstream-branch/features/batching, see: ["docs/inflight/branch-audit-orphans.md"],
+     note: "Batching shipped upstream separately; the tip may predate what landed."}
+  - {ref: upstream/PL-176/DontDrainIssue, tip: 4869ccf65, state: mirrored, tag: archive/upstream-branch/PL-176/DontDrainIssue, see: ["docs/inflight/branch-audit-orphans.md"],
+     note: "Name suggests real drain-behaviour work; unread."}
+  - {ref: upstream/docs/back-pressure, tip: 50cd1cf01, state: mirrored, tag: archive/upstream-branch/docs/back-pressure, see: [confluentinc#508],
+     note: "Back-pressure notes. confluentinc#508 was closed inside a dependabot batch on a CLA technicality, never judged on merits."}
+  - {ref: upstream/0.5.3.x, tip: c097a3745, state: mirrored, tag: archive/upstream-branch/0.5.3.x}
+  - {ref: upstream/v0.5.2.x-dev, tip: 5f5de9154, state: mirrored, tag: archive/upstream-branch/v0.5.2.x-dev}
+  - {ref: upstream/v0.6.x, tip: 58159a0b9, state: mirrored, tag: archive/upstream-branch/v0.6.x}
+  - {ref: upstream/v0.6.x-dev, tip: 60fd76d50, state: mirrored}
+  - {ref: upstream/improvements/vertx-vertical, tip: 02ab32894, state: mirrored, tag: archive/upstream-pr-204, pr: confluentinc#204}
+  - {ref: upstream/improvements/rebalance-messages, tip: 007ae0906, state: mirrored, tag: archive/upstream-pr-270, pr: confluentinc#270}
+  - {ref: upstream/improvements/remove-static, tip: 77a021ee1, state: mirrored, tag: archive/upstream-pr-405, pr: confluentinc#405}
+  - {ref: upstream/improvements/commit-command-actor, tip: 7e117a5ca, state: mirrored}
+  - {ref: upstream/improvements/lambda-actor-bus, tip: 96114737a, state: mirrored}
+  - {ref: upstream/improvements/package-restructure, tip: d86a87ef0, state: mirrored}
+  - {ref: upstream/improvements/transaction-docs, tip: b2be8dac7, state: mirrored}
+  - {ref: upstream/refactor/actor-base-fixes, tip: 09a13d070, state: mirrored}
+  - {ref: upstream/refactor/interface, tip: 400643c87, state: mirrored}
+  - {ref: upstream/features/retry-exception, tip: 1b087e554, state: mirrored}
+  - {ref: upstream/fix-charts, tip: 33d93af09, state: mirrored, tag: archive/upstream-pr-506, pr: confluentinc#506}
+  - {ref: upstream/DP-12547, tip: 87cdcf48c, state: mirrored, tag: archive/upstream-branch/DP-12547}
+  - {ref: upstream/correct-failing-license-check, tip: e8c6ff5fa, state: mirrored, tag: archive/upstream-branch/correct-failing-license-check}
+  - {ref: upstream/chore-service-bot-update, tip: "255916684", state: mirrored}
+  # --- our own branches, where a decision exists that the branch does not -----
+
+  - {ref: presentation, state: ours, see: ["docs/inflight/handoff-fork-branch-audit.md", "docs/inflight/process-fork-branch-archaeology.md"],
+     note: "Carries Demo.java, the code behind the asciinema cast embedded in the README. Unmerged since 2021 and named in no ledger - the branch that triggered the whole audit. DECIDED: archive under an archive/ tag, then delete. Not yet done, so this entry is the only record of the decision."}
+  - {ref: bugs/prod-tx-manager-retries, state: ours, see: ["docs/inflight/core-241-tx-commit-failure-taxonomy.md", confluentinc#144],
+     note: "Attached to sweep-2023-tx-failure-taxonomy, and the prototype to start from rather than the older tx-commit-failure branch. Verified 2026-08-20, closing the open question in branch-audit-orphans.md."}
+
 
 entries:
 
@@ -417,8 +494,8 @@ entries:
   # upstream's own refs/pull/<n>/head - it did not ask whether anything on THIS fork contained
   # them. The 2026-08-14 containment re-check asked that, and split the cohort: 29 are contained
   # by some origin/* branch here, and SIX are contained by no fork ref at all. Those six - not
-  # the whole cohort - are what the archive tags exist for (see preserved_heads below, and
-  # docs/upstream.md). Being contained by a fork branch is not the same as being raised from
+  # the whole cohort - are what the archive tags exist for (their tag and SHA are on the
+  # matching `branch_accounting` entries above, and the method is in docs/upstream.md). Being contained by a fork branch is not the same as being raised from
   # one, and is not permanent: deleting that branch re-orphans the head. Cite branch + SHA, not
   # just the PR number - and re-run the containment check rather than trusting this note, which
   # is a snapshot.
@@ -438,20 +515,8 @@ entries:
     fork: {branches: [docs/mirror-2023-admin-sweep], prs: [258], fork_issues: [227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254], status: pr-open}
     upstream: {repo: confluentinc/parallel-consumer, issues: [21, 24, 28, 29, 34, 40, 41, 48, 49, 50, 53, 57, 65, 119, 144, 154, 175, 183, 187, 191, 199, 203, 205, 246, 267, 319, 320, 372], prs: [22, 45, 46, 81, 106, 143, 179, 181, 204, 220, 270, 271, 291, 300, 303, 316, 325, 345, 346, 356, 366, 390, 405, 408, 441, 442, 443, 464, 473, 488, 492, 494, 496, 506, 524], status: closed, last_checked: 2026-08-07}
     adoc_anchor: null
-    # Swept PR heads that no ref on this fork contained, checked 2026-08-14. Pinned as
-    # annotated tags so they survive loss of the upstream branch or repository. The SHAs
-    # are recorded here, not only the PR numbers, so the containment check can be redone
-    # without re-querying upstream. Re-verify with:
-    #   git ls-remote --tags origin 'archive/upstream-pr-*'
-    # A missing tag, or one no longer pointing at the SHA below, means the copy is gone.
-    preserved_heads:
-      - {pr: 22, sha: ba6b71f10, tag: archive/upstream-pr-22}
-      - {pr: 204, sha: 02ab32894, tag: archive/upstream-pr-204}
-      - {pr: 270, sha: 007ae0906, tag: archive/upstream-pr-270}
-      - {pr: 405, sha: 77a021ee1, tag: archive/upstream-pr-405}
-      - {pr: 443, sha: 4533f6d8d, tag: archive/upstream-pr-443}
-      - {pr: 506, sha: 33d93af09, tag: archive/upstream-pr-506}
-    preserved_heads_checked: 2026-08-14
+    # Swept PR heads are pinned as archive/upstream-pr-* tags; the tag/SHA record lives
+    # once, in `branch_accounting` above, keyed by the branch whose tip each one is.
     notes: >
       Meta-entry for the cohort; the individual work items follow. All 28 issues were
       re-read in full (bodies + all 58 comments) and each verified against fork
@@ -747,3 +812,220 @@ entries:
       invasive form. #199 is largely satisfied: failFast(String, Callable) is used
       across the suite, only the reason-from-failure-cause form is missing; check
       current Awaitility before starting.
+
+  # ---------------------------------------------------------------------------
+  # THE 2026-08-20 MIRROR TRIAGE COHORT
+  #
+  # Ten open `upstream-mirror` issues that had never been assessed against the
+  # fork's own tree. They were not untriaged: each carried a `## Fork status`
+  # section written when it was mirrored, and that section - not this file and
+  # not the .adoc - was where the only existing judgement lived. The triage
+  # verified those sections against HEAD. Most had drifted, several were wrong,
+  # and three verdicts in `upstream-pr-analysis.adoc` were refuted outright.
+  #
+  # Each entry below points at a note in `docs/inflight/` carrying the detail,
+  # the draft reporter-facing answer, and the decision awaiting a maintainer.
+  # ---------------------------------------------------------------------------
+
+  - id: batch-failure-granularity
+    group: features
+    summary: A poison record re-forms the identical batch on every retry; no per-record failure attribution
+    fork: {branches: [], prs: [], fork_issue: 189, status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [887], prs: [], related: [266, 310, 196, 65], status: open, last_checked: 2026-08-20}
+    adoc_anchor: part1-group-b-features
+    notes: >
+      One user function failure marks every container in the batch failed, and because
+      shard selection is offset-ordered and the retry delay is a flat constant with no
+      jitter, the identical batch re-forms every second forever. There is no retry
+      ceiling, so the innocent records are re-executed indefinitely with their side
+      effects. runUserFunctionInternal declares intermediateResults, comments that it
+      captures each result against the input record, and never populates it, so batch
+      atomicity is an unfinished feature rather than a design invariant. The design
+      already exists in the 2026-08-17 batching ideation as a three-rung ladder
+      (retry jitter, poison-batch bisection, per-record manifest); only the first rung
+      needs a maintainer decision, because it changes retry timing for every existing
+      deployment. Detail in docs/inflight/core-189-batch-failure-granularity.md.
+
+  - id: java-24-security-manager-removal
+    group: deps-major
+    summary: Java 24 breakage was in kafka-clients, not in PC, and this tree is already past it
+    fork: {branches: [], prs: [], fork_issue: 181, status: merged}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [862], prs: [], related: [908, 920], status: open, last_checked: 2026-08-20}
+    adoc_anchor: part3-cat5-jdk
+    notes: >
+      REFUTES the .adoc's "confluentinc PR #908 may help". That PR migrates synchronized
+      to ReentrantLock for virtual-thread pinning, and JDK 24 removed pinning anyway, so
+      it is a different mechanism entirely. The real break: kafka-clients up to 3.9.0
+      calls Subject.getSubject(AccessController.getContext()) from its SASL callback
+      handlers. JDK 23 makes that throw unless a security manager is allowed, and JDK 24
+      removes that escape hatch, which is why the reporter drew the line at 24. Fixed in
+      kafka-clients 3.9.1 by KAFKA-19024; this tree is on 3.9.2. No main-code reference
+      to SecurityManager, AccessController, doPrivileged or sun.misc.Unsafe exists in any
+      module. Verified on a workstation only, and a MockConsumer cannot exercise SASL,
+      which is the one path that ever broke. Distinct from pr-53-java-baseline-kafka4,
+      which is about the build baseline for Kafka 4 rather than what the shipped Java 8
+      jar can run on. CI has no lane above Java 17 (astubbs#128, confluentinc#103), so
+      the claim is not yet publishable. Detail in docs/inflight/deps-181-java-24-compatibility.md.
+
+  - id: key-order-across-rebalance
+    group: rebalance-stability
+    summary: Same key on two worker threads across a rebalance - contract question plus a missing detector
+    fork: {branches: [], prs: [], fork_issue: 178, status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [843], prs: [], related: [777, 909, 893, 623], status: open, last_checked: 2026-08-20}
+    adoc_anchor: part3-cat2-correctness
+    notes: >
+      REFUTES the .adoc's "confluentinc PR #909 likely root cause", on two independent
+      terms. Consequence: the confluentinc#909 defect DROPS the fresh container and
+      wedges the offset, which is loss and stall rather than duplication - astubbs#322's
+      reproduction counts lost records and no duplicates. Precondition: it needs a
+      rebalance landing inside the registration loop, and the reporter denies any
+      rebalance in the window. confluentinc#893 falls the same way. The triage did find
+      the one inspected route to the reported symptom, and it is rebalance-gated:
+      ProcessingShard.removeStaleWorkContainersFromShard tests staleness without
+      checking isInFlight, and PC does not drain on revoke, so a redelivered record can
+      execute concurrently with the still-running old-epoch one. Present in 0.5.3.0 via
+      confluentinc#623, not fork-introduced. The chaos suite's KeyOrderLedger would catch
+      it except its window key includes the epoch, so a cross-epoch overlap passes.
+      Blocked on a maintainer ruling on the KEY-ordering contract across a rebalance.
+      Detail in docs/inflight/core-178-key-order-across-a-rebalance.md.
+
+  - id: bug-809-commit-timeout-close-path-zombie
+    group: rebalance-stability
+    summary: Sporadic commit-response timeouts that then fail to close - state stays RUNNING with dead control threads
+    fork: {branches: [], prs: [100, 108, 204], fork_issue: 175, status: merged}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [809], prs: [818, 819], related: [833, 857, 803], status: open, last_checked: 2026-08-20}
+    adoc_anchor: part3-cat1-stability
+    notes: >
+      NOT a duplicate of confluentinc#833 despite the shared message, so the .adoc's
+      "investigate together" is right but its "same defect" reading is not.
+      confluentinc#833 exits; confluentinc#809's headline stack is the close path and it
+      fails to exit, leaving state RUNNING and isClosedOrFailed false with nothing for a
+      liveness probe to read. That half was fixed upstream by confluentinc#818 and is
+      already carried here - AbstractParallelEoSStreamProcessor's doClose still names the
+      issue in a comment. The poll-thread death is astubbs#108's CommitFailedException
+      arm, NOT astubbs#100's RebalanceInProgressException, so the mirror body credits the
+      wrong PR. astubbs#204 fixed the per-attempt retry budget introduced by
+      confluentinc#819, which the mirror cites as a partial fix for this same issue.
+      Remaining strand is the AB-BA wedge, astubbs#29. Nothing anywhere tests the
+      confluentinc#818 close-state guarantee, which arrived as a finally block.
+      Detail in docs/inflight/upstream-175-sporadic-commit-timeouts.md.
+
+  - id: bug-777-revocation-duplicates
+    group: rebalance-stability
+    summary: In-flight work at revocation is redelivered - at-least-once by design, not a defect
+    fork: {branches: [], prs: [], fork_issue: 173, status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [777], prs: [], related: [857, 843, 893, 909], status: open, last_checked: 2026-08-20}
+    adoc_anchor: part3-cat2-correctness
+    notes: >
+      THE .adoc IS WRONG ABOUT THIS ONE, in three places (ranking row 6, the category 2
+      verdict, and the cross-reference matrix): "Fixed by merging confluentinc PR #893 +
+      #909". confluentinc#909 is already merged here as astubbs#31 and the behaviour is
+      unchanged - WorkManager.handleFutureResult still drops a result whose partition
+      moved, which is the reporter's step 3 verbatim. confluentinc#893 fixes a commit
+      running AHEAD of completion; this is the opposite shape, where the committed offset
+      is already correct and redelivery follows from that correctness. Upstream's own
+      maintainer answered in 2024-05, before either PR existed, that in-flight
+      reprocessing is expected and a real fix needs partition-scoped submission
+      suppression plus revoked-partition in-flight tracking.
+      DO NOT CLOSE confluentinc#777 WHEN astubbs#57 MERGES.
+      The mitigation is measured and it is not the obvious one: over 250,000 records,
+      eager assignment with no drain gives roughly six times the duplicates of
+      cooperative, while draining is second-order, because eager revokes every partition
+      from every member so the abandoned work was never the leaver's to drain. No
+      user-facing doc says this. astubbs#29's tryCommitOffsetsOnRevoke skips the
+      revocation commit under lock contention by design, so it moves this symptom the
+      wrong way. Detail in docs/inflight/upstream-173-revocation-duplicate-processing.md.
+
+  - id: serde-error-handling-poll-path
+    group: features
+    summary: No handler for a deserialization failure out of consumer.poll() - a poison record kills the instance
+    fork: {branches: [], prs: [], fork_issues: [163, 148, 153], status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [550, 304, 391], prs: [], related: [195, 310, 718], status: open, last_checked: 2026-08-20}
+    adoc_anchor: null
+    notes: >
+      Distinct from sweep-2023-retry-lifecycle, and the distinction is load-bearing: a
+      record that fails to deserialize never becomes a WorkContainer, so no max-retry,
+      terminal-exception or DLQ trigger can ever fire on it. The DLQ brainstorm
+      (astubbs#313) files these under adjacent demand and its open question 6 asks
+      whether they ride along - on the mechanism they cannot, so answering that question
+      yes would settle live requirements work on a false premise. The contained fix is
+      also smaller than the mirror bodies suggest: a typed poll-error seam already exists
+      in ConsumerManager (a bounded SaslAuthenticationException retry, a WakeupException
+      catch), so a deserialization policy is a third arm of it rather than new
+      architecture. Nothing in any module, main or test, mentions SerializationException
+      or RecordDeserializationException. Detail in
+      docs/inflight/core-163-poll-path-has-no-error-seam.md.
+
+  - id: bug-546-bootstrap-truncation-warning
+    group: rebalance-stability
+    summary: The "Truncating state" warning on assignment - three defects behind one string, only one of them fixed
+    fork: {branches: [], prs: [], fork_issue: 162, status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [546], prs: [563], related: [489, 545], status: open, last_checked: 2026-08-20}
+    adoc_anchor: null
+    notes: >
+      confluentinc PR #563 (RunLength decode returning base offset 0 after a no-progress
+      commit) is ALREADY IN this tree, guarded in OffsetRunLength and recorded in the
+      changelog. It does not close the issue: users reported the same warning on 0.5.2.7,
+      after that fix shipped, which is the most important fact in the upstream thread and
+      is absent from the mirror body. Two paths remain at HEAD. First,
+      PartitionState.maybeTruncateBelowOrAbove never checks whether commit data existed,
+      so a partition with no committed offset reports expecting 0 from loaded commit data
+      and truncates nothing - also the landing point for astubbs#217's metadata-decode
+      recovery, so a normal new consumer group gets a false warning. Second, the
+      below-expected reset branch was never diagnosed upstream; the untested hypothesis
+      is a commit and position read race at cooperative handoff. Neither is covered by
+      any test - nothing in the tree asserts on the warning at all. astubbs#106,
+      astubbs#306 and astubbs#207 touch this code and address neither. Detail in
+      docs/inflight/bug-162-offset-state-truncation.md.
+
+  - id: reactor-scheduler-rationale
+    group: features
+    summary: Reactor module's subscribeOn hop is deliberate, the opt-out exists, and none of it is documented
+    fork: {branches: [], prs: [303], fork_issue: 161, status: none}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [543, 793], prs: [798], related: [], status: mixed, last_checked: 2026-08-20}
+    adoc_anchor: null
+    notes: >
+      Half was already fixed: confluentinc#798 (fixing confluentinc#793, released
+      upstream in 0.5.3.0 and carried here) deleted the publishOn, leaving one
+      subscribeOn. The remaining hop is deliberate, but NOT for the reason the mirror
+      body gives - it says the Scheduler moves the user function off the control thread,
+      and it never was on the control thread. ExternalEngine.setupWorkerPool pins the
+      module to a single dispatch thread, so blocking before the publisher is returned
+      serialises dispatch of all in-flight work, which is a stronger reason to keep the
+      hop than the body gives. The opt-out already exists: the Supplier of Scheduler
+      constructor accepts Schedulers immediate. Undocumented everywhere - the word
+      scheduler appears nowhere in the README or its template. astubbs#303 covers most of
+      it in a per-module README but not the opt-out, so that sentence should land there
+      while the PR is open. Two unrecorded code findings ride along: the supplier is
+      resolved per work item rather than once (MutinyProcessor already does this
+      correctly), so a caller passing a factory leaks schedulers and their threads per
+      batch; and the two-argument constructor has no test.
+      Detail in docs/inflight/upstream-161-reactor-scheduler-rationale.md.
+
+  - id: api-thread-safety-contract
+    group: features
+    summary: Public API has no per-method thread-safety contract, and the run-state machine is unsafe from user threads
+    fork: {branches: [], prs: [226, 267, 268, 51], fork_issue: 139, status: in-progress}
+    upstream: {repo: confluentinc/parallel-consumer, issues: [186], prs: [346], related: [187, 191, 200, 520, 908], status: mixed, last_checked: 2026-08-20}
+    adoc_anchor: null
+    notes: >
+      Split out of sweep-2023-consumer-api-exposure, which owns the FEATURE half
+      (exposing Consumer APIs safely, fork mirror astubbs#158). This entry owns the
+      BLOCKER half: the existing surface has no stated thread contract, so nothing can
+      clear the label. confluentinc#186 has zero substantive comments upstream, meaning
+      the mirror body is the only analysis that has ever existed. Live at HEAD: the state
+      field is non-volatile while pauseIfRunning, resumeIfPaused and close write it from
+      user threads and the control loop spins on it, so a pause racing a close can write
+      PAUSED over CLOSING; addLoopEndCallBack registers onto a plain ArrayList walked
+      every control pass; setLongPollTimeout is an instance method writing a static, so
+      one instance changes every instance in the JVM; and RetryQueue's javadoc claims
+      thread safety while size and isEmpty read a plain HashMap unlocked. Refuted
+      prediction worth recording: workRemaining, getFailureCause and getPausedPartitionSize
+      are all safe. astubbs#226 fixes visibility but not atomicity, astubbs#267 fixes the
+      listeners, astubbs#268 is the worked example of marshalling reads onto the control
+      thread, and astubbs#51 converts synchronized to ReentrantLock in the same class and
+      collides with all three - so the maintainer decision that unblocks everything is
+      which lock primitive wins, and in what merge order. confluentinc#346 is a design
+      reference for the subscribe half only, not a cherry-pick: closed unmerged, on
+      pre-rename packages, and predating the fork's actor work.
+      Done-definition in docs/inflight/core-139-public-api-thread-safety-contract.md.

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -154,6 +154,36 @@ branch_accounting:
   - {ref: upstream/DP-12547, tip: 87cdcf48c, state: mirrored, tag: archive/upstream-branch/DP-12547}
   - {ref: upstream/correct-failing-license-check, tip: e8c6ff5fa, state: mirrored, tag: archive/upstream-branch/correct-failing-license-check}
   - {ref: upstream/chore-service-bot-update, tip: "255916684", state: mirrored}
+  # --- deleted, deliberately, with the reasoning that made it safe --------------
+
+  # Each kept its own entry rather than one aggregate row: this section's contract is that a
+  # deleted branch keeps its TIP, and a glob in `ref` also defeats the ref-matching check the
+  # section exists to feed. Shared reasoning, stated once: mirrored 2026-08-20 and removed the
+  # same day once contents were checked - each was a single commit touching only pom.xml,
+  # bumping a dependency of UPSTREAM's tree, which has diverged from ours in both dependency set
+  # and package paths, so they would not apply here and will never merge upstream either. Not
+  # tagged, so upstream's copy is the last one; accepted, because a recreatable version bump is
+  # not work. The tips below make them addressable from upstream while it exists.
+  - {ref: upstream/dependabot/maven/junit.platform.version-6.0.0, tip: 9a25939d7, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/dependabot/maven/org.apache.maven.plugins-maven-gpg-plugin-3.2.8, tip: d38e3cc67, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/dependabot/maven/testcontainers.version-1.21.3, tip: 52540d9a1, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/dependabot/maven/vertx.version-5.0.5, tip: c1320b1f2, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-com.github.tomakehurst-wiremock-jre8-3.x, tip: 99e35fb7c, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-com.github.tomakehurst-wiremock-jre8-replacement, tip: f87d9e55a, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-io.smallrye.reactive-mutiny-3.x, tip: 2fa2a10c4, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-kafka.version, tip: 76a6a695f, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-logback.version, tip: cf4c4b59c, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-major-kafka, tip: 6d1fceb6e, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-major-testing-libraries, tip: 52d774b05, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-major-vertx.version, tip: 3f5a215a4, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-maven-org.assertj-assertj-core-vulnerability, tip: 78da8a5e7, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-maven-org.postgresql-postgresql-vulnerability, tip: ac48acadd, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-micrometer-core.version, tip: c37794713, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/renovate/master-minor+patch-dependencies, tip: 35608cae9, state: deleted, deleted: 2026-08-20, see: ["docs/inflight/process-fork-branch-archaeology.md"]}
+  - {ref: upstream/dependabot/maven/org.threeten-threeten-extra-1.8.0, tip: 5bbfea783, state: deleted, deleted: 2026-08-20,
+     see: ["docs/inflight/process-fork-branch-archaeology.md"],
+     note: "Recorded separately because it was NOT a bot branch despite the name. A maintainer pushed four commits onto it - semaphore CI java-home fix, missing licence headers, gitignore, and a master merge - on top of the threeten-extra bump. Read before deleting: the CI config is upstream's semaphore, which we do not use, and the licence headers are on io/confluent paths this fork renamed, so none of it applies here. Kept as its own entry because a prefix sweep would have taken human commits silently, which is the failure this whole section exists to prevent."}
+
   # --- our own branches, where a decision exists that the branch does not -----
 
   - {ref: presentation, state: ours, see: ["docs/inflight/handoff-fork-branch-audit.md", "docs/inflight/process-fork-branch-archaeology.md"],

--- a/src/docs/development/upstream-pr-analysis.adoc
+++ b/src/docs/development/upstream-pr-analysis.adoc
@@ -322,7 +322,17 @@ Production-blocking issues reported by multiple users. Highest urgency.
 |#825 |checkAutoCommitIsDisabled fails with kafka-clients < 3.7.0 |ddqof |2024-08 |-- |--
 |===
 
-*Verdict:* #803 is the only "verified bug" in the entire tracker. Start here. #809 and #833 are likely related -- investigate together.
+*Verdict:* #803 is the only "verified bug" in the entire tracker. Start here.
+
+#809 and #833 are related, but *not the same defect* - the 2026-08-20 triage separated them.
+confluentinc#833 *exits*; confluentinc#809's headline stack is the close path and it *fails to
+exit*, leaving the instance RUNNING with dead control threads and nothing for a liveness probe to
+read. That half was fixed upstream by confluentinc#818 and is already carried here. astubbs#204
+(merged) covers the reporting and the retry budget for both; the remaining strand is the AB-BA
+wedge, astubbs#29. Detail: `docs/inflight/upstream-175-sporadic-commit-timeouts.md`.
+
+confluentinc#402 now has a fix in astubbs#201 (log noise only; the stall half was a separate
+defect, already fixed).
 
 [[part3-cat2-correctness]]
 === Category 2: Rebalance / offset correctness (data loss risk)
@@ -331,12 +341,28 @@ Production-blocking issues reported by multiple users. Highest urgency.
 |===
 |Issue |Title |Author |Date |Cross-ref PRs
 
-|#777 |Partition revocation leads to duplicate event processing |ajax-levashov-m |2024-05 |PR #893 (offset reset), PR #909 (stale container)
-|#843 |Record picked up by multiple threads simultaneously |singhsaurabh2409 |2024-12 |PR #909 likely root cause
+|#777 |Partition revocation leads to duplicate event processing |ajax-levashov-m |2024-05 |NOT confluentinc#893/#909 - see verdict
+|#843 |Record picked up by multiple threads simultaneously |singhsaurabh2409 |2024-12 |NOT confluentinc#909 - see verdict
 |#326 |Error in onPartitionsAssigned |milansanjeev |2022-07 |labeled not-a-bug, but related to rebalance
 |===
 
-*Verdict:* Merging PR #893 and PR #909 likely resolves #777 and #843. Verify after cherry-pick.
+*Verdict:* *REFUTED 2026-08-20.* This previously read "merging PR #893 and PR #909 likely
+resolves #777 and #843". Neither holds, and the correction matters because it would otherwise
+cause a wrong close.
+
+* *confluentinc#777 is not fixed by either.* confluentinc#909 is already merged here as
+  astubbs#31 and the behaviour is unchanged: `WorkManager.handleFutureResult` still drops a result
+  whose partition moved, which is the reporter's step 3 verbatim. confluentinc#893 fixes a commit
+  running *ahead* of completion; this is the opposite shape. Upstream's own maintainer answered in
+  2024-05, before either PR existed, that in-flight reprocessing at revocation is expected
+  at-least-once behaviour. *Do not close confluentinc#777 when the confluentinc#893 cherry-pick merges* (astubbs#337, split out of astubbs#57 on 2026-08-24).
+* *confluentinc#843 is not caused by confluentinc#909.* That defect *drops* the fresh container
+  and wedges the offset - loss and stall, not duplication - and astubbs#322's reproduction counts
+  lost records and no duplicates. It also requires a rebalance the reporter explicitly denies.
+  One rebalance-gated route to the reported symptom does exist and is live at HEAD; see
+  `docs/inflight/core-178-key-order-across-a-rebalance.md`.
+
+Detail: `docs/inflight/upstream-173-revocation-duplicate-processing.md`.
 
 [[part3-cat3-observability]]
 === Category 3: Observability & health (most requested feature gap)
@@ -380,10 +406,19 @@ Production-blocking issues reported by multiple users. Highest urgency.
 |#192 |Unique thread names for PC instances |nioertel |2022-02 |-- |--
 |#299 |Loom integration POC |astubbs |2022-05 |-- |PR #300 (closed), PR #908 (open)
 |#520 |Safe user API exposure of ALL Consumer APIs |astubbs |2022-12 |-- |PR #346 (closed)
-|#862 |PC cannot run on Java 24 |jvissers |2025-04 |-- |PR #908 may help
+|#862 |PC cannot run on Java 24 |jvissers |2025-04 |-- |NOT confluentinc#908 (refuted); fixed by kafka-clients 3.9.1
 |===
 
-*Verdict:* #186 is labeled *blocker for 1.0*. #862 (Java 24 compat) is time-critical. PR #908 ReentrantLock migration may resolve #862.
+*Verdict:* #186 is labeled *blocker for 1.0*, and it stays one - but as written it names no
+method, no thread and no check, so nothing can clear it. The audit and definition of done are in
+`docs/inflight/core-139-public-api-thread-safety-contract.md`.
+
+*REFUTED 2026-08-20:* this previously said "PR #908 ReentrantLock migration may resolve #862".
+It cannot. confluentinc#908 removes virtual-thread pinning on `synchronized`, and JDK 24 removed
+pinning anyway. confluentinc#862 was a kafka-clients defect - its SASL callback handlers called
+`Subject.getSubject`, which the JDK withdrew - fixed in kafka-clients 3.9.1 by KAFKA-19024. This
+tree is on 3.9.2, so the issue is settled here, though no CI lane runs above Java 17 to prove it.
+Detail: `docs/inflight/deps-181-java-24-compatibility.md`.
 
 === Category 6: Batch processing
 
@@ -534,7 +569,7 @@ Production-blocking issues reported by multiple users. Highest urgency.
 |3 |#27 |Micrometer metrics |Observability |5+ years open; pairs with #71
 |4 |#310 |DLQ implementation |Error handling |Most demanded feature; PR #366 exists as design ref
 |5 |#186 |Thread-safe PC APIs (blocker) |Safety |Labeled *blocker for 1.0*
-|6 |#777 |Partition revocation leads to duplicates |Correctness |Fixed by merging PR #893 + #909
+|6 |#777 |Partition revocation leads to duplicates |Correctness |NOT fixed by confluentinc#893 + #909 (refuted); at-least-once by design
 |7 |#862 |PC cannot run on Java 24 |Compat |Time-critical; JDK moves fast
 |8 |#266 |Batch same-key-only option |Batch |PR #915 already implements this
 |9 |#809 |Sporadic commit timeouts |Stability |Multiple users report; likely related to #803
@@ -562,9 +597,9 @@ Production-blocking issues reported by multiple users. Highest urgency.
 |#130 (static state tests) |-- |#126, #405 |Revive #126
 |#394 (least-loaded broker) |-- |#473 (impl) |Revive #473
 |#196 (max retries) |-- |#291 (terminal exceptions) |Revive #291
-|#777 (rebalance dupes) |*#893* (offset fix) |-- |Merge #893
-|#843 (multi-thread pickup) |*#909* (stale container) |-- |Merge #909
-|#862 (Java 24 compat) |*#908* (ReentrantLock migration) |-- |Merge #908
+|#777 (rebalance dupes) |-- |-- |Refuted 2026-08-20: confluentinc#893 does not address it
+|#843 (multi-thread pickup) |-- |-- |Refuted 2026-08-20: confluentinc#909 causes loss, not dupes
+|#862 (Java 24 compat) |-- |-- |Refuted 2026-08-20: settled by kafka-clients 3.9.1, not confluentinc#908
 |===
 
 == Part 4: How to use this document


### PR DESCRIPTION
<!-- This PR serves no single issue - it assesses ten of them - so per the template it cites none. -->

## Description

Ten open `upstream-mirror` issues had never been assessed against this tree. They turned out not to
be untriaged: each carries a `## Fork status` section written when it was mirrored, and **that
section - not `upstream-map.yaml`, not `upstream-pr-analysis.adoc` - is where the fork's only
judgement about most upstream issues lives.** Searching the two documents came up thin for exactly
that reason.

Most had drifted, and the branch grew from there into two adjacent questions with the same shape:
what else in this repo reads as verified and is not, and what is keeping a record that nothing
checks.

**Re-cut into seven atomic commits**, so each can be read, bisected or reverted on its own. The
review fixes are not among them: a re-cut stages final state, so the corrected claims simply *are*
commits 1-5, with how they came to be wrong kept in their messages.

| Commit | What it does |
|---|---|
| `docs(inflight): assess ten untriaged upstream mirrors...` | The ten notes, the population-level record of why bodies rot, three refuted `.adoc` verdicts, manifest corrections, the note-naming rule, and the Renovate counter-evidence |
| `docs(inflight): nothing has ever audited the fork's own branches...` | The branch audit folded in from `docs/fork-branch-archaeology`, and the upstream-branch gap it uncovered |
| `docs(map): give every branch one record...` | `branch_accounting`, replacing three overlapping registers |
| `docs(map): delete the mirrored bot branches...` | First use of that record |
| `fix(gates): the branch record this PR adds was validated by nothing` | The validator, a gate that actually runs it, and both halves of its tip rule under test |
| `feat(docs): index every GitHub issue in one file...` | `bin/issue-index.sh`, so grep reaches the tracker |
| `docs(merge): ask at merge prep whether the PR should close an issue` | The checklist rule, with the partial case as its emphasis |

## The ten mirrors, and why their bodies were wrong

The errors were the load-bearing kind - each would have caused a wrong action:

- **astubbs/parallel-consumer#241** restates an account of `commitOffsets` that
  confluentinc/parallel-consumer#355 falsified in 2022.
- **astubbs/parallel-consumer#163** says the poll path is unguarded with only a blanket catch. A
  typed per-exception seam already exists and is load-bearing, so the fix is far cheaper than
  recorded.
- **astubbs/parallel-consumer#161** says the scheduler moves the user function off the control
  thread. It was never on the control thread - which changes the answer to the reporter's question.
- **astubbs/parallel-consumer#173** contradicts our own README on what transactional mode
  guarantees, and names a fork PR as closest help when that PR moves the symptom the wrong way.
- **astubbs/parallel-consumer#175** credits the wrong PR for the reporter's failure, and omits the
  close-path failure the reporter himself called the bigger problem.
- **astubbs/parallel-consumer#162** misses that reporters hit the same warning *after* the fix
  shipped - the fact that decides whether it can close.

**Why they got that way** is recorded at population level in `upstream-mirror-bodies-are-stale.md`,
because the causes are structural and will recur: a tree-wide rename invalidated every `file:line`
citation in every body in one commit, silently (one had been wrong since the day it was written);
nothing re-checks a body once written, unlike a map entry with its `last_checked`; and nothing in
the format separates a verified claim from an inferred one.

### Three refuted verdicts, corrected rather than softened

- **"Merging confluentinc/parallel-consumer#893 + confluentinc/parallel-consumer#909 likely resolves
  confluentinc/parallel-consumer#777 and confluentinc/parallel-consumer#843."**
  confluentinc/parallel-consumer#909 is already merged here as astubbs/parallel-consumer#31 with the
  behaviour unchanged; confluentinc/parallel-consumer#893 fixes a commit running *ahead* of
  completion, the opposite shape. Upstream's maintainer answered
  confluentinc/parallel-consumer#777 in 2024, before either PR existed, saying the redelivery is
  expected at-least-once behaviour. **Left standing, this closes it the moment
  astubbs/parallel-consumer#57 merges.**
- **"confluentinc/parallel-consumer#909 is the likely root cause of
  confluentinc/parallel-consumer#843."** That defect *drops* records and wedges an offset - loss and
  stall, not duplication - and requires a rebalance the reporter explicitly denies.
- **"confluentinc/parallel-consumer#908 may resolve confluentinc/parallel-consumer#862."** The break
  was a kafka-clients SASL callback using a `Subject` API the JDK withdrew, fixed in kafka-clients
  3.9.1 by KAFKA-19024. This tree is on 3.9.2.

### Note names now carry the fork issue number

A fifth of `docs/inflight/` already carried a number and **the existing names disagree about what it
means** - `bug-857-family.md` is a confluentinc number, `perf-192-followups.md` a fork one. That is
the coin flip `docs/issue-references.md` exists to prevent, with none of the protection, because a
filename cannot be qualified. The three notes first added here as `upstream-543`, `upstream-777` and
`upstream-809` were the sharpest case: all three numbers also exist as fork issues meaning other
things. Older disagreeing names are left alone - renaming breaks every citation and improves nothing.

## The fork's own branches have never been audited

`origin/presentation` carries the code behind the asciinema cast embedded in the README, unmerged
since 2021 and named in no ledger. Chasing that found **109 branches on this fork accounted for by no
inventory at all.**

The transferable part is the mechanism. Four inventories exist; three were correctly scoped to
something that structurally excluded the branch. The fourth is the near miss: `docs/upstream.md`
carries an entry titled "Orphan branches never attached to a PR" - the right check pointed at the
wrong remote. It swept `upstream`; the branch exists only on `origin`. That reads as covering orphan
branches generally while covering five branches on one of two remotes, which is worse than not
looking, because it closes the question. **Every audit was seeded from a list of interesting things
and worked outward; none started from the complete set of refs and worked inward.**

**The upstream half, now closed.** 34 of upstream's 42 branches existed on no branch of this fork.
The tempting reading is that we deleted them; tested and refuted - for 33 of the 34 *every commit*
postdates this fork. The mechanism: **a fork receives branches once, at creation, and never again.**
This one dates from 2020, upstream kept creating branches for six more years, and none arrive.

All 42 are now mirrored under `upstream/*`, tips verified. The namespace is load-bearing: eight share
a name with one of ours carrying divergent work - including `master` - so pushing under their own
names would have overwritten our history. `pyallel-consumer` is the immediate value: a prior Python
client, prior art in the strongest sense, while a Python client is being written on
`feats/proxy-requirements`.

## One branch record, replacing three

`branch_accounting` records **what we decided about a branch, in a form that outlives the branch.**
The failure it prevents: a branch is reviewed, judged worthless and deleted, its only trace was
itself, and the next audit re-finds the absence, cannot tell a deliberate deletion from an accident,
and redoes the work. So `state: deleted` keeps its entry, with tip, date and reason.

It replaces three registers that held **the same commits** under different framings -
`preserved_branch_tips` and `sweep-2023-admin-closure.preserved_heads` recorded the same SHAs, and
confluentinc/parallel-consumer#443 and the `pyallel-consumer` tip turned out to be two names for one
commit. The rule in its header is what stops it rotting: **nothing a command answers.**

**First use: the bot branches are gone.** 17 mirrored dependency-bot branches deleted and *recorded
as deleted*. Sixteen were one commit touching one `pom.xml` against upstream's diverged tree. The
seventeenth was not a bot branch at all - a maintainer had pushed four commits onto
`dependabot/maven/org.threeten-threeten-extra-1.8.0`. It was read before deletion and given its own
entry. **A sweep keyed on `dependabot/*` would have taken human commits silently** - a name trusted
in place of contents, the same failure as the stale bodies. Our own `dependabot/*` branch is
untouched: it heads astubbs/parallel-consumer#38, and deleting it would have closed that PR.

## The record this PR adds was validated by nothing

`upstream-map.yaml` has a validator. This PR added `branch_accounting` and left it outside the
validator - so `state: TYPO_NOT_A_STATE` validated clean while the run printed
`OK: 39 entries, no schema errors`, a reassuring count of the section it *had* looked at. The success
line now names both sections.

The other half was worse: **`upstream-map.py validate` was invoked by no workflow, no gate and no
hook**, so fixing the schema check without giving it a caller would have fixed nothing.
`bin/check-upstream-map.sh` is that caller, and needed no registration - `check-all.sh` discovers by
glob, so the sweep went 38 → 40 with no workflow edit. Confirmed it will genuinely *run* in CI rather
than skip: `check-docs-data.sh` shares the PyYAML dependency and the last hygiene run reports it `ok`
with `0 could not run`.

**The new check immediately failed two of my own entries, and the rule was wrong rather than the
data.** Both are `state: ours` - live branches whose SHA is one `git rev-parse` away, and this
section's governing rule is *nothing a command answers*. A tip is now required only for `deleted` and
`archived`. The self-test carries both halves of that pair.

Every negative arm was **run against the pre-change validator and observed to pass wrongly** - all
print `OK: 39 entries` and exit 0, including the integer-tip case that bit for real in review
(`tip: 255916684` is all digits, so YAML makes it an int and it never compares equal to
`git rev-parse` output).

## What review and the master merge caught - all six now fixed

A multi-agent review, including an independent cross-model adversarial pass, turned this branch's own
thesis on it: several corrections overstated what had been checked. The worst was a postable draft
quoting a fourth chaos-suite cell as measured, when the owning test's javadoc records three and
*predicts* the fourth. Cut, with the run listed as work to do. Others were narrowed to what was
established: a first poll at offset 0 does not take the truncation branch, because the comparison is
strict; the poll-path claim is now about deserialization failures specifically; an anchor occurring
twice was replaced by the unique callee.

Merging master then brought gates that caught three more:

- **A citation naming a file that has never existed in any ref.** `check-file-refs.sh` could not see
  same-directory links until master fixed it; with that fixed it flagged `branch-language-proxy.md`,
  cited as where the Python client is being built. `git log --diff-filter=D --all` finds no deletion,
  because there was nothing to delete - a plausible filename written from an adjacent fact. **The
  third instance on this branch of the failure the branch was opened to document, and the second I
  committed myself.**
- **A dangling link from my own rename**, where a note lost its `next-` prefix and the link did not
  follow.
- **Two counts of the same thing disagreeing five lines apart** - an inherited, undated "41 branches"
  against this branch's dated, verified "42", which matches `git ls-remote` today. Master had just
  widened *never write down what a command can answer* to name counts explicitly.

**One review finding was rejected by validation and deliberately not applied**, recorded so it is not
re-raised: the java-24 entry's `status: merged` with no branch or PR is legitimate, because the
schema defines `merged` as "landed on fork master" without requiring either.

**Coverage gap, stated rather than hidden:** on the delta review the cross-model peer hit its
deadline and returned nothing, so that lens is uncovered for the later slice.

### A second review, asked to attack the claims, found six more - all fixed

Each was re-verified against HEAD before being touched:

1. **The `RetryQueue` claim was backwards.** The note said `size()` and `isEmpty()` read a plain
   `HashMap` "with no lock at all"; both take `lock.readLock()`. It was **true when written** and
   falsified by `d2e00faf0`, which arrived in a master merge *on this branch* hours later - so the
   branch's own hygiene step invalidated its own record and nothing re-checked it. Rewritten to what
   is true, and kept rather than deleted, because the defect was real (in `removeAll`'s fast path)
   and it is the worked example the note needs.
2. **A stale PR pointer in three places, two written here.** The confluentinc#893 cherry-pick was
   split out of astubbs/parallel-consumer#57 onto astubbs/parallel-consumer#337 before these notes
   were written; one note hung a deadline argument on the old PR being open, and the `.adoc` line
   *this branch rewrote* still named it. A live citation resolving to the wrong PR is worse than one
   that breaks.
3. **Two anchors whose greps return nothing** - a fabricated quotation around a fair paraphrase, and
   a `grep` instruction pointing at a string that does not exist in the file it names. Exactly what
   `AGENTS.md`'s "run the grep before you commit the citation" exists to catch, and neither grep was
   run.
4. **An overstated completeness claim** - "the only other references" missed a jcstress probe that
   also arrived by master merge. Narrowed to the suites the argument actually needs.
5. **`archived` had no test coverage.** The validator requires a tip for `deleted` *and* `archived`;
   only `deleted` was exercised, and the manifest has no archived entry, so a regression to
   `("deleted",)` would have been caught by nothing. Two arms added, and the regression injected to
   prove the negative one goes red rather than passing for its own reasons.
6. **Not fixed, recorded instead:** the re-cut destroyed the tracked `next-` to `process-` rename one
   commit message describes. Rewriting history again to repair a sentence *about* history costs more
   than it returns.

Three of those six were created by this branch's own merge and re-cut, *after* the content had been
written and reviewed - which is the argument for verifying claims after the final merge, not before.

## An index of every issue, so grep reaches the tracker

`gh issue list --state all` is, by `AGENTS.md`'s own admission, the most-skipped of its six
prior-art checks - structurally, not through laziness: an agent has to *think* of querying GitHub
before it can, and it greps by reflex. So the issue tracker was the one knowledge surface a keyword
sweep of `docs/` could not reach.

`bin/issue-index.sh` writes `docs/inflight/issue-index.md` - one line per issue, with number, state,
title and labels. Working on offset encoding now surfaces astubbs/parallel-consumer#237 without
anyone having formed the intent to look for it.

**It breaks "never write down what a command can answer" deliberately**, and the distinction matters
because the next reader should challenge it. That rule exists to stop a *second tracker* forming: a
copy that gets believed, drifts, and cannot be told from the truth. This one is not built to be
believed - it carries the date the data was read, says twice that rows go stale silently, and sends
you to `gh issue view` before acting. The precedent is already here:
`.claude/hooks/inject-recorded-knowledge.sh` injects the *titles* of every `docs/solutions/`
write-up at session start for exactly this reason.

**It earned its keep before merging.** Within minutes of generating it,
astubbs/parallel-consumer#41 stood out as labelled `wontfix` while being `OPEN` with
`stateReason=REOPENED` - closed as wontfix once, reopened, and the label never removed. The label was
wrong, not the issue; it has been removed and the row regenerated. Nobody was going to notice a stale
label on a two-year-old issue by reading the tracker, and a grep-visible row made it obvious.

It is also the worked example for why this is a discovery aid and not state: reading the label alone
gave the wrong answer, and only the state column beside it revealed the contradiction. That is what
the header warning is for.

**No `--check` gate, unlike `bin/todo-index.sh`.** That script regenerates from the tracked tree, so
staleness is decidable offline and a gate is free. This one cannot be - deciding whether it still
matches reality means asking GitHub, needing network and a token. Such a gate is skipped for fork PRs
and dies on a token expiry, which is the failure `bin/check-cve-exclusions.sh`'s header describes:
an unwatched list rotting exactly when its guard cannot run. Staleness is handled by *saying so, with
a date*.

The inflight tags are emitted **by the generator**, since the file is rewritten wholesale and a
hand-added tag would be dropped by the next run. `docs/inflight/AGENTS.md`'s "No committed index"
rule now says what it always meant - no index *of these notes* - and names this file, so it is not
deleted on sight by an agent correctly citing it.

## Other instances of the same defect

The class is *a record that reads as verified and is not*, sharpened by the invented citation into
its nastiest form: **a reference written from adjacent evidence that names something which never
existed.** `check-file-refs.sh` catches a broken *link*; it cannot see a bare filename in backticks.
So I swept the whole tree for backticked `.md` filenames resolving to nothing. **No further
instance** - every other hit is explained by its own prose (a note deliberately deleted, one landing
with a different branch, a superseded audit), and the two on this branch are the deliberate
cross-branch case, stated inline both times.

Also checked and ruled out: `upstream-map.yaml` entries were accurate where they existed, except the
two corrected here; `docs/solutions/` entries were cited by several assessors and none was stale. Two
pre-existing notes still carry `file:line` citations, left alone as out of scope.

Surfaced and worth fixing separately: `bin/check-issue-refs.sh` enumerates via `git diff --name-only`,
so it scans **tracked** files only - every agent's first "gate passes" asserted nothing about an
untracked new file.

## Deliberately not done

**No issue has been touched** - no comment, label, close or body edit. Every correction and every
reporter-facing answer is drafted in its note and left unposted, pending a maintainer's decision.
Two are recommended for closing (astubbs/parallel-consumer#161, and
astubbs/parallel-consumer#163 after answering), one is a judgement call
(astubbs/parallel-consumer#181 - closeable on the code, but no CI lane above Java 17 proves it), and
the rest stay open with corrected bodies.

`origin/presentation` is still live: its archive-then-delete decision is recorded in
`branch_accounting` but not executed, and that entry is currently the only record the decision exists.

## Checklist

- [x] Docs updated - `docs/upstream.md` and the manifest header name the new gate, and keep the
  still-true claim that the *fork* side is checked by nothing
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - no user-facing feature; internal triage records and a repo gate`
- [x] Tests added/updated - `bin/test-check-upstream-map.sh`, ten arms, every negative one verified red against the pre-change validator
- [x] Title & body reflect the final content of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFRbSkHwaRw6YYFHHBWZ7p



