### PR TITLE
ci(gates): run the shell self-tests and a bash 3.2 parse sweep on macOS

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,7 +33,7 @@ procedure or a steer. Why, and the gate's exact contract: [`docs/ci.md`](../../d
 | `publish.yml` | Publishes to Maven Central on every push to `master`; the pom version decides snapshot or release. |
 | `quarantine-lane.yml` | Runs the quarantined tests separately, so known-flaky tests neither block nor disappear. |
 | `release.yml` | Cuts a release. `workflow_dispatch`, and deliberately the most dangerous button here. |
-| `repo-hygiene.yml` | Small always-on repo checks - shell sigpipe traps, one pinned version per GitHub Action, and expiring the pom's temporary CVE exclusions. |
+| `repo-hygiene.yml` | Always-on repo checks - shell sigpipe traps, one pinned version per GitHub Action, and expiring the pom's temporary CVE exclusions - plus `shell: macos`, the one lane not on `ubuntu-latest`: it runs the shell self-tests and a `bash -n` sweep against Apple's bash 3.2, where GNU-only constructs fail silently. |
 
 ## One required check is not in this directory
 

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -90,3 +90,139 @@ jobs:
 
       - name: Every gate and every self-test, discovered rather than listed
         run: bash bin/check-all.sh --with-tests
