### PR TITLE
docs(agents): give a user-visible change a Release-Note: commit trailer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,9 @@ the model: an entry claimed a dependency version the pom had moved past). The te
 are *changing an existing claim to be true* (allowed) or *adding information about a change* (the
 generator's job).
 
-Write commit messages that can feed that generator - see [Commits](#commits).
+Write commit messages that can feed that generator - see [Commits](#commits), and give a
+user-visible change a `Release-Note:` trailer so the generator's input is a scan rather than a
+reading of every subject line.
 [`docs/releasing.md`](docs/releasing.md) **owns the rest** - how generation works, the state of each
 section - and wins where the two disagree.
 
@@ -410,6 +412,27 @@ Nothing lints commit messages, so all of this is on you.
   `(producer)`, `(changelog)`. A directory name is not a scope.
 - **Bodies feed the release notes**: what changed, what it changed for a user, plus the diagnosis,
   the experiment and the rejected alternatives.
+- **A user-visible change also gets a `Release-Note:` trailer.** One line, in the commit body,
+  stating the change in the words a user would read:
+
+  ```
+  Release-Note: A Reactor user function returning an empty publisher now completes its record
+  ```
+
+  **Why a trailer and not just a well-written body.** `CHANGELOG.adoc` is generated at release time
+  from the commit log, and finding what belongs in it currently means reading every subject and
+  judging. `git log --grep='^Release-Note:'` turns that judgement into a scan, and it works months
+  later when the branch, the PR thread and any working notes are long gone. Git history is the only
+  index here that outlives everything else - which is why the repo already carries `Upstream-Issue:`
+  and the DEP-3 trailers the same way.
+
+  **What earns one**: a change a user or operator would notice - behaviour, defaults, API, a fixed
+  defect they could have hit. Not refactors, not test work, not internal measurement, not docs. The
+  bar is the changelog's own, and the trailer exists so that assembling the changelog is a scan
+  rather than an archaeology exercise.
+
+  **Nothing enforces this**, in keeping with the rest of this section - a missed trailer costs a
+  release note, not a build.
 - **Branch names encode the upstream number**: `bugs/857-...`, `fix/909-...`,
   `cherry-pick/893-...`, `upstream-pr-905`. It keeps the mapping greppable.
 - Upstream-related commits carry DEP-3 provenance trailers -


### PR DESCRIPTION
<!-- No single issue: this is a convention gap found while doing other work, not tracked anywhere. -->

## Description

Adds a `Release-Note:` commit trailer for user-visible changes, and points the Changelog section at
it.

```
Release-Note: A Reactor user function returning an empty publisher now completes its record
```

**Why.** `CHANGELOG.adoc` is generated at release time from the commit log, and finding what belongs
in it currently means reading every subject and judging. `git log --grep='^Release-Note:'` turns that
into a scan, and it still works months later when the branch, the PR thread and any working notes are
gone. The repo already uses `Upstream-Issue:` and the DEP-3 trailers exactly this way.

**What prompted it, because the failure mode is the interesting part.** An agent fixing a silent
consumer stall in the Reactor engine (astubbs/parallel-consumer#329) correctly judged the change
release-note-worthy and was told by its brief to add the trailer. It checked, found no such
convention anywhere in the repo, and **declined to invent one** - which was the right call, and it
pushed back rather than complying. The convention did exist, but only on an unmerged research branch,
so it was invisible to precisely the branches that needed it. Any future agent cutting from `master`
would have hit the same dead end and made the same correct-but-wasteful decision.

**Deliberately only the trailer.** That research branch also proposed an `inflight-labels:` field, for
finding *open* notes that will need a release note. That half is **not** brought over: `master`'s
tagging scheme has since grown a third field, a machine-readable vocabulary in
`bin/lib/inflight-tags.sh`, and a gate that validates against it - so a fourth undeclared field would
at best duplicate `inflight-type` and at worst fail that gate. The trailer needs none of that
machinery, and it is the half that survives anyway: `docs/inflight/` `git rm`s a note when its work
lands, so a label on a note cannot outlive the note. History is permanent.

**Nothing enforces it**, in keeping with the rest of the Commits section - a missed trailer costs a
release note, not a build.

## Checklist

- [x] Docs updated - this PR *is* the doc change: `AGENTS.md`, the Commits section (the convention)
      and the Changelog section (a pointer to it from where a reader asks the question)
- [x] N/A - user-facing feature documentation under `docs/features/` - a contributor convention, with
      no user-facing behaviour
- [x] N/A - tests - `AGENTS.md` prose with no enforcing script. Adding a gate was considered and
      rejected: the Commits section states outright that nothing lints commit messages, so a gate
      here would be the only enforced rule in a section whose premise is that none of them are
- [x] Title & body reflect the final content of this PR
