### PR TITLE
fix(hooks): make the agent-harness scripts portable across GNU and BSD, failing closed where they guard

### DIFF
--- a/.claude/hooks/check-merge-outstanding-work.sh
+++ b/.claude/hooks/check-merge-outstanding-work.sh
@@ -145,11 +145,43 @@ print(verdict)
 [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || exit 0
 
 now="$(date +%s)"
+# PORTABLE MTIME. `stat -c %Y` is GNU; BSD/macOS stat rejects `-c` and this returned nothing while
+# still exiting 0, so every caller silently read "no mtime". PROBE the platform once rather than
+# falling back arm to arm. What a blind `-c || -f` would actually do on GNU coreutils 9.7, measured:
+# `stat -f %m FILE` exits 1 but PRINTS SIX LINES OF FILESYSTEM PROSE TO STDOUT - `File:`, `ID:`,
+# `Blocks: Total: ...`. So the fallback arm hands back not a wrong number but a wrong STRING, which
+# the caller then does arithmetic on. Probing means only one arm ever runs.
+#
+# `|| true` IS LOAD-BEARING, not tidiness: this script runs under `set -e`, and `mtime="$(_mtime ...)"`
+# takes the substitution's status, so a failing stat killed the hook AT that line - never reaching the
+# fail-closed branch below, and exiting non-zero, which PreToolUse reads as a non-blocking error and
+# ALLOWS the merge. The fail-closed arm was unreachable until this was here. `_mtime` therefore never
+# fails: it prints the mtime, or nothing.
+if stat -c %Y . >/dev/null 2>&1; then
+    _mtime() { stat -c %Y "$1" 2>/dev/null || true; }      # GNU coreutils
+else
+    _mtime() { stat -f %m "$1" 2>/dev/null || true; }      # BSD / macOS
+fi
+
 live_tasks=""
 while IFS= read -r f; do
     [ -f "$f" ] || continue
-    mtime="$(stat -c %Y "$f" 2>/dev/null || echo 0)"
-    [ "$mtime" -eq 0 ] && continue
+    mtime="$(_mtime "$f")"
+    # FAIL CLOSED, ON ANYTHING THAT IS NOT A TIMESTAMP - not just on empty. A file matched the
+    # session's tasks glob, so something is there; being unable to date it is not evidence that
+    # nothing is running. The old code skipped it, which is how this guard came to allow every merge
+    # on macOS.
+    #
+    # NOT `[ -z "$mtime" ]`: `stat` can FAIL AND STILL PRINT. Feed the arithmetic below a non-numeric
+    # `mtime` and `$(( now - mtime ))` evaluates it as an expression, so a word in it is a variable
+    # name and `set -u` aborts the hook - "File: unbound variable" - which exits non-zero with no
+    # verdict, and PreToolUse reads that as a non-blocking error and ALLOWS the merge. Testing the
+    # shape of the value, not merely its presence, is what keeps the closed arm closed.
+    case "$mtime" in
+        ''|*[!0-9]*)
+            live_tasks="${live_tasks}  - $(basename "$f" .output) (mtime unreadable - assuming live)"$'\n'
+            continue ;;
+    esac
     age=$(( now - mtime ))
     if [ "$age" -lt "$WINDOW_SECONDS" ]; then
         live_tasks="${live_tasks}  - $(basename "$f" .output) (wrote ${age}s ago)"$'\n'

--- a/.claude/hooks/inject-recorded-knowledge.sh
+++ b/.claude/hooks/inject-recorded-knowledge.sh
@@ -342,14 +342,14 @@ emit_deferred
 emit "# Dated plans and investigations"
     emit ""
     emit "\`docs/plans/\` - the method that settled a question of this shape before:"
-plans=$(find docs/plans -name '*.md' -type f 2>/dev/null | sort | sed 's|docs/plans/||;s|\.md$||' | paste -sd, | sed 's/,/, /g')
+plans=$(find docs/plans -name '*.md' -type f 2>/dev/null | sort | sed 's|docs/plans/||;s|\.md$||' | paste -sd, - | sed 's/,/, /g')
 emit "${plans:-(none)}"
 emit ""
 
 # Point-in-time audits of tests that do not run, do not assert, or were never written. Easy to miss
 # precisely because nothing goes red to tell you - which is why AGENTS.md says to read the newest
 # before re-enabling, deleting or rewriting a dark test.
-hardening=$(find docs/test-hardening -name '*.md' -type f 2>/dev/null | sort | sed 's|docs/test-hardening/||;s|\.md$||' | paste -sd, | sed 's/,/, /g')
+hardening=$(find docs/test-hardening -name '*.md' -type f 2>/dev/null | sort | sed 's|docs/test-hardening/||;s|\.md$||' | paste -sd, - | sed 's/,/, /g')
 if [ -n "$hardening" ]; then
     emit "# Dated test-hardening audits"
     emit ""

--- a/.claude/hooks/remind-inflight-on-push.sh
+++ b/.claude/hooks/remind-inflight-on-push.sh
@@ -78,7 +78,22 @@ branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 # THROTTLE. Same branch, same hour, one reminder.
 stamp="${TMPDIR:-/tmp}/pc-push-reminder-$(printf '%s' "$branch" | tr '/' '_')"
 if [ -f "$stamp" ]; then
-    last="$(stat -c %Y "$stamp" 2>/dev/null || echo 0)"
+    # PORTABLE MTIME, read where it is used - on a branch's first push there is no stamp and this
+    # never runs. `stat -c %Y` is GNU; BSD/macOS stat rejects `-c` and returned nothing while still
+    # exiting 0, so the throttle silently read "no mtime". PROBE the platform once rather than
+    # falling back arm to arm: on GNU, `stat -f %m FILE` exits 1 while PRINTING filesystem prose to
+    # stdout, so a blind `-c || -f` returns a string, not a number.
+    if stat -c %Y . >/dev/null 2>&1; then
+        last="$(stat -c %Y "$stamp" 2>/dev/null)"   # GNU coreutils
+    else
+        last="$(stat -f %m "$stamp" 2>/dev/null)"   # BSD / macOS
+    fi
+    # ANYTHING THAT IS NOT A TIMESTAMP MEANS REMIND, not stay silent - the safe direction for a
+    # reminder, where the guards in check-merge-outstanding-work.sh and bin/check-pr-ready.sh must
+    # instead assume live work. Reminding twice costs a paragraph; skipping loses the only prompt
+    # there is. Testing the shape and not just emptiness matters for the same reason it does there:
+    # `$(( now - last ))` on prose evaluates it as an expression and `set -u` would abort the hook.
+    case "$last" in ''|*[!0-9]*) last=0 ;; esac
     now="$(date +%s)"
     [ $(( now - last )) -lt "${INFLIGHT_PUSH_REMINDER_SECONDS:-3600}" ] && exit 0
 fi

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Self-test the local issue-reference checker's body plumbing
         run: bash bin/test-check-issue-refs.sh
 
+      # The local file-reference mirror has no `gh` plumbing, but it does have an EXIT CODE
+      # CONTRACT that .githooks/pre-commit reads: 1 blocks the commit, 2 warns and lets it through.
+      # A node that cannot start exits 1, so the script used to report "dangling references found"
+      # for a run that checked nothing. These cases pin both codes.
+      - name: Self-test the local file-reference checker's exit codes
+        run: bash bin/test-check-file-refs.sh
+
       # Runs BEFORE the gate below, per bin/AGENTS.md. It tests the script's ARGUMENT PARSING, which
       # is a permission boundary rather than a formatting concern: the reviewer is granted
       # `bin/todo-index.sh --check` exactly so it can ask whether the index is stale without being

--- a/bin/check-branch-self-reference.sh
+++ b/bin/check-branch-self-reference.sh
@@ -120,7 +120,16 @@ strip_spans() { sed 's/`[^`]*`/ /g' "$1"; }
 # UNTRACKED FILES COUNT. `git ls-files` alone reads the index, so a note you just wrote about your own
 # branch - the single commonest way to trip this gate - was invisible until you staged it, and the
 # local run this header advertises reported green on the exact case it exists for.