+
+  # WHY THIS LANE EXISTS. Every other job in this file is ubuntu, so the shell harness was only ever
+  # exercised against GNU coreutils and bash 5, while contributors run it on macOS with BSD userland
+  # and bash 3.2. Four live defects survived a deliberate portability sweep, two automated reviews
+  # and two human lgtms, and were found only because somebody happened to be working on a Mac
+  # (astubbs/parallel-consumer#341). The class, its four instances and the constructs to reach for
+  # instead are written up in
+  # docs/solutions/workflow-issues/gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md, which
+  # OWNS that knowledge - this comment says only why there is a job here.
+  #
+  # The damaging shape is not a flag that errors on BSD; that exits non-zero and somebody fixes it.
+  # It is the construct BSD ACCEPTS with a different meaning, so the script keeps running and
+  # reports a confident wrong answer - check-inflight-tags.sh extracted 0 of 17 impacts and printed
+  # "valid", rename-packages.sh printed "already applied, nothing to do" over an untouched tree.
+  macos:
+    name: "shell: macos"
+    runs-on: macos-latest
+    # The suite builds throwaway git fixture repos; 101s on an M-series laptop, and hosted macOS
+    # runners are slower. Generous ceiling, not an expected duration.
+    timeout-minutes: 20
+    steps:
+      # Fixtures are built in temp dirs and the parse sweep reads the working tree, so shallow is
+      # fine - same reasoning as the other jobs here.
+      - uses: actions/checkout@v6
+
+      # PATH bash decides what is actually under test: 60 of the 62 tracked scripts are
+      # `#!/usr/bin/env bash`, and each self-test invokes the gate it protects as a bare `bash`.
+      # Pinning it to the system 3.2 makes "this lane exercises bash 3.2" true by CONSTRUCTION
+      # rather than an assumption about the runner image. If an image ever put a newer bash first
+      # on PATH, the bash-3.2 half of this job would quietly stop testing anything and stay green -
+      # which is precisely the failure mode the lane exists to catch, one level up.
+      # The self-test suites are not self-contained: bin/check-docs-data.sh needs PyYAML and
+      # fails CLOSED without it, exit 2 "cannot run". ubuntu-latest ships it, hosted macOS does
+      # not, so the lane's first run reported 17 suites with 1 failed and every docs-data case
+      # returning 2 - including the baseline, which is the tell that it is an environment gap
+      # rather than a finding. Installing it is what makes the lane test the SCRIPTS rather than
+      # the runner image.
+      - name: Install the self-tests' Python dependency
+        run: python3 -m pip install --break-system-packages --quiet pyyaml
+
+      - name: Confirm PyYAML is importable, so a docs-data exit 2 means a real defect
+        run: python3 -c 'import yaml; print("PyYAML", yaml.__version__)'
+
+      # Same environment gap, second instance, surfaced when master's newer suites arrived here:
+      # bin/check-shell-lint.sh wraps ShellCheck, and bin/test-check-shell-lint.sh exits 2 "cannot
+      # run" without the binary. ubuntu-latest ships it, hosted macOS does not.
+      # bin/check-all.sh already names this exact pair as a hole it cannot close on such a machine -
+      # "the broken gate exits 2 and the linter exits 2, both land in cannot, and the sweep reports
+      # zero failures - a false green produced by two skips agreeing" - so installing it here is
+      # what gives that gate any BSD coverage at all, rather than a skip wearing a tick.
+      - name: Install the self-tests' shell-lint dependency
+        run: brew install shellcheck
+
+      - name: Confirm shellcheck runs, so a shell-lint exit 2 means a real defect
+        run: shellcheck --version
+
+      - name: Pin bash to the system 3.2
+        run: |
+          mkdir -p "$RUNNER_TEMP/bash32"
+          ln -sf /bin/bash "$RUNNER_TEMP/bash32/bash"
+          echo "$RUNNER_TEMP/bash32" >> "$GITHUB_PATH"
+
+      # And prove the pin took, because a pin that silently did not apply is the same defect again.
+      # macOS ships bash 3.2.57 (2007) - everything later is GPLv3 - and that shell has no `mapfile`
+      # and a `$( ... )` parser that does not skip `#` comments. Both are things this lane is here
+      # to notice.
+      - name: The bash under test really is 3.2
+        run: |
+          bash --version
+          v="$(bash -c 'echo "${BASH_VERSINFO[0]}"')"
+          [ "$v" = 3 ] || {
+              echo "::error::bash on PATH is major version $v, expected 3 - this lane is no longer exercising the bash 3.2 parser. If the runner image changed deliberately, update the pin step above and say so."
+              exit 1
+          }
+
+      # The whole self-test set by glob, not a hand-kept list: a suite added later gets macOS
+      # coverage without anyone remembering this file exists, and a hand-listed lane is exactly how
+      # the blind spot grows back. Runs all of them and reports every failure rather than stopping
+      # at the first - on a platform nobody develops on, one run should say everything that is
+      # broken.
+      #
+      # The count guard is not ceremony: a glob that matched nothing would otherwise be a green tick
+      # over zero tests, which is the "reports success having scanned nothing" result this workflow
+      # is written against.
+      #
+      # A SKIP IS NOT A PASS, and it is not a failure either - it is its own result, the house rule
+      # bin/check-all.sh states and this loop originally ignored. A bare `if bash "$t"` collapses
+      # every non-zero into one bucket, so bin/test-check-shell-lint.sh exiting 2 for a ShellCheck
+      # that is not installed was reported as "self-test fails on macOS": a suite that never ran,
+      # described as a suite that ran and found a defect. That is this lane's own subject matter -
+      # a confident wrong answer - reproduced in the lane, which is why the counts are split rather
+      # than the dependency merely installed above.
+      #
+      # Exit 2 still FAILS the job, deliberately. On a dedicated portability lane a suite that could
+      # not run is missing coverage, and the remedy is to install the tool in this job (PyYAML and
+      # ShellCheck above are both that remedy). Letting it pass is how the lane quietly stops
+      # testing anything while staying green - the failure mode the bash-3.2 pin assertion guards
+      # against one step up. The distinction bought here is ATTRIBUTION: the log now says which of
+      # the two happened, so nobody debugs a BSD defect that does not exist.
+      - name: Shell self-tests on BSD userland
+        run: |
+          ran=0; failed=0; cannot=0
+          for t in bin/test-*.sh; do
+              [ -f "$t" ] || continue
+              ran=$((ran + 1))
+              rc=0; bash "$t" || rc=$?
+              case "$rc" in
+                  0)
+                      echo "ok:     $t" ;;
+                  2)
+                      echo "::error file=$t::CANNOT RUN on macOS (exit 2) - the suite refused to measure, almost always a tool missing from the runner image. Install it in this job, as the PyYAML and ShellCheck steps do; do not let the lane count this as tested."
+                      cannot=$((cannot + 1)) ;;
+                  *)
+                      echo "::error file=$t::self-test FAILS on macOS (exit $rc)"
+                      failed=$((failed + 1)) ;;
+              esac
+          done
+          echo "macOS self-tests: $ran run, $failed failed, $cannot could not run"
+          [ "$ran" -gt 0 ] || { echo "::error::no self-tests matched bin/test-*.sh - this step checked nothing"; exit 1; }
+          [ "$failed" -eq 0 ] && [ "$cannot" -eq 0 ] || exit 1
+
+      # Catches the bash 3.2 PARSER class across every tracked script, including the ones that have
+      # no self-test at all: an apostrophe or an unbalanced paren inside a `#` comment inside
+      # `$( ... )` stops 3.2 reading the file. bin/test-check-branch-self-reference.sh shipped
+      # exactly that and exited 2 before a single case ran, while showing 31 green on ubuntu - so a
+      # passing self-test suite is not evidence this sweep is redundant. Seconds to run.
+      - name: Every tracked script parses under bash 3.2
+        run: |
+          scanned=0; bad=0
+          while IFS= read -r f; do
+              scanned=$((scanned + 1))
+              /bin/bash -n "$f" || { echo "::error file=$f::does not parse under bash 3.2"; bad=$((bad + 1)); }
+          done < <(git ls-files -- '*.sh')
+          echo "parse sweep: $scanned scanned, $bad failed"
+          [ "$scanned" -gt 0 ] || { echo "::error::no scripts matched - the sweep checked nothing"; exit 1; }
+          [ "$bad" -eq 0 ] || exit 1

