### PR TITLE
fix(core): the offset encoder read its range top after its snapshot, silently completing records (confluentinc#894 sibling)

### DIFF
--- a/docs/inflight/bug-async-commit-marked-successful-before-broker-ack.md
+++ b/docs/inflight/bug-async-commit-marked-successful-before-broker-ack.md
@@ -1,0 +1,17 @@
+# Async commit is marked successful before the broker acknowledges it
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: data-loss -->
+<!-- inflight-labels: concurrency -->
+
+Surfaced by the torn-read hunt of 2026-08-24 as an out-of-family finding, and split out of
+[`bug-torn-read-family.md`](bug-torn-read-family.md) so it is not deleted with that dossier when the
+family's work closes.
+
+`ConsumerOffsetCommitter` carries an existing `TODO` on this: in the asynchronous commit path the
+offset is treated as committed at the point the request is *sent*, not when the broker acknowledges
+it. A failed or dropped async commit therefore leaves state believing an offset is durable when it
+is not, which is the wrong-commit family's shape even though the mechanism is not a torn read.
+
+`grep -rn "TODO" parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerOffsetCommitter.java`
+is the marker. Not reproduced, not measured - recorded so it is not rediscovered a third time.

--- a/docs/inflight/bug-brokerpollsystem-pause-api-is-racy-and-uncalled.md
+++ b/docs/inflight/bug-brokerpollsystem-pause-api-is-racy-and-uncalled.md
@@ -1,0 +1,18 @@
+# BrokerPollSystem's public pause API is racy, and nothing in main code calls it
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: blind-spot -->
+<!-- inflight-labels: concurrency -->
+
+Surfaced by the torn-read hunt of 2026-08-24 as an out-of-family finding, and split out of
+[`bug-torn-read-family.md`](bug-torn-read-family.md) so it is not deleted with that dossier when the
+family's work closes.
+
+`BrokerPollSystem`'s pause API is public and racy, and has **zero main-code callers** - so it is
+latent rather than live. That is exactly what makes it worth a note: it is invisible to any
+reproduction attempt (nothing exercises it), it is reachable by anyone consuming the library, and
+wiring it up later would introduce the race without the change that wires it looking dangerous.
+
+The decision this needs is not a fix but a disposition: make it correct, make it non-public, or
+delete it. Fixing a racy API nobody calls is the least defensible of the three, and it is the one a
+reader arrives ready to do.

--- a/docs/inflight/bug-reset-offset-map-npe-on-partial-assignment.md
+++ b/docs/inflight/bug-reset-offset-map-npe-on-partial-assignment.md
@@ -1,0 +1,18 @@
+# resetOffsetMapAndRemoveWork can NPE on a partial-assignment error path
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: crash -->
+<!-- inflight-labels: concurrency -->
+
+Surfaced by the torn-read hunt of 2026-08-24 as an out-of-family finding, and split out of
+[`bug-torn-read-family.md`](bug-torn-read-family.md) so it is not deleted with that dossier when the
+family's work closes.
+
+`resetOffsetMapAndRemoveWork` dereferences state that a partial-assignment error path can leave
+absent, throwing `NullPointerException`. The hazard is where it throws from rather than the throw
+itself: the rebalance-listener path runs inside `consumer.poll`, so an escape there is the
+poller-death shape rather than a contained error - the same consequence class as
+astubbs#345's revoke-sweep NPE, by a different route.
+
+Not reproduced. Whoever picks it up should check whether astubbs#345's single-read `getShard(key)`
+idiom fix already covers this call path or merely resembles it.

--- a/docs/inflight/bug-torn-read-family.md
+++ b/docs/inflight/bug-torn-read-family.md
@@ -1,0 +1,198 @@
+# The torn-read family: the hunt's candidates, now settled, and the fixes they await
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: data-loss -->
+
+**The family, stated precisely:** multiple reads of moving shared state within one logical operation,
+combined as though they were one consistent snapshot. Confirmed instances so far, both silent-loss
+capable and both fixed: the commit base/payload tear in `createOffsetAndMetadata`
+(confluentinc#894, carried by astubbs#337) and the encoder snapshot/range tear in
+`encodeOffsetsCompressed`
+<!-- post-merge: checked-begin -->
+(astubbs#344, whose defect-class sweep produced this note).
+<!-- post-merge: checked-end -->
+
+A three-way parallel audit of the commit path, the state managers, and shards/retry/metrics traced
+every candidate thread-by-thread. Most were dismissed, and the dismissals fall into five shapes:
+safe-direction orderings, mailbox-confined single-threading verified in source, lock-guarded pairs,
+broker-backstopped combinations, and metrics-only consumers. **Re-derive rather than trust a tally
+here** - the audit's own totals were a point-in-time measurement whose report artifacts are not
+durable, and they stop being true as candidates are fixed or the lens widens. The live shape is
+`grep -rn "getOffsetHighestSucceeded\|getOffsetHighestSeen" parallel-consumer-core/src/main/java`
+read against the five dismissal shapes above. Three candidates survived, and **all three are now
+settled with control arms** (2026-08-25): two reproduced deterministically, one refuted as independently reachable and
+reclassified as a downstream stage of another. The armed red reproductions live on
+`test/torn-read-candidates-reproduction` and become the fix branches' regression tests.
+
+## Candidate 1 - bootstrap-reset tear: REFUTED as independent - it is candidate 3's downstream stage
+
+**Settled 2026-08-25, and the dossier below had it wrong in a specific way.** The tear is real -
+forced open, a mid-window read commits offset 101 with no payload on a partition the broker reset
+to 5, cancelling the replay - but it is **fenced**: the commit path collects only `dirty` states,
+`setDirty()` has exactly one call site (`onSuccess`), and a bootstrap-phase state cannot have had an
+epoch-matched completion. The one production route that dirties a bootstrap-phase state is candidate
+3's success-path tear, so fixing candidate 3 closes candidate 1's only door. Harden the reset-write
+ordering later, with the planned racing-double unification. Original analysis kept below for the
+record:
+
+<!-- post-merge: checked-begin -->
+**A review of astubbs#344 found that the encoder's single-sample fix changes the SHAPE of this
+candidate's window, and the direction is not the reassuring one.** Under the old two-read code, a
+reset landing mid-encode was observed by the second read: the range top came back lowered, so the
+payload was narrow and the interleaving was safe. Under the single-sample fix the high-water mark is
+captured first, so a reset that then replaces `incompleteOffsets` and lowers
+`offsetHighestSucceeded` leaves the *old, high* bound paired with the *new, empty* map - and every
+offset in that stale range encodes as complete, cancelling the broker-mandated replay. So the fix is
+strictly better against the completion seam it was written for, and strictly worse against this one.
+
+**The seam is UNREACHABLE, not merely fenced - and the argument is structural, so it does not depend
+on any other PR landing.** The first reading of this was the weaker "the dirty gate happens to be
+shut"; a second review found the stronger one, and it was verified against the source rather than
+accepted:
+
+1. `bootstrapPhase` has exactly **one** write site in `PartitionState` - the first line of
+   `maybeTruncateBelowOrAbove`, which flips it `true`→`false` and otherwise returns early. The
+   reset branch can therefore execute at most once per instance, on the first call.
+2. That call is reached from `maybeRegisterNewPollBatchAsWork`, which invokes
+   `maybeTruncateOrPruneTrackedOffsets` **before** its `addNewIncompleteRecord` loop - so the reset
+   strictly precedes any offset being registered on that instance.
+3. `dirty` can only be set by `onSuccess`, which can only fire for an offset registered in step 2.
+4. Reassignment cannot reopen the window: `PartitionStateManager.onPartitionsAssigned` always builds
+   new instances via `loadPartitionStateForAssignment` and `putAll`s them over the map entry, and
+   revocation substitutes the `RemovedPartitionState` singleton rather than mutating the old object,
+   so no instance can pair a stale `dirty == true` with a reinstated `bootstrapPhase == true`.
+
+The reset window and the dirty-encode window are therefore **temporally disjoint on any given
+instance**. That is why the encoder's single-sample read is safe here without tying the snapshot and
+the bound to one state generation, and why this does not wait on astubbs#346 - the earlier reading
+made the safety contingent on candidate 3's fix, and it is not.
+<!-- post-merge: checked-end -->
+
+`PartitionState.maybeTruncateBelowOrAbove` (reset-below arm) calls `initStateFromOffsetData`, which
+performs three separate plain writes - `offsetHighestSeen = -1`, `incompleteOffsets = new map`,
+`offsetHighestSucceeded = -1`; none volatile - while the broker-poll commit path can read across
+them (always concurrent in the default `PERIODIC_CONSUMER_ASYNCHRONOUS` mode). The committer can
+combine an old-map offset with a new-map (empty) incompletes payload, re-asserting a pre-reset
+offset and cancelling a broker-mandated replay. Trigger is rare - a bootstrap reset-below event -
+but the consequence is the wrong-commit family. The seam is injectable the same way
+`RacingEncodeWindowState` injects.
+
+## Candidate 2 - `ShardManager.removeWorkFromShardFor`: FIXED, landed by astubbs#345
+
+**Settled 2026-08-25: deterministic, 4/4** - the real production shard removal fired between the two
+map reads throws `NullPointerException` out of the revoke sweep; in production, out of the
+`ConsumerRebalanceListener` into `consumer.poll`. Control: the same removal landing before the sweep
+takes the confluentinc#757-guarded branch gracefully. The fix is the one-line single-read
+`getShard(key)` idiom the rest of the file already uses, and astubbs#345 landed it. Original
+analysis kept for the record:
+
+`containsKey` followed by `get`, the result dereferenced unconditionally. Broker-poll (revoke sweep
+via `PartitionState.onPartitionsRemoved`) races control (`onSuccess` → `removeShardIfEmpty`, which
+removes empty shards under KEY ordering). A hit between the two map reads throws NPE out of the
+`ConsumerRebalanceListener` into `consumer.poll` - the poller-death family. KEY ordering only,
+narrow window, hot path. Every other access in the file already uses the single-read
+`getShard(key)` Optional idiom; this is the one remaining pair.
+
+## Candidate 3 - `WorkManager.handleFutureResult`: REPRODUCED, both harms - fix before the release
+
+**Settled 2026-08-25: deterministic, 3/3, and the worst of the three.** The failure path re-queues a
+stale container into `retryQueue` where nothing can remove it - `workIsWaitingToBeProcessed()` then
+reads true forever with nothing assigned, a confluentinc#857-family stall signature. The success
+path trips `PartitionState.onSuccess`'s assert under `-ea`; without `-ea` it silently dirties a
+bootstrap-phase state, which is what opens candidate 1's gate. The no-data-loss claim below is
+verified for consumer-commit modes; transactional mode was not traced. Original analysis:
+
+Checkpoint 3's epoch check and the subsequent acting reads are two separate `partitionStates.get(tp)`
+lookups. Control passes the check, broker-poll completes a full revoke(+reassign) in the gap, control
+acts on the swapped state. Worst traced harms: the failure path re-adds a stale container to
+`retryQueue` that nothing removes (permanent orphan → near-zero control-loop block times, CPU churn,
+counter drift); the success path can trip `PartitionState.onSuccess`'s `assert` under `-ea`. No
+data-loss route found after tracing all sub-cases; it contradicts checkpoint 3's documented
+guarantee.
+
+## Related, tracked between branches - the seam re-hook, now DISCHARGED
+
+<!-- post-merge: checked-begin -->
+The fixed encoder no longer calls `getIncompleteOffsetsBelowHighestSucceeded()` - the exact seam
+astubbs#337's `RacingCommitCycleState` overrode to inject its race. This note predicted that whichever
+of the two landed second would inherit the re-hook. astubbs#337 landed first, so astubbs#344 did it:
+the double now overrides the bounded `getIncompleteOffsetsBelow(long)`, which catches **both** entry
+points because the no-arg convenience method delegates through it in the base class.
+
+**The prediction held, and so did the guard.** Taking master produced exactly seven failures - all
+three `PartitionStateCommitEncodeShift894Test` cases and all four
+`PartitionStateCommitShiftCompounding894Test` cases - each failing at its fired-assertion with a
+message naming the cause and the remedy. Worth recording that the compounding test *did* have a
+fired-assertion by then: this note previously said it did not and could go silently green, which was
+true when written and had been fixed on astubbs#337's side before it merged. Had it not been, the
+seven-failure signal would have been three, and the other four would have passed while proving
+nothing.
+
+The unification of the two near-clone racing doubles is still not done, and is still the right home
+for this: `RacingCommitCycleState` and `RacingEncodeWindowState` now differ only in which offset they
+race and what they record.
+<!-- post-merge: checked-end -->
+
+## Also surfaced, out of family - now tracked separately
+
+The hunt turned up four defects that are **not** members of this family. They have their own owners
+and lifecycles, so they are no longer recorded here: this dossier is deleted once the family's work
+closes, which would have taken four still-open findings with it, and a paragraph inside another note
+cannot be found by anyone listing this directory.
+
+- [`bug-async-commit-marked-successful-before-broker-ack.md`](bug-async-commit-marked-successful-before-broker-ack.md)
+- [`bug-unsynchronised-cross-thread-counter-maps.md`](bug-unsynchronised-cross-thread-counter-maps.md)
+- [`bug-reset-offset-map-npe-on-partial-assignment.md`](bug-reset-offset-map-npe-on-partial-assignment.md)
+- [`bug-brokerpollsystem-pause-api-is-racy-and-uncalled.md`](bug-brokerpollsystem-pause-api-is-racy-and-uncalled.md)
+
+## No shipped static analysis can see this family - verified empirically, not assumed
+
+Checked 2026-08-25, because the obvious question is "why does SpotBugs not catch these". SpotBugs
+4.10.3 at `effort=Max, threshold=Medium` (the repo's own configuration) reports **nothing** relevant
+on the unfixed code - only `EI_EXPOSE_REP2` noise. The nominally-relevant detector,
+`AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION`, also produced zero findings on a purpose-built
+textbook probe: a `containsKey`-then-`get` pair on a concretely-typed `ConcurrentHashMap`, the
+cleanest possible instance of the shape. So it is not a configuration or static-typing issue - the
+detector simply does not catch it in this version. Two further points close the question:
+
+- Even a firing detector would have been masked: the defects predate the fork, so the baseline job
+  would have recorded them as pre-existing. A baseline is drift protection, not bug discovery.
+- ArchUnit cannot see the family in principle - it checks structure, not dataflow, and "two reads
+  combined as one snapshot" is invisible to it. What it CAN enforce is the access idiom (e.g. all
+  `processingShards` access through `getShard`), which is convention enforcement, not detection.
+
+What can detect the family: the racing-double seam tests (deterministic, per known seam), and
+scheduler-controlled concurrency testing (Lincheck and jcstress, both now adopted - open items in
+[`test-lincheck-lane-open-items.md`](test-lincheck-lane-open-items.md) and
+[`test-jcstress-probe-module-open-items.md`](test-jcstress-probe-module-open-items.md)), which is the
+only tool class that finds UNKNOWN interleavings. Neither is pointed at this family's classes yet, so
+the hunt below remains this repo's only working detector for it.
+
+## Next iteration, so it is not forgotten
+
+One hunt pass found four actionable items (these three plus the cross-branch seam above) and this
+family keeps composing - candidate 3 feeding candidate 1 was invisible until both were settled. Once
+the two fixes land and the current PR set merges, **run another hunt iteration**: same lens, fresh
+eyes, including the out-of-family stragglers above and whatever the fixes themselves change.
+
+## Which merge closes which section
+
+The candidates above are settled but their sections stay open until the fixes land, and the mapping is
+not derivable from this note alone:
+
+- **astubbs#345** - merged; candidate 2 closed.
+- **astubbs#346 merges** - candidates 3 and 1 both close (1 is 3's downstream stage, so 3's fix shuts
+  its only door).
+<!-- post-merge: checked-begin -->
+- **astubbs#337 and astubbs#344** - astubbs#337 landed first, so astubbs#344 carried the seam re-hook
+  described under "Related" above. Discharged; it is not owed again.
+<!-- post-merge: checked-end -->
+- **astubbs#57 merges** - the unprompted-Lincheck-find note carried on astubbs#347's branch becomes
+  deletable.
+
+## Closing this note
+
+Each candidate closes by reproduction-plus-fix or by a demonstrated refutation with a control arm -
+a worked argument is not enough in either direction; that is the lesson the two confirmed instances
+taught twice. The dismissal write-ups (every candidate, with call paths) live in the hunt agents'
+report artifacts from 2026-08-24; the durable summary is this note.

--- a/docs/inflight/bug-unsynchronised-cross-thread-counter-maps.md
+++ b/docs/inflight/bug-unsynchronised-cross-thread-counter-maps.md
@@ -1,0 +1,18 @@
+# The metrics counter maps are plain HashMaps written from more than one thread
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: reliability -->
+<!-- inflight-labels: concurrency -->
+
+Surfaced by the torn-read hunt of 2026-08-24 as an out-of-family finding, and split out of
+[`bug-torn-read-family.md`](bug-torn-read-family.md) so it is not deleted with that dossier when the
+family's work closes.
+
+`slowWorkCounters`, `succeededRecordsCounters` and `failedRecordsCounters` are unsynchronised
+`HashMap`s reached from more than one thread. Consumers are metrics-only, so the consequence is
+counter drift rather than a data-loss route - but an unsynchronised `HashMap` under concurrent write
+can also spin or corrupt its table, which is a liveness risk rather than a reporting one.
+
+Related but distinct from the shared-collection work in
+[`bug-shared-collections-across-the-poll-boundary.md`](bug-shared-collections-across-the-poll-boundary.md);
+read that first, since a shared fix may cover both.

--- a/docs/inflight/ci-build-hardening-register.md
+++ b/docs/inflight/ci-build-hardening-register.md
@@ -7,16 +7,14 @@ Every entry in the first list is grounded in a failure observed in this repo in 
 a tool catalogue. The recurring shape behind almost all of them: **a check that dies or is blind
 reports the same green as a check that passed.** Rank order is proven-value first.
 
-**This register was written on astubbs#344's branch, which is an encoder-race fix and not a CI
-change.** It moved here so the CI work can proceed without waiting on that PR, and so that the
-register is not reviewed as part of a diff nobody opened it for.
-
-**astubbs#344 is not being edited to remove its copy, deliberately.** Both branches add this path
-with no common ancestor version, so whichever lands second hits an add/add conflict when it next
-takes master. That is the reconciliation working, not a problem to pre-empt: the conflict is
-blocking and visible, and the resolution is to take master's version, which is a superset of what
-astubbs#344 carries. Reaching onto another open PR's branch to smooth it over would be reshaping work
-to dodge a conflict, which this project does not do.
+<!-- post-merge: checked-begin -->
+**This register was written on astubbs#344, an encoder-race fix rather than a CI change, and moved
+here so the CI work did not wait on it.** Both sides then held the path with no common ancestor, so
+astubbs#344 hit the add/add conflict this file predicted and resolved it by taking the version here -
+the superset, which is what the prediction said to do. The reconciliation is complete; it is recorded
+because the deliberate choice not to reach onto another open PR's branch to pre-empt the conflict is
+the part a reader would otherwise mistake for an oversight.
+<!-- post-merge: checked-end -->
 
 ## What this register was, and where its work went
 

--- a/docs/inflight/release-0.6.0.0.md
+++ b/docs/inflight/release-0.6.0.0.md
@@ -224,6 +224,27 @@ All four now exist as data. Each keeps its planning note, which holds the reason
 
 What does not exist yet is the rendered documentation an agent generates from all of it.
 
+**Fifth item, added 2026-08-25: the correctness campaign as a story.** In one week the torn-read
+hunt (`bug-torn-read-family.md`) found five concurrency defects sharing one root shape - two of them
+silent record loss present in every released 0.5.x line, invisible to users and to every static
+analyser tried - reproduced each one deterministically with control arms, and fixed them. That
+narrative is announcement material in its own right: it says, more credibly than any feature list,
+that the fork's priority is correctness, and it speaks directly to the users who reported
+confluentinc#894 and confluentinc#857. Tell it plainly and without alarm - the same register as the
+release-note guidance recorded for astubbs#337 (its entry in this file arrives on that PR's branch):
+what was found, the narrow preconditions, that every release since 0.5.0.0 carried it, and that it
+is fixed and regression-guarded.
+
+**And the detectors are a testing FEATURE for the announcement, not just process.** The
+racing-double seam tests are a reusable deterministic technique for race reproduction, and the
+Lincheck / jcstress evaluation resolved to adopt both arms:
+the Lincheck lane (astubbs#347) and the jcstress probe module (astubbs#348) both merged 2026-08-25,
+the calibration having held - Lincheck refound four real races unaided. That gives the fork
+scheduler-controlled concurrency testing as a standing lane, something upstream never had, and it is
+shipped rather than roadmap material. **Owed before the release: an entry in
+`docs/data/testing-evidence.yaml`** alongside the suite-as-evidence material, which is where this
+paragraph always said landed PoCs belong.
+
 ## 0.5.3.3 was never released, by anyone
 
 Worth knowing before writing release copy or triaging a mirror: **`0.5.3.3` exists as a changelog

--- a/docs/inflight/test-lincheck-lane-open-items.md
+++ b/docs/inflight/test-lincheck-lane-open-items.md
@@ -311,15 +311,18 @@ The claim that core's `<argLine>@{argLine} ${lincheck.jvm.args}</argLine>` feeds
 `SurefireConfigConverter` logs `Replacing properties in argLine` and resolves it. No
 `-DparseSurefireArgLine=false` is warranted.
 
-## Cross-branch obligation this note now owns
+## Cross-branch obligation this note used to own - discharged
 
-`test-lincheck-jcstress-evaluation.md` scopes a two-tool evaluation - a Lincheck arm and a jcstress
-arm - and it lives on astubbs#344's branch, not on master, so it could not be updated from here. Its
-**Lincheck arm is executed**: the calibration ran against a pre-fix tree and refound four real races
-unaided, with the verdicts and cost tables in
-[`docs/plans/2026-08-25-001-test-lincheck-poc-plan.md`](../plans/2026-08-25-001-test-lincheck-poc-plan.md).
-Whoever lands astubbs#344 records that against the evaluation note and leaves the jcstress arm open;
-the `jcstress-poc` probe module carries it.
+<!-- post-merge: checked-begin -->
+The two-tool evaluation that scoped this lane and the jcstress probe was never updatable from here,
+because it lived only on astubbs#344. That PR settled it: both arms executed and were adopted - the
+Lincheck calibration ran against a pre-fix tree and refound four real races unaided, with the verdicts
+and cost tables in
+[`docs/plans/2026-08-25-001-test-lincheck-poc-plan.md`](../plans/2026-08-25-001-test-lincheck-poc-plan.md)
+- so the evaluation note was deleted rather than kept as a record of finished work. This note and
+[`test-jcstress-probe-module-open-items.md`](test-jcstress-probe-module-open-items.md) are its
+successors, and each names its own deletion condition.
+<!-- post-merge: checked-end -->
 
 This paragraph exists because the handoff note that used to carry the obligation was deleted at merge
 prep, as `docs/inflight/AGENTS.md` requires - a "delete this when it merges" marker must never reach

--- a/docs/plans/2026-08-25-001-test-lincheck-poc-plan.md
+++ b/docs/plans/2026-08-25-001-test-lincheck-poc-plan.md
@@ -4,7 +4,11 @@
 `test/lincheck-poc-torn-read-calibration`, not merged.
 **Written:** 2026-08-25
 **Executes:** `docs/inflight/test-lincheck-jcstress-evaluation.md`, items 1 and 3 (the Lincheck half). The jcstress half is a sibling piece of work and is not covered here.
-<!-- file-refs: N/A - the evaluation note and the dossier arrive on master with astubbs#344; until it merges they exist only on fix/encoder-reads-highest-succeeded-after-the-snapshot, so their paths are named deliberately rather than broken. -->
+<!-- file-refs: N/A - the dossier arrives on master with astubbs#344. The evaluation note cited above never
+     reached master: it was deleted on that same PR once both its arms had executed, so no commit on master
+     holds it and there is no history pointer to give. Its scope survives in the successor notes it handed
+     its open items to - test-lincheck-lane-open-items.md and test-jcstress-probe-module-open-items.md - and
+     the note's own text is on astubbs/parallel-consumer#344. -->
 
 ---
 

--- a/docs/plans/2026-08-25-002-test-jcstress-poc-plain-long-visibility.md
+++ b/docs/plans/2026-08-25-002-test-jcstress-poc-plain-long-visibility.md
@@ -39,7 +39,11 @@ Per AGENTS.md, before forming any hypothesis. Reported including the nothings.
 | `ls docs/inflight/`, grep | **Nothing on this branch's base** - `docs/inflight/test-lincheck-jcstress-evaluation.md` exists only on `fix/encoder-reads-highest-succeeded-after-the-snapshot`, alongside `bug-torn-read-family.md`. Both were read from that ref via `git show`. This work executes item 2 of that evaluation's scope early. |
 | `grep -rn jcstress` over the whole tree | **Nothing** - no pom, script, workflow or doc mentions it. Greenfield. |
 | Cross-thread readers of the two fields | Established by grep rather than assumed - see the correspondence section. |
-<!-- file-refs: N/A - docs/inflight/test-lincheck-jcstress-evaluation.md is named deliberately as a file on another branch, which is the point of the row -->
+<!-- file-refs: N/A - the evaluation note named in that row never reached master: it was deleted on
+     astubbs#344 once both its arms had executed, so no commit on master holds it and there is no history
+     pointer to give. Its scope survives in the successor notes it handed its open items to -
+     test-lincheck-lane-open-items.md and test-jcstress-probe-module-open-items.md - and the note's own text
+     is on astubbs/parallel-consumer#344. -->
 
 The evaluation note lives on another branch, so this branch cannot tick its item 2. Whoever merges
 second should update it there.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -632,6 +632,18 @@ rather than fixed there so the gate's scope stayed one decision.
   test helper so it has a single home and disappears in one edit. Re-check on the Kafka 4.x upgrade -
   the behaviour may already have changed.
 
+### The offset-decode test helper, copy-pasted x7
+
+- `deserialiseIncompleteOffsetMapFromBase64` is wrapped by a near-identical private `decode` helper in
+  seven test files across two packages: `OffsetEncoderWidenedRangeRaceTest`,
+  `PartitionStateCommitEncodeShift894Test`, `PartitionStateCommitShiftCompounding894Test`,
+  `PartitionStateLincheckTest`, `OffsetEncodingBackPressureTest`,
+  `WorkManagerOffsetMapCodecManagerTest` and `CommitHistory`. Each is a call plus a debug log. Fold
+  into one shared helper. Surfaced by the duplicate-code bot flagging one pair of them; the pair is
+  not the finding, the seven are. Related but distinct from the racing-double unification tracked in
+  `docs/inflight/bug-torn-read-family.md`, which is about the two `Racing*State` doubles rather than
+  this helper.
+
 ### Cross-module test clones (the file-similarity backlog behind astubbs#40)
 
 Deferred half of [#40](https://github.com/astubbs/parallel-consumer/issues/40). Its first half - the

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/OffsetMapCodecManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/OffsetMapCodecManager.java
@@ -258,8 +258,12 @@ public class OffsetMapCodecManager<K, V> {
      * Can remove string encoding in favour of the boolean array for the `BitSet` if that's how things settle.
      */
     byte[] encodeOffsetsCompressed(long baseOffsetForPartition, PartitionState<K, V> partitionState) throws NoEncodingPossibleException {
-        var incompleteOffsets = partitionState.getIncompleteOffsetsBelowHighestSucceeded();
+        // Sample the high-water mark ONCE and derive both the incomplete-offsets snapshot and the encoder's range
+        // top from that single sample, so the two cannot disagree by construction. Two separate reads here raced
+        // concurrent completions into silent record loss - the full mechanism is on
+        // PartitionState#getIncompleteOffsetsBelow; guarded by OffsetEncoderWidenedRangeRaceTest.
         long highestSucceeded = partitionState.getOffsetHighestSucceeded();
+        var incompleteOffsets = partitionState.getIncompleteOffsetsBelow(highestSucceeded);
         if (log.isDebugEnabled()) {
             log.debug("Encoding partition {}, highest succeeded {}, incomplete offsets to encode {}",
                     partitionState.getTp(),

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/PartitionState.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/PartitionState.java
@@ -500,9 +500,24 @@ public class PartitionState<K, V> {
      * @return incomplete offsets which are lower than the highest succeeded
      */
     public SortedSet<Long> getIncompleteOffsetsBelowHighestSucceeded() {
-        long highestSucceeded = getOffsetHighestSucceeded();
+        return getIncompleteOffsetsBelow(getOffsetHighestSucceeded());
+    }
+
+    /**
+     * The bounded filter behind {@link #getIncompleteOffsetsBelowHighestSucceeded()}, taking the bound as a parameter
+     * so a caller that also needs the bound itself can sample it <em>once</em> and use the same value for both -
+     * {@code OffsetMapCodecManager#encodeOffsetsCompressed} must, because its encoder marks every offset in
+     * {@code [base, bound]} that is absent from this set as completed, so deriving set and bound from two separate
+     * reads of the moving {@code offsetHighestSucceeded} let a concurrent completion above the mark widen the range
+     * around a stale set (see {@code OffsetEncoderWidenedRangeRaceTest}).
+     *
+     * @param highestSucceededBound the exclusive upper bound - a caller's single sample of
+     *                              {@link #getOffsetHighestSucceeded()}
+     * @return incomplete offsets which are lower than the given bound
+     */
+    public SortedSet<Long> getIncompleteOffsetsBelow(long highestSucceededBound) {
         return incompleteOffsets.keySet().parallelStream()
-                .filter(x -> x < highestSucceeded)
+                .filter(x -> x < highestSucceededBound)
                 .collect(toTreeSet());
     }
 

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/RemovedPartitionState.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/RemovedPartitionState.java
@@ -81,8 +81,12 @@ public class RemovedPartitionState<K, V> extends PartitionState<K, V> {
         return true;
     }
 
+    /**
+     * Guards both entry points: {@link #getIncompleteOffsetsBelowHighestSucceeded()} delegates through this bounded
+     * overload in the base class, so overriding here keeps the no-op contract whichever one a caller reaches for.
+     */
     @Override
-    public SortedSet<Long> getIncompleteOffsetsBelowHighestSucceeded() {
+    public SortedSet<Long> getIncompleteOffsetsBelow(long highestSucceededBound) {
         log.debug(NO_OP);
         return READ_ONLY_EMPTY_SET;
     }

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/OffsetEncoderWidenedRangeRaceTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/OffsetEncoderWidenedRangeRaceTest.java
@@ -1,0 +1,246 @@
+package bz.stub.parallelconsumer.state;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.internal.PCModuleTestEnv;
+import bz.stub.parallelconsumer.offsets.OffsetDecodingError;
+import bz.stub.parallelconsumer.offsets.OffsetMapCodecManager;
+import bz.stub.parallelconsumer.offsets.OffsetMapCodecManager.HighestOffsetAndIncompletes;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import pl.tlinkowski.unij.api.UniLists;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Behavioural reproduction of the widened-range encode race: {@code OffsetMapCodecManager.encodeOffsetsCompressed}
+ * snapshots the incomplete offsets (filtered on the high-water mark as it stood at that instant), then takes a
+ * <em>second</em> read of {@code getOffsetHighestSucceeded()} for the encoder's range top. A completion landing
+ * between the two reads, of an offset <b>above</b> the high-water mark, widens the range against the stale
+ * snapshot - and {@code OffsetSimultaneousEncoder} encodes every offset in the range that is absent from the
+ * snapshot as <em>completed</em>, including offsets that are still incomplete.
+ * <p>
+ * <b>Why the window is reachable.</b> In {@code PERIODIC_CONSUMER_SYNC}/{@code ASYNCHRONOUS} commit modes the
+ * encode runs on the broker-poll thread ({@code BrokerPollSystem} → {@code ConsumerOffsetCommitter.maybeDoCommit}
+ * → {@code AbstractOffsetCommitter.retrieveOffsetsAndCommit}), while completions land from the control thread's
+ * mailbox processing ({@code AbstractParallelEoSStreamProcessor} → {@code WorkManager.handleFutureResult} →
+ * {@code PartitionState.onSuccess}). In ASYNCHRONOUS mode - the default - the control thread does not wait for the
+ * commit, so the two run concurrently with no shared lock.
+ * <p>
+ * <b>Why the consequence is silent record loss.</b> On restore after a rebalance, the decoded payload sets
+ * {@code offsetHighestSucceeded} to the widened range top. The genuinely-incomplete offsets inside the widened
+ * stretch are not in the decoded incomplete set, so {@link PartitionState#isRecordPreviouslyCompleted} dismisses
+ * them ({@code recOffset <= offsetHighestSucceeded}) - they never run and are never retried, with no error and no
+ * lag anomaly.
+ * <p>
+ * <b>The forced race.</b> {@link RacingEncodeWindowState} fires one completion at the instant the encoder's
+ * snapshot has been taken - the same deterministic seam as the confluentinc#894 reproduction
+ * ({@code RacingCommitCycleState}, which arrives with astubbs#337), one read later. The racing offset (10) is
+ * above the high-water mark (6), the interleaving that reproduction's javadoc explicitly records as unreached
+ * there.
+ * <p>
+ * The racing offset is deliberately <em>not</em> the lowest incomplete, so the commit's base offset
+ * ({@code getOffsetToCommit}) is identical before and after the race - this test cannot trip, and is not perturbed
+ * by, the sibling confluentinc#894 base-offset defect.
+ * <p>
+ * <b>What the controls actually discriminate, for anyone mutation-checking this.</b> These tests pin the read
+ * <em>ordering</em>, not the presence of two reads. Reinstating the defect order - the incomplete-offsets snapshot
+ * taken before the range-top read - goes red; the two reads present but <em>swapped</em> stays green, because that
+ * direction is conservative and cannot widen the range. A whole-file revert of the fix does not compile at all
+ * (the test double calls the bounded method), so it is a compile failure rather than a behavioural control - do not
+ * record it as one, and do not "strengthen" these tests into asserting that two reads exist.
+ *
+ * @author Antony Stubbs
+ */
+@Slf4j
+class OffsetEncoderWidenedRangeRaceTest {
+
+    ModelUtils mu = new ModelUtils(new PCModuleTestEnv());
+
+    TopicPartition tp = new TopicPartition("topic", 0);
+
+    /** Offsets 0..10 have been polled when the commit cycle starts. */
+    static final long HIGHEST_OFFSET_POLLED = 10L;
+
+    /** Completed before the commit cycle: 0-4 and 6 - so the high-water mark is 6 when the encoder snapshots. */
+    static final long HIGH_WATER_MARK_AT_SNAPSHOT = 6L;
+
+    /** The offset whose completion lands mid-encode - ABOVE the high-water mark, so it moves it to 10. */
+    static final long RACING_OFFSET = 10L;
+
+    /** Still incomplete throughout the whole cycle: 5 (below the mark) and 7, 8, 9 (the widened stretch). */
+    static final List<Long> NEVER_COMPLETED_IN_WIDENED_STRETCH = UniLists.of(7L, 8L, 9L);
+
+    /** The base the commit cycle uses: the lowest incomplete, unmoved by the race. */
+    static final long EXPECTED_COMMIT_OFFSET = 5L;
+
+    /**
+     * The core invariant: <b>an offset that never completed must not decode as completed</b>. Decoded against the
+     * committed offset, an offset is claimed completed when it is inside the payload's range and absent from the
+     * incomplete set. On the unfixed code the race widens the range to 10 around the stale snapshot {5}, so 7, 8
+     * and 9 - incomplete before, during and after the commit - decode as completed.
+     */
+    @Test
+    void offsetsThatNeverCompletedMustNotDecodeAsCompleted() throws OffsetDecodingError {
+        RacingEncodeWindowState state = newStateWithRacingCompletion();
+
+        OffsetAndMetadata committed = state.createOffsetAndMetadata();
+
+        assertRaceFiredAndEncodingPathTaken(state, committed);
+
+        HighestOffsetAndIncompletes restored = decode(committed);
+        long restoredHighestSeen = restored.getHighestSeenOffset().orElseThrow(IllegalStateException::new);
+
+        assertWithMessage("fixture: offset 5 stayed incomplete and sits below every read of the high-water mark, "
+                + "so it must decode as incomplete in both the racy and the clean interleaving")
+                .that(restored.getIncompleteOffsets())
+                .contains(EXPECTED_COMMIT_OFFSET);
+
+        for (long neverCompleted : NEVER_COMPLETED_IN_WIDENED_STRETCH) {
+            boolean decodedAsCompleted = neverCompleted <= restoredHighestSeen
+                    && !restored.getIncompleteOffsets().contains(neverCompleted);
+            assertWithMessage("offset %s never completed, but the committed payload (range top %s, incompletes %s) "
+                            + "decodes it as completed - the encoder's range was widened by a completion that "
+                            + "landed after the incomplete-offsets snapshot was taken",
+                    neverCompleted, restoredHighestSeen, restored.getIncompleteOffsets())
+                    .that(decodedAsCompleted)
+                    .isFalse();
+        }
+    }
+
+    /**
+     * The same defect carried through to the user-visible consequence: a new owner restores from the committed
+     * data, the genuinely-unprocessed records arrive from the broker, and
+     * {@link PartitionState#isRecordPreviouslyCompleted} must not dismiss them - on the unfixed code it does,
+     * silently, and they never run.
+     */
+    @Test
+    void afterRestoreTheUnprocessedRecordsMustStillBeRunnable() throws OffsetDecodingError {
+        RacingEncodeWindowState state = newStateWithRacingCompletion();
+
+        OffsetAndMetadata committed = state.createOffsetAndMetadata();
+
+        assertRaceFiredAndEncodingPathTaken(state, committed);
+
+        // the rebalance: a new owner rebuilds partition state from what was committed
+        PartitionState<String, String> afterRebalance =
+                new PartitionState<>(1, mu.getModule(), tp, decode(committed));
+
+        for (long neverCompleted : NEVER_COMPLETED_IN_WIDENED_STRETCH) {
+            assertWithMessage("offset %s never ran, but the state restored from the committed data dismisses it as "
+                            + "previously completed - it will never be processed and never retried, silently",
+                    neverCompleted)
+                    .that(afterRebalance.isRecordPreviouslyCompleted(recordAt(neverCompleted)))
+                    .isFalse();
+        }
+    }
+
+    /**
+     * Control arm for the fixture: with the race disarmed, the very same fixture must encode faithfully - on the
+     * unfixed code too. This pins the failures above on the injected completion, not on the fixture.
+     */
+    @Test
+    void withoutTheRaceTheSameFixtureEncodesFaithfully() throws OffsetDecodingError {
+        RacingEncodeWindowState state = newState();
+        // deliberately not armed
+
+        OffsetAndMetadata committed = state.createOffsetAndMetadata();
+
+        assertWithMessage("control: no race was armed, so none may fire")
+                .that(state.raceHasFired())
+                .isFalse();
+
+        assertWithMessage("control: the clean commit must use the lowest incomplete as its base")
+                .that(committed.offset())
+                .isEqualTo(EXPECTED_COMMIT_OFFSET);
+
+        HighestOffsetAndIncompletes restored = decode(committed);
+
+        assertWithMessage("control: with no mid-encode completion the payload's range top is the high-water mark "
+                + "the snapshot was filtered on")
+                .that(restored.getHighestSeenOffset().orElseThrow(IllegalStateException::new))
+                .isEqualTo(HIGH_WATER_MARK_AT_SNAPSHOT);
+
+        PartitionState<String, String> afterRebalance =
+                new PartitionState<>(1, mu.getModule(), tp, restored);
+        for (long neverCompleted : NEVER_COMPLETED_IN_WIDENED_STRETCH) {
+            assertWithMessage("control: offset %s is above the payload's range, so the restored state must treat "
+                            + "it as new work", neverCompleted)
+                    .that(afterRebalance.isRecordPreviouslyCompleted(recordAt(neverCompleted)))
+                    .isFalse();
+        }
+    }
+
+    private void assertRaceFiredAndEncodingPathTaken(RacingEncodeWindowState state, OffsetAndMetadata committed) {
+        assertWithMessage("precondition: the injected race must actually have fired - without this the test "
+                + "passes trivially if the seam silently stops being called, or if the arm was forgotten")
+                .that(state.raceHasFired())
+                .isTrue();
+
+        assertWithMessage("precondition: the racing completion must actually have ADVANCED the high-water mark "
+                        + "(before %s, after %s). Firing alone is not the property under test: an armed offset at or "
+                        + "below the mark would still fire and still flip the flag, but both reads would then return "
+                        + "the same value and these tests could stay green against the defective ordering",
+                state.markBeforeRace(), state.markAfterRace())
+                .that(state.markAfterRace())
+                .isGreaterThan(state.markBeforeRace());
+
+        assertWithMessage("precondition: the race must move the mark to the racing offset, so the widened range is "
+                        + "the one the defect would encode")
+                .that(state.markAfterRace())
+                .isEqualTo(RACING_OFFSET);
+
+        assertWithMessage("precondition: this commit cycle must take the encoding path, not the empty early-return")
+                .that(committed.metadata())
+                .isNotEmpty();
+
+        assertWithMessage("precondition: the racing completion is not the lowest incomplete, so the committed "
+                + "offset must be unmoved by it - anything else means this fixture strayed into the sibling "
+                + "confluentinc#894 base-offset defect")
+                .that(committed.offset())
+                .isEqualTo(EXPECTED_COMMIT_OFFSET);
+    }
+
+    /**
+     * Builds the state at the start of the commit cycle by polling and completing records, not by handing the
+     * constructor a state object. Offsets 0..10 are polled; 0-4 and 6 complete - ordinary out-of-order completion,
+     * the whole point of this library - leaving the high-water mark at 6 and {5, 7, 8, 9, 10} incomplete.
+     */
+    private RacingEncodeWindowState newState() {
+        RacingEncodeWindowState state =
+                new RacingEncodeWindowState(mu.getModule(), tp, HighestOffsetAndIncompletes.of());
+        for (long offset = 0; offset <= HIGHEST_OFFSET_POLLED; offset++) {
+            state.addNewIncompleteRecord(recordAt(offset));
+        }
+        for (long offset = 0; offset <= HIGH_WATER_MARK_AT_SNAPSHOT; offset++) {
+            if (offset != EXPECTED_COMMIT_OFFSET) {
+                state.onSuccess(offset);
+            }
+        }
+        return state;
+    }
+
+    private RacingEncodeWindowState newStateWithRacingCompletion() {
+        RacingEncodeWindowState state = newState();
+        // Arm last, so the fixture's own completions above do not consume the one shot.
+        state.armRaceOn(RACING_OFFSET);
+        return state;
+    }
+
+    private ConsumerRecord<String, String> recordAt(long offset) {
+        return new ConsumerRecord<>(tp.topic(), tp.partition(), offset, "key", "value");
+    }
+
+    private HighestOffsetAndIncompletes decode(OffsetAndMetadata committed) throws OffsetDecodingError {
+        HighestOffsetAndIncompletes restored = OffsetMapCodecManager.deserialiseIncompleteOffsetMapFromBase64(
+                committed.offset(), committed.metadata());
+        log.debug("Committed {} -> restored {}", committed, restored);
+        return restored;
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/RacingCommitCycleState.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/RacingCommitCycleState.java
@@ -19,17 +19,30 @@ import static com.google.common.truth.Truth.assertWithMessage;
  * has finished reading the state it encodes. Shared by the two
  * <a href="https://github.com/confluentinc/parallel-consumer/issues/894">confluentinc#894</a> reproductions.
  * <p>
- * <b>The seam.</b> {@code OffsetMapCodecManager.encodeOffsetsCompressed} calls
- * {@link #getIncompleteOffsetsBelowHighestSucceeded()} exactly once, to snapshot the set it encodes, and that
- * snapshot is a fresh copy. Completing an offset immediately afterwards therefore cannot alter the payload's
- * contents - only a <em>subsequent</em> read of the offset to commit can see it, which is the defect under test.
+ * <b>The seam.</b> {@code OffsetMapCodecManager.encodeOffsetsCompressed} snapshots the set it encodes exactly
+ * once, through the bounded filter {@link #getIncompleteOffsetsBelow(long)}, and that snapshot is a fresh copy.
+ * Completing an offset immediately afterwards therefore cannot alter the payload's contents - only a
+ * <em>subsequent</em> read of the offset to commit can see it, which is the defect under test.
+ * <p>
+ * <b>The override is on the bounded overload, and that is load-bearing.</b> It used to sit on
+ * {@link #getIncompleteOffsetsBelowHighestSucceeded()}, which the encoder no longer calls. Overriding the bounded
+ * method catches both entry points, because the no-arg convenience method delegates through it in the base class -
+ * so this double keeps working whichever one a future caller reaches for. Do not move it back: a seam the encoder
+ * does not call is a dead seam, and these tests would then arm races that never fire.
  * <p>
  * <b>What this does NOT establish.</b> The completion cannot move
  * {@code offsetHighestSucceeded} <em>in these fixtures</em>, because every offset they race is the lowest
  * outstanding one and so already sits below it. That is a property of the fixtures, not a general property of the
- * seam: {@code encodeOffsetsCompressed} takes its own second read of {@code getOffsetHighestSucceeded()} after the
- * snapshot, so a completion ABOVE the current high-water mark would widen the encoder's range against a stale set.
- * These tests do not reach that interleaving, and nothing here should be read as evidence it is safe.
+ * seam.
+ * <!-- post-merge: checked-begin -->
+ * This paragraph used to continue: that {@code encodeOffsetsCompressed} took a <em>second</em> read of
+ * {@code getOffsetHighestSucceeded()} after the snapshot, so a completion above the high-water mark would widen the
+ * encoder's range against a stale set, and that these tests never reach that interleaving. That second read is gone -
+ * astubbs#344 samples the mark once and derives both the snapshot and the range top from it - and the interleaving
+ * it warned about has its own reproduction in {@code OffsetEncoderWidenedRangeRaceTest}. The caveat is kept rather
+ * than deleted because it is what a reader of these fixtures still needs: they establish the base/payload tear, not
+ * the widened-range one.
+ * <!-- post-merge: checked-end -->
  *
  * @author Antony Stubbs
  */
@@ -83,8 +96,8 @@ class RacingCommitCycleState extends PartitionState<String, String> {
     }
 
     @Override
-    public SortedSet<Long> getIncompleteOffsetsBelowHighestSucceeded() {
-        SortedSet<Long> snapshotTheEncoderWillUse = super.getIncompleteOffsetsBelowHighestSucceeded();
+    public SortedSet<Long> getIncompleteOffsetsBelow(long highestSucceededBound) {
+        SortedSet<Long> snapshotTheEncoderWillUse = super.getIncompleteOffsetsBelow(highestSucceededBound);
         if (armedRacingOffset != null) {
             long racing = armedRacingOffset;
             armedRacingOffset = null;

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/RacingEncodeWindowState.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/RacingEncodeWindowState.java
@@ -1,0 +1,102 @@
+package bz.stub.parallelconsumer.state;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.internal.PCModule;
+import bz.stub.parallelconsumer.offsets.OffsetMapCodecManager.HighestOffsetAndIncompletes;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.SortedSet;
+
+/**
+ * A {@link PartitionState} that lands one work completion inside a single commit cycle, at the moment the encoder
+ * has taken its snapshot of the incomplete offsets - the same seam as {@code RacingCommitCycleState} (the
+ * confluentinc#894 reproduction, which arrives with astubbs#337), one read later.
+ * <p>
+ * <b>The seam.</b> {@code OffsetMapCodecManager.encodeOffsetsCompressed} snapshots the incomplete offsets through
+ * the bounded filter {@link #getIncompleteOffsetsBelow(long)} (reached via
+ * {@link #getIncompleteOffsetsBelowHighestSucceeded()} on the unfixed shape). This double fires one
+ * {@link #onSuccess(long)} the moment that snapshot has been taken, before it is returned. Unlike the
+ * confluentinc#894 double, the racing offset here is <em>above</em> the current high-water mark, so the completion
+ * moves {@code offsetHighestSucceeded} itself - on the unfixed code, which re-read the mark after the snapshot for
+ * the encoder's range top, the range widens past the bound the snapshot was filtered on, and every incomplete
+ * offset inside the widened stretch is encoded as completed. On the fixed code the mark is sampled once, before
+ * the snapshot, so the completion this double fires can no longer reach the encoder's range.
+ * <p>
+ * The firing state is tracked in an explicit {@code raceFired} boolean rather than inferred from the armed slot
+ * being emptied, because a nulled slot cannot tell "armed, then fired" from "never armed" - a guard built on it
+ * passes on a test that forgot to arm, which is exactly the failure it exists to catch.
+ * <p>
+ * <b>Firing is necessary but not sufficient, so the mark either side of the completion is recorded too.</b>
+ * {@code raceFired} alone proves the callback was <em>attempted</em>, not that the widened-range race was
+ * actually injected: if fixture drift ever left the armed offset at or below the current high-water mark,
+ * {@link #onSuccess(long)} would still run and still set the flag, but the mark would not move - both reads
+ * would then return the same value and the behavioural tests could stay green against the defective ordering.
+ * {@link #markBeforeRace()} and {@link #markAfterRace()} let a caller assert the mark genuinely advanced, which
+ * is the property the reproduction actually depends on.
+ *
+ * @author Antony Stubbs
+ */
+@Slf4j
+class RacingEncodeWindowState extends PartitionState<String, String> {
+
+    /** The offset to complete when the encoder next takes its snapshot, or {@code null} when not armed. */
+    private Long armedRacingOffset;
+
+    /** Set when an armed race actually fires - see class javadoc for why this is tracked explicitly. */
+    private boolean raceFired;
+
+    /** The high-water mark immediately before the racing completion, or {@code -1} if no race has fired. */
+    private long markBeforeRace = -1;
+
+    /** The high-water mark immediately after the racing completion, or {@code -1} if no race has fired. */
+    private long markAfterRace = -1;
+
+    RacingEncodeWindowState(PCModule<String, String> module,
+                            TopicPartition topicPartition,
+                            HighestOffsetAndIncompletes offsetData) {
+        super(0, module, topicPartition, offsetData);
+    }
+
+    /** Arm one completion for the next encoder snapshot. One-shot: disarms itself after firing. */
+    void armRaceOn(long offset) {
+        this.armedRacingOffset = offset;
+    }
+
+    /** @return whether a race has actually fired - the guard against a silently dead seam, or a forgotten arm. */
+    boolean raceHasFired() {
+        return raceFired;
+    }
+
+    /** @return the high-water mark sampled immediately before the racing completion, or {@code -1} if none fired. */
+    long markBeforeRace() {
+        return markBeforeRace;
+    }
+
+    /** @return the high-water mark sampled immediately after the racing completion, or {@code -1} if none fired. */
+    long markAfterRace() {
+        return markAfterRace;
+    }
+
+    @Override
+    public SortedSet<Long> getIncompleteOffsetsBelow(long highestSucceededBound) {
+        SortedSet<Long> snapshotTheEncoderWillUse = super.getIncompleteOffsetsBelow(highestSucceededBound);
+        fireIfArmed(snapshotTheEncoderWillUse);
+        return snapshotTheEncoderWillUse;
+    }
+
+    private void fireIfArmed(SortedSet<Long> snapshotTheEncoderWillUse) {
+        if (armedRacingOffset != null) {
+            long racing = armedRacingOffset;
+            armedRacingOffset = null;
+            raceFired = true;
+            markBeforeRace = getOffsetHighestSucceeded();
+            log.debug("Racing completion of offset {} lands after the encoder snapshot {}",
+                    racing, snapshotTheEncoderWillUse);
+            onSuccess(racing);
+            markAfterRace = getOffsetHighestSucceeded();
+        }
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/RemovedPartitionStateTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/RemovedPartitionStateTest.java
@@ -1,0 +1,135 @@
+package bz.stub.parallelconsumer.state;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.internal.PCModuleTestEnv;
+import bz.stub.parallelconsumer.offsets.OffsetMapCodecManager.HighestOffsetAndIncompletes;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniLists;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * Pins the no-op contract of {@link RemovedPartitionState} for the incomplete-offsets accessors, and - more to the
+ * point - pins it in a way that can actually go red.
+ * <p>
+ * <b>Why the obvious version of this test proves nothing.</b> Asserting that the shipped singleton returns an empty
+ * set does not discriminate the override at all: the singleton's underlying incomplete-offsets map is empty, so the
+ * <em>base</em> filter returns an empty set too. Delete the override and that test still passes. So the state here is
+ * arranged so that reaching the base implementation would visibly differ - records are added through the base
+ * {@link PartitionState#addNewIncompleteRecord} path, which {@link RemovedPartitionState} does not override.
+ * <p>
+ * <b>The two entry points need different techniques, because they are not guarded the same way.</b> The bounded
+ * overload is guarded once, by its own override, so a populated instance plus an explicit bound discriminates it.
+ * The convenience method is guarded <em>twice</em> - it reaches the bounded override, but
+ * {@link RemovedPartitionState#getOffsetHighestSucceeded()} is also overridden to
+ * {@link PartitionState#KAFKA_OFFSET_ABSENCE}, so the bound it passes is below every offset and the base filter would
+ * return empty regardless. No arrangement of state can tell those apart, so the delegation claim is pinned with an
+ * observable dispatch seam instead of pretending state does it.
+ *
+ * @author Antony Stubbs
+ */
+class RemovedPartitionStateTest {
+
+    private static final String TOPIC = "topic";
+
+    private static final List<Long> POPULATED_OFFSETS = UniLists.of(1L, 2L, 3L, 4L, 5L);
+
+    private final ModelUtils mu = new ModelUtils(new PCModuleTestEnv());
+
+    private final TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+    /**
+     * A removed state that records every bound the base class routes through the overridden method, so the
+     * delegation itself is observable rather than inferred.
+     */
+    private static final class DispatchRecordingRemovedState extends RemovedPartitionState<String, String> {
+
+        private final List<Long> boundsReceived = new ArrayList<>();
+
+        @Override
+        public SortedSet<Long> getIncompleteOffsetsBelow(long highestSucceededBound) {
+            boundsReceived.add(highestSucceededBound);
+            return super.getIncompleteOffsetsBelow(highestSucceededBound);
+        }
+    }
+
+    /**
+     * The bounded entry point - the one the offset encoder calls directly - must be a no-op even when the base
+     * filter, if it were reached, would return a non-empty set. Deleting the override turns this red.
+     */
+    @Test
+    void boundedEntryPointIsANoOpEvenWhenTheBaseFilterWouldReturnOffsets() {
+        // Control arm: the identical arrangement on a live partition DOES return the offsets, which is what makes
+        // the subject below a discriminating test rather than empty-equals-empty.
+        PartitionState<String, String> live = new PartitionState<>(1, mu.getModule(), tp, HighestOffsetAndIncompletes.of());
+        populate(live);
+
+        assertWithMessage("control: on a live partition this exact arrangement must return the offsets - if it does "
+                + "not, the subject assertion below proves nothing and this test has quietly gone tautological")
+                .that(live.getIncompleteOffsetsBelow(Long.MAX_VALUE))
+                .containsExactlyElementsIn(POPULATED_OFFSETS);
+
+        RemovedPartitionState<String, String> removed = new RemovedPartitionState<>();
+        populate(removed);
+
+        assertWithMessage("a removed partition reports no incomplete offsets even though the base filter would "
+                + "return %s for this bound - if this fails, the no-op override was lost", POPULATED_OFFSETS)
+                .that(removed.getIncompleteOffsetsBelow(Long.MAX_VALUE))
+                .isEmpty();
+    }
+
+    private void populate(PartitionState<String, String> state) {
+        for (long offset : POPULATED_OFFSETS) {
+            state.addNewIncompleteRecord(recordAt(offset));
+        }
+    }
+
+    /**
+     * The convenience entry point must reach the no-op contract by dispatching through the bounded override, which is
+     * the claim {@link RemovedPartitionState}'s javadoc makes and the reason only one override is needed.
+     */
+    @Test
+    void convenienceEntryPointDispatchesThroughTheBoundedOverride() {
+        DispatchRecordingRemovedState removed = new DispatchRecordingRemovedState();
+
+        SortedSet<Long> result = removed.getIncompleteOffsetsBelowHighestSucceeded();
+
+        assertWithMessage("the convenience method must route through the bounded overload - that delegation is what "
+                + "lets a single override guard both entry points; a base class that filtered inline instead would "
+                + "bypass the guard silently")
+                .that(removed.boundsReceived)
+                .hasSize(1);
+
+        assertWithMessage("a removed partition has no incomplete offsets to report")
+                .that(result)
+                .isEmpty();
+    }
+
+    /**
+     * The shipped singleton, across bounds that would be nonsense on a live partition. Cheap, and it covers the
+     * instance production actually hands out.
+     */
+    @Test
+    void theSingletonIsANoOpForAnyBound() {
+        PartitionState<String, String> singleton = RemovedPartitionState.getSingleton();
+
+        for (long bound : new long[]{Long.MIN_VALUE, PartitionState.KAFKA_OFFSET_ABSENCE, 0L, 5L, Long.MAX_VALUE}) {
+            assertWithMessage("the singleton reports no incomplete offsets whatever bound is asked for (bound: %s)",
+                    bound)
+                    .that(singleton.getIncompleteOffsetsBelow(bound))
+                    .isEmpty();
+        }
+    }
+
+    private ConsumerRecord<String, String> recordAt(long offset) {
+        return new ConsumerRecord<>(TOPIC, 0, offset, "key", "value");
+    }
+}


### PR DESCRIPTION
Same defect class as confluentinc/parallel-consumer#894, one read later - and this one is live in the **default commit mode**.

depends on astubbs/parallel-consumer#371

**That dependency is now discharged, and the line is kept as the record of the ordering.** astubbs/parallel-consumer#371 fixed the PIT mutation lane, which was broken on master: a comment inside a line continuation truncated the invocation, so it dropped `-pl parallel-consumer-core -am`, mutated every module and exited 127. That lane is non-required, so this PR *could* have merged with it red. The reason to sequence anyway was that **this is the PR that rewrote two test classes, and its central claim is that those tests now discriminate** — a mutation lane is precisely the instrument that scores whether tests kill mutants, so merging first would have meant the one change whose value is "the tests got sharper" never got a real mutation score.

astubbs/parallel-consumer#371 has since merged, and this branch has taken master, so it now carries the fixed lane. Worth knowing: astubbs/parallel-consumer#371 changed no Java, so its own mutation run correctly reported "nothing in scope" and never exercised the fixed invocation. **This PR is the first one that will**, because it changes core main-source classes.

## The defect

`OffsetMapCodecManager.encodeOffsetsCompressed` read moving partition state twice and treated the two reads as one snapshot:

```java
var incompleteOffsets = partitionState.getIncompleteOffsetsBelowHighestSucceeded();  // read A
long highestSucceeded = partitionState.getOffsetHighestSucceeded();                   // read B
```

Read A filters on its **own** internal read of `offsetHighestSucceeded`; read B is taken afterwards and becomes the encoder's range top. `OffsetSimultaneousEncoder` marks every offset in `[base, highestSucceeded]` absent from the set as **completed**. A completion landing between the reads - of an offset *above* the high-water mark - widens the range around a snapshot filtered on the older, lower mark, and every still-incomplete offset in the widened stretch is encoded as complete. On restore they are dismissed by `isRecordPreviouslyCompleted` and never processed: silent record loss.

Reproduced deterministically: committed base 5, restored range top 10, offsets 7, 8 and 9 decoded as completed although they were never run.

## Why it is reachable, and where

The encode runs on the **broker-poll thread** (`BrokerPollSystem` → `ConsumerOffsetCommitter.maybeDoCommit`); completions land from the **control thread** (`WorkManager.handleFutureResult` → `PartitionState.onSuccess`). In `PERIODIC_CONSUMER_SYNC` the control thread blocks on the commit response, and in `PERIODIC_TRANSACTIONAL_PRODUCER` both run on the control thread - so the concurrent window exists specifically in **`PERIODIC_CONSUMER_ASYNCHRONOUS`, the default** (`ParallelConsumerOptions.commitMode`, `@Builder.Default`). Nothing upstream serialises the two reads there.

The code dates to 2022 (`919c85ddb2`) and is in every release since; it predates the fork.

## The fix

Sample `getOffsetHighestSucceeded()` **once** and derive both the snapshot and the range top from that single sample, so they cannot disagree by construction - the same shape as the confluentinc#894 fix carried in astubbs/parallel-consumer#337, one layer down. `PartitionState` gains the bounded filter `getIncompleteOffsetsBelow(long)`; the existing `getIncompleteOffsetsBelowHighestSucceeded()` delegates to it. **No existing signature changed.**

**On residual races at the seam - this claim was narrowed by review, and the narrowing matters.** Against the *completion* seam this PR was written for, the residual is safe-direction: at-least-once replay, never a false completeness claim. Against a concurrent *bootstrap reset* it is not. Sampling the mark first means a reset that then replaces `incompleteOffsets` and lowers `offsetHighestSucceeded` leaves the old high bound paired with the new empty map, encoding the stale range as complete and cancelling the broker-mandated replay - where the old two-read code would have observed the reset on its second read and narrowed the range instead. So this change is strictly better against the seam it targets and strictly worse against that one.

**It is not merely fenced — it is unreachable, for structural reasons, and two reviews were needed to get there.** The first argument was "the dirty gate happens to be shut". The stronger one, verified against the source:

1. `bootstrapPhase` has exactly **one** write site — the first line of `maybeTruncateBelowOrAbove`, which flips it `true`→`false` and otherwise returns early — so the reset branch runs at most once per instance.
2. It is reached from `maybeRegisterNewPollBatchAsWork`, which calls `maybeTruncateOrPruneTrackedOffsets` **before** its `addNewIncompleteRecord` loop, so the reset strictly precedes any offset being registered.
3. `dirty` is set only by `onSuccess`, which can only fire for an offset registered in step 2.
4. Reassignment cannot reopen it: `onPartitionsAssigned` always constructs fresh state via `loadPartitionStateForAssignment` and `putAll`s over the entry, and revocation substitutes the `RemovedPartitionState` singleton rather than mutating in place — so nothing can pair a stale `dirty == true` with a reinstated `bootstrapPhase == true`.

The reset window and the dirty-encode window are therefore **temporally disjoint on any given instance**. Note what this changes: the safety of this PR is *not* contingent on astubbs/parallel-consumer#346 landing first, which the earlier weaker argument implied. Recorded in `docs/inflight/bug-torn-read-family.md` under candidate 1.

## Evidence

- `OffsetEncoderWidenedRangeRaceTest`, using the same racing-seam pattern as astubbs/parallel-consumer#337's tests: `RacingEncodeWindowState` fires one completion at the instant the encoder takes its snapshot, and asserts the race actually fired (an explicit boolean set at firing time - a guard inferred from a nulled field cannot distinguish "fired" from "never armed", a tautology mutation-checking caught twice in the sibling investigation).
- Controls, all observed and independently re-run at review of this PR:
  - defect ordering (read A then read B) reinstated → **red**, naming range top 10 against snapshot {5}
  - reads present but **swapped** → green - the conservative direction, so the test discriminates the ordering, not merely the presence of two reads
  - race disarmed on the defect ordering → green - the failure comes from the race, not the fixture
  - arm deleted → red on the race-fired precondition specifically
  - **armed offset moved to at-or-below the high-water mark → red** on the new mark-advanced precondition ("before 6, after 6"). Review pointed out that `raceHasFired()` proves only that the callback was *attempted*: had fixture drift ever left the armed offset from advancing the mark, both reads would return the same value and these tests could stay green against the defective ordering. The double now records the mark either side of the completion and the tests require it to advance.
- `RemovedPartitionStateTest` was rebuilt after review showed it could not fail. Asserting the singleton returns an empty set discriminated nothing - its underlying map is empty, so the *base* filter returns empty too, and deleting the override left it green. It now populates a removed state through the un-overridden base path, with a live-partition control arm proving the same arrangement does return offsets. Both new controls proven red against their mutants: **override deleted → red**, **base method stops delegating through the bounded overload → red**.
- The racing offset is deliberately above the high-water mark and **not** the lowest incomplete, so the commit base is unmoved and the confluentinc#894 base-offset defect (fixed in astubbs/parallel-consumer#337, not here) cannot contaminate the result - asserted as a precondition.
- Full all-modules unit suite green (core 391 tests, 0 failures; 11 modules BUILD SUCCESS). Fix presence in the run verified via `javap` on `target/classes`.

## Relationship to astubbs/parallel-consumer#337

Independent - no shared main-code file, no dependency either way, they can merge in either order. astubbs/parallel-consumer#337 closes the base/payload tear in `createOffsetAndMetadata`; this closes the contents/range tear one call below it. Found by that PR's code review asking whether the fix's "every path is closed" claim held; it did not, its claims were narrowed accordingly, and this PR is the missing path.

## Defect-class sweep (two reads of moving state around one operation)

- `createOffsetAndMetadata` - the confluentinc#894 sibling, owned by astubbs/parallel-consumer#337, deliberately not re-fixed here.
- `tryToEncodeOffsets`' second `getOffsetHighestSucceeded()` read - feeds only a metrics ratio denominator; dismissed, noted in the commit body.
- `isRecordPreviouslyCompleted`, `getOffsetHighestSequentialSucceeded` - checked; every interleaving lands safe.
- No other correctness instances found.

## Checklist

- [x] Changelog entry added - **N/A**: `AGENTS.md` forbids a PR adding changelog entries; the section is generated at release from commit messages, and the commit body carries what the generator reads.
- [x] Docs updated - **N/A for repo docs**: the mechanism is documented in the commit body, the test javadoc, and `docs/solutions/` coverage is flagged as a follow-up in astubbs/parallel-consumer#337's write-up, which already names this window as unestablished-safe.
- [x] Tests added/updated - `OffsetEncoderWidenedRangeRaceTest` + `RacingEncodeWindowState`, controls in both directions.
- [x] Other instances of the same defect - swept, listed above.