-mapfile -t candidates < <(
+#
+# NO `mapfile`. It is bash 4; macOS ships bash 3.2, where the line died with "mapfile: command not
+# found" and the script still exited 0 - a local run reporting success having checked nothing, which
+# is the exact failure this gate exists to prevent, one level up. The read loop below is the same
+# portable idiom bin/check-inflight-tags.sh and bin/check-copyright-headers.sh already use.
+candidates=()
+while IFS= read -r doc; do
+    [ -n "$doc" ] || continue
+    candidates+=("$doc")
+done < <(
     {
         git ls-files -- 'docs/inflight/*.md' || true
         git ls-files --others --exclude-standard -- 'docs/inflight/*.md' || true

--- a/bin/check-file-refs.sh
+++ b/bin/check-file-refs.sh
@@ -40,11 +40,18 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-if ! command -v node >/dev/null 2>&1; then
-    echo "ERROR: node not found - needed to reuse .github/scripts/file-ref-gate.js." >&2
-    echo "The authoritative gate is the 'PR Checklist' workflow; this is the local mirror of it." >&2
-    exit 2
-fi
+# Resolve the helper BEFORE sourcing it - a failed `source` under `set -e` is fatal on bash 3.2, so a
+# guard written after one is unreachable. bin/lib/node-gate.sh's header owns that reasoning.
+node_gate="${BASH_SOURCE[0]%/*}/lib/node-gate.sh"
+[ -r "$node_gate" ] || node_gate="bin/lib/node-gate.sh"
+[ -r "$node_gate" ] \
+    || { echo "ERROR: cannot load bin/lib/node-gate.sh - the helper that classifies node's exit." >&2
+         echo "       This is NOT a finding. Nothing was checked." >&2
+         exit 2; }
+# shellcheck source=bin/lib/node-gate.sh
+source "$node_gate"
+
+node_gate_require_node ".github/scripts/file-ref-gate.js" || exit $?
 
 case "${1:-}" in
     "") ;;
@@ -69,6 +76,9 @@ case "${1:-}" in
         ;;
 esac
 
+# `set +e` so a non-zero node status reaches node_gate_verdict instead of exiting here with it -
+# which is precisely how a node that never started got reported as "dangling references found".
+set +e
 node <<'NODE'
 const fs = require("fs");
 const { execFileSync } = require("child_process");
@@ -126,3 +136,8 @@ if (dangling.length === 0) {
 console.error(gate.formatFailure(dangling));
 process.exit(1);
 NODE
+node_status=$?
+set -e
+
+node_gate_verdict "$node_status" ".github/scripts/file-ref-gate.js" || exit $?
+exit 0

--- a/bin/check-inflight-tags.sh
+++ b/bin/check-inflight-tags.sh
@@ -136,12 +136,16 @@ if [ -r "$OWNER_DOC" ]; then
     for v in $INFLIGHT_TYPES $INFLIGHT_BUG_IMPACTS $INFLIGHT_TASK_IMPACTS; do
         grep -q "\`${v}\`" "$OWNER_DOC" || note "vocabulary '$v' is in bin/lib/inflight-tags.sh but never described in $OWNER_DOC"
     done
-    # every impact the doc's table declares must be one the gate accepts
+    # every impact the doc's table declares must be one the gate accepts.
+    # `sed -E`, NOT a basic regex: `\+` and `\|` are GNU BRE extensions that BSD sed does not
+    # implement, so on macOS this expression matched nothing and extracted ZERO impacts - this whole
+    # direction of the agreement check passed by never running. It reported success, which is worse
+    # than failing. Measured: 0 rows on BSD against 17 with the form below.
     while IFS= read -r v; do
         [ -n "$v" ] || continue
         in_set "$v" "$INFLIGHT_BUG_IMPACTS $INFLIGHT_TASK_IMPACTS" \
             || note "$OWNER_DOC documents impact '$v', which bin/lib/inflight-tags.sh does not accept"
-    done <<< "$(sed -n 's/^| `\([a-z-]\+\)` | \(bug\|task\|feature\|register\).*/\1/p' "$OWNER_DOC")"
+    done <<< "$(sed -E -n 's/^\| `([a-z-]+)` \| (bug|task|feature|register).*/\1/p' "$OWNER_DOC")"
 fi
 
 if [ "$problems" -gt 0 ]; then

--- a/bin/check-issue-refs.sh
+++ b/bin/check-issue-refs.sh
@@ -46,11 +46,18 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-if ! command -v node >/dev/null 2>&1; then
-    echo "ERROR: node not found - needed to reuse .github/scripts/issue-ref-gate.js." >&2
-    echo "The authoritative gate is the 'PR Checklist' workflow; this is the local mirror of it." >&2
-    exit 2
-fi
+# Resolve the helper BEFORE sourcing it - a failed `source` under `set -e` is fatal on bash 3.2, so a
+# guard written after one is unreachable. bin/lib/node-gate.sh's header owns that reasoning.
+node_gate="${BASH_SOURCE[0]%/*}/lib/node-gate.sh"
+[ -r "$node_gate" ] || node_gate="bin/lib/node-gate.sh"
+[ -r "$node_gate" ] \
+    || { echo "ERROR: cannot load bin/lib/node-gate.sh - the helper that classifies node's exit." >&2
+         echo "       This is NOT a finding. Nothing was checked." >&2
+         exit 2; }
+# shellcheck source=bin/lib/node-gate.sh
+source "$node_gate"
+
+node_gate_require_node ".github/scripts/issue-ref-gate.js" || exit $?
 
 BASE_REF="${1:-}"
 if [ -z "$BASE_REF" ]; then
@@ -66,6 +73,9 @@ if ! MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null); then
     exit 2
 fi
 
+# `set +e` so a non-zero node status reaches node_gate_verdict instead of exiting here with it -
+# which is precisely how a node that never started got reported as "unqualified refs found".
+set +e
 node - "$MERGE_BASE" <<'NODE'
 const { execFileSync } = require("child_process");
 const fs = require("fs");
@@ -143,3 +153,8 @@ console.error(gate.formatFailure(hits, opts));
 process.exit(1);
 })();
 NODE
+node_status=$?
+set -e
+
+node_gate_verdict "$node_status" ".github/scripts/issue-ref-gate.js" || exit $?
+exit 0

--- a/bin/check-pr-ready.sh
+++ b/bin/check-pr-ready.sh
@@ -76,11 +76,27 @@ fi
 
 # BACKGROUND WORK IN THIS SESSION, the same window check-merge-outstanding-work.sh uses.
 if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    # PORTABLE MTIME, identical to .claude/hooks/check-merge-outstanding-work.sh, which carries the
+    # full reasoning: PROBE the platform once, because a blind `-c || -f` fallback does not merely
+    # give a wrong number on GNU - `stat -f %m FILE` exits 1 while PRINTING filesystem prose to
+    # stdout, so the fallback arm returns a string the caller then does arithmetic on.
+    # `|| true` for the same reason it is there: this script has no `set -e` today, so it is not
+    # load-bearing HERE, but it makes the two copies identical and stops adding `-e` later from
+    # silently restoring the fail-open the sibling hook had.
+    if stat -c %Y . >/dev/null 2>&1; then
+        _mtime() { stat -c %Y "$1" 2>/dev/null || true; }      # GNU coreutils
+    else
+        _mtime() { stat -f %m "$1" 2>/dev/null || true; }      # BSD / macOS
+    fi
     now=$(date +%s); live=0
     while IFS= read -r f; do
         [ -f "$f" ] || continue
-        m=$(stat -c %Y "$f" 2>/dev/null || echo 0)
-        [ "$m" -eq 0 ] && continue
+        m=$(_mtime "$f")
+        # FAIL CLOSED on anything that is not a timestamp, not merely on empty - an undateable task
+        # file counts as live. Same reasoning, and the same `stat` can-fail-and-still-print trap, as
+        # the merge guard: `$(( now - m ))` on a non-numeric `m` evaluates it as an expression and
+        # `set -u` aborts the script mid-count.
+        case "$m" in ''|*[!0-9]*) live=$((live + 1)); continue ;; esac
         [ $(( now - m )) -lt 120 ] && live=$((live + 1))
     done < <(find "/tmp/claude-$(id -u)" -maxdepth 4 -path "*/${CLAUDE_CODE_SESSION_ID}/tasks/*.output" 2>/dev/null || true)
     [ "$live" -gt 0 ] && block "${live} background task(s) wrote in the last 2 minutes - work is still in flight"