--- a/bin/check-branch-self-reference.sh
+++ b/bin/check-branch-self-reference.sh
@@ -122,9 +122,15 @@ strip_spans() { sed 's/`[^`]*`/ /g' "$1"; }
 # local run this header advertises reported green on the exact case it exists for.
 #
 # NO `mapfile`. It is bash 4; macOS ships bash 3.2, where the line died with "mapfile: command not
-# found" and the script still exited 0 - a local run reporting success having checked nothing, which
-# is the exact failure this gate exists to prevent, one level up. The read loop below is the same
-# portable idiom bin/check-inflight-tags.sh and bin/check-copyright-headers.sh already use.
+# found" and `set -e` took the script down with it - measured exit 127, a loud failure. An earlier
+# version of this comment said it "still exited 0"; that reading came from `... | tail`, which
+# reports tail's status rather than the script's, and the same mismeasurement is warned about for
+# git commands in the root AGENTS.md. Redirect to a file and read `$?` directly.
+#
+# The read loop below is the same portable idiom bin/check-inflight-tags.sh and
+# bin/check-copyright-headers.sh already use. A reintroduction is caught by the `shell: macos` job
+# in .github/workflows/repo-hygiene.yml: on bash 3.2 the self-test fails all 31 cases against a
+# mapfile version, where on ubuntu's bash 5 it passes all 31 and proves nothing.
 candidates=()
 while IFS= read -r doc; do
     [ -n "$doc" ] || continue

--- a/docs/inflight/ci-bsd-portability-gaps.md
+++ b/docs/inflight/ci-bsd-portability-gaps.md
@@ -13,17 +13,6 @@ which **owns that knowledge**. This note keeps only what is still open. Delete i
 resolved.
 <!-- post-merge: checked-end -->
 
-## Nothing runs any of this on macOS in CI
-
-**This is the item that matters.** Every lane is ubuntu, so the entire class is caught only when
-somebody happens to be working on a Mac - which is how four live defects survived a deliberate
-sweep, two automated reviews and two human lgtms. The next one will survive the same way.
-
-A `macos-latest` lane running `bin/test-check-*.sh`, `bin/test-rename-packages.sh` and a
-`/bin/bash -n` parse sweep over every tracked script would cost a couple of minutes and close it.
-Not done here because adding a required check is a repo-wide decision, not a side effect of a
-portability fix.
-
 ## A latent instance of the bash 3.2 `source` defect
 
 `bin/check-quarantine-registry.sh`, `bin/quarantine-lane-report.sh` and
