### PR TITLE
perf(core): give external engines the pipeline buffer, and the dispatch ceiling that bounds it

### DIFF
--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -253,9 +253,13 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     // transitions are driven from inside this class, and a subclass setting it arbitrarily is the shape of bug this
     // class has spent astubbs#296 hardening against. Reading is protected because a subclass may legitimately want
     // to know whether it is still running. Both are used only by this package's tests today.
+    // volatile because it is no longer read only by the thread that writes it: ExternalEngine's dispatch
+    // thread blocks on the external dispatch ceiling and reads this to learn that a close has begun. That is a
+    // plain flag with no lock to name, so `volatile` is the whole fix and there is no @GuardedBy to write - see
+    // parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md.
     @Setter(AccessLevel.PACKAGE)
     @Getter(PROTECTED)
-    private State state = State.UNUSED;
+    private volatile State state = State.UNUSED;
 
     /**
      * Wrapped {@link ConsumerRebalanceListener} passed in by a user that we can also call on events

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ExternalEngine.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ExternalEngine.java
@@ -5,26 +5,94 @@ package bz.stub.parallelconsumer.internal;
  * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
+import bz.stub.parallelconsumer.ParallelConsumer;
 import bz.stub.parallelconsumer.ParallelConsumerOptions;
 import bz.stub.parallelconsumer.PollContextInternal;
 import bz.stub.parallelconsumer.state.WorkContainer;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import pl.tlinkowski.unij.api.UniLists;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static bz.stub.parallelconsumer.internal.utils.StringUtils.msg;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * Overrides key aspects required in common for other threading engines like Vert.x and Reactor
+ * Overrides key aspects required in common for other threading engines like Vert.x and Reactor.
+ * <p>
+ * <b>The pipeline buffer, and the ceiling that has to bound it.</b> External engines request the same pipelined
+ * target as core - {@code getQueueTargetLoaded()}, the in-flight target times the load factor - NOT merely the
+ * shortfall against records in flight. That buffer is what removes a whole control-loop iteration from the path
+ * between one record completing and the next being dispatched.
+ * <p>
+ * From 0.4.0.0 to 0.6.0.0 a {@code getTargetOutForProcessing()} override cut the request to only
+ * {@code getTargetAmountOfRecordsInFlight()}, on the reasoning that there is no executor pool here to pipeline into.
+ * The reasoning confused the pool with the pipeline - but deleting the override on its own is not enough either,
+ * because <b>for an external engine there is nowhere for a buffer to wait</b>: the single dispatch thread hands every
+ * record it is given straight to the async engine and returns, so records taken from the work manager become records
+ * concurrently in flight in the user's engine. Requesting the pipelined target and nothing else therefore puts the
+ * buffer THROUGH the ceiling rather than behind it, and {@code maxConcurrency} is breached by the load factor.
+ * <p>
+ * So the buffer is kept and a hard ceiling is placed where an external engine actually needs one - at dispatch.
+ * {@link #runUserFunction} takes one permit per record from a semaphore sized at
+ * {@link ParallelConsumerOptions#getTargetAmountOfRecordsInFlight()} and blocks the dispatch thread until capacity
+ * exists; {@link #addToMailbox} returns the permit when the record's flight ends. The surplus the pipelined request
+ * pulled in then waits in the worker pool's queue - behind the ceiling, exactly where core's buffer waits - and the
+ * next dispatch is driven by an async completion rather than by the next control-loop iteration, which is where the
+ * throughput comes from.
+ * <p>
+ * Measured on the Reactor engine in the regime this exists for - short work, low ceiling, so the control loop and
+ * not the work is the limit: 2ms per record, {@code maxConcurrency} 100, 50,000 records, four runs an arm.
+ * 25,303-27,144 msg/s with the 0.4.0.0 override; 28,011-29,691 msg/s with the buffer and this gate, about +11%, at
+ * a peak in flight of exactly 100 in both. The buffer WITHOUT the gate reads 34,435-36,954 msg/s and peaks at 200 -
+ * so most of that larger number is the ceiling being breached rather than the pipeline being filled, and it is not
+ * a throughput this library may offer. Reactor and Mutiny peak at 1.5-1.95x {@code maxConcurrency} without the
+ * gate; Vert.x does not, because its WebClient connection pool is a second ceiling of its own, which is why an
+ * earlier Vert.x-only benchmark read the ungated buffer as safe for every engine. The version-by-version bisection
+ * of the original regression is on astubbs/parallel-consumer#363 - cited as the PR rather than as its
+ * {@code docs/inflight/} note, which lives only on that branch and would dangle from here whichever merges first.
  */
 @Slf4j
 public abstract class ExternalEngine<K, V> extends AbstractParallelEoSStreamProcessor<K, V> {
+
+    /**
+     * How long a blocked dispatch waits before re-checking whether the controller is shutting down. It only bounds
+     * how long a close can be delayed by a dispatch waiting on capacity - it is not a dispatch latency, because a
+     * returning permit wakes the waiter immediately.
+     */
+    private static final long DISPATCH_CAPACITY_SHUTDOWN_POLL_MS = 100;
+
+    /**
+     * The hard ceiling on records dispatched into the external engine at once. Sized at
+     * {@link ParallelConsumerOptions#getTargetAmountOfRecordsInFlight()}, which is
+     * {@code maxConcurrency x batchSize} - so a whole batch always fits and a full batch can never deadlock itself.
+     */
+    private final Semaphore dispatchCeiling;
+
+    /**
+     * The records currently holding a permit, by IDENTITY - {@link WorkContainer#equals} is offset-based, and two
+     * generations of the same offset are different flights. Membership is what makes the return idempotent: a
+     * completion signal delivered more than once for one record (a user {@code Publisher} that emits several
+     * elements reaches the mailbox once per element) must not hand back a permit it does not hold, or the ceiling
+     * would ratchet upwards for the life of the process.
+     */
+    private final Set<WorkContainer<K, V>> holdingDispatchPermit =
+            Collections.newSetFromMap(Collections.synchronizedMap(new IdentityHashMap<>()));
 
     protected ExternalEngine(final ParallelConsumerOptions<K, V> newOptions) {
         super(newOptions);
 
         validate(options);
+
+        this.dispatchCeiling = new Semaphore(options.getTargetAmountOfRecordsInFlight());
     }
 
     private void validate(ParallelConsumerOptions options) {
@@ -33,17 +101,13 @@ public abstract class ExternalEngine<K, V> extends AbstractParallelEoSStreamProc
         }
     }
 