--- a/bin/lib/node-gate.sh
+++ b/bin/lib/node-gate.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# THE single home of "did the node gate actually RUN, or did node die before it got there?" -
+# shared by bin/check-issue-refs.sh and bin/check-file-refs.sh. Source this; do not copy from it.
+#
+# WHY IT EXISTS. Both scripts guarded with `command -v node`, which proves node is PRESENT and says
+# nothing about whether it can RUN. When NODE_OPTIONS carries a `--require` naming a file that no
+# longer exists - an agent harness writes a preload into a temp directory, the temp directory is
+# later cleaned up - every node process dies during preload, before one line of the gate executes:
+#
+#     Error: Cannot find module '.../restore-node-options.cjs'
+#     requireStack: [ 'internal/preload' ]
+#
+# node's exit status for that is **1**, and both scripts reserve 1 for "violations found". So a gate
+# that checked nothing reported a policy violation. That is not hypothetical - it happened on a real
+# machine and cost a real debugging detour, because `bin/check-issue-refs.sh` exiting 1 reads as
+# "you wrote a bare #NN", not as "your environment is broken". Both scripts already document 2 for
+# "cannot run"; the guard simply never reached it. Failing closed where a script guards is the whole
+# point of the branch this landed on (astubbs/parallel-consumer#341).
+#
+# WHY THE PROBE RUNS ON THE FAILURE PATH RATHER THAN UPFRONT. An unconditional `node -e ''` before
+# each gate would cost ~90ms of interpreter start apiece, and .githooks/pre-commit budgets ~1.5s for
+# its whole run - which these two gates already very nearly spend between them. Probing only after a
+# non-zero result costs nothing on the clean path, and the one case it slows down is a case whose
+# output you are about to read anyway. It is also the stronger check: an upfront probe only proves
+# node worked a moment BEFORE the run.
+#
+# THE PROBE LOADS THE GATE MODULE, it does not merely start node, so "node cannot start" and "the
+# module cannot be loaded or parsed" both land on 2 - "cannot run" - instead of the second
+# masquerading as a finding. A module that loads and then throws at runtime is still reported as a
+# finding; that residue is covered by the modules' own unit tests in the `PR Checklist` workflow.
+#
+# HOW TO LOAD THIS FILE, and why both callers do it the long way. Under `set -e` on bash 3.2 - the
+# system bash on every macOS host - a `source` of a file it cannot read is FATAL to the shell, so a
+# `|| { ...; exit 2; }` guard written after one never runs: the caller dies exit 1 with no output,
+# which is exactly the false accusation this helper exists to prevent. So a caller tests `[ -r ]`
+# first and sources only then. Keep that shape if a third caller is ever added; the callers carry a
+# one-line pointer here rather than a copy of this paragraph.
+
+# node_gate_require_node <gate-module-path-from-repo-root>
+#
+# NECESSARY BUT NOT SUFFICIENT, which is the whole reason this file exists: this answers "is node
+# installed", and a node that is installed can still die at startup. That second case is classified
+# after the run, by node_gate_verdict below. Both callers need the same preflight and the same
+# wording, so it lives here rather than as two copies that drift.
+#
+# Call it as `node_gate_require_node <module> || exit $?`, for the same `set -e` reason as below.
+node_gate_require_node() {
+    command -v node >/dev/null 2>&1 && return 0
+
+    echo "ERROR: node not found - needed to reuse $1." >&2
+    echo "The authoritative gate is the 'PR Checklist' workflow; this is the local mirror of it." >&2
+    return 2
+}
+
+# node_gate_verdict <node-exit-status> <gate-module-path-from-repo-root>
+#
+# Returns the CALLING SCRIPT's exit code, per the contract both callers state in their headers:
+#   0 - node ran and reported clean
+#   1 - node ran and reported a real finding
+#   2 - node never reached a verdict, so nothing was checked
+#
+# Call it as `node_gate_verdict "$status" <module> || exit $?` - on the left of `||` so the caller's
+# `set -e` does not turn the 1 and 2 answers into an exit before the message is used.
+node_gate_verdict() {
+    local status=$1 module=$2
+
+    if [ "$status" -eq 0 ]; then
+        return 0
+    fi
+
+    # `require` from `-e` resolves relative to the current directory, and both callers cd to the
+    # repo root first. Output is discarded: if node itself is broken, the run above has already
+    # printed the same stack trace, and a second copy buries the explanation below.
+    if node -e 'require(process.argv[1])' "./$module" >/dev/null 2>&1; then
+        return "$status"
+    fi
+
+    echo "ERROR: the gate in ${module} did not run - node exited ${status} without reaching a verdict." >&2
+    echo "       This is NOT a finding. Nothing was checked; see node's own error above." >&2
+    if [ -n "${NODE_OPTIONS:-}" ]; then
+        echo "       NODE_OPTIONS is set: ${NODE_OPTIONS}" >&2
+        echo "       A stale --require in there - one naming a file that has since been deleted - kills" >&2
+        echo "       node during preload, before any script runs. Clear it and run this again." >&2
+    fi
+    echo "       The authoritative gate is the 'PR Checklist' workflow; this is the local mirror of it." >&2
+    return 2
+}

--- a/bin/rename-packages.sh
+++ b/bin/rename-packages.sh
@@ -799,8 +799,16 @@ is_sweep_excluded() { # <path> - excluded from the COMPLETENESS CHECK. Deliberat
     is_self "$1"
 }
 