@@ -37,17 +26,17 @@ same defect fixed in the two node gates, which now test `[ -r ]` before sourcing
 It is **latent, not live**: `${BASH_SOURCE[0]%/*}` resolves for every ordinary invocation, so the
 first `source` succeeds and the dead fallback is never reached. `bin/test-check-quarantine-registry.sh`
 passes on macOS. It becomes real the moment that path stops resolving - and then it fails silently,
-with an exit code that means something else. Left alone here because these three are master-state
-and nothing on this branch touches them.
+with an exit code that means something else. Nothing has claimed these three yet, and the
+`shell: macos` lane cannot surface it either: the fallback stays unreached on every platform until
+that path breaks.
 
-## Two fixes still have no executing coverage
+## One fix still has no executing coverage
 
-- `bin/check-branch-self-reference.sh` - the pre-fix `mapfile` version was swapped back in and
-  `bin/test-check-branch-self-reference.sh` still passed 31/31. That suite cannot catch a
-  reintroduced `mapfile` bug on any bash 4+ host. It does at least now *run* on bash 3.2, where it
-  previously failed to parse.
-- `bin/check-pr-ready.sh` - `bin/test-check-pr-ready.sh` holds no `stat` or `mtime` reference at
-  all; it greps the script's source text.
+`bin/check-pr-ready.sh` was fixed for BSD `stat`, but `bin/test-check-pr-ready.sh` holds no `stat`
+or `mtime` reference at all - it greps the script's source text. **The `shell: macos` lane does not
+help here**, unlike the other fixes: a source-text grep passes identically on both platforms, so
+running it on macOS asserts nothing new. This one needs a case that actually dates a file and reads
+the result back.
 
 ## The "probe, never fall back" reasoning is stated three times
 


### PR DESCRIPTION
Closes the "no CI lane runs any of this on macOS" item in `docs/inflight/ci-bsd-portability-gaps.md`.

## Description

Adds a `shell: macos` job to `repo-hygiene.yml` running the shell self-tests and a bash 3.2 parse
sweep, and corrects a factual error in a script header.

**This overrides an explicit inherited decision, recorded rather than done silently.** Commit
`cf0007df1a` ends: *"Adding the macOS lane is a repo-wide decision rather than a side effect of a
portability fix, so it is recorded and not done here."* That condition is now met - the repo-wide
decision has been taken, and this is a dedicated CI change rather than a side effect. The commit body
names that commit and quotes the sentence.

**Why the lane, in one line:** four BSD portability defects reached master, were found by hand on the
only macOS machine in play, and no CI job went red, because every shell self-test lane is
`ubuntu-latest`.

The job **pins PATH bash to `/bin/bash`** before running anything and then asserts the pin took. Most
scripts are `#!/usr/bin/env bash` and the self-tests invoke gates as bare `bash`, so PATH bash decides
what is actually under test; pinning makes the claim true by construction rather than by hope. Suites
are selected by glob, not a hand-list, so a new `bin/test-*.sh` gets covered automatically, and the
job fails if the glob matches nothing.

**Two items in the original scope turned out to be already fixed on master** by `ffba75936`, so they
are not here. They were verified rather than assumed: the gate exits 0, its self-test is 31/31, and
all tracked scripts parse under bash 3.2.

**One factual error corrected.** The header of `bin/check-branch-self-reference.sh` claimed the
pre-fix gate "still exited 0". It exited **127** - `set -euo pipefail` sits above the `mapfile` line,
so it could not exit 0. The wrong figure came from reading `$?` through a pipe. Swept the tree: one
instance, and the solutions write-up does not repeat it.

## What the first hosted runs found

The original version of this section said the lane assumed hosted macOS provides `node`, `gh` and
`python3`, and that the first CI run would be the test of that. It has now run. `node`, `gh` and
`python3` are all present. Two other things were not, and each surfaced as a suite refusing to
measure rather than as a suite finding a defect:

- **PyYAML.** `bin/check-docs-data.sh` needs it and fails closed at exit 2 without it. Installed,
  then asserted importable, so a later exit 2 there means a real defect.
- **ShellCheck.** `bin/check-shell-lint.sh` wraps it and `bin/test-check-shell-lint.sh` exits 2
  without it. Same treatment. `bin/check-all.sh` had already named this exact pair as a hole it
  cannot close on such a machine: *"the broken gate exits 2 and the linter exits 2, both land in
  cannot, and the sweep reports zero failures - a false green produced by two skips agreeing."*
  Installing it here is what gives that gate any BSD coverage at all.

## The lane had this PR's own bug in it

Worth calling out, because it is the subject matter turning up in the implementation.

The self-test loop was `if bash "$t"; then ok; else "self-test fails on macOS"; fi`, which collapses
every non-zero exit into one bucket. So the missing ShellCheck did not surface as "could not run";
it surfaced as

```
::error file=bin/test-check-shell-lint.sh::self-test fails on macOS
```

A suite that never executed a single case, reported as one that ran and found a BSD defect. That is
exactly the class this lane exists to catch, as its own header says two jobs up: not a construct that
errors, but one that keeps running and reports a confident wrong answer.

The loop now gives exit 2 its own counter and its own message naming the remedy, and prints
`N run, N failed, N could not run`. **A SKIP IS NOT A PASS** is already the house rule in
`bin/check-all.sh`, which gives exit 2 its own column for this reason; the lane simply did not
implement it.

**Exit 2 still fails the job, deliberately.** On a dedicated portability lane a suite that could not
run is missing coverage, not a tolerable skip - letting it pass is how the lane quietly stops testing
anything while staying green, the same failure mode the bash 3.2 pin assertion guards against one
step up. What the change buys is attribution, not leniency.

Fixing only the dependency would have gone green and left the conflation in place until the next
exit-2 suite arrived, so both land together.

## Proof the lane can fail

Mutation arms, not just a green run. The suite and script counts below are from when the arms were
run; the merge described next has since raised the suite count, which is the point of globbing rather
than hand-listing.

| Arm | Result |
|---|---|
| self-tests, unmodified | 17 run, 0 failed |
| `mapfile` reintroduced | exit 1, **31/31 cases fail on bash 3.2** - and all 31 pass on bash 5, which is the coverage only this lane adds |
| parse sweep, unmodified | 62 scanned, 0 failed |
| parse sweep, apostrophe restored | exit 1, names the file |
| version assert, stub bash reporting 5.x | exit 1 |
| exit-2 attribution, three-arm fixture under real `/bin/bash` 3.2 | a suite exiting 0, one exiting 2 and one exiting 1 are counted and named separately; exit-2-only still exits 1 |

## Merging master, and the one conflict worth recording

Master collapsed Repo Hygiene's nine per-gate jobs into a single job running
`bin/check-all.sh --with-tests`. This branch still had the nine-job shape plus its macOS lane.

Resolved as **master's structure plus the macOS job**. `check-all.sh` discovers the ubuntu gates by
glob, so re-adding them would double-run each, while the macOS lane is the one thing master cannot
subsume.

**Folding `shell: macos` into `check-all.sh` would not work**, and is worth stating because it is the
natural-looking simplification: `check-all.sh` runs on `ubuntu-latest`, so it exercises none of what
this lane exists for. The lane's value is the platform, not the list of scripts.

`.github/workflows/README.md` is the directory that claims to index every check, and its
`repo-hygiene.yml` line did not mention the new job; it now does.

## Checklist

- [x] Docs updated - `docs/inflight/ci-bsd-portability-gaps.md` shrunk to what remains open, per that
      directory's rule against FIXED narratives; the three surviving items each say whether this lane
      helps. `.github/workflows/README.md` now indexes the new job.
- [x] User-facing feature documentation data added under `docs/features/` - **N/A** - CI-only change,
      no user-facing behaviour.
- [x] Tests added/updated - the lane runs the existing suites on a platform they have never run on;
      the mutation arms above demonstrate it can go red, including the new exit-2 attribution arm.
- [x] Title & body reflect the final content of this PR