-    /**
-     * @return the number of records to try to get, based on the current count of records outstanding - but unlike core,
-     *         we don't pipeline messages into the executor pool for processing.
-     */
-    protected int getTargetOutForProcessing() {
-        return getOptions().getTargetAmountOfRecordsInFlight();
-    }
-
     @Override
     protected void checkPipelinePressure() {
-        // no-op - as calculateQuantityToRequest does not use a pressure system, unlike the core module
+        // Deliberately still a no-op: the load factor stays at its initial value, so the pipelined request - and
+        // therefore the queue of records waiting on a dispatch permit - is bounded at initialLoadFactor x the
+        // in-flight target. The patch experiment's second arm showed the BUFFER is the recovery and the pressure
+        // system's stepping adds nothing on top for these engines; letting it step would only deepen the wait queue
+        // and the memory held behind the ceiling, never the concurrency, which #dispatchCeiling fixes.
     }
 
     /**
@@ -56,6 +120,72 @@ public abstract class ExternalEngine<K, V> extends AbstractParallelEoSStreamProc
     @Override
     protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
         return super.setupWorkerPool(1);
+    }
+
+    /**
+     * Enforces the external dispatch ceiling: no record reaches the user's async engine until a permit is free.
+     * <p>
+     * This is the whole reason the pipelined request is safe here. The control loop deliberately takes more work
+     * than {@code maxConcurrency} so a buffer exists; this is the point at which that surplus stops, on the single
+     * dispatch thread, and waits for an in-flight record to finish rather than being handed to the engine as extra
+     * concurrency.
+     */
+    @Override
+    protected <R> List<ParallelConsumer.Tuple<ConsumerRecord<K, V>, R>> runUserFunction(Function<PollContextInternal<K, V>, List<R>> usersFunction,
+                                                                                        Consumer<R> callback,
+                                                                                        List<WorkContainer<K, V>> workContainerBatch) {
+        if (!takeDispatchCapacity(workContainerBatch)) {
+            // Same disposition as a submission the pool rejects while shutting down: the batch is dropped
+            // uncommitted, so it is redelivered after the rebalance. No permit was taken, so none is owed.
+            return UniLists.of();
+        }
+        return super.runUserFunction(usersFunction, callback, workContainerBatch);
+    }
+
+    /**
+     * Returns the permit taken for this record. Every route a record can leave its flight by - async success, async
+     * failure, a synchronous throw from the user function, and stale work skipped before it ever ran - funnels
+     * through here, which is why the permit is returned here rather than in any one of them.
+     */
+    @Override
+    protected void addToMailbox(PollContextInternal<K, V> pollContext, WorkContainer<K, V> wc) {
+        try {
+            super.addToMailbox(pollContext, wc);
+        } finally {
+            if (holdingDispatchPermit.remove(wc)) {
+                dispatchCeiling.release();
+            }
+        }
+    }
+
+    /**
+     * @return false if the controller is shutting down and the batch must not be dispatched
+     */
+    private boolean takeDispatchCapacity(List<WorkContainer<K, V>> batch) {
+        int records = batch.size();
+        while (true) {
+            try {
+                if (dispatchCeiling.tryAcquire(records, DISPATCH_CAPACITY_SHUTDOWN_POLL_MS, MILLISECONDS)) {
+                    // Registered before the user function runs, so a completion that fires immediately still finds
+                    // the record here to hand its permit back for.
+                    holdingDispatchPermit.addAll(batch);
+                    return true;
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.debug("Interrupted waiting for external dispatch capacity, dropping {} record(s) for redelivery", records);
+                return false;
+            }
+            if (isShuttingDown()) {
+                log.debug("Shutting down ({}) while waiting for external dispatch capacity, dropping {} record(s) for redelivery", getState(), records);
+                return false;
+            }
+        }
+    }
+
+    private boolean isShuttingDown() {
+        State current = getState();
+        return current == State.CLOSING || current == State.CLOSED;
     }
 
     /**

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ExternalEnginePipelineBufferTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ExternalEnginePipelineBufferTest.java
@@ -1,0 +1,201 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import bz.stub.parallelconsumer.PollContextInternal;
+import bz.stub.parallelconsumer.state.WorkContainer;
+import bz.stub.parallelconsumer.state.WorkManager;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniLists;
+import pl.tlinkowski.unij.api.UniMaps;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Pins the two halves of {@link ExternalEngine}'s pipeline buffer, which are only safe together: the request formula
+ * it deliberately inherits rather than overrides - an external engine asks the work manager for the PIPELINED target,
+ * not merely the shortfall against records in flight - and the hard dispatch ceiling that keeps that surplus BEHIND
+ * {@code maxConcurrency} instead of through it. Why each is the right shape, and the regression each direction
+ * caused, is on {@link ExternalEngine} itself - not restated here, so the two cannot drift.
+ */
+@Slf4j
+class ExternalEnginePipelineBufferTest {
+
+    static final String TOPIC = "topic";
+    static final int PARTITION = 0;
+
+    /**
+     * The smallest possible concrete engine - the abstract surface, and nothing else.
+     * <p>
+     * {@code async} models what every real external engine does: the user function returns as soon as the async work
+     * is handed to the engine, so nothing retires itself and retirement is driven by whatever signals completion.
+     * Here that is the test, through {@link #retire}, which is the same {@code addToMailbox} call the Reactor,
+     * Mutiny and Vert.x completion handlers make.
+     */
+    static class BareExternalEngine extends ExternalEngine<String, String> {
+
+        private final boolean async;
+
+        BareExternalEngine(PCModuleTestEnv module, boolean async) {
+            super(module.options());
+            this.async = async;
+        }
+
+        @Override
+        protected boolean isAsyncFutureWork(List<?> resultsFromUserFunction) {
+            return async;
+        }
+
+        void setWm(WorkManager<String, String> wm) {
+            super.wm = wm;
+        }
+
+        void retire(WorkContainer<String, String> wc) {
+            addToMailbox(new PollContextInternal<>(UniLists.of(wc)), wc);
+        }
+    }
+
+    private static BareExternalEngine engineWithMaxConcurrency(int maxConcurrency) {
+        return new BareExternalEngine(new PCModuleTestEnv(ParallelConsumerOptions.<String, String>builder()
+                .maxConcurrency(maxConcurrency)
+                .build()), false);
+    }
+
+    @Test
+    void anExternalEngineRequestsThePipelineBufferNotJustTheShortfall() {
+        var engine = engineWithMaxConcurrency(100);
+
+        int inFlightTarget = engine.getOptions().getTargetAmountOfRecordsInFlight();
+        int requested = engine.calculateQuantityToRequest();
+
+        assertWithMessage("with nothing in flight, the request must be the loaded queue target - the in-flight "
+                + "target times the load factor - so a buffer of ready work sits behind the ceiling")
+                .that(requested).isEqualTo(engine.getQueueTargetLoaded());
+        assertWithMessage("the buffer must actually be a buffer: strictly more than the in-flight target, which "
+                + "is all the 0.4.0.0..0.6.0.0 override ever requested")
+                .that(requested).isGreaterThan(inFlightTarget);
+    }
+
+    @Test
+    void thePressureSystemStaysDisabledSoTheBufferIsBoundedAtTheInitialFactor() {
+        var engine = engineWithMaxConcurrency(100);
+
+        int before = engine.getQueueTargetLoaded();
+        // core steps the factor here when the pool queue runs low; external engines keep it a no-op, so the
+        // request target must not grow however often pressure is checked
+        for (int i = 0; i < 50; i++) {
+            engine.checkPipelinePressure();
+        }
+        assertThat(engine.getQueueTargetLoaded()).isEqualTo(before);
+    }
+
+    /**
+     * The half the request formula cannot supply on its own.
+     * <p>
+     * An external engine hands every record it is given straight to the user's async engine and returns, so without
+     * this gate the pipelined request IS the concurrency and {@code maxConcurrency} is breached by the load factor -
+     * measured at 1.52-1.95x on Reactor and 1.80-1.93x on Mutiny, three runs each, before the gate existed. The
+     * buffer must still be real,
+     * so this asserts both directions at once: strictly more records taken and counted out for processing than the
+     * ceiling, and never more than the ceiling actually dispatched.
+     */
+    @Test
+    void dispatchIsCappedAtTheCeilingWhileTheBufferWaitsBehindIt() throws InterruptedException {
+        int ceiling = 4;
+        int taken = 3 * ceiling;
+
+        var module = new PCModuleTestEnv(ParallelConsumerOptions.<String, String>builder()
+                .maxConcurrency(ceiling)
+                .build());
+        var wm = module.workManager();
+        var tp = new TopicPartition(TOPIC, PARTITION);
+        wm.onPartitionsAssigned(UniLists.of(tp));
+
+        var engine = new BareExternalEngine(module, true);
+        engine.setWm(wm);
+        engine.setState(State.RUNNING);
+
+        var entered = new AtomicInteger();
+        // one latch per interesting count, so every wait is bounded and no test needs a sleep to be meaningful
+        var reachedCeiling = new CountDownLatch(ceiling);
+        var wentOverCeiling = new CountDownLatch(ceiling + 1);
+        var reachedCeilingAgain = new CountDownLatch(ceiling + 2);
+        Function<PollContextInternal<String, String>, List<Object>> dispatchProbe = context -> {
+            entered.incrementAndGet();
+            reachedCeiling.countDown();
+            wentOverCeiling.countDown();
+            reachedCeilingAgain.countDown();
+            // async work: the engine keeps it in flight until something signals completion
+            return UniLists.of(new Object());
+        };
+        Consumer<Object> callback = ignore -> {
+        };
+
+        try {
+            var work = takeWork(wm, taken);
+            assertWithMessage("fixture: the buffered take must be bigger than the ceiling, or this proves nothing")
+                    .that(taken).isGreaterThan(ceiling);
+
+            engine.submitWorkToPool(dispatchProbe, callback, work);
+
+            assertWithMessage("the engine must dispatch up to its ceiling without waiting for a control loop pass")
+                    .that(reachedCeiling.await(10, SECONDS)).isTrue();
+            assertWithMessage("dispatch must stop AT the ceiling - the buffered surplus waits, it is not extra "
+                    + "concurrency handed to the user's engine")
+                    .that(wentOverCeiling.await(500, MILLISECONDS)).isFalse();
+            assertWithMessage("and the surplus really is buffered: taken from the work manager and counted out for "
+                    + "processing, which is what the pipelined request bought")
+                    .that(wm.getNumberRecordsOutForProcessing()).isEqualTo(taken);
+
+            // a completion is what frees a slot - not the next control loop pass, which is where the throughput is
+            engine.retire(work.get(0));
+            engine.retire(work.get(1));
+
+            assertWithMessage("a retired record must hand its slot straight to the next buffered one")
+                    .that(reachedCeilingAgain.await(10, SECONDS)).isTrue();
+            assertWithMessage("two slots freed means exactly two more dispatched, never the whole backlog")
+                    .that(entered.get()).isEqualTo(ceiling + 2);
+        } finally {
+            engine.setState(State.CLOSED);
+            engine.close();
+            engine.workerThreadPool.get().shutdownNow();
+        }
+    }
+
+    /**
+     * Takes work exactly as the control loop does, so every container really is in flight and really is counted.
+     * <p>
+     * A key per record: the default ordering is KEY, so sharing one would serialise them and only the first would
+     * ever be selectable.
+     */
+    private List<WorkContainer<String, String>> takeWork(WorkManager<String, String> wm, int count) {
+        var records = new ArrayList<ConsumerRecord<String, String>>();
+        for (int i = 0; i < count; i++) {
+            records.add(new ConsumerRecord<>(TOPIC, PARTITION, i, "key-" + i, "value"));
+        }
+        var tp = new TopicPartition(TOPIC, PARTITION);
+        wm.registerWork(new EpochAndRecordsMap<>(new ConsumerRecords<>(UniMaps.of(tp, records)), wm.getPm()));
+
+        var taken = wm.getWorkIfAvailable(count);
+        assertWithMessage("fixture: all %s records must be taken as work", count)
+                .that(taken).hasSize(count);
+        return taken;
+    }
+}

--- a/parallel-consumer-reactor/src/main/java/bz/stub/parallelconsumer/reactor/ReactorProcessor.java
+++ b/parallel-consumer-reactor/src/main/java/bz/stub/parallelconsumer/reactor/ReactorProcessor.java
@@ -100,7 +100,16 @@ public class ReactorProcessor<K, V> extends ExternalEngine<K, V> {
                     .flatMapMany(it -> it)
                     .doOnNext(signal -> log.trace("doOnNext {}", signal))
                     .subscribeOn(getScheduler())
-                    .subscribe(ignore -> onComplete(pollContext), throwable -> onError(pollContext, throwable));
+                    // Three arguments, not two, and that is load-bearing. The two-argument overload has no
+                    // completion callback, so onComplete was wired as the ON NEXT consumer: a Publisher emitting
+                    // several elements retired its records once per element, and one completing EMPTY - Mono.empty(),
+                    // or a user function returning null - retired them never, leaving the record uncommitted, its
+                    // in-flight accounting leaked, and (since the dispatch ceiling landed) its dispatch permit gone
+                    // for the life of the process. Retiring on the terminal signal is once per flight in every case.
+                    // MutinyProcessor's subscribe().with(onItem, onFailure, onCompletion) already had this shape.
+                    .subscribe(signal -> log.trace("Reactor element {}", signal),
+                            throwable -> onError(pollContext, throwable),
+                            () -> onComplete(pollContext));
 
             log.trace("asyncPoll - user function finished ok.");
             return UniLists.of(flux);

--- a/parallel-consumer-reactor/src/test/java/bz/stub/parallelconsumer/reactor/ReactorPCTest.java
+++ b/parallel-consumer-reactor/src/test/java/bz/stub/parallelconsumer/reactor/ReactorPCTest.java
@@ -71,6 +71,33 @@ class ReactorPCTest extends ReactorUnitTestBase {
                 });
     }
 