-frozen_lines() { # <file> -> line numbers inside a freeze region, markers included
-    awk -v b="$FREEZE_BEGIN_ERE" -v e="$FREEZE_END_ERE" '
+frozen_lines() { # <file> -> line numbers inside a freeze region, markers included, COMMA-separated
+    # Comma, not newline, and it is not cosmetic. Both readers below take this set through `awk -v`,
+    # and a -v assignment containing a newline is rejected outright by BSD awk - "awk: newline in
+    # string" - which is a diagnostic on stderr, not a non-zero exit. So on macOS both filters lost
+    # their frozen set while the run carried on: has_rewritable_match saw no match outside a freeze
+    # region, every file carrying a marker was dropped from the rewrite list, and the script printed
+    # "already applied, nothing to do" over a tree it had not touched. The freeze feature was dead on
+    # the platform, silently, exactly as the FREEZE_ID_ERE comment above predicts for a bracket
+    # expression - same failure, one construct along.
+    awk -v b="$FREEZE_BEGIN_ERE" -v e="$FREEZE_END_ERE" 'BEGIN { ORS = "," }
         $0 ~ b { f = 1; print NR; next }
         $0 ~ e { f = 0; print NR; next }
         f      { print NR }
@@ -811,7 +819,7 @@ frozen_lines() { # <file> -> line numbers inside a freeze region, markers includ
 # copy-pasted into each. They differ only in which field carries the line number, and the thing that
 # must never happen is the rewrite and the completeness check disagreeing about what is frozen - so
 # they read the set from one place.
-AWK_FROZEN_SET='BEGIN { n = split(frozen, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") fz[a[i]] = 1 }'
+AWK_FROZEN_SET='BEGIN { n = split(frozen, a, ","); for (i = 1; i <= n; i++) if (a[i] != "") fz[a[i]] = 1 }'
 
 has_freeze_marker() { # <file> - cheap gate, so the line-set scan runs only where it can matter
     grep -qE "$FREEZE_BEGIN_ERE" "$1" 2>/dev/null

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -538,7 +538,7 @@ expect DENY  "the override token AFTER the command is not a prefix"        'gh p
 # THE PR'S OWN INFLIGHT NOTE, surfaced at merge. A note recording what is still open is written so
 # the items are not forgotten and is then read by nobody at the moment it could still change the
 # outcome. These cases prove the arm fires, quotes the right part, and stays out of the way otherwise.
-touch -d '@1000000000' "$ow_tasks/agent-live.output"   # nothing in flight, so only the note arm can fire
+touch -t 200109090146 "$ow_tasks/agent-live.output"   # nothing in flight, so only the note arm can fire
 mkdir -p docs/inflight
 cat > docs/inflight/pr-90001-selftest.md <<'NOTE'
 # astubbs#90001 - self-test fixture
@@ -564,8 +564,63 @@ assert "the Already-fixed section is NOT quoted" stopped "$got"
 rm -f docs/inflight/pr-90001-selftest.md
 
 # Stale task file == nothing in flight. Proves the window is load-bearing rather than "any file".
-touch -d '@1000000000' "$ow_tasks/agent-live.output"
+touch -t 200109090146 "$ow_tasks/agent-live.output"
 expect ALLOW "a task that stopped writing long ago does not block"         'gh pr merge 31 --rebase'
+
+# BOTH ARMS OF THE MTIME READ, plus the two that cannot be reached with a working stat.
+#
+# CI is Linux, so the BSD arm shipped unexecuted, and the fail-closed arm is unreachable on any
+# platform with a functioning stat - a file `find` has just listed can always be dated. A stub `stat`
+# earlier on PATH forces each in turn: same file, same command throughout, only stat changing.
+stub_bin="$TMP/stub-stat"; mkdir -p "$stub_bin"
+saved_path="$PATH"
+stub_stat() { cat > "$stub_bin/stat"; chmod +x "$stub_bin/stat"; PATH="$stub_bin:$saved_path"; }
+
+# A BSD stat: rejects -c, answers `-f %m <file>`. MODELLED, not borrowed - the mtime read goes
+# through python3 (which this suite already requires for every payload) rather than the host's stat,
+# because on macOS the host stat IS BSD stat and would reject the `-c` a delegating stub hands it.
+# That is how this case reddened on the very platform the branch exists for.
+stub_stat <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+    -c) exit 1 ;;                     # BSD stat has no -c
+    -f) exec python3 -c 'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$3" ;;
+esac
+exit 1
+STUB
+expect ALLOW "BSD stat: a long-stale task still does not block"            'gh pr merge 31 --rebase'
+printf 'still writing\n' > "$ow_tasks/agent-live.output"
+expect DENY  "BSD stat: a task still writing is still caught"              'gh pr merge 31 --rebase'
+
+# A stat that answers nothing. The file matched the session's tasks glob, so something is there;
+# being unable to date it is not evidence that nothing is running. Red against the pre-fix code,
+# which skipped the file and allowed the merge - the macOS behaviour this branch exists to fix.
+stub_stat <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+touch -t 200109090146 "$ow_tasks/agent-live.output"
+expect DENY  "an undateable task file is assumed LIVE, not stale"          'gh pr merge 31 --rebase'
+
+# A stat that FAILS AND STILL PRINTS - which is what real GNU coreutils does when handed `-f %m
+# FILE`: exit 1, six lines of filesystem prose on stdout (measured on 9.7). So the value reaching
+# the guard is not absent, it is garbage, and a fail-closed arm testing only `-z` waves it through
+# to `$(( now - mtime ))`, where the arithmetic evaluates `File` as a variable name and `set -u`
+# aborts the hook - non-zero with no verdict, which PreToolUse ALLOWS. Hence the arm tests the
+# value's SHAPE. Keep the task file LIVE so nothing but that arm can produce the refusal.
+stub_stat <<'STUB'
+#!/usr/bin/env bash
+case "$1" in -c) exit 1 ;; esac
+printf '  File: "x"\n    ID: 7f048f3f Namelen: 255     Type: tmpfs\nBlock size: 4096\n'
+exit 1
+STUB
+printf 'still writing\n' > "$ow_tasks/agent-live.output"
+expect DENY  "a stat that fails but still PRINTS cannot defeat the guard"  'gh pr merge 31 --rebase'
+
+PATH="$saved_path"
+rm -f "$stub_bin/stat"
+touch -t 200109090146 "$ow_tasks/agent-live.output"
+expect ALLOW "the same stale file, with stat working, does not block"      'gh pr merge 31 --rebase'
 
 # Fail-open paths. A guard that blocks on its own bug jams the tool call shut.
 printf 'still writing\n' > "$ow_tasks/agent-live.output"

--- a/bin/test-check-branch-self-reference.sh
+++ b/bin/test-check-branch-self-reference.sh
@@ -64,10 +64,13 @@ assert() {
         git -c user.email=t@e.invalid -c user.name=t commit -qm x
         [ "$stage" = 0 ] && printf '%b' "$body" > "$target"
         # UNSET the CI variables, or the fixture is not isolated: on a real PR, Actions sets
-        # GITHUB_HEAD_REF to the actual branch, the gate prefers it over the fixture's checkout, and
-        # every branch-name case silently tests the wrong name. Green on a developer machine where
-        # the variable is absent, red only in CI - which is the worst place to learn it.
+        # GITHUB_HEAD_REF to the actual branch, the gate prefers it over the checkout in the
+        # fixture, and every branch-name case silently tests the wrong name. Green on a developer
+        # machine where the variable is absent, red only in CI - the worst place to learn it.
         # assert_ci below covers the path this unset removes.
+        # NO APOSTROPHES IN THIS BLOCK: bash 3.2, the system bash on macOS, does not skip comments
+        # when scanning a $( ... ) for its closing paren, so one reads as an opening quote and the
+        # whole file fails to parse. Nothing catches that - the suite simply never runs there.
         unset GITHUB_HEAD_REF GITHUB_REF GITHUB_REF_NAME
         PR_NUMBER=326 bash "$GATE" 2>&1
     )"

--- a/bin/test-check-file-refs.sh
+++ b/bin/test-check-file-refs.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Self-test for bin/check-file-refs.sh - its EXIT CODE CONTRACT, which the gate module's own unit
+# tests (file-ref-gate.test.js) cannot reach: they test the rule, this tests the shell that decides
+# what the rule's answer, or its absence, means to a caller.
+#
+# WHY THAT CONTRACT NEEDS A TEST AT ALL. .githooks/pre-commit classifies exit 2 from this script as
+# "could not run" and WARNS, while 1 blocks the commit. The two codes are therefore load-bearing in
+# both directions: a "could not run" reported as 1 blocks a commit over a violation nobody committed,
+# and a real finding reported as 2 is waved through with a warning. That first direction is not
+# hypothetical - a stale `--require` in NODE_OPTIONS kills node during preload, node exits 1 for it,
+# and this script used to hand that 1 straight on as "dangling references found".
+#
+# No network and no `gh`: this gate reads only git and the filesystem, so the fixture repo is the
+# whole world it sees.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- fixture repo, with the script under test in its real layout ---------------------------------
+mkdir -p "$TMP/repo/bin/lib" "$TMP/repo/.github/scripts" "$TMP/repo/docs"
+cp "$REPO_ROOT/bin/check-file-refs.sh" "$TMP/repo/bin/"
+cp "$REPO_ROOT/bin/lib/node-gate.sh" "$TMP/repo/bin/lib/"
+cp "$REPO_ROOT/.github/scripts/file-ref-gate.js" "$TMP/repo/.github/scripts/"
+
+cd "$TMP/repo"
+git init -q -b master
+git config user.email test@example.invalid
+git config user.name test
+# The base tree the gate ratchets against must be clean, so a finding added below is NEW rather than
+# inherited - that is the distinction newFindings() draws and this fixture has to respect it.
+echo "A citation of bin/check-file-refs.sh, which exists." > docs/note.md
+git add -A
+git commit -qm base
+
+fails=0
+
+run() { # <env-prefix...> -- sets $out and $got
+    out="$("$@" 2>&1)"
+    got=$?
+}
+
+check() { # <name> <expected-exit> <must-contain>
+    local name=$1 want=$2 must=$3
+    if [ "$got" != "$want" ]; then
+        echo "FAIL: $name (expected exit $want, got $got)"
+        echo "$out" | sed 's/^/      /'
+        fails=$((fails + 1))
+        return
+    fi
+    case "$out" in
+        *"$must"*) ;;
+        *) echo "FAIL: $name (output lacks: $must)"; echo "$out" | sed 's/^/      /'; fails=$((fails + 1)); return ;;
+    esac
+    echo "ok:   $name"
+}
+
+# --- 0: node ran and found nothing ----------------------------------------------------------------
+run env -u NODE_OPTIONS bash bin/check-file-refs.sh
+check "a tree whose citations all resolve exits 0" 0 "No new dangling file references"
+
+# --- 1: node ran and found something --------------------------------------------------------------
+echo "See bin/check-nothing-of-the-sort.sh for the details." >> docs/note.md
+git add docs/note.md
+run env -u NODE_OPTIONS bash bin/check-file-refs.sh
+check "a citation of a path that is not in the tree exits 1" 1 "check-nothing-of-the-sort.sh"
+
+# --- 2: node never ran, so there is no answer to report -------------------------------------------
+# `command -v node` proved node was installed and nothing more. A `--require` naming a file that has
+# since been deleted - an agent harness writes a preload into a temp directory, the temp directory is
+# later cleaned up - kills node during preload, before one line of the gate executes, and node's exit
+# status for that is 1: this script's code for "dangling references found".
+#
+# BOTH arms must be 2. The dirty one because a gate that did not run may not be believed even when it
+# would have been right; the clean one because there the 1 is a pure fabrication, and that is the
+# form the real incident took.
+broken_preload="$TMP/nodepreflight-deleted-by-the-harness.cjs"   # deliberately never created
+
+run env NODE_OPTIONS="--require=$broken_preload" bash bin/check-file-refs.sh
+check "dirty tree: a node that cannot start is 'cannot run', not a finding" 2 "This is NOT a finding"
+check "and the message names NODE_OPTIONS, without which the failure is baffling" 2 "NODE_OPTIONS is set"
+
+git checkout -q docs/note.md
+run env NODE_OPTIONS="--require=$broken_preload" bash bin/check-file-refs.sh
+check "clean tree: the same, so a gate that checked nothing cannot accuse anyone" 2 "did not run"
+
+# --- 2 is also the code for a bad argument, and must stay that way ---------------------------------
+run env -u NODE_OPTIONS bash bin/check-file-refs.sh --nonsense
+check "an unexpected argument is still 'cannot run', not a finding" 2 "unexpected argument"
+
+
+# --- the verdict helper itself is unreadable -------------------------------------------------------
+# The same fault one level up. `source` returns 1 for a file it cannot read, and under `set -e` that
+# becomes THIS script's exit status - 1, its code for "unqualified refs found". So a missing helper
+# accused the tree of exactly the thing the helper exists to stop being misreported. Measured, not
+# reasoned: before the fix this exited 1 with no message of its own.
+mv bin/lib/node-gate.sh "$TMP/node-gate.sh.away"
+out="$(env -u NODE_OPTIONS bash bin/check-file-refs.sh master 2>&1)"
+got=$?
+mv "$TMP/node-gate.sh.away" bin/lib/node-gate.sh
+helper_ok=1
+[ "$got" = 2 ] || helper_ok=0
+case "$out" in *"node-gate.sh"*) ;; *) helper_ok=0 ;; esac
+case "$out" in *"NOT a finding"*) ;; *) helper_ok=0 ;; esac
+if [ "$helper_ok" = 1 ]; then
+    echo "ok:   an unreadable verdict helper is 'cannot run', never a violation"
+else
+    echo "FAIL: unreadable verdict helper (expected exit 2 naming the helper, got $got)"
+    echo "$out" | sed 's/^/      /'
+    fails=$((fails + 1))
+fi
+
+# --- node genuinely absent, as opposed to present-but-broken --------------------------------------
+# The other node cases all break a node that EXISTS (a poisoned NODE_OPTIONS). Nothing exercised the
+# plain "not installed" branch, and when it moved into bin/lib/node-gate.sh as node_gate_require_node
+# it became shared code with no test at all - so a later edit there could flip this gate's answer for
+# BOTH callers silently. Calling the function directly, rather than the gate, keeps the case
+# deterministic on any host: it needs no external command (`echo` and `source` are builtins), so it
+# does not depend on where node happens to live, or on it being absent from the machine running this.
+out="$(bash -c 'PATH=/nonexistent-dir-for-test; source bin/lib/node-gate.sh; node_gate_require_node ".github/scripts/file-ref-gate.js"' 2>&1)"
+got=$?
+absent_ok=1
+[ "$got" = 2 ] || absent_ok=0
+case "$out" in *"node not found"*) ;; *) absent_ok=0 ;; esac
+case "$out" in *"file-ref-gate.js"*) ;; *) absent_ok=0 ;; esac
+if [ "$absent_ok" = 1 ]; then
+    echo "ok:   node absent is 'cannot run' and names the module it needed"
+else
+    echo "FAIL: node-absent branch (expected exit 2 naming the module, got $got)"
+    echo "$out" | sed 's/^/      /'
+    fails=$((fails + 1))
+fi
+
+if [ "$fails" -gt 0 ]; then
+    echo "$fails case(s) failed"
+    exit 1
+fi
+echo "all cases passed"

--- a/bin/test-check-inflight-tags.sh
+++ b/bin/test-check-inflight-tags.sh
@@ -88,7 +88,13 @@ cp bin/check-inflight-tags.sh "$dry_dir/bin/"
 cp bin/lib/inflight-tags.sh "$dry_dir/bin/lib/"
 cp docs/inflight/AGENTS.md "$dry_dir/docs/inflight/"
 
-sed -i 's/^INFLIGHT_TASK_IMPACTS="\(.*\)"$/INFLIGHT_TASK_IMPACTS="\1 undocumented-value"/' "$dry_dir/bin/lib/inflight-tags.sh"
+# Not `sed -i`: GNU takes the suffix attached (-i.bak), BSD takes it as the NEXT argument, so the one
+# spelling cannot mean in-place on both. On BSD this read the script as the suffix and the file as the
+# script - "sed: 1: invalid command code f" - leaving the fixture unedited, so both directions of this
+# doc-and-lib agreement check silently tested nothing and reported the gate as broken.
+sed 's/^INFLIGHT_TASK_IMPACTS="\(.*\)"$/INFLIGHT_TASK_IMPACTS="\1 undocumented-value"/' \
+    "$dry_dir/bin/lib/inflight-tags.sh" > "$dry_dir/inflight-tags.tmp"
+mv "$dry_dir/inflight-tags.tmp" "$dry_dir/bin/lib/inflight-tags.sh"
 out=$( cd "$dry_dir" && bash bin/check-inflight-tags.sh 2>&1 )
 case "$out" in *undocumented-value*) dry_got=caught ;; *) dry_got=missed ;; esac
 dry_assert "a lib value the doc never explains is caught" "$dry_got"

--- a/bin/test-check-issue-refs.sh
+++ b/bin/test-check-issue-refs.sh
@@ -18,14 +18,23 @@
 
 set -uo pipefail
 