+    /**
+     * A user function may legitimately have nothing to emit - {@code Mono.empty()}, or a {@code null} the wrapper
+     * turns into an empty sequence - and the record still has to retire.
+     * <p>
+     * It did not. {@code onComplete} was wired as the subscriber's ON NEXT consumer, so an empty sequence fired
+     * neither it nor {@code onError}: the record never reached the mailbox, its offset was never committed, its
+     * in-flight accounting leaked, and once {@link bz.stub.parallelconsumer.internal.ExternalEngine} gained a
+     * dispatch ceiling, its permit leaked too - which turns a stuck record into a wedged engine.
+     * <p>
+     * More records than {@code maxConcurrency} is the whole point of the quantity here: a per-record leak only
+     * becomes a stall once it has consumed every permit, so a handful of records would pass against the defect.
+     */
+    @SneakyThrows
+    @Test
+    void anEmptyPublisherStillRetiresTheRecord() {
+        var quantity = MAX_CONCURRENCY + (MAX_CONCURRENCY / 2);
+        ktu.send(consumerSpy, ktu.generateRecords(quantity - 1)); // -1 coz already has 1 record primed (all tests do)
+
+        reactorPC.react(recordContext -> Mono.empty());
+
+        await()
+                .atMost(defaultTimeout)
+                .untilAsserted(() -> assertThat(consumerSpy)
+                        .hasCommittedToPartition(topicPartition)
+                        .atLeastOffset(quantity));
+    }
+
     @SneakyThrows
     @Test
     void concurrencyTest() {


### PR DESCRIPTION
## Description

**External engines get their pipeline buffer back - and, for the first time, a hard ceiling on what they dispatch. `maxConcurrency` is enforced at the point an external engine actually breaches it, and the recovered throughput is what remains once it is.**

Two defects were found and fixed while building that ceiling: the ceiling itself (Codex P1, reproduced locally), and a Reactor completion gap the ceiling turns from a stuck record into a wedged engine (found by the automated review).

Since 0.4.0.0, `ExternalEngine` overrode `getTargetOutForProcessing()` down to the bare in-flight target, reasoning that there is no executor pool to pipeline into. The reasoning confused the pool with the pipeline: without a buffer, every completion costs one control-loop iteration before the next record can dispatch - once the ceiling is full the request is roughly zero and the engine drip-feeds. astubbs/parallel-consumer#363 bisected that regression version by version and root-caused it to exactly this.

**Deleting the override is necessary and, on its own, unsafe** - which is what this PR now says, and its first version did not. For an external engine there is nowhere for a buffer to wait: the single dispatch thread hands every record it is given straight to the async engine and returns, so records taken from the work manager *become* records concurrently in flight in the user's engine. Requesting the pipelined target and nothing else puts the buffer **through** the ceiling rather than behind it, and `maxConcurrency` is breached by the load factor. Found by a local controlled run and independently by Codex's P1 on this PR.

### What changed

- **The `getTargetOutForProcessing()` override is deleted**, so external engines inherit core's `getQueueTargetLoaded()` - the in-flight target times the load factor. That is the buffer.
- **A hard dispatch ceiling is added where an external engine needs one - at dispatch.** `runUserFunction` takes one permit per record from a semaphore sized at `getTargetAmountOfRecordsInFlight()` (`maxConcurrency x batchSize`, so a whole batch always fits and cannot deadlock itself) and blocks the dispatch thread until capacity exists. `addToMailbox` returns the permit when the record's flight ends - every route out of a flight funnels through it (async success, async failure, a synchronous throw from the user function, and stale work skipped before it ever ran), which is why the permit is returned there rather than in any one of them. The return is idempotent by **identity**, so a user `Publisher` that emits several elements - which reaches the mailbox once per element - cannot ratchet the ceiling upwards.
- The surplus the pipelined request pulled in waits in the worker pool's queue, behind the ceiling, exactly where core's buffer waits. **The next dispatch is driven by an async completion rather than by the next control-loop pass, which is where the throughput comes from** - the gate does not put the drip-feed back.
- `checkPipelinePressure()` stays a no-op, so the buffer is bounded at `initialLoadFactor x` the in-flight target.
- **`AbstractParallelEoSStreamProcessor.state` becomes `volatile`**, in the same commit as the ceiling: the blocked dispatch thread reads it to learn a close has begun, which is the first read of that field from outside the control thread, and the engine's own `AGENTS.md` requires the invariant be recorded in the change that introduces the access. A plain flag with no lock to name, so `volatile` is the whole fix and there is no `@GuardedBy` to write.

The gate covers all three engines that ride `ExternalEngine` (Vert.x, Reactor, Mutiny) - none of them overrides `runUserFunction`, `submitWorkToPool` or `addToMailbox`, so there is no way past it.

### The gap the gate exposed, in `ReactorProcessor`

`ReactorProcessor` subscribed with the **two**-argument `Flux.subscribe(onNext, onError)`, which has no completion callback - so `onComplete(pollContext)`, the method that retires a record, was wired as the **onNext** consumer. Two pre-existing defects follow:

- a `Publisher` emitting **several elements** retired its records once per element, so one container reached the mailbox repeatedly and decremented `numberRecordsOutForProcessing` once per emission - the counter drift `WorkManager#isSufficientlyLoaded`'s own comment names as the silent-stall signature;
- a `Publisher` completing **empty** - `Mono.empty()`, or a user function returning `null`, both legitimate ways to say "nothing to emit" - fired neither callback, so the record never retired: uncommitted, and permanently counted in flight.

The dispatch ceiling raises the second from a stuck record to a wedged engine, because the record's permit is never returned either. It is fixed here rather than tracked, with the **three**-argument `subscribe(onNext, onError, onComplete)`: Reactive Streams delivers exactly one terminal signal, `onComplete` or `onError`, so a record retires once per flight in every case. `MutinyProcessor` already had this shape (`subscribe().with(onItem, onFailure, onCompletion)`); Vert.x is unaffected, because `Future.onSuccess`/`onFailure` resolve exactly once with no zero-element case.


### Commit structure

Two commits, neither broken at any point, so a bisect never lands on a known regression:

1. `perf(core) astubbs#342: restore the pipeline buffer to external engines, bounded by a dispatch ceiling` - the buffer and the ceiling that bounds it are one change, because the buffer is unsafe without the ceiling. Builds and passes `ExternalEnginePipelineBufferTest` and the whole reactor unit suite on its own.
2. `fix(reactor) astubbs#342: retire a record on the terminal signal, not on each element` - a distinct correctness defect in a different module, older than this PR, that the ceiling only made fatal. It gets its own release-note line.

### Verification

**Ceiling.** One term changes between arms - the dispatch ceiling - with the request formula pipelined in the last two. `ReactorPCTest#concurrencyTest` and `MutinyPCTest#concurrencyTest`, `maxConcurrency` 1000, 100,000 records, test threshold 1200, three runs each. "Peak in flight" is the largest concurrency the tests' own instrument sampled; "overshoot events" is how often it read above 1000.

| arm | Reactor peak (3 runs) | Mutiny peak (3 runs) | overshoot events, Reactor / Mutiny | outcome |
|---|---|---|---|---|
| pre-PR override (drip feed) | 1000 / 1000 / 1001 | 1000 / 1000 / 1000 | 1-8 / 0 | **6/6 pass** |
| buffer, no gate (this PR, first version) | 1747 / 1516 / 1950 | 1876 / 1802 / 1928 | 1950-3571 / 3479-5333 | **6/6 FAIL** |
| buffer + dispatch gate (this PR now) | 1001 / 1003 / 1027 | 1003 / 1001 / 1001 | 89-117 / 4-17 | **6/6 pass** |

The gated arm's readings a few above 1000 are the instrument, not the engine: the tests measure with `ConcurrentLinkedQueue.size()`, which is documented weakly consistent, and every one of those log lines re-reads the size as 998-1003. The ungated arm is 52-95% over.

`VertxConcurrencyIT` is unchanged at highest concurrency exactly 100/100. Vert.x was never at risk either way, because its WebClient connection pool is a second ceiling of its own - which is exactly why this PR's original benchmark, run on the Vert.x arm, measured peak in flight at 100 and read as proof the buffer was safe for every engine. It was proof that *Vert.x* has another ceiling.

**Throughput, and a correction.** The concurrency tests above cannot measure it - at 1000 concurrency against a mean 50ms delay they are delay-bound, and the override and gated arms finish in the same time (9.3-9.7s vs 9.4-9.8s). Measured separately in the regime the buffer exists for, where the control loop and not the work is the limit: Reactor, 2ms per record, `maxConcurrency` 100, 50,000 records, four runs an arm.

| arm | msg/s (4 runs) | mean | peak in flight (ceiling 100) |
|---|---|---|---|
| pre-PR override | 27,144 / 25,303 / 26,232 / 26,164 | 26,211 | 100 |
| buffer, no gate | 35,971 / 34,435 / 36,496 / 36,954 | 35,964 | **200** |
| buffer + dispatch gate | 29,691 / 28,011 / 29,222 / 29,274 | **29,050** | 100 |

**+10.8% over the pre-PR override, at a ceiling that holds.** That replaces this PR's earlier headline of ~+23% "recovered without over-dispatching": the ungated arm's +37% is mostly the ceiling being breached, and is not a throughput this library may offer. The recovery is real and smaller than first claimed.

**Reactor completion.** `ReactorPCTest#anEmptyPublisherStillRetiresTheRecord` sends more records than `maxConcurrency` through a user function returning `Mono.empty()` and asserts they all commit - deliberately more than the ceiling, because a per-record permit leak only becomes a stall once it has consumed every permit. Proven red on the old two-argument subscribe (30s awaitility timeout, nothing ever commits).

**Unit-level pinning.** `ExternalEnginePipelineBufferTest` pins both halves, because neither is safe alone: the request formula (proven red on the pre-PR code - the request read 100 where the pipelined target is 200), and `dispatchIsCappedAtTheCeilingWhileTheBufferWaitsBehindIt`, which asserts in one test that strictly more records than the ceiling are taken and counted out for processing *and* that never more than the ceiling reach the user's engine, then that a single retirement frees exactly one slot (proven red against an unbounded semaphore).

### Operational note, stated plainly

This changes shipped behaviour of the three engines that ride `ExternalEngine`. Each instance now holds up to `initialLoadFactor x` more fetched records in memory behind the ceiling, and a rebalance has correspondingly more unprocessed buffered records to redeliver. That is core's long-standing behaviour, now applied consistently - but it is a behavioural change for async-engine users, which is why this PR is standalone and carries its evidence here.

The dispatch thread now blocks while waiting for capacity. It is a dedicated single thread that does nothing else, and the wait re-checks the controller state every 100ms, so a close is delayed by at most that rather than by the shutdown timeout. An interrupt, or a `CLOSING`/`CLOSED` state, drops the batch uncommitted for redelivery - the same disposition a pool rejection already had, and reached only after the drain phase has ended.

### Same defect class

The class is *a ceiling asserted by a request formula rather than enforced at the point of use*. Where I looked, and what I found:

- `AbstractParallelEoSStreamProcessor.getTargetOutForProcessing()` in **core** - the same formula, and correct there: the surplus really does wait in the executor pool queue and the pool's thread count is the ceiling. No change.
- `WorkManager.isSufficientlyLoaded()` - gates the broker poller, not dispatch, so a lag there costs prefetch and not concurrency. Not this class.
- The three `ExternalEngine` subclasses - none overrides `runUserFunction`, `submitWorkToPool` or `addToMailbox`, so none can bypass the gate. Checked, no other instance.
- astubbs/parallel-consumer#311 (batching over-requests against the same expression) is related but request-side, and deliberately untouched here.

A second class opened up once the ceiling existed - *a record dispatched but never retired* - and it has one instance, `ReactorProcessor` above. `MutinyProcessor` and `VertxParallelEoSStreamProcessor` were both checked against the same shape and are correct; `runUserFunction`'s catch double-adds stale containers to the mailbox, which the identity-keyed permit return absorbs by design.

The open user report astubbs/parallel-consumer#187 ("30 times slower than normal consumer", confluentinc#884) should be re-read against this fix before being answered - unverified whether it is this defect.

### On the diagnosis note this used to cite

The javadoc cited `docs/inflight/perf-throughput-regression-since-0-3.md`, which exists only on the `perf/engine-concurrency` branch (astubbs/parallel-consumer#363) and would dangle on master if this merged first. It now cites **astubbs/parallel-consumer#363 itself**, which resolves whichever way the merge order falls.

Deliberately *not* a `depends on` line: 363 is a **draft** integration branch with eight parents of its own, and gating this shipped, tested fix behind it is the astubbs#332 anti-pattern `AGENTS.md` names. Deliberately *not* landing the note here either - `docs/inflight/AGENTS.md` tracks only what is currently open, and a note describing work this PR itself lands is what astubbs#206 got wrong.

The gap Codex identified underneath it is real and stays open: `.github/scripts/file-ref-gate.js` excludes `.java` from `CITING_FILE` on purpose ("a `.java` file's imports are the compiler's problem"), so no gate can catch a dangling path citation in javadoc. Teaching it to read Java without tripping over imports, package paths and string literals is its own change, not a drive-by in a perf PR.

## Checklist

- [x] Docs updated - the fix carries its full rationale and its measurements in `ExternalEngine`'s javadoc; the campaign's records live on astubbs/parallel-consumer#363
- [ ] User-facing feature documentation data added under `docs/features/` - N/A - a fix restoring intended behaviour, no new feature surface
- [x] Tests added/updated - `ExternalEnginePipelineBufferTest` and `ReactorPCTest#anEmptyPublisherStillRetiresTheRecord`, each proven red against the code it guards
- [x] Title & body reflect the final content of this PR