+# EVERY case below controls NODE_OPTIONS explicitly - `env -u` where it wants a real verdict, `env
+# NODE_OPTIONS=...` where it is deliberately breaking node. Inheriting it makes this suite fail for
+# a reason that has nothing to do with the gate: on a machine whose ambient NODE_OPTIONS carries a
+# stale `--require`, every verdict case becomes "cannot run" and the suite reports failures that
+# read as a broken gate. That is not hypothetical - it happened while this fix was being reviewed,
+# 8 cases going red on an unrelated environment fault. Which is the same misreading the gate under
+# test exists to prevent, one level up: the harness has to be immune to the condition it asserts on.
+
 REPO_ROOT="$(cd "${BASH_SOURCE[0]%/*}/.." && pwd)"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 # --- fixture repo, with the script under test in its real layout ---------------------------------
-mkdir -p "$TMP/repo/bin" "$TMP/repo/.github/scripts" "$TMP/stub"
+mkdir -p "$TMP/repo/bin/lib" "$TMP/repo/.github/scripts" "$TMP/stub"
 cp "$REPO_ROOT/bin/check-issue-refs.sh" "$TMP/repo/bin/"
+cp "$REPO_ROOT/bin/lib/node-gate.sh" "$TMP/repo/bin/lib/"
 cp "$REPO_ROOT/.github/scripts/issue-ref-gate.js" "$TMP/repo/.github/scripts/"
 
 cat > "$TMP/stub/gh" <<'STUB'
@@ -49,7 +58,7 @@ mkdir -p docs
 fails=0
 check() { # <name> <expected-exit> <must-contain> [must-not-contain]
     local name=$1 want=$2 must=$3 mustnot=${4:-} out got
-    out="$(bash bin/check-issue-refs.sh master 2>&1)"
+    out="$(env -u NODE_OPTIONS bash bin/check-issue-refs.sh master 2>&1)"
     got=$?
     if [ "$got" != "$want" ]; then
         echo "FAIL: $name (expected exit $want, got $got)"
@@ -115,7 +124,7 @@ check "clean diff and clean body pass, and the success line says the body was ch
 # must cover all four, and the assertion must include the LEAD line: tail -3 passed for months
 # while provably cutting the very sentence the trailer exists to deliver.
 export GH_STUB_JSON='{"number":42,"body":"This fixes #858 for good."}' # issue-refs: exempt - fixture
-out="$(bash bin/check-issue-refs.sh master 2>&1 | tail -4)"
+out="$(env -u NODE_OPTIONS bash bin/check-issue-refs.sh master 2>&1 | tail -4)"
 tail_ok=1
 case "$out" in *"Fix: qualify each ref"*) ;; *) tail_ok=0 ;; esac
 case "$out" in *"issue-refs: N/A"*) ;; *) tail_ok=0 ;; esac
@@ -123,6 +132,92 @@ if [ "$tail_ok" = 1 ]; then
     echo "ok:   the last four lines of a failure carry the whole fix/opt-out reminder"
 else
     echo "FAIL: the fix/opt-out reminder did not survive | tail -4 intact"
+    echo "$out" | sed 's/^/      /'
+    fails=$((fails + 1))
+fi
+
+# --- node is PRESENT but cannot RUN ---------------------------------------------------------------
+# The guard was `command -v node`, which proves node is installed and nothing more. A stale
+# `--require` in NODE_OPTIONS - an agent harness writes a preload into a temp directory, the temp
+# directory is later cleaned up - kills node during preload, before one line of the gate executes,
+# and node's status for that is 1: this script's code for "unqualified refs found". A gate that had
+# checked nothing therefore reported a policy violation, and it cost a real debugging detour.
+#
+# BOTH arms must be 2, "cannot run". The clean tree because the accusation is pure fiction; the
+# dirty one because a gate that did not run may not be believed even when it would have been right.
+broken_preload="$TMP/nodepreflight-deleted-by-the-harness.cjs"   # deliberately never created
+
+check_cannot_run() { # <name>
+    local name=$1 out got
+    out="$(env NODE_OPTIONS="--require=$broken_preload" bash bin/check-issue-refs.sh master 2>&1)"
+    got=$?
+    if [ "$got" != 2 ]; then
+        echo "FAIL: $name (expected exit 2, got $got)"
+        echo "$out" | sed 's/^/      /'
+        fails=$((fails + 1))
+        return
+    fi
+    case "$out" in
+        *"This is NOT a finding"*) ;;
+        *) echo "FAIL: $name (output does not say it is not a finding)"
+           echo "$out" | sed 's/^/      /'; fails=$((fails + 1)); return ;;
+    esac
+    case "$out" in
+        *"NODE_OPTIONS is set"*) ;;
+        *) echo "FAIL: $name (output does not name NODE_OPTIONS, the likely cause)"
+           echo "$out" | sed 's/^/      /'; fails=$((fails + 1)); return ;;
+    esac
+    echo "ok:   $name"
+}
+
+export GH_STUB_JSON='{"number":42,"body":"All refs qualified, honest."}'
+echo "See astubbs#857 for details" > docs/note.md
+git add docs/note.md
+check_cannot_run "clean tree: a node that cannot start is 'cannot run', never a violation"
+
+echo "See #857 for details" > docs/note.md # issue-refs: exempt - fixture
+git add docs/note.md
+check_cannot_run "dirty tree: a gate that could not run is still 'cannot run', not a finding"
+
+
+# --- the verdict helper itself is unreadable -------------------------------------------------------
+# The same fault one level up. `source` returns 1 for a file it cannot read, and under `set -e` that
+# becomes THIS script's exit status - 1, its code for "unqualified refs found". So a missing helper
+# accused the tree of exactly the thing the helper exists to stop being misreported. Measured, not
+# reasoned: before the fix this exited 1 with no message of its own.
+mv bin/lib/node-gate.sh "$TMP/node-gate.sh.away"
+out="$(env -u NODE_OPTIONS bash bin/check-issue-refs.sh master 2>&1)"
+got=$?
+mv "$TMP/node-gate.sh.away" bin/lib/node-gate.sh
+helper_ok=1
+[ "$got" = 2 ] || helper_ok=0
+case "$out" in *"node-gate.sh"*) ;; *) helper_ok=0 ;; esac
+case "$out" in *"NOT a finding"*) ;; *) helper_ok=0 ;; esac
+if [ "$helper_ok" = 1 ]; then
+    echo "ok:   an unreadable verdict helper is 'cannot run', never a violation"
+else
+    echo "FAIL: unreadable verdict helper (expected exit 2 naming the helper, got $got)"
+    echo "$out" | sed 's/^/      /'
+    fails=$((fails + 1))
+fi
+
+# --- node genuinely absent, as opposed to present-but-broken --------------------------------------
+# The other node cases all break a node that EXISTS (a poisoned NODE_OPTIONS). Nothing exercised the
+# plain "not installed" branch, and when it moved into bin/lib/node-gate.sh as node_gate_require_node
+# it became shared code with no test at all - so a later edit there could flip this gate's answer for
+# BOTH callers silently. Calling the function directly, rather than the gate, keeps the case
+# deterministic on any host: it needs no external command (`echo` and `source` are builtins), so it
+# does not depend on where node happens to live, or on it being absent from the machine running this.
+out="$(bash -c 'PATH=/nonexistent-dir-for-test; source bin/lib/node-gate.sh; node_gate_require_node ".github/scripts/issue-ref-gate.js"' 2>&1)"
+got=$?
+absent_ok=1
+[ "$got" = 2 ] || absent_ok=0
+case "$out" in *"node not found"*) ;; *) absent_ok=0 ;; esac
+case "$out" in *"issue-ref-gate.js"*) ;; *) absent_ok=0 ;; esac
+if [ "$absent_ok" = 1 ]; then
+    echo "ok:   node absent is 'cannot run' and names the module it needed"
+else
+    echo "FAIL: node-absent branch (expected exit 2 naming the module, got $got)"
     echo "$out" | sed 's/^/      /'
     fails=$((fails + 1))
 fi

--- a/bin/test-rename-packages.sh
+++ b/bin/test-rename-packages.sh
@@ -740,7 +740,11 @@ ORPH="$TMP/prose-orphan"
 new_fixture "$ORPH"
 plant_prose_guard "$ORPH"
 # Delete the guarded sentence outright - the shape of a branch cut before the sentence was written.
-sed -i '/drop-in replacement/d' "$ORPH/src/docs/README_TEMPLATE.adoc"
+# Not `sed -i`: GNU takes the suffix attached (-i.bak), BSD takes it as the NEXT argument, so the one
+# spelling cannot mean in-place on both. BSD would read the script as the suffix and the file as the
+# script, failing "invalid command code". Rewriting through a temp file is the portable form.
+sed '/drop-in replacement/d' "$ORPH/src/docs/README_TEMPLATE.adoc" > "$ORPH/README_TEMPLATE.tmp"
+mv "$ORPH/README_TEMPLATE.tmp" "$ORPH/src/docs/README_TEMPLATE.adoc"
 (cd "$ORPH" && git add -A && git commit -qm "a branch that never had the guarded sentence")
 
 if grep -q '^src/docs/README_TEMPLATE.adoc|drop-in replacement' "$ORPH/bin/rename-packages.sh"; then

--- a/docs/inflight/ci-bsd-portability-gaps.md
+++ b/docs/inflight/ci-bsd-portability-gaps.md
@@ -1,0 +1,56 @@
+# BSD portability in the agent harness: what is still open after the Mac run
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: blind-spot -->
+
+<!-- post-merge: checked-begin -->
+The hooks in `.claude/hooks/` and the gates in `bin/` were swept for GNU-only constructs, and the
+sweep was then **executed on a Mac** rather than reasoned about
+(astubbs/parallel-consumer#341). The whole `bin/` suite passes there now. What the class *is*, the
+four defects it produced and how to avoid the next one are written up in
+[`docs/solutions/workflow-issues/gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md`](../solutions/workflow-issues/gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md),
+which **owns that knowledge**. This note keeps only what is still open. Delete it when these are
+resolved.
+<!-- post-merge: checked-end -->
+
+## Nothing runs any of this on macOS in CI
+
+**This is the item that matters.** Every lane is ubuntu, so the entire class is caught only when
+somebody happens to be working on a Mac - which is how four live defects survived a deliberate
+sweep, two automated reviews and two human lgtms. The next one will survive the same way.
+
+A `macos-latest` lane running `bin/test-check-*.sh`, `bin/test-rename-packages.sh` and a
+`/bin/bash -n` parse sweep over every tracked script would cost a couple of minutes and close it.
+Not done here because adding a required check is a repo-wide decision, not a side effect of a
+portability fix.
+
+## A latent instance of the bash 3.2 `source` defect
+
+`bin/check-quarantine-registry.sh`, `bin/quarantine-lane-report.sh` and
+`bin/check-quarantine-owners.sh` all run
+
+    source "${BASH_SOURCE[0]%/*}/lib/quarantine-common.sh" 2>/dev/null || source bin/lib/quarantine-common.sh
+
+under `set -e`. On bash 3.2 a failed `source` is fatal, so the `||` fallback is unreachable - the
+same defect fixed in the two node gates, which now test `[ -r ]` before sourcing.
+
+It is **latent, not live**: `${BASH_SOURCE[0]%/*}` resolves for every ordinary invocation, so the
+first `source` succeeds and the dead fallback is never reached. `bin/test-check-quarantine-registry.sh`
+passes on macOS. It becomes real the moment that path stops resolving - and then it fails silently,
+with an exit code that means something else. Left alone here because these three are master-state
+and nothing on this branch touches them.
+
+## Two fixes still have no executing coverage
+
+- `bin/check-branch-self-reference.sh` - the pre-fix `mapfile` version was swapped back in and
+  `bin/test-check-branch-self-reference.sh` still passed 31/31. That suite cannot catch a
+  reintroduced `mapfile` bug on any bash 4+ host. It does at least now *run* on bash 3.2, where it
+  previously failed to parse.
+- `bin/check-pr-ready.sh` - `bin/test-check-pr-ready.sh` holds no `stat` or `mtime` reference at
+  all; it greps the script's source text.
+
+## The "probe, never fall back" reasoning is stated three times
+
+The identical argument is repeated near-verbatim in three files. `bin/AGENTS.md` has the precedent
+for collapsing that - the SIGPIPE class got a named write-up and a CI guard - and the write-up half
+now exists (linked above). The guard half does not.

--- a/docs/solutions/workflow-issues/gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md
+++ b/docs/solutions/workflow-issues/gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md
@@ -1,0 +1,94 @@
+---
+title: "GNU-only shell constructs do not error on BSD - they return a wrong answer, and the gate reports success"
+date: 2026-08-25
+category: workflow-issues
+module: build-system
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+status: "SOLVED for the sites found - the harness was swept, and a real macOS run replaced the reasoning that had stood in for it. The remaining latent site and the missing CI lane are tracked in `docs/inflight/ci-bsd-portability-gaps.md`."
+applies_when:
+  - Writing or reviewing any script under `bin/` or `.claude/hooks/`
+  - A gate passes on Linux and you have not run it on macOS
+  - Reasoning about BSD behaviour from documentation instead of executing it
+  - A self-test suite reports success and you have not checked that it ran
+  - Choosing a regex flavour, an in-place edit, or a way to pass a list into awk
+tags:
+  - portability
+  - bsd
+  - macos
+  - false-negative
+  - shell
+  - gates
+  - observability
+---
+
+# GNU-only constructs fail silently on BSD
+
+## Context
+
+This repo's agent harness is shell: gates under `bin/`, guards under `.claude/hooks/`. It is
+developed and CI-tested on Linux with GNU coreutils, and run by contributors on macOS with BSD
+userland. Over a dozen defects of one shape have now been found in it.
+
+**The shape is not "a flag that errors on the other platform".** That case is harmless - it exits
+non-zero and somebody fixes it. The damaging case is the construct that is *accepted* and means
+something different, or that fails in a way the surrounding script does not check. The script keeps
+running and produces a confident wrong answer.
+
+Four instances, all measured on Darwin 25.5.0 with system bash 3.2.57:
+
+| Construct | What BSD does | What the script then reported |
+|---|---|---|
+| `sed -n 's/\([a-z]\+\)/\1/p'` | `\+` and `\|` are GNU BRE extensions; the expression matches nothing | `bin/check-inflight-tags.sh` extracted **0** documented impacts instead of 17, and printed "N note(s) valid" - half the check dead, success reported |
+| `awk -v x="$(printf '1\n2')"` | rejects a newline in a `-v` assignment, diagnostic on stderr, **exit still 0** | `bin/rename-packages.sh` got an empty frozen-line set, so every file carrying a freeze marker was dropped from the rewrite list and it printed "already applied, nothing to do" over an untouched tree |
+| `source missing.sh \|\| { echo; exit 2; }` under `set -e` | on bash 3.2 a failed `source` is fatal; the `\|\|` arm never runs | `bin/check-file-refs.sh` and `bin/check-issue-refs.sh` died **exit 1 with empty output** - their code for "violations found", so a missing helper accused the tree |
+| `sed -i 's/x/y/' f` | `-i` takes the suffix as the NEXT argument, so the script becomes the suffix | fixture edits silently did not happen; the self-tests then failed against a gate that was fine |
+
+A fifth, adjacent: an apostrophe inside a comment inside `$( ... )` stops bash 3.2 parsing the file
+at all. `bin/test-check-branch-self-reference.sh` exited 2 before any case ran, so its 31 green
+cases on Linux were never evidence about the platform its `mapfile` fix was written for.
+
+## Guidance
+
+**Reasoning about BSD from documentation is not a substitute for running it, and it gets the sign
+wrong in both directions.** The sweep that preceded this run recorded `xargs -r` as a live defect,
+measured by simulating BSD `xargs` on Linux. macOS `xargs` **accepts** `-r`; its man page says the
+flag exists for GNU compatibility and does nothing. The same sweep flagged bare `mktemp -d` as
+probably broken; it works. Two asserted findings, both false, both argued carefully. Meanwhile the
+four real defects above were not on the list at all.
+
+**Prefer the construct both implement, rather than branching on platform.**
+
+- Regex: `sed -E` with a POSIX extended regex. Never `\+`, `\?` or `\|` in a basic regex.
+- In-place edit: read through a temp file and `mv`. There is no `sed -i` spelling that means
+  in-place on both - GNU wants the suffix attached, BSD wants it as the next argument.
+- Passing a list into awk: choose a separator that is not a newline. `-v` cannot carry one on BSD.
+- Loading a helper under `set -e`: test `[ -r "$f" ]` **before** `source`, never `source ... ||`.
+  On bash 3.2 the failed source is fatal and the guard after it is unreachable.
+
+**When you must branch, probe - never fall back.** `stat -c %Y || stat -f %m` is the same defect one
+level up: on GNU, `stat -f` exits 1 *while printing six lines of prose to stdout*, which then flows
+into the arithmetic. Probe once, pick a branch, and validate the value's shape rather than trusting
+the exit code.
+
+**The bash on macOS is 3.2, from 2007.** It is not merely "old bash": it lacks `mapfile`, and its
+`$( ... )` parser does not skip comments, so an apostrophe or an unbalanced paren in a comment
+inside a substitution breaks the file. `/bin/bash -n <file>` over every tracked script is a cheap
+sweep and catches that whole class in one pass.
+
+**Check that the self-test RAN, not that it passed.** Three of the defects above lived inside test
+harnesses, where the failure mode is a suite that reports success having tested nothing - or, for
+the parse error, one that never starts. A test count that has not changed is not proof; on this run
+the count was zero and nothing said so.
+
+## Verification
+
+The whole `bin/` suite now passes on macOS - 15 of 15 `test-check-*.sh`, plus
+`bin/test-rename-packages.sh` and `bin/test-todo-index.sh` - against 11 of 15 and 7 failures
+respectively at the start. Every fix has a control arm on a detached `origin/master` taken at the
+same moment, so "this was already broken" and "I broke this" are distinguished by measurement rather
+than by assumption. All 62 tracked shell scripts parse under bash 3.2.
+
+**No CI lane runs any of this on macOS**, so the whole class is still caught only by somebody
+happening to work on a Mac. That is the open item.


### PR DESCRIPTION
Twelve places where a repo script could not run correctly on macOS, and in most of them the failure was a *silent* success or a confident wrong answer. The unifying defect is not "GNU-only flag": it is **a script that reports "cannot run" as though it were a verdict**.

Seven were found by reading, and are the table below. The other five were found by **running the suite on an actual Mac**, which this branch had never done until now - and that run also refuted two of the findings reading had produced. Reading got the sign wrong in both directions; the second half of this description is the executed part.

## Why this is not cosmetic

`.claude/hooks/check-merge-outstanding-work.sh` exists to refuse `gh pr merge` while a background task from the session is still writing work that belongs in the PR. Its header cites the incident it was written for: astubbs/parallel-consumer#31 merged about ten minutes before a spawned agent finished the broker-level reproduction of confluentinc/parallel-consumer#909 - the exact gap that PR's own description declared open.

On macOS that guard **allowed every merge**, because it dated task files with GNU `stat -c %Y`, BSD stat rejects `-c`, and the code read an unreadable clock as "nothing running".

The hook is explicit about which fail-open cases are deliberate - no session id, no scratch dir, no python3, unparseable JSON. This was not one of them. Those all mean *there is nothing to check*; this one found the evidence and threw it away.

## The sites

| File | Construct | Effect |
|---|---|---|
| `.claude/hooks/check-merge-outstanding-work.sh` | `stat -c %Y` | guard allowed every merge on macOS |
| `bin/check-pr-ready.sh` | `stat -c %Y` | same check, same blind spot |
| `.claude/hooks/remind-inflight-on-push.sh` | `stat -c %Y` | throttle never suppressed a repeat |
| `bin/check-branch-self-reference.sh` | `mapfile` | died, **still exited 0** |
| `bin/test-check-agent-hooks.sh` | `touch -d '@…'` | fixtures kept a current mtime |
| `.claude/hooks/inject-recorded-knowledge.sh` | bare-stdin `paste` | emptied two prior-art lists on macOS |
| `bin/check-issue-refs.sh`, `bin/check-file-refs.sh` | `command -v node` | **a gate that never ran reported a policy violation** |

The `touch -d` one hid four of the others: with the harness unable to age its own fixtures, its failures read as bugs in the scripts under test.

**Before:** `bin/test-check-agent-hooks.sh` reported **10 failures** on macOS.
**After:** it passes 159 cases with 0 failures, measured on macOS and green on CI's ubuntu.

## The node gates: exit 1 means "you broke policy", not "my environment is broken"

Both gates guarded with `command -v node`, which proves node is *present* and says nothing about whether it can *run*. When `NODE_OPTIONS` carries a `--require` naming a file that no longer exists - an agent harness writes a preload into a temp directory, the directory is later cleaned up - every node process dies during preload, before one line of the gate executes. node's status for that is **1**, and both scripts reserve 1 for "violations found".

So a gate that checked nothing accused the tree, and because both also run from the pre-commit hook it presented as a commit blocked by two policy failures that did not exist. Both scripts already documented `2 = cannot run`; the guard simply never reached it.

The probe now **loads the gate module** rather than merely starting node, so "node cannot start" and "the module cannot be parsed" both land on 2 instead of the second masquerading as a finding. It runs only on the failure path - an unconditional `node -e ''` would cost ~90ms per gate against the pre-commit hook's ~1.5s budget, and probing after a non-zero result is the stronger check anyway, since an upfront probe only proves node worked a moment *before* the run.

## Three decisions worth reviewing

**The guards fail closed.** A file that matched the session's tasks glob but cannot be dated counts as live, and the refusal message says the mtime was unreadable rather than implying a reading it does not have. Being unable to read a clock is not evidence that nothing is running.

**Platform detected by probing, never by falling back.** A blind `stat -c %Y || stat -f %m` would be the same defect one level up - and the measured reason is worse than the one this description used to give. On GNU, `stat -f %m FILE` does **not** return a filesystem number: it exits 1 while printing six lines of prose to stdout. That prose reaches `$(( now - mtime ))`, `set -u` aborts the hook, and `PreToolUse` reads a non-zero exit with no verdict as a non-blocking error - so the guard allows the merge. The helper probes `stat -c` once and picks a branch, and the fail-closed arm now tests the value's *shape*, because `stat` can fail and still print.

**Guards are inlined; gates share through `bin/lib/`.** For the `PreToolUse` guards, sourcing a helper adds a failure mode where the helper cannot be found, and a guard that cannot load its dependency fails open again - four repeated lines beat a new way to pass silently. The node preflight is different: `bin/check-issue-refs.sh` and `bin/check-file-refs.sh` are gates, not guards, so a load failure is visible rather than silently permissive, and one shared `bin/lib/node-gate.sh` beats two drifting copies of a verdict rule. It still has to fail closed like everything else here: `source` returns 1 for a file it cannot read, and under `set -e` that became the script's own "violations found" code, so a missing helper accused the tree. Both gates now exit 2 and name the helper.

## Scope, and what the sweep missed

Found while babysitting astubbs/parallel-consumer#57; master-state rather than that PR's, so it is here on its own branch.

The sweep covered every tracked `*.sh` for `stat -c`, `mapfile`, `readarray`, `grep -P`, `date -d`, `readlink -f`, `sed -i`, `touch -d` and bare-stdin `paste`. The `sed -i ''` occurrences are the BSD form and are correct; `.claude/hooks/check-upstream-map-merged.sh` was checked and is clean, since it dates nothing.

**This description previously disclosed a further site the sweep had missed - `xargs -r` in `.claude/hooks/inject-recorded-knowledge.sh` - and the macOS run refuted it.** That claim was measured by simulating BSD `xargs` on Linux, and the simulation was wrong: macOS `xargs` **accepts** `-r`. Its man page says so outright, that the flag exists "for command-line compatibility with GNU xargs, but the -r option does nothing", because BSD `xargs` already declines to run on empty input. The cross-check agreed rather than contradicting - on macOS the hook prints the full 13-entry Registers section with its "Not shown above" list intact. There was no such site, so the finding and its disclosure are both deleted.

A second unproven worry died the same way: bare `mktemp -d` and bare `mktemp`, which about twenty `bin/` scripts use including the copyright gate, **both succeed** on BSD. Modern BSD `mktemp` supplies a default template.

## Verification

Every fix has a red control - the assertion was run against the *unfixed* script and shown to fail first. The node self-test cases were shown reporting "expected exit 2, got 1" against master's version; the missing-helper cases likewise. The self-test suite was also made immune to the fault it asserts on, after it inherited a stale ambient `NODE_OPTIONS` and reported 8 failures that had nothing to do with the gate - the same defect one level up, and worse there, because a red suite reads as "your fix is broken" rather than "your environment is".

**It has now run on a Mac** - Darwin 25.5.0 arm64, system `bash` 3.2.57, with no GNU coreutils installed at all, so `sed`, `awk`, `grep`, `stat`, `paste`, `xargs` and `mktemp` already resolve to `/usr/bin` under the ordinary `PATH`. No pinning was needed to reach BSD userland; there is none to strip on this host.

**The headline claim holds, executed rather than reasoned**: `bin/test-check-agent-hooks.sh` passes **159 cases, 0 failures**. But running the *whole* suite rather than only that script found **four more defects**, none of which any amount of reading had surfaced. Each is fixed here, and each is measured against a detached `origin/master` taken at the same moment, so "already broken" and "broken by this branch" are distinguished by control arm rather than by assumption.

| Defect | What it actually reported | Whose |
|---|---|---|
| `source … \|\| { …; exit 2; }` under `set -e` - on bash 3.2 a failed `source` is fatal, so the guard arm never runs | both node gates died **exit 1 with empty output**, their code for "unqualified references found" - the exact false accusation the guard exists to prevent | **this branch's**, the guard and its test are new here |
| `sed -n 's/…\\+…\\\|…/\1/p'` in `bin/check-inflight-tags.sh` - `\+` and `\|` are GNU BRE extensions BSD does not implement | extracted **0** documented impacts instead of 17, and printed "N note(s) valid". Half the doc-and-lib agreement check dead, success reported | master-state |
| `awk -v frozen="1\n2"` in `bin/rename-packages.sh` - BSD awk rejects a newline in `-v`, on stderr, **exit still 0** | empty frozen set, so every file carrying a freeze marker was dropped from the rewrite list and it printed **"already applied, nothing to do"** over an untouched tree | master-state |
| GNU `sed -i` in two self-test fixtures | fixture edits silently did not happen, so the tests failed against gates that were fine | master-state |

Plus one that is not a wrong answer but a file bash cannot read: an **apostrophe inside a comment inside `$( … )`** stops bash 3.2 parsing, so `bin/test-check-branch-self-reference.sh` exited 2 before a single case ran. Its 31 green cases on Linux were never evidence about the platform its `mapfile` fix was written for.

The `rename-packages.sh` one is the one worth a second look: `AGENTS.md` binds every agent merging any branch to run that script, the fork-wide package migration depends on it, and on a Mac its freeze regions - the thing that keeps migration prose naming the old package on purpose - were not merely ignored but inverted, since the files they protect were the files that stopped being processed.

**Result on macOS: 15 of 15 `bin/test-check-*.sh` pass** (was 11), `bin/test-rename-packages.sh` passes in full (was 7 failures), and all 62 tracked shell scripts parse under bash 3.2 (was 61).

### Two follow-ups from review, also here

**The duplicate-code report's larger clone is gone.** The bash 3.2 `source` fix had grown the block shared by `bin/check-file-refs.sh` and `bin/check-issue-refs.sh` from 16 identical lines to 22. Eight of those were the `command -v node` preflight, duplicated for no reason — `bin/lib/node-gate.sh` is sourced by that point and its header already explains why a present node is not a runnable node — so it became `node_gate_require_node`. Three more were a paragraph of reasoning copied into both callers, which moved into the helper's header with a one-line pointer left behind. Longest identical run: 22 lines to 16. The remaining 16 are `set -euo pipefail`, the `cd`, and the readability-tested source itself — the bootstrap, which cannot live in the shared helper it exists to load.

The report's other clone, the 13-line `unreadable verdict helper` case duplicated across the two self-tests, is **declined rather than overlooked**: extracting it means each test sources a new shared file, and doing that safely on bash 3.2 needs the same eight-line `[ -r ]` bootstrap, so the trade is 13 duplicated lines for 8 plus a new file plus a new failure mode, across two suites whose independence is the point.

**The node-absent branch now has a test.** Every prior node case broke a node that *exists*, via a poisoned `NODE_OPTIONS`; nothing exercised "not installed". That was survivable as eight inlined lines per gate and stopped being so once it became one shared function behind both. The case calls the function directly with `PATH` pointed at a non-existent directory, so it needs no external command and cannot be fooled by where node lives — the naive `PATH=/usr/bin` version would pass on macOS and silently assert nothing on a runner that keeps node in `/usr/bin`. Shown red against the old helper (127, `command not found`) before green against the new (2, naming the module).

The class now has the `docs/solutions/` write-up it had been missing, with the construct to reach for in each case. `docs/inflight/ci-bsd-portability-gaps.md` shrinks to what is still open - chiefly that **no CI lane runs any of this on macOS**, which is how four live defects survived a deliberate sweep, two automated reviews and two lgtms. Adding a `macos-latest` lane is a repo-wide decision rather than a side effect of this PR, so it is recorded, not done.

## Checklist

- [x] Changelog entry added - **N/A**: `AGENTS.md` forbids a PR adding changelog entries; the section is generated at release from commit messages.
- [x] Docs updated - the class now has a `docs/solutions/` write-up (`gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md`) with the four measured defects and the construct to use instead in each case; `docs/inflight/ci-bsd-portability-gaps.md` shrinks to what is still open. No user-facing behaviour changed, so no README or user-doc edit.
- [x] Tests added/updated - `bin/test-check-agent-hooks.sh` now runs correctly on BSD (10 failures to 0, 159 cases green); `bin/test-check-issue-refs.sh` and `bin/test-check-file-refs.sh` gain cases for the cannot-run and missing-helper paths, each shown red against the unfixed script. The macOS run then took the whole `bin/` suite from 11/15 to **15/15**, and `bin/test-rename-packages.sh` from 7 failures to 0, each against an `origin/master` control.
- [x] Other instances of the same defect - swept the whole tree at merge prep across twelve construct families, and the sweep is reported rather than summarised. Clean: `date -d`, `touch -d`, `grep -P`, GNU BRE `\+`/`\?`/`\|` outside `sed -E`, and all 62 tracked scripts parse under bash 3.2. Ruled out with a reason: every surviving `stat -c` sits in a probed GNU arm; every `paste` passes an explicit `-` operand; the remaining `sed -i` hits are comments and one heredoc fixture; `mapfile` survives only in a comment forbidding it; both `awk -v` frozen-set callers go through the fixed comma-separated producer. Real hits: three quarantine scripts carry the `source`-under-`set -e` shape and are **latent, not live** (`${BASH_SOURCE[0]%/*}` resolves for every ordinary invocation, and `bin/test-check-quarantine-registry.sh` passes on macOS) - master-state, recorded in `docs/inflight/ci-bsd-portability-gaps.md` rather than changed here. Two further `source ... || exit` sites (`bin/check-inflight-tags.sh`, `.claude/hooks/inject-recorded-knowledge.sh`) were checked and are **not** the defect: both run under `set -uo pipefail` with no `-e`, so their fallbacks are reachable.



