### PR TITLE
ci(static): turn on the analysis this repo was not running, and register what stays off

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -117,14 +117,24 @@ jobs:
 
   # Mutation testing (PIT). ci-mutation-test.sh scopes to the classes CHANGED vs the PR base
   # (GITHUB_BASE_REF), so it's fast enough for the 2-core hosted runner - the full internal.* sweep would
-  # time out here (which is why it used to be self-hosted-only). Advisory / non-gating.
+  # time out here (which is why it used to be self-hosted-only).
+  #
+  # ADVISORY ABOUT SCORES, NOT ABOUT ITSELF. `continue-on-error: true` stays - it keeps a mutation
+  # result from failing the workflow run, while the check ROW still renders red when the step fails
+  # (measured, see docs/inflight/ci-mutation-lane-skip-reads-as-a-pass.md). So red was always
+  # honest here and green never was: measured 2026-08-25 over the last 40 pull_request runs of this
+  # workflow, 40 green ticks and zero mutants scored, because every path out of the script exited 0.
+  # The step below reads bin/ci-mutation-test.sh's exit code instead and reacts to each state
+  # separately - survivors still fail nothing, but a lane that could not run, or ran and measured
+  # nothing, now goes red. The exit-code contract lives in that script's header;
+  # docs/inflight/ci-mutation-testing.md has the measurement.
   mutation:
     if: github.event_name == 'pull_request'
     needs: prepare-deps
     name: "Mutation Tests (PIT, PR-scoped)"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true      # advisory - never gates merge
+    continue-on-error: true      # advisory - never gates merge; a failed STEP still reddens the row
     steps:
       - uses: actions/checkout@v6
         with:
@@ -140,8 +150,25 @@ jobs:
           key: setup-java-Linux-x64-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             setup-java-Linux-x64-maven-
+      - name: Self-test the mutation verdict
+        # Ahead of the lane it protects, the same ordering repo-hygiene.yml and pr-checklist.yml use.
+        # Seconds, no maven: it feeds canned PIT logs through the verdict and asserts the exit codes.
+        run: bash bin/test-ci-mutation-test.sh
+
       - name: Mutation testing (changed classes only)
-        run: bin/ci-mutation-test.sh
+        run: |
+          set +e
+          bin/ci-mutation-test.sh
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "PIT scored mutants - see the job summary for the survivor list." ;;
+            3) echo "::notice::PIT had nothing in scope: no core main-source class in a decidable package changed." ;;
+            2) echo "::error::PIT could not run, or ran and scored nothing. This is a broken lane, not a clean PR."
+               exit 1 ;;
+            *) echo "::error::PIT exited ${rc}."
+               exit "$rc" ;;
+          esac
 
   # Quarantine AUDIT: the seconds-fast enforcement job on every PR - registry drift and broken owner
   # claims are real, actionable errors that turn it red. It does NOT run any tests (that is
@@ -318,9 +345,94 @@ jobs:
           compare_with_base: true
           max_increase: 10
 
+  # RacerD (Meta's Infer) - the only detector here that finds races WITHOUT being told where to look.
+  # Error Prone's GuardedBy only fires where somebody wrote the annotation, and this codebase has
+  # none; the racing-double seam tests can only re-prove seams already found by hand. RacerD infers
+  # which locks protect which state from how the code uses them.
+  #
+  # AN IDENTITY SET, not a count. config/racerd-known-findings.txt records which races are known, keyed on
+  # bug type plus class.method. A bare count ceiling could not distinguish "one race fixed" from "one
+  # race swapped for a different one" - both leave the total unchanged - which an independent
+  # cross-model review caught, and which is the same reports-green-while-it-changed class this lane
+  # exists to police. Twelve lines, checked in, so both directions are a visible diff.
+  #
+  # Fails BOTH ways: a new identity is a new race, and a known one that stops firing means somebody
+  # fixed a race without ratcheting the file.
+  racerd:
+    if: github.event_name == 'pull_request'
+    name: "static: racerd"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: prepare-deps
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: setup-java-Linux-x64-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            setup-java-Linux-x64-maven-
+
+      # Keyed on the version alone - the toolchain changes only when we bump it, which makes this a
+      # better cache key than the pom-hash ones above. Unpacked it is ~950 MB, so the TARBALL is what
+      # gets cached and it is unpacked per run: the repo-wide cache budget is 10 GB and several jobs
+      # already hold ~/.m2.
+      - name: Restore the Infer toolchain
+        id: infer-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/infer-dist/infer.tar.xz
+          key: infer-linux-x86_64-v1.3.0
+
+      - name: Download Infer
+        if: steps.infer-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/infer-dist
+          curl -sSL --fail -o ~/infer-dist/infer.tar.xz \
+            https://github.com/facebook/infer/releases/download/v1.3.0/infer-linux-x86_64-v1.3.0.tar.xz
+
+      # Runs UNCONDITIONALLY, not only on a cache miss, because the cache is the mutable half. A
+      # fresh download arrives over TLS from a pinned release URL; a restored one arrives from a
+      # writable store keyed by a string anyone with write access to a branch can populate. Verifying
+      # only what was just downloaded would check the half that is already the safer of the two, and
+      # then unpack the other half unexamined.
+      #
+      # The digest was taken from two independent fetches of the pinned URL and the tarball confirmed
+      # to be an Infer distribution. If this step ever fails, do not "fix" it by re-recording the
+      # digest from whatever arrived - that is the failure mode it exists to catch. Bump the cache key
+      # to force a clean download and see whether the digest returns; a genuine upstream re-cut of a
+      # published tag is the rarer explanation and should be confirmed against the release page.
+      - name: Verify the Infer archive against its pinned digest
+        run: |
+          echo "02be62ba931cb43e2d42bbf7abf4bd9a410cf8464cce5453934e25c90a825850  $HOME/infer-dist/infer.tar.xz" \
+            | sha256sum --check --strict -
+
+      - name: Unpack and confirm it runs
+        run: |
+          mkdir -p ~/infer
+          tar -xJf ~/infer-dist/infer.tar.xz -C ~/infer --strip-components=1
+          ~/infer/bin/infer --version
+
+      # Asserts the ceiling in both directions. Analysis itself is ~11s over core's 73 files; the
+      # timeout is for the download on a cache miss.
+      # INFER_BIN and RACERD_JDK are set here rather than in an `env:` block on purpose. An earlier
+      # version set all three in `env:` AND overrode two of them inline, so the env values were dead
+      # - and worse, wrong: INFER_BIN pointed at the workspace, while the unpack step above puts the
+      # toolchain in $HOME/infer. Deleting the inline prefix, which is exactly what a later tidy-up
+      # would do, would have pointed the lane at nothing. `$HOME` and `$JAVA_HOME` are not available
+      # to `env:` at all, which is what forced the inline form in the first place.
+      - name: RacerD
+        run: INFER_BIN="$HOME/infer/bin/infer" RACERD_JDK="$JAVA_HOME" bash bin/racerd-test.sh
+
   # SpotBugs static analysis - finds null derefs, concurrency issues, resource leaks.
-  # Uses a baseline from the base branch so only NEW bugs introduced by the PR are
-  # reported. The baseline is generated by the push build and cached.
+  # Whole reactor, main AND test code, with fb-contrib and find-sec-bugs detectors loaded.
+  # Suppression is by rule in config/spotbugs-exclude.xml; the registry that justifies every entry is
+  # docs/inflight/static-spotbugs-rule-registry.md.
   spotbugs:
     if: github.event_name == 'pull_request'
     name: "static: spotbugs"
@@ -340,25 +452,35 @@ jobs:
           key: setup-java-Linux-x64-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             setup-java-Linux-x64-maven-
-      - name: Restore SpotBugs baseline
-        id: spotbugs-baseline
-        uses: actions/cache/restore@v4
-        with:
-          path: .spotbugs-baseline.xml
-          key: spotbugs-baseline-${{ github.base_ref }}-${{ hashFiles('**/src/main/**/*.java') }}
-          restore-keys: |
-            spotbugs-baseline-${{ github.base_ref }}-
-            spotbugs-baseline-
+      # No baseline restore, and no baseline job: suppression is by RULE now, in the checked-in
+      # config/spotbugs-exclude.xml the pom points at, with every entry justified in
+      # docs/inflight/static-spotbugs-rule-registry.md. The job this replaces regenerated an exclude
+      # filter on every push to master, keyed on class + method + bug type, and recorded nothing
+      # about what it swallowed.
+      #
+      # test-compile, not compile: the pom sets includeTests, and target/test-classes has to exist
+      # for that to mean anything. Whole reactor, not `-pl parallel-consumer-core -am` - `-am` adds
+      # only the parent pom, so vertx, reactor, mutiny and the examples went unanalysed.
+      #
+      # `spotbugs:check` IS THE REPORTING HALF, and it is not optional. `spotbugs:spotbugs` writes
+      # spotbugsXml.xml and prints not one finding - the build log says "Skipping ... report goal"
+      # and nothing else - so every bit of reporting was GitHub-side: annotations, the sticky comment,
+      # the check run. Anyone running the build locally got total silence over hundreds of findings,
+      # which review caught by asking the obvious question nobody had: "do they at least get reported,
+      # and in the mvn build output?"
+      #
+      # `failOnError=false` keeps it advisory, so this changes what the lane SAYS and not what it
+      # gates - the staged position the rule registry documents, with its own trigger for making
+      # findings blocking. What `check` adds that neither the annotations nor the sticky comment give
+      # is the RULE NAME on every line, which is the one thing needed to tier a finding in that
+      # registry:
+      #   [ERROR] Medium: ... UTAO_JUNIT_ASSERTION_ODDITIES_ACTUAL_CONSTANT
+      #
+      # Not bound to a lifecycle phase on purpose: SpotBugs at effort=Max over the whole reactor is
+      # minutes, and paying that on every local `mvn test` would get the plugin switched off. Run the
+      # same two goals by hand when you want the list.
       - name: Compile and run SpotBugs
-        run: |
-          EXCLUDE_ARG=""
-          if [ -f .spotbugs-baseline.xml ]; then
-            EXCLUDE_ARG="-Dspotbugs.excludeFilterFile=.spotbugs-baseline.xml"
-            echo "Using baseline — only new bugs will be reported"
-          else
-            echo "No baseline found — reporting all bugs (first run on this base branch)"
-          fi
-          ./mvnw --batch-mode -Pci compile spotbugs:spotbugs $EXCLUDE_ARG -pl parallel-consumer-core -am
+        run: ./mvnw --batch-mode -Pci test-compile spotbugs:spotbugs spotbugs:check -Dspotbugs.failOnError=false
       - name: Post SpotBugs annotations on PR
         if: always()
         uses: jwgmeligmeyling/spotbugs-github-action@v1.2
@@ -372,7 +494,6 @@ jobs:
           script: |
             const fs = require('fs');
             const { execSync } = require('child_process');
-            const hasBaseline = fs.existsSync('.spotbugs-baseline.xml');
             const files = execSync('find . -path "*/target/spotbugsXml.xml" -type f').toString().trim().split('\n').filter(f => f);
             let body;
             if (files.length === 0) {
@@ -384,9 +505,7 @@ jobs:
                 const matches = content.match(/<BugInstance/g);
                 totalBugs += matches ? matches.length : 0;
               }
-              const baselineNote = hasBaseline
-                ? ' (new bugs only — baseline from base branch excluded)'
-                : ' (no baseline available — showing all bugs)';
+              const baselineNote = ' (rule-level exclusions only - see docs/inflight/static-spotbugs-rule-registry.md)';
               if (totalBugs === 0) {
                 body = `## :white_check_mark: SpotBugs Report\n\nNo bugs found${baselineNote}.\n`;
               } else {
@@ -418,57 +537,6 @@ jobs:
           allow-dependencies-licenses: pkg:githubactions/actions/github-script
 
   # ── Push Builds (master) ───────────────────────────────────────────────
-
-  # Generate SpotBugs baseline for PR comparisons. Runs on every push to
-  # master so PR builds can exclude known bugs and only report new ones.
-  spotbugs-baseline:
-    if: github.event_name == 'push'
-    name: "static: spotbugs baseline"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: prepare-deps
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Restore Maven cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.m2/repository
-          key: setup-java-Linux-x64-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            setup-java-Linux-x64-maven-
-      - name: Compile and generate SpotBugs XML
-        run: ./mvnw --batch-mode -Pci compile spotbugs:spotbugs -pl parallel-consumer-core -am
-      - name: Convert SpotBugs results to exclude filter
-        run: |
-          # Transform the SpotBugs XML into an exclude filter that can be
-          # passed to future runs via -Dspotbugs.excludeFilterFile. Each
-          # BugInstance becomes a Match element keyed on class + method + bug type.
-          python3 -c "
-          import xml.etree.ElementTree as ET, sys
-          tree = ET.parse('parallel-consumer-core/target/spotbugsXml.xml')
-          root = tree.getroot()
-          out = ET.Element('FindBugsFilter')
-          for bug in root.findall('.//BugInstance'):
-              match = ET.SubElement(out, 'Match')
-              cls = bug.find('Class')
-              method = bug.find('Method')
-              if cls is not None:
-                  ET.SubElement(match, 'Class', name=cls.get('classname', ''))
-              if method is not None:
-                  ET.SubElement(match, 'Method', name=method.get('name', ''))
-              ET.SubElement(match, 'Bug', pattern=bug.get('type', ''))
-          ET.ElementTree(out).write('.spotbugs-baseline.xml', xml_declaration=True, encoding='utf-8')
-          print(f'Baseline: {len(root.findall(\".//BugInstance\"))} bugs excluded')
-          "
-      - name: Cache SpotBugs baseline
-        uses: actions/cache/save@v4
-        with:
-          path: .spotbugs-baseline.xml
-          key: spotbugs-baseline-${{ github.ref_name }}-${{ hashFiles('**/src/main/**/*.java') }}
 
   # Single full build on default Kafka version to gate SNAPSHOT publishing.
   # Uses the same ci-build.sh script that PRs use for Kafka compat testing.

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -26,6 +26,61 @@ permissions:
   contents: read
 
 jobs:
+  # ShellCheck over bin/ and .claude/hooks/, ERRORS only. Register item 2.
+  #
+  # The self-test runs BEFORE the gate, the same sequencing sigpipe uses below: a lint lane looks
+  # identical whether it examined 59 scripts or zero, so the control that proves it can fire has to
+  # run first. It carries two red arms, two green near-misses, and one deliberately green assertion
+  # recording that ShellCheck cannot see a bash-4 builtin on a bash 3.2 platform - that class belongs
+  # to the macos lane, not this one.
+  shell-lint:
+    name: "shell: lint"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      # ubuntu-latest ships shellcheck, but an image change that removed it must fail rather than
+      # silently pass - bin/check-shell-lint.sh exits 2 for "cannot run", and this makes that
+      # explicit at the point a reader looks.
+      - name: Confirm shellcheck is present
+        run: shellcheck --version
+
+      - name: Self-test the lint gate
+        run: bash bin/test-check-shell-lint.sh
+
+      # The RacerD preflight self-test needs a JDK, because one of its arms proves the JDK guard does
+      # NOT fire on a valid JDK. Pinned here rather than left to whatever the runner image ships:
+      # the arm used to look only for a developer's SDKMAN path, find nothing on a hosted runner, and
+      # print `skip` while the job reported success - so the one arm that matters never ran in CI.
+      # It now fails closed when no JDK resolves, which makes this step a real dependency rather than
+      # a nice-to-have. No `cache: maven` here, per the warning at the top of maven.yml.
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      # racerd-test.sh's preflight guards AND its identity ratchet. The ratchet arms used to need a
+      # real Infer run and so ran nowhere; they now drive the script through RACERD_DRY_RUN_REPORT
+      # against canned reports, including the same-count swap a bare ceiling waves through.
+      - name: Self-test the RacerD gate's preflight
+        run: bash bin/test-check-racerd.sh
+
+      # The PR-surface reporter's own self-test. It runs here rather than beside the reporter because
+      # the reporter needs a live PR and this does not: `gh` is faked on PATH, so the arms that matter
+      # - a finding on a line the diff wrote versus one merely in a file it opened - run anywhere.
+      - name: Self-test the PR analysis-surface reporter
+        run: bash bin/test-check-pr-analysis-surfaces.sh
+
+      # The run-all's own self-test. Worth having in CI for one reason above the others: it pins the
+      # assertion that catches its exception list going stale, and a stale list means the sweep is
+      # quietly checking fewer gates than it reports.
+      - name: Self-test the run-all sweep
+        run: bash bin/test-check-all.sh
+
+      - name: Lint the shell corpus
+        run: bash bin/check-shell-lint.sh
+
   sigpipe:
     name: "shell: sigpipe"
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ CLAUDE.md
 !/CLAUDE.md
 !/bin/CLAUDE.md
 !/docs/inflight/CLAUDE.md
+!/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/CLAUDE.md
 
 # Local per-worktree ownership markers (see AGENTS.md "Worktree ownership")
 .worktree-owner

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ is untracked (a whole triage doc was once written duplicating `docs/refactoring.
 | [`docs/merge-checklist.md`](docs/merge-checklist.md) | Getting a PR ready to merge - what to offer the author, including the squash message and reorganising the commits |
 | [`bin/AGENTS.md`](bin/AGENTS.md) | Writing or changing a script in `bin/` - the shell conventions, including the ones no check enforces |
 | [`docs/inflight/AGENTS.md`](docs/inflight/AGENTS.md) | Adding or editing a note in `docs/inflight/` - what may live there, and when to delete it |
+| [`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md`](parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md) | Changing a field in the engine - the `@GuardedBy` rule, the known shared state and its ledgers, and the shard-map pin |
 
 **A directory with its own `AGENTS.md` owns the rules for what goes in it - read it before you write
 there, not after review catches you.** The table above routes the ones that exist today; `find . -name
@@ -257,9 +258,11 @@ section does.
 - **Assert the renames git RECORDED *and* their pairing - a bare R-count reads a mis-paired rename
   as healthy.** `bin/rename-packages.sh` asserts both; if you moved anything by hand, do both by
   hand.
-- **Confirm the mutation lane scored mutants rather than trusting its tick.**
-  `bin/ci-mutation-test.sh` exits **0** printing "nothing to mutate, skipping" when its package
-  regex is stale, which is indistinguishable from a pass in the job summary.
+- **Confirm the mutation lane scored mutants rather than trusting its tick.** A stale package regex
+  used to exit **0** printing "nothing to mutate, skipping", indistinguishable from a pass;
+  `bin/ci-mutation-test.sh` now exits 2 for it, and 3 for a genuine skip.
+  [`docs/ci.md`](docs/ci.md) owns the lane and its exit codes, so this bullet goes with the rest of
+  this section.
 
 ## Overview
 
@@ -416,6 +419,20 @@ Nothing lints commit messages, so all of this is on you.
   [`docs/upstream.md`](docs/upstream.md).
 
 ## PR Discipline
+
+- **Before you push, run `bin/check-all.sh`** - it globs every gate and self-test in `bin/`, so the
+  set cannot drift from whatever you remembered. `bin/AGENTS.md` owns the detail, including why a
+  skip is never counted as a pass. This exists because a hand-picked sweep of seven gates missed one
+  and CI caught it.
+
+- **Read the analysis output on your own PR before asking for review:
+  `bin/check-pr-analysis-surfaces.sh [PR]`.** The tools report to five places that are not each
+  other, so checking by hand is a scavenger hunt nobody performs - and a finding nobody read is
+  indistinguishable from one that does not exist. The script splits findings **on a line your diff
+  wrote** (yours, and the only thing that sets its exit code) from those merely **in a file you
+  touched** (inherited - leave those to the registries). Its header owns the detail and the worked
+  incident: astubbs#356 turned `-Xlint:all` and SpotBugs-over-tests on, both fired on files it was
+  editing - one on a line it had just rewritten for a different detector - and nobody looked.
 
 - **Before merging a fix, look for other instances of the same defect - and say what you found,
   including "none".** A fix that removes today's instance invites tomorrow's. Once you can name the

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -140,7 +140,20 @@ rate recovered from starved runs prices every candidate budget at once.
 
 The proof requires a deliberately mismatched pair: old code, new tests. Any procedure that reverts
 both together produces a matched pair and a vacuous pass, so a red-proof that does not go red is
-first evidence against the method, not for the code.
+first evidence against the method, not for the code. The same demand applied to an analyser rather
+than a test is what catches inert configuration.
+
+**Inert configuration**
+Analysis or build settings that are present in the source, syntactically valid, and never reach the
+run they were written for - so the tool executes correctly against a configuration that is not the
+one you wrote. Distinct from a broken tool: nothing errors, nothing is skipped, and the report is
+truthful about a scope nobody intended.
+
+It is invisible to every signal except a count, because the absence of findings it produces is
+indistinguishable from a clean codebase. Suppressions are the mirror case: one matching nothing looks
+exactly like one that works. The verification is therefore to assert the number - that a disabled
+rule reports zero, that an enabled one reports more than zero - never to observe that the build
+passed.
 
 **Positive control**
 An arm of a measurement whose only job is to register a hit, proving the instrument could have detected

--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -18,6 +18,25 @@ Everything else about the allowlist - the two boundaries it sits between, what s
 grant, and why a grant must land before the pull request that needs it - is in
 [`docs/ci.md`](../docs/ci.md) -> "Editing the reviewer".
 
+## Run them all with `bin/check-all.sh`, not from memory
+
+**Before you push: `bin/check-all.sh`.** It globs `bin/test-*.sh` then `bin/check-*.sh`, so a gate
+added tomorrow is swept with no edit anywhere - nobody has to remember to register it, and nobody
+has to remember it exists.
+
+That property is the whole design, and it is why the discovery loop must stay a glob. The script
+exists because astubbs#356 pushed a branch that failed `check-branch-self-reference.sh` in CI after
+a local sweep of seven gates chosen by hand. The gate was not new, subtle, or broken; it was not on
+somebody's list.
+
+- **A skip is never a pass.** Exit 2 (cannot run) and exit 3 (nothing in scope) get their own
+  columns and are excluded from the pass count, because a gate that measured nothing must not read
+  like one that measured and found nothing.
+- **Five scripts are not tree gates** - four report the state of a *pull request* and one needs a
+  maven-log argument - so they are skipped by default and run under `--pr`. Since a hand-maintained
+  list is exactly what this script abolishes, every name in it is **asserted to exist**: rename one
+  and the runner exits 2 rather than quietly sweeping one gate fewer than it claims.
+
 ## Scripts that guard other scripts
 
 `test-check-*.sh` files are self-tests for the corresponding `check-*.sh`, and CI runs them **before**

--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# EVERY GATE IN bin/, DISCOVERED RATHER THAN LISTED. Run this before you push.
+#
+# WHY THIS EXISTS. There are eighteen `check-*.sh` gates and twenty-one self-tests, and an agent
+# preparing a push had to know which ones applied. In practice that means running a subset
+# remembered from earlier in the session, which is how astubbs#356 pushed a branch that failed
+# `check-branch-self-reference.sh` in CI: the sweep before that push ran seven gates chosen by hand,
+# and that was not one of them. The gate was not new, not subtle, and not broken. It simply was not
+# on somebody's list.
+#
+# So the list is gone. This script GLOBS, and a gate added tomorrow is picked up with no edit here -
+# which also means nobody has to remember to register it. That property is the point, and it is why
+# the discovery loop must never become an explicit array however tempting it looks.
+#
+# A SKIP IS NOT A PASS, the house rule this repo keeps relearning. Gates that exit 2 for "cannot
+# run" - no `gh`, no credential, no network - get their own column and are never counted as passes,
+# because a run that could not measure anything must not look like one that measured and found
+# nothing. Same for exit 3, "nothing in scope".
+#
+# THE ONE EXCEPTION LIST, and the assertion that keeps it honest. A few `check-*.sh` are not tree
+# gates: they take a required argument, or they report the state of a PULL REQUEST rather than the
+# state of the tree, so running them in a pre-push sweep produces noise that trains people to ignore
+# the output. They are skipped by default and run under `--pr`. Because a hand-maintained list is
+# exactly what this script exists to abolish, every name in it is ASSERTED TO EXIST: rename one of
+# these scripts and this runner fails loudly instead of quietly checking less than you think.
+#
+# Exit codes: 0 everything that could run passed, 1 at least one FAILED, 2 nothing ran at all.
+#
+# Usage:
+#   bin/check-all.sh                 # self-tests, then tree gates - what to run before a push
+#   bin/check-all.sh --pr            # also the PR-state reporters (merge prep)
+#   bin/check-all.sh --gates-only    # skip the self-tests
+#   bin/check-all.sh --tests-only    # only the self-tests
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+MODE=all
+WITH_PR=0
+for arg in "$@"; do
+    case "$arg" in
+        --pr)         WITH_PR=1 ;;
+        --gates-only) MODE=gates ;;
+        --tests-only) MODE=tests ;;
+        -h|--help)    sed -n '5,35p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "check-all: unknown argument '$arg'" >&2; exit 2 ;;
+    esac
+done
+
+SELF="$(basename "$0")"
+
+# NOT TREE GATES. Each line is a name and the reason it is not in the default sweep.
+PR_SCOPED="check-pr-ready.sh check-human-lgtm.sh check-review-posted.sh check-pr-analysis-surfaces.sh"
+NEEDS_ARGS="check-ossindex-audit.sh"
+
+reason_for() {
+    case "$1" in
+        check-pr-ready.sh)             echo "reports PR readiness, not tree health" ;;
+        check-human-lgtm.sh)           echo "asks GitHub whether a human approved" ;;
+        check-review-posted.sh)        echo "asks GitHub whether a review was posted" ;;
+        check-pr-analysis-surfaces.sh) echo "reads a PR's analysis annotations" ;;
+        check-ossindex-audit.sh)       echo "requires a maven log argument" ;;
+        *)                             echo "excluded" ;;
+    esac
+}
+
+# THE ASSERTION THAT STOPS THIS LIST ROTTING, in both directions.
+#
+# Existence alone is the weaker half: it catches a rename, and is blind to a script whose REASON
+# stopped being true. If `check-ossindex-audit.sh` were changed to stop requiring an argument it
+# would sit in NEEDS_ARGS being skipped forever, which is "checking less than it claims" arriving by
+# staleness rather than deletion. So each recorded reason is corroborated by an independent signal
+# in the script itself, and a mismatch fails loudly: the list is five entries, a false positive
+# costs a minute, and silent staleness is the defect this whole script exists to remove.
+missing=""; uncorroborated=""
+for n in $PR_SCOPED $NEEDS_ARGS; do
+    if [ ! -f "bin/$n" ]; then missing="${missing} ${n}"; continue; fi
+    case " $PR_SCOPED " in
+        *" $n "*)  # claimed to report PR state - it must actually talk to GitHub
+            grep -q "gh " "bin/$n" || uncorroborated="${uncorroborated} ${n}(no gh call)" ;;
+    esac
+    case " $NEEDS_ARGS " in
+        *" $n "*)  # claimed to need an argument - it must actually say so
+            grep -q "usage:" "bin/$n" || uncorroborated="${uncorroborated} ${n}(no usage line)" ;;
+    esac
+done
+if [ -n "$missing" ]; then
+    echo "check-all: the exception list names script(s) that do not exist:${missing}" >&2
+    echo "check-all: renamed or deleted? Fix the list - until then this sweep is checking less than" >&2
+    echo "check-all: it claims to, which is the exact failure this script was written to prevent." >&2
+    exit 2
+fi
+if [ -n "$uncorroborated" ]; then
+    echo "check-all: an exception's stated reason is no longer corroborated:${uncorroborated}" >&2
+    echo "check-all: the script changed character. Re-read it: if it is now an ordinary tree gate," >&2
+    echo "check-all: drop it from the list rather than leaving it skipped on a reason that expired." >&2
+    exit 2
+fi
+
+pass=0; fail=0; cannot=0; nothing=0; ran=0; skipped=0
+failed_names=""; cannot_names=""
+
+run_one() {
+    local script="$1" label="$2" start end rc out syntax
+    start=$(date +%s)
+
+    # A GATE BASH CANNOT PARSE ALSO EXITS 2, colliding with the exit-2 "cannot run" convention this
+    # repo uses everywhere - leave an unresolved merge-conflict marker in a check script and `bash
+    # the-script` returns 2 from the PARSER, before one line of its logic runs.
+    #
+    # THE SWEEP IS NOT USUALLY BLIND TO THAT, and the review that raised it overstated the case:
+    # `check-shell-lint.sh` runs ShellCheck over all of `bin/` at severity=error, and an unterminated
+    # `if` is SC1072/SC1073, so the sweep normally goes red via the linter. Measured, not assumed.
+    #
+    # The residual hole is narrow and real: `check-shell-lint.sh` itself exits 2 when ShellCheck is
+    # not installed. On such a machine the broken gate exits 2 and the linter exits 2, both land in
+    # `cannot`, and the sweep reports zero failures - a false green produced by two skips agreeing.
+    # The second reason is plain attribution: "does not parse" names the broken gate, where "CANNOT
+    # RUN (usually a missing tool or credential)" sends the reader looking for a missing credential.
+    if ! syntax="$(bash -n "$script" 2>&1)"; then
+        end=$(date +%s)
+        ran=$((ran + 1)); fail=$((fail + 1)); failed_names="${failed_names} ${label}"
+        printf '  FAIL    %-42s %ss  (does not parse - this is a broken gate, not a skip)\n' \
+            "$label" "$((end - start))"
+        printf '%s\n' "$syntax" | head -3 | sed 's/^/          | /'
+        return
+    fi
+
+    out="$(PR_NUMBER="${PR_NUMBER:-}" bash "$script" 2>&1)"
+    rc=$?
+    end=$(date +%s)
+    ran=$((ran + 1))
+    case "$rc" in
+        0) pass=$((pass + 1));     printf '  ok      %-42s %ss\n' "$label" "$((end - start))" ;;
+        2) cannot=$((cannot + 1)); cannot_names="${cannot_names} ${label}"
+           printf '  CANNOT  %-42s %ss  (exit 2 - not a pass)\n' "$label" "$((end - start))" ;;
+        3) nothing=$((nothing + 1))
+           printf '  none    %-42s %ss  (exit 3 - nothing in scope)\n' "$label" "$((end - start))" ;;
+        *) fail=$((fail + 1)); failed_names="${failed_names} ${label}"
+           printf '  FAIL    %-42s %ss  (exit %s)\n' "$label" "$((end - start))" "$rc"
+           printf '%s\n' "$out" | tail -6 | sed 's/^/          | /' ;;
+    esac
+}
+
+# Self-tests first, the order CI uses: bin/AGENTS.md requires a gate's self-test to run BEFORE the
+# gate it protects, so a broken checker surfaces as a broken checker rather than as a mysterious
+# failure in whatever it was checking.
+if [ "$MODE" = "all" ] || [ "$MODE" = "tests" ]; then
+    echo "=== self-tests ==="
+    for t in bin/test-*.sh; do
+        [ -f "$t" ] || continue
+        run_one "$t" "$(basename "$t")"
+    done
+fi
+
+if [ "$MODE" = "all" ] || [ "$MODE" = "gates" ]; then
+    echo "=== gates ==="
+    for g in bin/check-*.sh; do
+        [ -f "$g" ] || continue
+        n="$(basename "$g")"
+        [ "$n" = "$SELF" ] && continue                       # never recurse
+        if [ "$WITH_PR" -eq 0 ] && [[ " $PR_SCOPED " == *" $n "* ]]; then
+            skipped=$((skipped + 1))
+            printf '  skip    %-42s      (%s - use --pr)\n' "$n" "$(reason_for "$n")"
+            continue
+        fi
+        if [[ " $NEEDS_ARGS " == *" $n "* ]]; then
+            skipped=$((skipped + 1))
+            printf '  skip    %-42s      (%s)\n' "$n" "$(reason_for "$n")"
+            continue
+        fi
+        run_one "$g" "$n"
+    done
+fi
+
+echo
+if [ "$ran" -eq 0 ]; then
+    echo "check-all: NOTHING RAN - no scripts matched. A broken checkout, not a clean tree." >&2
+    exit 2
+fi
+printf 'check-all: %s ran - %s passed, %s failed, %s could not run, %s nothing-in-scope, %s skipped\n' \
+    "$ran" "$pass" "$fail" "$cannot" "$nothing" "$skipped"
+
+if [ "$cannot" -gt 0 ]; then
+    printf 'check-all: COULD NOT RUN:%s\n' "$cannot_names"
+    echo   "check-all:   these measured nothing. Usually a missing tool or credential - fix it, or"
+    echo   "check-all:   know that CI is the first place that gate actually runs."
+fi
+if [ "$fail" -gt 0 ]; then
+    printf 'check-all: FAILED:%s\n' "$failed_names" >&2
+    exit 1
+fi
+echo "check-all: no gate failed."
+exit 0

--- a/bin/check-pr-analysis-surfaces.sh
+++ b/bin/check-pr-analysis-surfaces.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# EVERY ANALYSIS FINDING THAT LANDS ON A FILE YOUR PR TOUCHES, from every surface, in one command.
+#
+# WHY THIS EXISTS. The tools in this repo report to five different places, and no two of them are the
+# same place: the Maven console, GitHub check annotations on the Files Changed tab, sticky PR
+# comments, job summaries, and artifact files inside `target/`. Checking a PR against all five is a
+# scavenger hunt, so in practice nobody does it - and the failure is silent, because a finding nobody
+# read looks exactly like a finding that does not exist.
+#
+# It is not a hypothetical. astubbs/parallel-consumer#356 is the PR that TURNED ON `-Xlint:all` and
+# SpotBugs-over-test-code. Both immediately fired on files that same PR was editing - a deprecated
+# call and an unchecked conversion in `AbstractParallelEoSStreamProcessor`, and an fb-contrib finding
+# on the exact `PCMetricsDef.toCamelCase` line the PR had just rewritten to satisfy a DIFFERENT
+# detector. The author never looked at any of them. They were found by a human scrolling the Files
+# Changed tab. An agent that switches a channel on and does not read it has not enabled analysis; it
+# has enabled a channel.
+#
+# SCOPE: gh READS only, which is what keeps the `check-` prefix honest - see bin/AGENTS.md, "Naming a
+# script here can grant it to the PR reviewer". It writes nothing, posts nothing, and needs no token
+# beyond whatever `gh` already has.
+#
+# WHAT IT CANNOT SEE, stated so a clean run is not mistaken for a clean PR:
+#   - Job summaries (PIT's survivor table, the CVE tables) are not exposed by the REST API at all.
+#     The run URLs are printed instead; those you open by hand.
+#   - Console-only output. A finding a tool prints to the Maven log and nowhere else is invisible
+#     here, which is the argument for making tools annotate rather than merely print.
+#   - Findings on files your PR does NOT touch. Deliberate: this answers "did I make it worse", not
+#     "is the codebase clean". The standing haul is the registries' job.
+#
+# Exit codes: 0 nothing on your files, 1 findings on files you changed, 2 CANNOT RUN.
+# The 2 matters - "gh is not authenticated" must never read as "no findings", the same fail-closed
+# contract bin/ci-mutation-test.sh and bin/racerd-test.sh hold.
+
+set -euo pipefail
+
+REPO="${PR_SURFACES_REPO:-astubbs/parallel-consumer}"
+PR="${1:-}"
+
+if ! command -v gh > /dev/null 2>&1; then
+    echo "check-pr-analysis-surfaces: gh is not installed - CANNOT RUN (this is not a pass)." >&2
+    exit 2
+fi
+if ! command -v python3 > /dev/null 2>&1; then
+    echo "check-pr-analysis-surfaces: python3 is not installed - CANNOT RUN." >&2
+    exit 2
+fi
+
+if [ -z "$PR" ]; then
+    PR="$(gh pr view --repo "$REPO" --json number -q .number 2>/dev/null || true)"
+fi
+if [ -z "$PR" ]; then
+    echo "check-pr-analysis-surfaces: no PR given and none for the current branch - CANNOT RUN." >&2
+    echo "  Usage: bin/check-pr-analysis-surfaces.sh [PR_NUMBER]" >&2
+    exit 2
+fi
+
+echo "check-pr-analysis-surfaces: PR #${PR} in ${REPO}"
+
+# The head SHA is what check runs hang off. A PR number alone is not enough: annotations are per
+# commit, so asking about the PR without pinning the head silently mixes in a superseded push.
+HEAD_SHA="$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid 2>/dev/null || true)"
+if [ -z "$HEAD_SHA" ]; then
+    echo "check-pr-analysis-surfaces: could not resolve PR #${PR}'s head - CANNOT RUN." >&2
+    exit 2
+fi
+echo "check-pr-analysis-surfaces: head ${HEAD_SHA:0:9}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- the changed-file set -------------------------------------------------------------------------
+if ! gh pr view "$PR" --repo "$REPO" --json files -q '.files[].path' > "$WORK/changed.txt" 2>/dev/null; then
+    echo "check-pr-analysis-surfaces: could not list PR #${PR}'s files - CANNOT RUN." >&2
+    exit 2
+fi
+CHANGED=$(wc -l < "$WORK/changed.txt" | tr -d ' ')
+if [ "$CHANGED" -eq 0 ]; then
+    echo "check-pr-analysis-surfaces: PR #${PR} changes no files - CANNOT RUN (that is not a clean PR)." >&2
+    exit 2
+fi
+echo "check-pr-analysis-surfaces: ${CHANGED} changed file(s)"
+
+# THE LINES, not just the files. "A finding in a file you opened" and "a finding on a line you wrote"
+# are different obligations, and collapsing them is what makes this kind of report ignorable: a PR
+# that adds one helper to a 1800-line class inherits every pre-existing finding in it, the list runs
+# to dozens, and the two findings that are actually yours are lost in it. The added-line ranges come
+# from the diff's own hunk headers.
+if ! gh pr diff "$PR" --repo "$REPO" > "$WORK/diff.txt" 2>/dev/null; then
+    echo "check-pr-analysis-surfaces: could not read PR #${PR}'s diff - CANNOT RUN." >&2
+    exit 2
+fi
+
+# --- surface 1: check-run annotations (SpotBugs, and javac via setup-java's problem matcher) --------
+if ! gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" > "$WORK/runs.json" 2>/dev/null; then
+    echo "check-pr-analysis-surfaces: could not read check runs - CANNOT RUN." >&2
+    exit 2
+fi
+
+# Annotations page at 100. A truncated fetch under-reports, which is the one failure mode this script
+# must not have, so every page is followed rather than assuming one is enough.
+: > "$WORK/ann.json"
+while read -r id name; do
+    [ -n "$id" ] || continue
+    for page in 1 2 3 4 5; do
+        if ! gh api "repos/${REPO}/check-runs/${id}/annotations?per_page=100&page=${page}" > "$WORK/p.json" 2>/dev/null; then
+            break
+        fi
+        count=$(python3 -c "import json,sys; print(len(json.load(open(sys.argv[1]))))" "$WORK/p.json" 2>/dev/null || echo 0)
+        [ "$count" -gt 0 ] || break
+        python3 -c "
+import json,sys
+for a in json.load(open(sys.argv[1])):
+    a['check_name'] = sys.argv[2]
+    print(json.dumps(a))
+" "$WORK/p.json" "$name" >> "$WORK/ann.json"
+        if [ "$count" -eq 100 ] && [ "$page" -eq 5 ]; then
+            # SILENT TRUNCATION IS THE ONE THING THIS SCRIPT MUST NOT DO. 5 pages of 100 is the cap,
+            # and this repo already sees 601 findings unfiltered across the reactor - well inside the
+            # range where a check run's annotations reach it. Under-reporting without saying so would
+            # make "no findings on your diff" mean "no findings in the first 500", which is the
+            # false-clean this tool exists to prevent.
+            echo "check-pr-analysis-surfaces: WARNING - ${name} has more than 500 annotations." >&2
+            echo "  Only the first 500 were read, so findings on your diff may be MISSING from the" >&2
+            echo "  report below. Treat a clean result from this run as unproven." >&2
+        fi
+        [ "$count" -eq 100 ] || break
+    done
+done < <(python3 -c "
+import json
+for r in json.load(open('$WORK/runs.json'))['check_runs']:
+    if (r.get('output') or {}).get('annotations_count', 0) > 0:
+        print(r['id'], r['name'])
+")
+
+python3 - "$WORK/changed.txt" "$WORK/ann.json" "$WORK/diff.txt" <<'PYEOF'
+import json, sys, collections, re
+
+changed = {line.strip() for line in open(sys.argv[1]) if line.strip()}
+
+# Added-line numbers per file, straight from the unified diff. Only '+' lines count: a finding on a
+# context line is pre-existing code the PR merely sat next to.
+added = collections.defaultdict(set)
+cur = None
+newno = 0
+for raw in open(sys.argv[3], errors='replace'):
+    if raw.startswith('+++ b/'):
+        cur = raw[6:].rstrip('\n')
+        continue
+    m = re.match(r'@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@', raw)
+    if m:
+        newno = int(m.group(1))
+        continue
+    if cur is None:
+        continue
+    if raw.startswith('+'):
+        added[cur].add(newno)
+        newno += 1
+    elif raw.startswith('-'):
+        pass
+    elif raw.startswith(' '):
+        newno += 1
+rows = []
+try:
+    for line in open(sys.argv[2]):
+        line = line.strip()
+        if line:
+            rows.append(json.loads(line))
+except FileNotFoundError:
+    rows = []
+
+# De-duplicate across check runs. The SAME javac warning is annotated once per compiling job, because
+# every job that runs setup-java registers its javac problem matcher - so one warning can appear
+# three or four times wearing different job names. Counting those separately would overstate the
+# finding count several-fold and bury the distinct ones.
+by_key = collections.OrderedDict()
+# start_line ALONE is not enough to decide whose finding it is. Annotations carry an end_line too,
+# and a SpotBugs finding that spans a method can start on an untouched line while ending inside one
+# the PR added - classifying that as "inherited" is a false negative in the direction that matters,
+# because it is the author's own change that provoked it. The span is kept and any overlap counts.
+spans = {}
+for a in rows:
+    if a.get('path') not in changed:
+        continue
+    key = (a.get('path'), a.get('start_line'), (a.get('message') or '').strip())
+    by_key.setdefault(key, []).append(a.get('check_name'))
+    spans[key] = (a.get('start_line'), a.get('end_line') or a.get('start_line'))
+
+def render(title, subtitle, items):
+    print()
+    print('=' * 96)
+    print(title)
+    print('=' * 96)
+    print('  ' + subtitle)
+    if not items:
+        print('  none')
+        return
+    per_file = collections.defaultdict(list)
+    for (path, line, msg), names in items.items():
+        per_file[path].append((line, msg, sorted(set(names))))
+    print('  %d distinct finding(s) across %d file(s)' % (len(items), len(per_file)))
+    for path in sorted(per_file):
+        print()
+        print('  %s' % path)
+        for line, msg, names in sorted(per_file[path], key=lambda x: (x[0] or 0)):
+            short = ' '.join(msg.split())
+            if len(short) > 150:
+                short = short[:147] + '...'
+            print('    line %-6s %s' % (line, short))
+            print('    %-11s reported by: %s' % ('', ', '.join(names)))
+
+yours, inherited = collections.OrderedDict(), collections.OrderedDict()
+for key, names in by_key.items():
+    path, line, _ = key
+    lo, hi = spans.get(key, (line, line))
+    try:
+        span = range(int(lo), int(hi) + 1)
+    except (TypeError, ValueError):
+        span = [line]
+    touched = added.get(path, ())
+    mine = any(n in touched for n in span)
+    (yours if mine else inherited)[key] = names
+
+render('ON LINES THIS PR WROTE - these are yours',
+       'A finding here is on a line in your diff. Fix it, or say in the PR why not.',
+       yours)
+render('IN FILES THIS PR TOUCHES, on lines it did not write - inherited',
+       'Context, not an obligation. Do NOT bulk-fix these in this PR; they belong to the '
+       'registries under docs/inflight/.',
+       inherited)
+
+# Only the lines this PR wrote fail the check. Inheriting a file's history is not a defect, and a
+# gate that says otherwise would make every small PR to a large class unmergeable - which is how a
+# check gets switched off rather than obeyed.
+sys.exit(1 if yours else 0)
+PYEOF
+ANN_RC=$?
+
+# --- surface 2: bot comments on the PR --------------------------------------------------------------
+echo
+echo "================================================================================================"
+echo "BOT COMMENTS ON THIS PR - read these, they carry counts the annotations do not"
+echo "================================================================================================"
+gh api "repos/${REPO}/issues/${PR}/comments?per_page=100" --jq \
+    '.[] | select(.user.type == "Bot" or .user.login == "github-actions") | "  \(.created_at)  \(.user.login)\n    \(.body | split("\n")[0:2] | join(" ") | .[0:150])"' \
+    2>/dev/null || echo "  (could not read comments)"
+
+# --- surface 3: what this script cannot reach --------------------------------------------------------
+echo
+echo "================================================================================================"
+echo "SURFACES THIS SCRIPT CANNOT READ - open these by hand"
+echo "================================================================================================"
+echo "  Job summaries (PIT survivor table, CVE tables) are not exposed by the REST API."
+gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+    --jq '.check_runs[] | select(.name | test("Mutation|spotbugs|racerd|CVE|Quarantine")) | "    \(.name): \(.html_url)"' \
+    2>/dev/null | sort -u || true
+echo
+echo "  Console-only output: a tool that prints to the Maven log and does not annotate is invisible"
+echo "  here. Read the job log for those."
+
+echo
+if [ "$ANN_RC" -ne 0 ]; then
+    echo "check-pr-analysis-surfaces: findings ON LINES THIS PR WROTE (above)."
+    echo "  Fix them, or state in the PR why each stands. Inherited findings are listed separately"
+    echo "  and are NOT what this exit code is about."
+    exit 1
+fi
+echo "check-pr-analysis-surfaces: no annotations on the files this PR changes."
+echo "  NOTE: that is not 'the analysis is clean' - it is 'nothing landed on your diff'. Findings"
+echo "  elsewhere in the tree belong to the registries under docs/inflight/."
+exit 0

--- a/bin/check-quarantine-registry.sh
+++ b/bin/check-quarantine-registry.sh
@@ -47,7 +47,7 @@ for e in $(registry_entries); do
     if [ -z "$f" ]; then
         echo "DRIFT: $REGISTRY lists $e but no @Quarantined annotation found in a class named $cls - stale entry; delete it (rule 3: annotation and entry go together)."
         drift=1
-    elif [ -n "$method" ] && ! grep -qE "[[:space:]]$method[[:space:]]*\(" "$f"; then
+    elif [ -n "$method" ] && ! grep -qE "[[:space:]]${method}[[:space:]]*\(" "$f"; then
         echo "DRIFT: $REGISTRY lists $e but no method '$method' exists in $f - stale method entry; fix or delete it."
         drift=1
     fi

--- a/bin/check-shell-lint.sh
+++ b/bin/check-shell-lint.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# ShellCheck over bin/ and .claude/hooks/, gating on ERRORS only.
+#
+# WHY IT EXISTS. August 2026 produced a portability class this repo paid for repeatedly - `mapfile`
+# on a bash 3.2 platform, `stat -c`, `awk -v` with an embedded newline, GNU `sed -i` - and the
+# expensive ones were never the constructs that error out. They were the ones ACCEPTED with a
+# different meaning, or failing where the script does not check, so the run continues and produces a
+# confident wrong answer. ShellCheck is largely machine-detectable coverage for that class, and it
+# also flags unquoted expansion and exit-code swallowing, which is the mechanism underneath several
+# of this month's silent false greens. The lane's severity tiers and what stays off are in
+# docs/inflight/static-shell-lint-severity-tiers.md.
+#
+# WHY ERRORS ONLY, AND NOT WARNINGS. Measured on the tree that introduced this script: 3 errors, 10
+# warnings, 49 info, 18 style. Gating the whole 80 would mean either a red build on arrival or a
+# suppression file nobody reads - and this repo has just spent a PR replacing exactly that shape for
+# SpotBugs. The severities that are off, and what turns each back on, are in
+# docs/inflight/static-shell-lint-severity-tiers.md. Raise the floor by lowering SEVERITY below;
+# there is no per-code suppression list on purpose, because the moment there is one, it grows.
+#
+# Both errors it found on arrival were real:
+#   - bin/check-quarantine-registry.sh read `"$method[[:space:]]"` as an array expansion (SC1087).
+#   - bin/check-shell-sigpipe.sh opened a PROSE comment with the word `shellcheck`, so ShellCheck
+#     parsed it as a directive, errored SC1072/SC1073, and stopped analysing the rest of that file.
+#     A sentence about the linter had silently switched the linter off - in the script whose entire
+#     job is guarding against silent failure.
+#
+# Exit codes: 0 clean, 1 findings at or above SEVERITY, 2 cannot run (shellcheck missing).
+# The 2 matters: "the linter is not installed" must never read as "the code is clean", which is the
+# same fail-closed contract bin/lib/node-gate.sh gives the node-backed gates.
+
+set -euo pipefail
+
+SEVERITY="${SHELL_LINT_SEVERITY:-error}"
+
+if ! command -v shellcheck > /dev/null 2>&1; then
+    echo "check-shell-lint: shellcheck is not installed - CANNOT RUN (this is not a pass)" >&2
+    echo "  macOS: brew install shellcheck    Debian/Ubuntu: apt-get install -y shellcheck" >&2
+    exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+targets=()
+while IFS= read -r f; do
+    targets+=("$f")
+done < <(git ls-files 'bin/*.sh' '.claude/hooks/*.sh' | sort)
+
+if [ "${#targets[@]}" -eq 0 ]; then
+    echo "check-shell-lint: NO SCRIPTS MATCHED - refusing to report success over an empty set" >&2
+    exit 2
+fi
+
+echo "check-shell-lint: ${#targets[@]} script(s), severity floor '${SEVERITY}'"
+
+if shellcheck --severity="$SEVERITY" --shell=bash "${targets[@]}"; then
+    echo "check-shell-lint: clean at severity '${SEVERITY}'"
+    exit 0
+fi
+
+cat >&2 <<'GUIDANCE'
+
+check-shell-lint FAILED.
+
+Fix the finding rather than adding a suppression. If a finding is genuinely wrong for this codebase,
+raise it - the severity tiers live in docs/inflight/static-shell-lint-severity-tiers.md and changing
+them is a decision with a written reason, not an inline silence.
+GUIDANCE
+exit 1

--- a/bin/check-shell-sigpipe.sh
+++ b/bin/check-shell-sigpipe.sh
@@ -18,8 +18,11 @@
 # review posted" on four PRs whose reviews had posted; the one that broke it had the citation 4.7 KB
 # in with a 127 KB report behind it.
 #
-# shellcheck does NOT catch this - verified against the known-bad line, which it passed clean. Hence
-# a bespoke grep rather than a linter.
+# NOTE: ShellCheck does NOT catch this - verified against the known-bad line, which it passed clean.
+# Hence a bespoke grep rather than a linter. (The `NOTE:` prefix is load-bearing: a comment whose
+# first word is `shellcheck` is parsed as a DIRECTIVE, and this one errored as SC1072/SC1073, which
+# aborts analysis of the rest of the file. A prose sentence about the linter silently switched the
+# linter off here.)
 #
 # THE FIX is always the same: a herestring. `grep -q PATTERN <<<"$data"` has no pipeline, so no
 # SIGPIPE and nothing for pipefail to promote.
@@ -71,7 +74,18 @@ for f in $(for d in $SCAN_DIRS; do ls "$d"/*.sh 2>/dev/null; done); do
         violations=$((violations + 1))
     # Matches `| grep -q`, `-qE`, `-Eq`, split flags (`grep -v -q`) and `--quiet`/`--silent`.
     # A bare word like `query` cannot match: a leading `-` is required on the q-bearing token.
-    done < <(grep -nE '\|[[:space:]]*grep([[:space:]]+-[a-zA-Z-]+)*[[:space:]]+(-[a-zA-Z]*q|--quiet|--silent)' "$f" \
+    #
+    # The `(^|[^|])` prefix is what stops `||` reading as a pipe. `cmd || grep -q x <<<"$s"` is a
+    # logical OR followed by a HERESTRING - the prescribed fix, not the defect - and the old regex
+    # flagged it because the second `|` of `||` sits immediately before ` grep -q`. That is the worst
+    # shape a guard can have: it fired on correct code while the thing it polices was already absent,
+    # so the only way to satisfy it was to rewrite a correct line. Caught when this gate went red on
+    # a herestring added in the same PR.
+    #
+    # `||grep -q` (no space) is still correctly ignored: the first `|` is not followed by `grep`, and
+    # the second is preceded by a `|`, which `[^|]` rejects. A genuine `foo | grep -q` keeps matching
+    # via `[^|]`, and a continuation line starting with `| grep -q` via `^`.
+    done < <(grep -nE '(^|[^|])\|[[:space:]]*grep([[:space:]]+-[a-zA-Z-]+)*[[:space:]]+(-[a-zA-Z]*q|--quiet|--silent)' "$f" \
              | grep -vE '^[0-9]+:[[:space:]]*#' || true)
 done
 

--- a/bin/ci-mutation-test.sh
+++ b/bin/ci-mutation-test.sh
@@ -15,15 +15,47 @@
 # Usage: bin/ci-mutation-test.sh [extra-maven-args...]   (e.g. -Dverbose=true)
 #
 # Env overrides: PIT_THREADS, PIT_BASE_REF, PIT_FULL_SWEEP, PIT_TARGET_CLASSES, PIT_TARGET_TESTS,
-# PIT_DECIDABLE_PACKAGES (regex: which changed classes a PR run will mutate - see below).
+# PIT_DECIDABLE_PACKAGES (regex: which changed classes a PR run will mutate - see below),
+# PIT_MIN_MUTANTS (the floor a run must score to count as a run; default 1), PIT_DRY_RUN_LOG
+# (self-test seam - see bin/test-ci-mutation-test.sh).
 # Prefer PIT_TARGET_CLASSES / PIT_TARGET_TESTS over passing a second -DtargetClasses in "$@": duplicate
 # -D flags resolve by last-wins, which is implicit and easy to get backwards.
 #
 # WHERE THIS RUNS: exactly one per-PR lane - maven.yml -> "Mutation Tests (PIT, PR-scoped)", advisory.
 # The full sweep is manual-only (.github/workflows/mutation-full-sweep.yml) because it has never
 # completed. See docs/plans/2026-08-03-002-mutation-testing-plan.md.
+#
+# ---------------------------------------------------------------------------------------------
+# THE EXIT CODE IS THE VERDICT. Four states, and none of them share a code:
+#
+#   0  PIT ran and EVALUATED at least PIT_MIN_MUTANTS mutants. Survivors do NOT change this - a
+#      score is a conversation starter, not a gate, and that is unchanged.
+#   2  CANNOT RUN. The scope matches nothing that exists, the tree has no main sources, PIT was
+#      asked to mutate something and produced no statistics / zero mutants, or it generated mutants
+#      and evaluated none of them (every result MEMORY_ERROR / RUN_ERROR / NON_VIABLE, or no
+#      mutations.xml written at all).
+#   3  NOTHING IN SCOPE. No core main-source class changed, or none of the ones that did are in a
+#      package where a survivor is decidable. Legitimate, common, and deliberately not 0.
+#   *  PIT's own exit status, passed through.
+#
+# WHY, measured 2026-08-25: across the last 40 `maven.yml` pull_request runs the
+# "Mutation Tests (PIT, PR-scoped)" check reported success 40 times and scored ZERO mutants 40
+# times - 23 runs with no core main-source change, 14 outside the decidable packages, the rest
+# still in flight. Each skip was individually correct. The problem is that "correct skip", "stale
+# scope that can never match again" and "185 mutants killed" were all the same green tick, which is
+# precisely the shape AGENTS.md warns about under "Confirm the mutation lane scored mutants rather
+# than trusting its tick". Separating the codes is what lets maven.yml react differently to each.
+#
+# The 2 follows bin/check-shell-lint.sh and bin/lib/node-gate.sh: "the tool could not run" must
+# never share a code with "the tool ran and the code is clean".
+# ---------------------------------------------------------------------------------------------
 
 set -euo pipefail
+
+# One transform, two callers. Converts a repo-relative .java path to a fully-qualified class name.
+# It was written out twice - once in the inert-config guard and once in the changed-class scan - and
+# a transform that exists twice is one that can be corrected in one place only.
+path_to_fqcn() { sed -E 's#.*/src/main/java/##; s#/#.#g; s#\.java$##'; }
 
 # Append to the GitHub job summary when running in Actions; no-op locally. A mutation run's output is
 # otherwise a log nobody reads behind a tick that means "nothing to mutate" at least as often as it
@@ -43,7 +75,53 @@ else
   CORES=2
 fi
 THREADS="${PIT_THREADS:-$CORES}"
+MIN_MUTANTS="${PIT_MIN_MUTANTS:-1}"
 echo "PIT: using ${THREADS} thread(s) (cores=${CORES}); minion heap -Xmx2g => ~$((THREADS * 2))g peak"
+
+# DECIDABLE PACKAGES. Which changed classes a PR run will mutate; see the long argument at the point
+# of use below. Read here rather than there so the inert-config guard can validate it on EVERY run,
+# including the ones that would otherwise skip before ever looking at it.
+#
+# Still offsets.* alone. `state.*` was the standing next candidate and was MEASURED on 2026-08-25
+# rather than argued: it hangs, exactly as internal.* does. The numbers and the control arm are in
+# docs/inflight/ci-mutation-testing.md - do not widen it back without reading them.
+DECIDABLE="${PIT_DECIDABLE_PACKAGES:-^bz\.stub\.parallelconsumer\.offsets\.}"
+
+# ---------------------------------------------------------------------------------------------
+# INERT-CONFIG GUARD: does the scope still match anything that exists?
+#
+# Every scoping decision below is a regex or a glob over fully qualified class names, and the
+# package has already moved once (io.confluent.* -> bz.stub.*). A scope that no longer matches
+# anything does not error - it falls through to "nothing to mutate, skipping" and exits 0, which in
+# the checks list is the same green tick as a run that killed every mutant. AGENTS.md names this
+# exact failure.
+#
+# So the scope is validated against the classes actually in the tree BEFORE it decides anything,
+# on every run - including runs that would have skipped. A stale scope is then caught by the next
+# PR of any kind, rather than by the next PR that happens to touch the one package it names.
+# ---------------------------------------------------------------------------------------------
+ALL_MAIN_CLASSES=$(git ls-files -- parallel-consumer-core/src/main/java 2>/dev/null \
+  | { grep -E '\.java$' || true; } \
+  | path_to_fqcn)
+if [ -z "$ALL_MAIN_CLASSES" ]; then
+  echo "PIT: no core main-source classes found under parallel-consumer-core/src/main/java - CANNOT RUN." >&2
+  echo "PIT: this is NOT a pass. Either the checkout is wrong or the module moved." >&2
+  summary "### Mutation (PIT): CANNOT RUN"
+  summary "No core main-source classes were found under \`parallel-consumer-core/src/main/java\`."
+  summary "Either the checkout is wrong or the module moved. **This is not a clean result.**"
+  exit 2
+fi
+DECIDABLE_IN_TREE=$(printf '%s\n' "$ALL_MAIN_CLASSES" | { grep -cE "$DECIDABLE" || true; })
+if [ "$DECIDABLE_IN_TREE" -eq 0 ]; then
+  echo "PIT: the decidable scope '${DECIDABLE}' matches NOTHING in the tree - CANNOT RUN." >&2
+  echo "PIT: the scope is stale (a package rename is the usual cause), so every run would 'skip'." >&2
+  summary "### Mutation (PIT): CANNOT RUN - the scope is stale"
+  summary "\`PIT_DECIDABLE_PACKAGES\` is \`${DECIDABLE}\`, which matches **no class** in"
+  summary "\`parallel-consumer-core/src/main/java\`. Every run would report \"nothing to mutate\""
+  summary "and exit green while scoring nothing. Fix the regex; do not silence this."
+  exit 2
+fi
+echo "PIT: decidable scope '${DECIDABLE}' matches ${DECIDABLE_IN_TREE} class(es) in the tree"
 
 # Scope: on a PR, mutate ONLY the core main-source classes CHANGED vs the base branch. The full sweep is
 # impractically slow (it has never completed on CI). Set PIT_BASE_REF to override; GITHUB_BASE_REF is set
@@ -81,14 +159,16 @@ if [ -n "$BASE_REF" ] && git rev-parse --verify -q "origin/${BASE_REF}^{commit}"
   # --diff-filter=d drops deletions: a deleted class has no target/classes entry, and pitest's
   # failWhenNoMutations (default true) would then fail the goal outright instead of the "nothing to mutate" skip.
   CHANGED_ALL=$(git diff --name-only --diff-filter=d "origin/${BASE_REF}" HEAD -- parallel-consumer-core/src/main/java/ 2>/dev/null \
-    | sed -E 's#.*/src/main/java/##; s#/#.#g; s#\.java$##' \
+    | path_to_fqcn \
     | { grep -E '^bz\.stub\.parallelconsumer\.' || true; })
   if [ -z "$CHANGED_ALL" ]; then
     echo "PIT: no core main-source classes changed vs origin/${BASE_REF} - nothing to mutate, skipping."
     summary "### Mutation (PIT): skipped"
     summary "No core main-source classes changed vs \`origin/${BASE_REF}\`, so there was nothing to mutate."
     summary "**This green tick is not evidence about test quality** - it means no work was done."
-    exit 0
+    # 3, not 0 - "nothing in scope" is a distinct outcome from "scored mutants" and the caller has to
+    # be able to tell them apart. See the exit-code contract in this file's header.
+    exit 3
   fi
 
   # DECIDABLE PACKAGES ONLY. Mutating what changed is the right instinct, but it is not free of the
@@ -98,10 +178,10 @@ if [ -n "$BASE_REF" ] && git rev-parse --verify -q "origin/${BASE_REF}^{commit}"
   # no protection, it just converts "slow" into "cancelled with nothing scored", which is the same zero
   # signal the full sweep produced for months.
   #
-  # So the lane mutates changed classes only where a survivor is DECIDABLE. Start narrow, deliberately:
-  # offsets.* alone, the case argued in the plan doc. Widen it (state.* is the obvious candidate) once
-  # this demonstrably works, not before - walk the scope SIDEWAYS, then up, and only on evidence.
-  DECIDABLE="${PIT_DECIDABLE_PACKAGES:-^bz\.stub\.parallelconsumer\.offsets\.}"
+  # So the lane mutates changed classes only where a survivor is DECIDABLE. The scope walks SIDEWAYS
+  # on evidence, never up by argument; DECIDABLE is read at the top of this file so the inert-config
+  # guard can validate it, and docs/inflight/ci-mutation-testing.md records what each widening
+  # measured before it was made.
   CHANGED=$(printf '%s\n' "$CHANGED_ALL" | { grep -E "$DECIDABLE" || true; })
   SKIPPED=$(printf '%s\n' "$CHANGED_ALL" | { grep -Ev "$DECIDABLE" || true; })
   if [ -z "$CHANGED" ]; then
@@ -116,7 +196,10 @@ if [ -n "$BASE_REF" ] && git rev-parse --verify -q "origin/${BASE_REF}^{commit}"
     summary '```'
     summary "$SKIPPED"
     summary '```'
-    exit 0
+    # 3, not 0 - see the exit-code contract in this file's header. The scope regex has already been
+    # proved live against the tree above, so this really is "your PR touched nothing decidable"
+    # rather than "the scope is broken".
+    exit 3
   fi
   # Emit "Foo,Foo$*" per FQCN: the class itself PLUS its nested/synthetic members (Lombok @Builder inner
   # classes, anonymous classes, lambdas). A bare "Foo*" would over-match siblings that merely share the
@@ -130,6 +213,34 @@ if [ -n "$BASE_REF" ] && git rev-parse --verify -q "origin/${BASE_REF}^{commit}"
   fi
 else
   echo "PIT: no resolvable base ref - full sweep of ${TARGET_CLASSES}"
+  # The same inert-config question for the full-sweep path, whose target is a PIT glob rather than a
+  # regex. Only the literal prefix before the first '*' can be checked, which is enough to catch the
+  # rename class: `bz.stub.parallelconsumer.offsets.` either names classes that exist or it does not.
+  # pitest's own failWhenNoMutations would eventually notice, but as a maven failure at the end of a
+  # coverage pass rather than as a stale-scope diagnosis before it.
+  #
+  # It is a COMMA-SEPARATED LIST, and one entry matching is enough. Treating it as a single string
+  # was the first version of this guard and it rejected a perfectly good `Foo,Foo$*` target - caught
+  # by running the lane rather than by the self-test, which is why both cases are now arms in
+  # bin/test-ci-mutation-test.sh.
+  TC_MATCHED=0
+  TC_PREFIXES=""
+  IFS=',' read -r -a TC_PARTS <<< "$TARGET_CLASSES"
+  for tc_part in "${TC_PARTS[@]}"; do
+    tc_prefix="${tc_part%%\**}"   # everything before the first glob star
+    tc_prefix="${tc_prefix%\$}"   # a trailing '$' marks nested classes; it is not part of a name
+    if [ -z "$tc_prefix" ]; then TC_MATCHED=1; break; fi   # a bare '*' targets everything
+    TC_PREFIXES="${TC_PREFIXES}${TC_PREFIXES:+, }${tc_prefix}"
+    if grep -qF "$tc_prefix" <<< "$ALL_MAIN_CLASSES"; then TC_MATCHED=1; break; fi
+  done
+  if [ "$TC_MATCHED" -eq 0 ]; then
+    echo "PIT: full-sweep target '${TARGET_CLASSES}' matches NOTHING in the tree - CANNOT RUN." >&2
+    echo "PIT: this is NOT a pass. The target is stale - a package rename is the usual cause." >&2
+    summary "### Mutation (PIT): CANNOT RUN - the sweep target is stale"
+    summary "No class under \`parallel-consumer-core/src/main/java\` starts with any of \`${TC_PREFIXES}\`."
+    summary "Every sweep would score nothing. Fix the target; **this is not a clean result.**"
+    exit 2
+  fi
 fi
 
 # The Lincheck lane is excluded BY NAME in -DexcludedTestClasses below, not by tag, for the reason the
@@ -149,20 +260,36 @@ fi
 # skipFailingTests is set in the POM, not here: its PitMojo @Parameter declares a defaultValue and no
 # `property`, so -DskipFailingTests is SILENTLY IGNORED - no warning, it just doesn't apply. Check for a
 # `property` before concluding that some other pitest setting "doesn't work" from the command line.
-set +e
-./mvnw --batch-mode -Pci test-compile org.pitest:pitest-maven:mutationCoverage \
-  -Djacoco.skip=true \
-  -DtargetClasses="${TARGET_CLASSES}" \
-  -DtargetTests="${TARGET_TESTS}" \
-  -DexcludedTestClasses="bz.stub.parallelconsumer.integrationTests.*,bz.stub.parallelconsumer.state.*Lincheck*" \
-  -DjvmArgs=-Xmx2g \
-  -DoutputFormats=XML,HTML \
-  -DtimeoutConstant=30000 -DtimeoutFactor=3.0 \
-  -Dthreads="${THREADS}" \
-  -pl parallel-consumer-core -am \
-  "$@" 2>&1 | tee "$PIT_LOG"
-STATUS=${PIPESTATUS[0]}
-set -e
+if [ -n "${PIT_DRY_RUN_LOG:-}" ]; then
+  # SELF-TEST SEAM, and nothing in CI sets it. bin/test-ci-mutation-test.sh needs to prove that the
+  # verdict below can go red - "PIT produced no statistics" and "PIT generated zero mutants" - and
+  # neither is reachable in seconds through a real build. So the run is replaced by a canned log and
+  # everything downstream is exercised unchanged. It announces itself loudly for the same reason the
+  # skip paths do: a seam that can silently stand in for the real thing is the defect this file is
+  # about.
+  echo "PIT: DRY RUN - reading a canned PIT log from ${PIT_DRY_RUN_LOG} instead of building."
+  cp "$PIT_DRY_RUN_LOG" "$PIT_LOG"
+  STATUS=0
+else
+  set +e
+  ./mvnw --batch-mode -Pci test-compile org.pitest:pitest-maven:mutationCoverage \
+    -Djacoco.skip=true \
+    -DtargetClasses="${TARGET_CLASSES}" \
+    -DtargetTests="${TARGET_TESTS}" \
+    # The Lincheck harnesses are excluded as PIT TESTS (astubbs#347, inherited via master):
+    # each asserts that a violation IS found, so using them as the suite PIT mutates against
+    # is meaningless and slow. They remain mutable TARGETS - this excludes them from the test
+    # set, not from the target set.
+    -DexcludedTestClasses="bz.stub.parallelconsumer.integrationTests.*,bz.stub.parallelconsumer.state.*Lincheck*" \
+    -DjvmArgs=-Xmx2g \
+    -DoutputFormats=XML,HTML \
+    -DtimeoutConstant=30000 -DtimeoutFactor=3.0 \
+    -Dthreads="${THREADS}" \
+    -pl parallel-consumer-core -am \
+    "$@" 2>&1 | tee "$PIT_LOG"
+  STATUS=${PIPESTATUS[0]}
+  set -e
+fi
 
 # Report what actually happened. PIT prints ">> " lines twice over: a per-class running tally during
 # analysis, then the run totals under a "- Statistics" banner at the end. Take only the final block -
@@ -172,6 +299,12 @@ set -e
 STATS=$(awk '/^- Statistics$/ {found = 1; out = ""; next}
              found && /^>> / {out = out $0 "\n"}
              END {printf "%s", out}' "$PIT_LOG")
+# THE NUMBER, not the presence of the block. A tidy, complete statistics block over zero mutants is
+# the harder half of the vacuity problem to spot: everything reads normal and the score line says
+# nothing was measured. `tail -1` because a mutated-class tally can carry the same wording, and the
+# final block is the run total. Missing block => 0, which the floor below then rejects.
+GENERATED=$(sed -nE 's/^>> Generated ([0-9]+) mutations.*/\1/p' <<< "$STATS" | tail -1)
+GENERATED="${GENERATED:-0}"
 summary "### Mutation (PIT)"
 summary ""
 summary "Mutated: \`${TARGET_CLASSES}\`"
@@ -226,8 +359,19 @@ if [ -n "$STATS" ]; then
       summary "#### Survived (${TOTAL}) - each is a behaviour nothing asserts"
       summary '```'
       # Cap the table, but never silently: a truncated list that looks complete is worse than no list.
-      printf '%s\n' "$SURVIVORS" | head -50 \
-        | awk -F'\t' '{ printf "%-12s %-34s %s\n", $3, $1 ":" $2, $4 }' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+      #
+      # The cap is awk's, NOT `head -50`, and that is a correctness fix rather than a tidy-up. Under
+      # `set -o pipefail`, `printf ... | head -50` lets head exit after 50 lines; once the unread
+      # remainder exceeds the 64 KiB pipe buffer, printf takes SIGPIPE, the pipeline reports 141, and
+      # pipefail promotes that to the script's exit status - killing the run BEFORE the mutation
+      # verdict below. A large but perfectly valid PIT report would have made this lane look broken.
+      # awk consumes its whole input and simply stops printing after NR 50, so nothing closes early.
+      #
+      # bin/check-shell-sigpipe.sh guards the sibling case (`| grep -q`) but deliberately scopes
+      # `head` out as "common, usually harmless" - correct as a blanket rule, and this is the site
+      # where it was not harmless. Found by an independent review, not by the gate.
+      printf '%s\n' "$SURVIVORS" \
+        | awk -F'\t' 'NR <= 50 { printf "%-12s %-34s %s\n", $3, $1 ":" $2, $4 }' >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
       summary '```'
       if [ "$TOTAL" -gt 50 ]; then
         summary "_Showing the first 50 of ${TOTAL}. Full detail in the HTML report under \`${REPORT%/*}\`._"
@@ -271,4 +415,53 @@ else
     summary "Usual causes: the coverage pass never finished, or minions died (MEMORY_ERROR / TIMED_OUT)."
   fi
 fi
-exit "$STATUS"
+
+# ---------------------------------------------------------------------------------------------
+# THE VERDICT. Everything above reports; this decides. See the exit-code contract in the header.
+#
+# PIT's own failure wins, because it is the more specific diagnosis - a maven or minion failure is
+# a different thing from "ran fine, measured nothing", and collapsing them would lose which.
+# ---------------------------------------------------------------------------------------------
+if [ "$STATUS" -ne 0 ]; then
+  echo "PIT: exited ${STATUS} after generating ${GENERATED} mutant(s)." >&2
+  exit "$STATUS"
+fi
+# GENERATED counts mutants CREATED, which is not the same as mutants EVALUATED, and the verdict must
+# turn on the second. A run whose minions all die returns MEMORY_ERROR or RUN_ERROR for every mutant:
+# it generated plenty, scored none, and against a generated-count floor it exits 0. That is not
+# hypothetical here - the plan that scoped this lane recorded `state.*` hanging with minions dying,
+# which is exactly the shape. An independent review caught the verdict still reading GENERATED while
+# the survivor table twenty lines up already drew the right distinction.
+#
+# KILLED / SURVIVED / TIMED_OUT / NO_COVERAGE are all real outcomes (PIT scores a timeout as a kill,
+# and no-coverage is a genuine finding). MEMORY_ERROR / RUN_ERROR / NON_VIABLE are infrastructure
+# failures or invalid bytecode - the mutant was never actually tried.
+EVALUATED=0
+UNEVALUATED=0
+VERDICT_REPORT="parallel-consumer-core/target/pit-reports/mutations.xml"
+if [ -f "$VERDICT_REPORT" ]; then
+  # The `|| true` is load-bearing under `set -o pipefail`: a grep that matches nothing exits 1, which
+  # kills the whole script mid-assignment and produces an exit 1 with no output at all - neither the
+  # pass this run might deserve nor the exit 2 a vacuous one must give. An all-KILLED report has no
+  # MEMORY_ERROR in it, so the no-match case is the NORMAL case here, not the exceptional one.
+  EVALUATED=$({ grep -oE "status='(KILLED|SURVIVED|TIMED_OUT|NO_COVERAGE)'" "$VERDICT_REPORT" || true; } | wc -l | tr -d ' ')
+  UNEVALUATED=$({ grep -oE "status='(MEMORY_ERROR|RUN_ERROR|NON_VIABLE)'" "$VERDICT_REPORT" || true; } | wc -l | tr -d ' ')
+fi
+
+if [ "$EVALUATED" -lt "$MIN_MUTANTS" ]; then
+  echo "PIT: the run scored NOTHING - ${GENERATED} mutant(s) generated, ${EVALUATED} EVALUATED, floor is ${MIN_MUTANTS}." >&2
+  if [ "$UNEVALUATED" -gt 0 ]; then
+    echo "PIT: ${UNEVALUATED} mutant(s) came back MEMORY_ERROR / RUN_ERROR / NON_VIABLE - the minions died or the bytecode would not load." >&2
+    echo "PIT: that is an infrastructure failure, not a clean run. Generating mutants is not scoring them." >&2
+  fi
+  echo "PIT: exiting 2. A lane that measured nothing must not report the same result as one that did." >&2
+  summary ""
+  summary "**This run scored NOTHING** (${GENERATED} generated, ${EVALUATED} evaluated, floor \`${MIN_MUTANTS}\`),"
+  summary "even though it had classes to mutate. That is a broken lane, not a clean pull request."
+  exit 2
+fi
+if [ "$UNEVALUATED" -gt 0 ]; then
+  echo "PIT: warning - ${UNEVALUATED} of ${GENERATED} mutant(s) were never evaluated (minion death or unloadable bytecode)." >&2
+fi
+echo "PIT: scored ${EVALUATED} evaluated mutant(s) of ${GENERATED} generated - the lane did work."
+exit 0

--- a/bin/racerd-test.sh
+++ b/bin/racerd-test.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# RacerD (Meta's Infer) over parallel-consumer-core's main code. Non-gating, and run BOTH locally and
+# by the `static: racerd` job in .github/workflows/maven.yml.
+#
+# WHY THIS EXISTS. Every other detector here needs to be told where to look: Error Prone's
+# @GuardedBy only fires where somebody wrote the annotation, and the racing-double seam tests can
+# only re-prove seams already found by hand. RacerD infers which locks protect which state from how
+# the program actually uses them, so it reports races nobody named. It is the only tool in this repo
+# that can.
+#
+# HOW IT RUNS IN CI, and what that costs. The `static: racerd` job on ubuntu-latest is the production
+# caller - so treat runtime, cache and toolchain changes here as changes to a hosted lane, not to a
+# local convenience script. It needs a ~220 MB toolchain Infer publishes only for linux-x86_64 and
+# osx-arm64; the job caches the archive keyed on the pinned version and verifies it against a pinned
+# SHA-256 on every run, cache hits included, because the cache is the mutable half.
+#
+# This header previously said the opposite - "WHY IT IS NOT A CI LANE ... no workflow calls it",
+# following bin/lincheck-test.sh's precedent - and stayed that way in the very commit that added the
+# job. An independent review caught it. The self-hosted highcpu runner is still the better long-term
+# home, since the toolchain would persist between runs instead of being cached per job; that is a
+# move, not a reason to describe the lane as absent.
+#
+# WHY THE JAVAC ROUTE AND NOT `infer run -- ./mvnw`. Infer's Maven integration runs the build under a
+# JDK of its own choosing, and this project requires 17. Established with a two-arm control: the exact
+# command Infer runs succeeds standalone at JDK 17, and Infer's captured Maven output carries JDK 24+
+# warnings the JDK 17 run does not emit. Capturing javac directly sidesteps the wrapper that picks the
+# JDK. That diagnosis cost a false "RacerD cannot run here" that stood for several hours.
+#
+# Exit codes: 0 clean, 1 findings, 2 cannot run. The 2 matters - "Infer is not installed" must never
+# read as "no races", the same fail-closed contract bin/lib/node-gate.sh gives the node gates.
+
+set -euo pipefail
+
+INFER_BIN="${INFER_BIN:-infer}"
+JDK="${RACERD_JDK:-$HOME/.sdkman/candidates/java/17.0.18-tem}"
+
+# DRY RUN: read a canned report instead of running Infer, so the ratchet below can be tested without
+# a 220 MB toolchain and a real analysis. Mirrors PIT_DRY_RUN_LOG in bin/ci-mutation-test.sh, which
+# exists for the same reason - the interesting logic is the comparison, not the tool that feeds it.
+#
+# This is not a convenience. Before it existed the ratchet arms in bin/test-check-racerd.sh could not
+# run anywhere without an Infer run, so they did not run at all: the self-test printed a `skip` in CI
+# and, when a report WAS supplied, an `ok:` that incremented the pass counter while asserting
+# nothing, under a comment claiming four arms were exercised. The decisive arm - the same-count swap
+# that a count ceiling waves through - has never been machine-checked until now.
+RACERD_DRY_RUN_REPORT="${RACERD_DRY_RUN_REPORT:-}"
+
+if [ -z "$RACERD_DRY_RUN_REPORT" ] && ! command -v "$INFER_BIN" > /dev/null 2>&1 && [ ! -x "$INFER_BIN" ]; then
+    cat >&2 <<'MISSING'
+racerd-test: Infer is not installed - CANNOT RUN (this is not a pass).
+
+  Download v1.3.0 from https://github.com/facebook/infer/releases, unpack it, and either put its
+  bin/ on PATH or set INFER_BIN to the infer executable.
+
+  CHECK THE DIGEST BEFORE YOU UNPACK IT. These are the two builds this project uses, each taken
+  from two independent fetches of the pinned release URL; CI verifies the linux one on every run.
+  A mismatch is not a download to retry - it is a different artefact than the one this project
+  was tested against.
+
+    linux-x86_64  02be62ba931cb43e2d42bbf7abf4bd9a410cf8464cce5453934e25c90a825850
+    osx-arm64     60eccd231e27f2a3d65947ef75b9adcd1983528296bd1da6f67a6da02e22a96e
+
+  sha256sum on Linux, shasum -a 256 on macOS.
+MISSING
+    exit 2
+fi
+
+if [ -z "$RACERD_DRY_RUN_REPORT" ] && [ ! -x "$JDK/bin/javac" ]; then
+    echo "racerd-test: no JDK 17 javac at $JDK - CANNOT RUN. Set RACERD_JDK." >&2
+    exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+if [ -n "$RACERD_DRY_RUN_REPORT" ]; then
+    if [ ! -f "$RACERD_DRY_RUN_REPORT" ]; then
+        echo "racerd-test: RACERD_DRY_RUN_REPORT=$RACERD_DRY_RUN_REPORT does not exist - CANNOT RUN." >&2
+        exit 2
+    fi
+    echo "racerd-test: DRY RUN - reading a canned report from $RACERD_DRY_RUN_REPORT instead of running Infer."
+    mkdir -p "$work/infer-out"
+    cp "$RACERD_DRY_RUN_REPORT" "$work/infer-out/report.json"
+    rc=0
+else
+
+echo "racerd-test: resolving the compile classpath"
+# SCOPED TO CORE, and `-am` is load-bearing twice over. Without `-pl` the goal runs for every module
+# and each one OVERWRITES the single -Dmdep.outputFile, so the file left behind is the LAST module's
+# classpath - which is how this lane first shipped: it analysed core's sources against the example
+# module's dependencies plus a stale installed core jar, and reported a finding count from it. And
+# `-pl` WITHOUT `-am` trips the enforcer's ReactorModuleConvergence rule, whose failure reads as
+# "your change broke the build" rather than "you scoped the reactor wrong".
+JAVA_HOME="$JDK" ./mvnw --batch-mode -Pci dependency:build-classpath \
+    -pl parallel-consumer-core -am \
+    -Dmdep.outputFile="$work/cp.txt" -q > "$work/cp.log" 2>&1 || {
+    echo "racerd-test: could not resolve the classpath - see $work/cp.log" >&2
+    exit 2
+}
+
+find parallel-consumer-core/src/main/java -name '*.java' > "$work/srcs.txt"
+count="$(wc -l < "$work/srcs.txt" | tr -d ' ')"
+if [ "$count" -eq 0 ]; then
+    echo "racerd-test: NO SOURCES MATCHED - refusing to report success over an empty set" >&2
+    exit 2
+fi
+echo "racerd-test: analysing $count source file(s)"
+
+mkdir -p "$work/classes"
+set +e
+"$INFER_BIN" run --racerd-only --results-dir "$work/infer-out" -- \
+    "$JDK/bin/javac" -cp "$(cat "$work/cp.txt")" -d "$work/classes" -proc:full "@$work/srcs.txt" \
+    > "$work/racerd.log" 2>&1
+rc=$?
+set -e
+
+# Infer's own status, checked rather than merely printed. A javac failure part-way through the batch
+# can still leave a syntactically valid but PARTIAL report.json, and a partial report undercounts -
+# which against a ceiling reads as "fewer races than before" rather than "the analysis did not
+# finish". Healthy runs exit 0 here; `infer run` does not use a nonzero code to signal findings.
+if [ "$rc" -ne 0 ]; then
+    echo "racerd-test: infer exited $rc - CANNOT RUN, the analysis did not complete." >&2
+    echo "  Any report it left is partial, and a partial report undercounts against the ceiling." >&2
+    echo "  Log: $work/racerd.log" >&2
+    cp "$work/racerd.log" "${TMPDIR:-/tmp}/racerd-failure.log" 2>/dev/null || true
+    exit 2
+fi
+
+fi
+
+report="$work/infer-out/report.json"
+if [ ! -f "$report" ]; then
+    echo "racerd-test: Infer produced no report - CANNOT RUN. Log: $work/racerd.log" >&2
+    cp "$work/racerd.log" "${TMPDIR:-/tmp}/racerd-failure.log" 2>/dev/null || true
+    exit 2
+fi
+
+found="$(python3 -c "import json,sys; print(len(json.load(open(sys.argv[1]))))" "$report")"
+echo "racerd-test: $found thread-safety finding(s) (infer exit $rc)"
+cp "$report" "${TMPDIR:-/tmp}/racerd-report.json"
+echo "racerd-test: full report copied to ${TMPDIR:-/tmp}/racerd-report.json"
+
+python3 -c "
+import json,sys
+for i in json.load(open(sys.argv[1])):
+    print('  %s:%s  %s' % (i.get('file','?').split('/')[-1], i.get('line','?'), ' '.join(i.get('qualifier','').split())[:120]))
+" "$report"
+
+# AN IDENTITY SET, not a count. config/racerd-known-findings.txt records which races are known, keyed on
+# bug type plus class.method. A bare ceiling could not tell "one race fixed" from "one race swapped
+# for a different one" - the count is 13 either way - which an independent review caught and which is
+# the same reports-green-while-it-changed class this lane exists to police. The file is 12 lines.
+#
+# Fails BOTH ways on purpose: an identity that is new means a race was introduced, and one that no
+# longer fires means somebody fixed a race and did not ratchet, which is how a set quietly stops
+# meaning anything. Unset RACERD_KNOWN to get report-only, which is what a local exploratory run
+# wants.
+known="${RACERD_KNOWN:-$repo_root/config/racerd-known-findings.txt}"
+if [ -f "$known" ]; then
+    current="$work/current.txt"
+    python3 -c "
+import json,re,sys,collections
+c=collections.Counter()
+for i in json.load(open(sys.argv[1])):
+    proc=i.get('procedure','')
+    m=re.search(r'([A-Za-z0-9_\$]+)\.([A-Za-z0-9_\$<>]+)\(', proc+'(')
+    c[(i.get('bug_type','?'), m.group(1)+'.'+m.group(2) if m else proc)] += 1
+for (bt,sig),n in sorted(c.items()): print(n, bt, sig)
+" "$report" | LC_ALL=C sort > "$current"
+    # BOTH sides sorted the same way, with the same collation. comm compares sorted streams and
+    # silently produces nonsense otherwise - Python's tuple order and the shell's lexical order
+    # disagree, and the first version of this check reported known findings as new because of it.
+    expected="$work/expected.txt"
+    grep -vE '^\s*(#|$)' "$known" | LC_ALL=C sort > "$expected" || true
+
+    added="$(comm -13 "$expected" "$current" || true)"
+    gone="$(comm -23 "$expected" "$current" || true)"
+
+    if [ -n "$added" ]; then
+        echo "racerd-test: NEW race(s) - not in config/racerd-known-findings.txt:" >&2
+        echo "$added" | sed 's/^/    /' >&2
+        exit 1
+    fi
+    if [ -n "$gone" ]; then
+        echo "racerd-test: these known races no longer fire:" >&2
+        echo "$gone" | sed 's/^/    /' >&2
+        echo "  If you fixed them, delete those lines from config/racerd-known-findings.txt in the same" >&2
+        echo "  change. A set nobody shrinks stops meaning anything." >&2
+        exit 1
+    fi
+    echo "racerd-test: all $found finding(s) are known, none new"
+    exit 0
+fi
+
+[ "$found" -eq 0 ]

--- a/bin/rename-packages.sh
+++ b/bin/rename-packages.sh
@@ -1873,10 +1873,10 @@ if [ -s "$MANUAL_FOLLOWUPS" ]; then
 fi
 echo
 echo "  NOT covered here, and NOT green merely because this exited 0:"
-echo "   - The mutation lane EXITS 0 when it matches nothing. On the first PR after this lands,"
-echo "     change a class under the decidable packages and read the job summary for a mutation score"
-echo "     and a survivor list. A green tick carrying 'nothing to mutate, skipping' is the FAILURE"
-echo "     mode, not the pass."
+echo "   - The mutation lane no longer exits 0 when its scope matches nothing - it exits 2, and 3"
+echo "     for a genuine skip. Read the exit code, not the tick. On the first PR after this lands,"
+echo "     change a class under the decidable packages and confirm the job summary carries a"
+echo "     mutation score and a survivor list."
 echo "   - ArchUnit rules pin package names as STRINGS and pass vacuously when they select nothing."
 echo "     Break one on purpose and watch it go red before believing the suite still guards anything."
 echo

--- a/bin/test-check-all.sh
+++ b/bin/test-check-all.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Self-test for bin/check-all.sh.
+#
+# The runner has one job that matters and one that is easy to get subtly wrong. The job: never let a
+# gate that could not run be counted as a gate that passed. The subtlety: it maintains a small
+# exception list of scripts that are not tree gates, and a hand-maintained list inside a script whose
+# whole purpose is to abolish hand-maintained lists will rot the moment somebody renames a file - so
+# the assertion that catches that rot is itself under test here.
+#
+# Fixtures are a throwaway bin/ containing a copy of the subject plus stub gates, so the real
+# repository's gate set cannot make these arms pass or fail by accident.
+
+set -uo pipefail
+
+subject="$(cd "$(dirname "$0")" && pwd)/check-all.sh"
+pass=0
+fail=0
+
+# $1 fixture root. Creates the five scripts the subject's exception list asserts must exist, so that
+# assertion is satisfied unless an arm is deliberately testing it.
+stub_exceptions() {
+    # The PR-scoped four must carry a `gh ` call and the needs-args one a `usage:` line, because the
+    # subject now corroborates each recorded reason rather than merely checking the name resolves.
+    # Stubs that skipped that would be testing a laxer script than the one that ships.
+    for n in check-pr-ready.sh check-human-lgtm.sh check-review-posted.sh \
+             check-pr-analysis-surfaces.sh; do
+        printf '#!/usr/bin/env bash\n# gh pr view - stub\nexit 0\n' > "$1/bin/$n"
+        chmod +x "$1/bin/$n"
+    done
+    printf '#!/usr/bin/env bash\n# usage: check-ossindex-audit.sh <log>\nexit 0\n' \
+        > "$1/bin/check-ossindex-audit.sh"
+    chmod +x "$1/bin/check-ossindex-audit.sh"
+}
+
+# $1 name, $2 exit code the fixture gate returns
+make_fixture() {
+    local dir; dir="$(mktemp -d)"
+    mkdir -p "$dir/bin"
+    cp "$subject" "$dir/bin/check-all.sh"
+    stub_exceptions "$dir"
+    printf '#!/usr/bin/env bash\necho "fixture gate speaking"\nexit %s\n' "$2" > "$dir/bin/check-$1.sh"
+    chmod +x "$dir/bin/check-$1.sh"
+    echo "$dir"
+}
+
+assert() {
+    local name="$1" want_rc="$2" want="$3" out="$4" rc="$5"
+    if [ "$rc" = "$want_rc" ] && grep -qF "$want" <<< "$out"; then
+        printf 'ok:   %s\n' "$name"; pass=$((pass + 1))
+    else
+        printf 'FAIL: %s (exit %s, wanted %s, looking for "%s")\n%s\n' "$name" "$rc" "$want_rc" "$want" "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+run() { local d="$1"; shift; ( cd "$d" && bash bin/check-all.sh --gates-only "$@" 2>&1 ); }
+
+echo "=== a failing gate must fail the sweep, and be named ==="
+d="$(make_fixture failing 1)"; out="$(run "$d")"; rc=$?
+assert "red: a gate exiting 1 fails the sweep" 1 "FAILED: check-failing.sh" "$out" "$rc"
+rm -rf "$d"
+
+# GREEN NEAR-MISS: identical fixture, gate returns 0. If this went red too, the runner would be
+# failing on the fixture's existence rather than on its verdict.
+d="$(make_fixture failing 0)"; out="$(run "$d")"; rc=$?
+assert "green near-miss: the same gate exiting 0 passes" 0 "no gate failed" "$out" "$rc"
+rm -rf "$d"
+
+echo
+echo "=== a skip is not a pass, which is the whole point ==="
+
+# A gate that CANNOT RUN must never be counted among the passes. This is the defect the runner
+# exists to avoid importing from the gates it wraps.
+d="$(make_fixture cannot 2)"; out="$(run "$d")"; rc=$?
+assert "exit 2 is reported as CANNOT RUN, not as a pass" 0 "COULD NOT RUN: check-cannot.sh" "$out" "$rc"
+assert "...and the pass count excludes it" 0 "0 passed" "$out" "$rc"
+rm -rf "$d"
+
+d="$(make_fixture nothing 3)"; out="$(run "$d")"; rc=$?
+assert "exit 3 is nothing-in-scope, also not a pass" 0 "1 nothing-in-scope" "$out" "$rc"
+rm -rf "$d"
+
+echo
+echo "=== the exception list must not rot silently ==="
+
+# Rename one of the excepted scripts and the runner must refuse, rather than quietly sweeping one
+# gate fewer than it claims. A list nobody validates is how this class comes back.
+d="$(make_fixture ok 0)"; rm -f "$d/bin/check-review-posted.sh"
+out="$(run "$d")"; rc=$?
+assert "red: an exception naming a missing script exits 2" 2 "do not exist" "$out" "$rc"
+assert "...and says which one" 2 "check-review-posted.sh" "$out" "$rc"
+rm -rf "$d"
+
+echo
+echo "=== nothing to run is not success ==="
+d="$(mktemp -d)"; mkdir -p "$d/bin"; cp "$subject" "$d/bin/check-all.sh"; stub_exceptions "$d"
+# Only the excepted stubs exist, and every one of them is skipped, so nothing actually runs.
+out="$(run "$d")"; rc=$?
+assert "red: a sweep where nothing ran exits 2" 2 "NOTHING RAN" "$out" "$rc"
+rm -rf "$d"
+
+echo
+echo "=== --pr opts the PR-state reporters back in ==="
+d="$(make_fixture ok 0)"; out="$(run "$d" --pr)"; rc=$?
+assert "green: --pr runs the PR-scoped gates instead of skipping them" 0 "5 passed" "$out" "$rc"
+# The needs-an-argument gate stays skipped even under --pr, because --pr changes SCOPE and not the
+# fact that the script cannot be invoked bare. Pinned so nobody "fixes" that into a usage error.
+assert "...but the needs-an-argument gate is still skipped" 0 "1 skipped" "$out" "$rc"
+rm -rf "$d"
+
+echo
+echo "=== a gate bash cannot parse is BROKEN, not skipped ==="
+
+# `bash a-script-with-a-syntax-error` exits 2, the same code the repo uses for "cannot run". Without
+# a parse pre-check the two are indistinguishable and a broken gate lands in the skip bucket. The
+# sweep normally still goes red via ShellCheck - measured - but not on a machine without ShellCheck,
+# where the linter itself exits 2 and both skips agree on a false green.
+d="$(mktemp -d)"; mkdir -p "$d/bin"; cp "$subject" "$d/bin/check-all.sh"; stub_exceptions "$d"
+printf '#!/usr/bin/env bash\nif true\necho unreachable\n' > "$d/bin/check-malformed.sh"
+chmod +x "$d/bin/check-malformed.sh"
+out="$(run "$d")"; rc=$?
+assert "red: an unparseable gate FAILS the sweep" 1 "FAILED: check-malformed.sh" "$out" "$rc"
+assert "...and is not laundered into the cannot-run bucket" 1 "does not parse" "$out" "$rc"
+rm -rf "$d"
+
+echo
+echo "=== an exception whose stated reason expired must not stay silently skipped ==="
+
+# Existence catches a rename. It cannot catch a script that stopped being what the list says it is,
+# which is the same under-checking arriving by staleness - so each reason is corroborated.
+d="$(make_fixture ok 0)"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$d/bin/check-review-posted.sh"   # no gh call any more
+out="$(run "$d")"; rc=$?
+assert "red: a PR-scoped exception with no gh call exits 2" 2 "no longer corroborated" "$out" "$rc"
+assert "...and names the script" 2 "check-review-posted.sh" "$out" "$rc"
+rm -rf "$d"
+
+echo
+echo "=== the self-tests loop actually runs, and runs FIRST ==="
+
+# Every other arm passes --gates-only, so the MODE=all branch - the one CI and the documented
+# pre-push command use - had no coverage at all. The ordering is a claim in both the header and
+# bin/AGENTS.md: a gate's self-test runs before the gate it protects.
+d="$(make_fixture ok 0)"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$d/bin/test-fixture.sh"; chmod +x "$d/bin/test-fixture.sh"
+out="$( cd "$d" && bash bin/check-all.sh 2>&1 )"; rc=$?
+assert "green: the default mode runs the self-tests too" 0 "test-fixture.sh" "$out" "$rc"
+tests_at="$(grep -n '=== self-tests ===' <<< "$out" | head -1 | cut -d: -f1)"
+gates_at="$(grep -n '=== gates ===' <<< "$out" | head -1 | cut -d: -f1)"
+if [ -n "$tests_at" ] && [ -n "$gates_at" ] && [ "$tests_at" -lt "$gates_at" ]; then
+    printf 'ok:   self-tests are reported BEFORE gates, as bin/AGENTS.md claims\n'; pass=$((pass + 1))
+else
+    printf 'FAIL: self-tests/gates ordering (tests at %s, gates at %s)\n%s\n' "$tests_at" "$gates_at" "$out"
+    fail=$((fail + 1))
+fi
+rm -rf "$d"
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/bin/test-check-pr-analysis-surfaces.sh
+++ b/bin/test-check-pr-analysis-surfaces.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Self-test for bin/check-pr-analysis-surfaces.sh.
+#
+# The whole value of that script is one distinction: a finding ON A LINE THE PR WROTE versus a
+# finding merely IN A FILE THE PR OPENED. Get that wrong in either direction and the tool is useless
+# - too loose and every small PR to a big class inherits dozens of findings and the report gets
+# ignored; too tight and it reports "none" over a defect the author just introduced, which is the
+# false green this whole branch exists to remove.
+#
+# So the arms are paired: the SAME annotation, at the SAME line, against a diff that either did or
+# did not add that line. Nothing but the diff changes between them.
+#
+# `gh` is faked on PATH rather than mocked inside the script, so the subject runs completely
+# unmodified - no test-only branch inside it that could drift from the real path.
+
+set -euo pipefail
+
+subject="$(cd "$(dirname "$0")" && pwd)/check-pr-analysis-surfaces.sh"
+pass=0
+fail=0
+
+# Builds a fake `gh` answering exactly the calls the subject makes.
+# $1 fixture dir, $2 the line number the diff ADDS, $3 the line number the annotation is ON.
+make_gh() {
+    local dir="$1" added_line="$2" ann_line="$3" runs="${4:-1}"
+    mkdir -p "$dir/bin"
+    cat > "$dir/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -eu
+case "\$*" in
+    *"--json number"*)      echo 999 ;;
+    *"--json headRefOid"*)  echo "abc123def456" ;;
+    *"--json files"*)       echo "src/main/java/Foo.java" ;;
+    *"pr diff"*)
+        printf '%s\n' "diff --git a/src/main/java/Foo.java b/src/main/java/Foo.java"
+        printf '%s\n' "--- a/src/main/java/Foo.java"
+        printf '%s\n' "+++ b/src/main/java/Foo.java"
+        printf '%s\n' "@@ -${added_line},0 +${added_line},1 @@"
+        printf '%s\n' "+        int addedByThisPr = 1;"
+        ;;
+    *"commits/"*"check-runs"*)
+        # \$runs check runs, each reporting the SAME finding - the duplication a javac problem
+        # matcher produces across every compiling job.
+        printf '{"check_runs":['
+        for i in \$(seq 1 ${runs}); do
+            [ "\$i" = 1 ] || printf ','
+            printf '{"id":%s,"name":"job%s","html_url":"http://x","output":{"annotations_count":1}}' "\$i" "\$i"
+        done
+        printf ']}'
+        ;;
+    *"check-runs/"*"annotations"*page=1*)
+        printf '[{"path":"src/main/java/Foo.java","start_line":${ann_line},"message":"the one finding"}]'
+        ;;
+    *"annotations"*)  printf '[]' ;;
+    *"issues/"*"comments"*) printf '' ;;
+    *) printf '' ;;
+esac
+GHEOF
+    chmod +x "$dir/bin/gh"
+}
+
+run_subject() {
+    local dir="$1" out rc
+    set +e
+    out="$(PATH="$dir/bin:$PATH" bash "$subject" 999 2>&1)"
+    rc=$?
+    set -e
+    printf '%s\n---RC:%s\n' "$out" "$rc"
+}
+
+assert_arm() {
+    local name="$1" want_rc="$2" want="$3" result="$4"
+    local rc; rc="$(sed -n 's/^---RC:\(.*\)$/\1/p' <<< "$result")"
+    if [ "$rc" = "$want_rc" ] && grep -qF "$want" <<< "$result"; then
+        printf 'ok:   %s\n' "$name"; pass=$((pass + 1))
+    else
+        printf 'FAIL: %s (exit %s, wanted %s, looking for "%s")\n%s\n' "$name" "$rc" "$want_rc" "$want" "$result"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "=== the distinction the whole script exists for ==="
+
+# --- RED: the annotation sits on a line the diff ADDED. That is the author's own defect. ----------
+d1="$(mktemp -d)"; make_gh "$d1" 42 42
+r1="$(run_subject "$d1")"
+assert_arm "red: a finding on a line THIS PR ADDED exits 1" 1 "ON LINES THIS PR WROTE" "$r1"
+assert_arm "red: ...and it is counted as the author's, not inherited" 1 "1 distinct finding(s)" "$r1"
+rm -rf "$d1"
+
+# --- GREEN NEAR-MISS: same annotation, same file, one line away from the diff ---------------------
+# If this went red too, the script would be reporting "every finding in a file you opened", which is
+# the failure mode that gets a report ignored rather than read.
+d2="$(mktemp -d)"; make_gh "$d2" 42 900
+r2="$(run_subject "$d2")"
+assert_arm "green near-miss: the same finding one line outside the diff exits 0" 0 "inherited" "$r2"
+assert_arm "green near-miss: ...and the author's section is empty" 0 "none" "$r2"
+rm -rf "$d2"
+
+echo
+echo "=== duplication across jobs must not inflate the count ==="
+
+# One javac warning is annotated once per compiling job. Counting those separately would report
+# eight findings where there is one, and bury the distinct ones.
+d3="$(mktemp -d)"; make_gh "$d3" 42 42 4
+r3="$(run_subject "$d3")"
+assert_arm "4 check runs reporting one finding is ONE distinct finding" 1 "1 distinct finding(s)" "$r3"
+assert_arm "...and every reporting job is still named" 1 "job1, job2, job3, job4" "$r3"
+rm -rf "$d3"
+
+echo
+echo "=== cannot-run must never read as clean ==="
+
+# --- RED CONTROL: no gh at all. The contract bin/racerd-test.sh and ci-mutation-test.sh hold. -----
+# The PATH keeps /usr/bin:/bin - enough for bash and coreutils - and `gh` is not installed there on
+# macOS or on a hosted Linux runner, so this removes gh WITHOUT removing the shell. An empty PATH
+# made this arm exit 127 on "bash: command not found", which is a pass for entirely the wrong reason
+# and would have kept passing if the subject had stopped checking for gh at all.
+d4="$(mktemp -d)"; mkdir -p "$d4/bin"
+if PATH=/usr/bin:/bin command -v gh > /dev/null 2>&1; then
+    printf 'skip: cannot stage an absent gh - it is installed in /usr/bin or /bin on this machine\n'
+else
+    set +e
+    out4="$(PATH="$d4/bin:/usr/bin:/bin" bash "$subject" 999 2>&1)"; rc4=$?
+    set -e
+    if [ "$rc4" = "2" ] && grep -qF "CANNOT RUN" <<< "$out4"; then
+        printf 'ok:   red: absent gh exits 2, not 0\n'; pass=$((pass + 1))
+    else
+        printf 'FAIL: absent gh exited %s (wanted 2)\n%s\n' "$rc4" "$out4"; fail=$((fail + 1))
+    fi
+fi
+rm -rf "$d4"
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/bin/test-check-racerd.sh
+++ b/bin/test-check-racerd.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Self-test for bin/racerd-test.sh.
+#
+# WHY IT EXISTS, and why it is late. The other two gates this branch added shipped with self-tests;
+# this one did not, and it is the only one of the three that reached CI red. A code review found two
+# defects in it that neither of its siblings had: the classpath was resolved over the whole reactor
+# so the file left behind was the LAST module's, and Infer's own exit status was captured and never
+# checked. Both are the branch's own defect class - an analysis that ran against something other than
+# what was intended, reporting a number that looked like a measurement. The gate with no test was the
+# gate that had them.
+#
+# WHAT IT COVERS, AND WHAT IT DOES NOT - stated because a partial self-test that reads as complete is
+# the same failure one level up. The two preflight guards run before any Maven or Infer work, so they
+# are cheap to exercise and are covered here with red arms and green near-misses. The ceiling
+# arithmetic and the new exit-status check sit AFTER a full analysis, and the script is not currently
+# structured to let a fake Infer reach them - it resolves a real classpath and enumerates real
+# sources first. Covering those needs the verdict logic extracted into a function this test can call
+# directly, which is a refactor and not a test. Until then those arms are exercised by hand, and this
+# header is the record that they are not exercised here.
+
+set -euo pipefail
+
+pass=0
+fail=0
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# $1 name, $2 expected exit, $3 substring the output must contain, then env assignments
+assert_guard() {
+    local name="$1" want_rc="$2" want="$3"; shift 3
+    local out rc
+    set +e
+    out="$(cd "$repo_root" && env "$@" bin/racerd-test.sh 2>&1)"
+    rc=$?
+    set -e
+    if [ "$rc" != "$want_rc" ]; then
+        printf 'FAIL: %s (expected exit %s, got %s)\n%s\n' "$name" "$want_rc" "$rc" "$out"
+        fail=$((fail + 1))
+    elif ! grep -qF "$want" <<< "$out"; then
+        # Exit code alone is not proof. Both guards return 2, so without this a script that died for
+        # an unrelated reason would score the arm it was never asked about.
+        printf 'FAIL: %s (exit %s was right, but never said why - wanted %s)\n%s\n' \
+            "$name" "$rc" "$want" "$out"
+        fail=$((fail + 1))
+    else
+        printf 'ok:   %s\n' "$name"
+        pass=$((pass + 1))
+    fi
+}
+
+# --- RED: a missing toolchain must be "cannot run", never "no races found" -----------------------
+assert_guard "red: absent Infer exits 2, not 0" 2 "CANNOT RUN" \
+    INFER_BIN=/nonexistent/infer
+
+# --- RED: a missing JDK is also cannot-run, and says which knob fixes it -------------------------
+assert_guard "red: absent JDK 17 exits 2 and names RACERD_JDK" 2 "RACERD_JDK" \
+    INFER_BIN=/bin/echo RACERD_JDK=/nonexistent/jdk
+
+# --- GREEN NEAR-MISS: the JDK guard must not fire when the JDK is fine ---------------------------
+# Same invocation as the arm above with only RACERD_JDK corrected. If this went red the second arm
+# would be proving nothing - it would be failing on the absent Infer it shares, not on the JDK.
+#
+# RESOLVING THE JDK IS THE POINT OF THIS ARM, so it may not quietly give up. It used to try exactly
+# one path - a developer's own SDKMAN install - and `return` when it was absent, printing `skip` and
+# incrementing neither counter. `repo-hygiene.yml` runs this file on ubuntu-latest with no
+# `setup-java` and no `RACERD_JDK`, where that path never exists, so the arm proving a good JDK gets
+# PAST the guard has never once run in CI while the job reported success. A green tick over an arm
+# that did not execute is the precise defect this whole branch is about, sitting inside its own
+# self-test. Found by an independent review.
+#
+# So: try the explicit knob, then the runner's own JDK, then the developer path. Any javac will do -
+# the guard under test only checks that `$JDK/bin/javac` is executable, not which version it is.
+# And when nothing resolves, a local developer may skip, but CI must FAIL: on a hosted runner an
+# unresolvable JDK means the fixture is wrong, not that the check is unnecessary.
+jdk_near_miss() {
+    local out rc real_jdk=""
+    for candidate in "${RACERD_JDK:-}" "${JAVA_HOME:-}" "$HOME/.sdkman/candidates/java/17.0.18-tem"; do
+        if [ -n "$candidate" ] && [ -x "$candidate/bin/javac" ]; then real_jdk="$candidate"; break; fi
+    done
+    if [ -z "$real_jdk" ]; then
+        if [ -n "${CI:-}" ]; then
+            printf 'FAIL: green near-miss found no JDK on a CI runner - set RACERD_JDK or add setup-java.\n'
+            printf '      A skipped arm is not a passed arm, and this one is the only proof the JDK guard\n'
+            printf '      does not fire on a valid JDK.\n'
+            fail=$((fail + 1))
+            return
+        fi
+        printf 'skip: green near-miss needs a JDK (tried RACERD_JDK, JAVA_HOME, the SDKMAN path)\n'
+        return
+    fi
+    set +e
+    out="$(cd "$repo_root" && INFER_BIN=/nonexistent/infer RACERD_JDK="$real_jdk" bin/racerd-test.sh 2>&1)"
+    rc=$?
+    set -e
+    if [ "$rc" = "2" ] && grep -qF "Infer is not installed" <<< "$out"; then
+        printf 'ok:   green near-miss: a good JDK leaves only the Infer guard firing\n'
+        pass=$((pass + 1))
+    else
+        printf 'FAIL: green near-miss (exit %s, expected the Infer guard alone)\n%s\n' "$rc" "$out"
+        fail=$((fail + 1))
+    fi
+}
+jdk_near_miss
+
+# --- The ratchet's four arms, exercised against a canned report so no Infer run is needed --------
+# The decisive one is the SAME-COUNT SWAP: fix one race, introduce another, and the total is 13 both
+# times. The count ceiling this ratchet replaced passed that, which is what an independent review
+# caught - so an identity ratchet that is never machine-checked would be the same trap one level up.
+#
+# This block used to be a lie. It required RACERD_TEST_REPORT, which nothing ever set, so in CI it
+# printed `skip`; and when a report WAS supplied it printed `ok:` and incremented the pass counter
+# WITHOUT RUNNING ANY ARM, under this same comment claiming four were exercised. A green tick over an
+# assertion that does not exist is the exact defect this branch is about. The arms below are real,
+# they need no Infer run (bin/racerd-test.sh grew RACERD_DRY_RUN_REPORT for it), and they therefore
+# run everywhere - locally and on every hosted runner.
+#
+# The fixtures are built here rather than checked in: they must stay in step with the identity format
+# the ratchet computes (`<count> <bug_type> <Class.method>`), and a checked-in fixture drifts from it
+# silently. Two known identities is enough to express every arm.
+ratchet_arms() {
+    local tmp report known out rc
+    tmp="$(mktemp -d)"
+
+    # A minimal Infer report.json: the ratchet reads bug_type and procedure, nothing else.
+    _report() {
+        python3 -c "
+import json,sys
+out=[]
+for spec in sys.argv[2:]:
+    bug,cls,meth = spec.split(':')
+    out.append({'bug_type':bug,'procedure':'void %s.%s(java.lang.Object)' % (cls,meth),
+                'file':'src/main/java/%s.java' % cls,'line':42,'qualifier':'canned fixture'})
+json.dump(out, open(sys.argv[1],'w'))
+" "$1" "${@:2}"
+    }
+
+    report="$tmp/report.json"
+    known="$tmp/known.txt"
+    printf '1 THREAD_SAFETY_VIOLATION Alpha.methodOne\n1 THREAD_SAFETY_VIOLATION Beta.methodTwo\n' > "$known"
+
+    _arm() {
+        local name="$1" want_rc="$2" want="$3"; shift 3
+        _report "$report" "$@"
+        set +e
+        out="$(cd "$repo_root" && RACERD_DRY_RUN_REPORT="$report" RACERD_KNOWN="$known" bin/racerd-test.sh 2>&1)"
+        rc=$?
+        set -e
+        if [ "$rc" = "$want_rc" ] && { [ -z "$want" ] || grep -qF "$want" <<< "$out"; }; then
+            printf 'ok:   %s\n' "$name"
+            pass=$((pass + 1))
+        else
+            printf 'FAIL: %s (exit %s, wanted %s)\n%s\n' "$name" "$rc" "$want_rc" "$out"
+            fail=$((fail + 1))
+        fi
+    }
+
+    # GREEN BASELINE: exactly the known set, so the ratchet must pass.
+    _arm "ratchet: the known set exactly reproduced passes" 0 "all 2 finding(s) are known" \
+        THREAD_SAFETY_VIOLATION:Alpha:methodOne THREAD_SAFETY_VIOLATION:Beta:methodTwo
+
+    # RED: an identity that is not in the set means a race was introduced.
+    _arm "ratchet: a NEW identity fails" 1 "NEW race(s)" \
+        THREAD_SAFETY_VIOLATION:Alpha:methodOne THREAD_SAFETY_VIOLATION:Beta:methodTwo \
+        THREAD_SAFETY_VIOLATION:Gamma:methodThree
+
+    # RED: a known identity that stopped firing means somebody fixed a race without ratcheting.
+    # Fails on purpose - a set nobody shrinks stops meaning anything.
+    _arm "ratchet: a known identity that no longer fires fails" 1 "no longer fire" \
+        THREAD_SAFETY_VIOLATION:Alpha:methodOne
+
+    # THE DECISIVE ARM: one known identity swapped for one unknown. The COUNT IS UNCHANGED at 2, so a
+    # ceiling passes this and an identity set must not. This is the arm the whole rewrite was for.
+    _arm "ratchet: a same-count SWAP fails (the arm a ceiling passes)" 1 "NEW race(s)" \
+        THREAD_SAFETY_VIOLATION:Alpha:methodOne THREAD_SAFETY_VIOLATION:Delta:methodFour
+
+    rm -rf "$tmp"
+}
+ratchet_arms
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/bin/test-check-shell-lint.sh
+++ b/bin/test-check-shell-lint.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Self-test for bin/check-shell-lint.sh.
+#
+# A green lint lane proves nothing on its own: it looks identical whether the linter examined 59
+# scripts or zero of them. `docs/agent-harness.md` requires a red control that shows the gate can
+# fire, AND - since 18a61321b - a green near-miss arm, so the control proves the gate is looking at
+# the right thing rather than merely capable of failing.
+#
+# Every case runs against a THROWAWAY copy of the tree in a temp directory. Nothing here edits a
+# tracked file, so an interrupted run cannot leave a mutant behind.
+
+set -euo pipefail
+
+pass=0
+fail=0
+
+if ! command -v shellcheck > /dev/null 2>&1; then
+    echo "SKIP: shellcheck not installed - cannot self-test the lint gate" >&2
+    exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# Runs the gate over a scratch repo containing one script, and asserts the outcome.
+# $1 name, $2 expected (pass|fail), $3 script body, $4 optional substring the output must contain
+assert_case() {
+    local name="$1" expected="$2" body="$3" want="${4:-}"
+    local tmp out got
+    tmp="$(mktemp -d)"
+    (
+        cd "$tmp" || exit 1
+        git init -q .
+        mkdir -p bin
+        cp "$repo_root/bin/check-shell-lint.sh" bin/
+        printf '%s\n' "$body" > bin/subject.sh
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m fixture
+    ) > /dev/null 2>&1
+
+    if out="$(cd "$tmp" && bin/check-shell-lint.sh 2>&1)"; then got=pass; else got=fail; fi
+
+    if [ "$got" != "$expected" ]; then
+        printf 'FAIL: %s (expected %s, got %s)\n%s\n' "$name" "$expected" "$got" "$out"
+        fail=$((fail + 1))
+    elif [ -n "$want" ] && ! grep -qF "$want" <<< "$out"; then
+        # A red case must SAY what it caught. A gate that crashes on every input scores a pass on
+        # exit code alone, which is how three earlier gates in this repo were found to be vacuous.
+        printf 'FAIL: %s (output did not contain %s)\n%s\n' "$name" "$want" "$fail"
+        fail=$((fail + 1))
+    else
+        printf 'ok:   %s\n' "$name"
+        pass=$((pass + 1))
+    fi
+    rm -rf "$tmp"
+}
+
+# --- RED CONTROL: the array-expansion ambiguity, a real finding from the tree this landed on -----
+# SC1087: `"$var[..."` reads as an array expansion. In bin/check-quarantine-registry.sh it was a
+# regex character class and happened to work, but the two are indistinguishable to a reader.
+assert_case "red: ambiguous array expansion is caught" fail \
+    '#!/usr/bin/env bash
+method=foo
+grep -qE "[[:space:]]$method[[:space:]]*\\(" /dev/null' \
+    "SC1087"
+
+# --- WHAT THIS LANE CANNOT DO, asserted so nobody assumes otherwise ------------------------------
+# ShellCheck has NO bash-version awareness: --shell=bash means "bash, any version", so a bash-4
+# builtin on a bash 3.2 platform is invisible to it. `mapfile` - the headline example of this
+# repo's August portability class, which died with exit 127 on macOS - passes clean here. It is
+# flagged only under --shell=sh/dash, as POSIX portability, which these bash scripts are not.
+# The detector for THAT class is running the scripts on macOS, which is the `shell: macos` lane in
+# astubbs/parallel-consumer#355, not this one. This case is a green assertion on purpose: if a
+# future ShellCheck gains version awareness it will go red, and that is the signal to widen this
+# lane and narrow astubbs#355's claim.
+assert_case "green (documented gap): bash-4 mapfile is INVISIBLE to shellcheck" pass \
+    '#!/usr/bin/env bash
+mapfile -t xs < <(printf "a\nb\n")
+echo "${xs[0]}"'
+
+# --- RED CONTROL: the directive that silently disabled the linter --------------------------------
+# A prose comment whose first word is `shellcheck` parses as a DIRECTIVE and aborts analysis of the
+# file. This is the real finding from the tree this gate landed on, kept as a permanent case.
+assert_case "red: prose comment parsed as a directive is caught" fail \
+    '#!/usr/bin/env bash
+# shellcheck does not catch this, so we grep instead
+echo hi' \
+    "shellcheck"
+
+# --- GREEN NEAR-MISS: one character away from the case above -------------------------------------
+# Same sentence, prefixed so it is prose rather than a directive. If this went red the gate would be
+# matching on the word `shellcheck` rather than on directive syntax, and the red case above would be
+# proving nothing.
+assert_case "green near-miss: the same comment, prefixed, is fine" pass \
+    '#!/usr/bin/env bash
+# NOTE: shellcheck does not catch this, so we grep instead
+echo hi'
+
+# --- GREEN NEAR-MISS: a warning-severity finding must NOT fail an error-severity gate ------------
+# SC2164 (cd without ||) is a warning. It has to pass here, or the severity floor is not the floor.
+assert_case "green near-miss: a warning does not trip the error floor" pass \
+    '#!/usr/bin/env bash
+cd /tmp
+echo hi'
+
+# --- The severity floor is real, not decorative --------------------------------------------------
+severity_case() {
+    local tmp out
+    tmp="$(mktemp -d)"
+    (
+        cd "$tmp" || exit 1
+        git init -q .
+        mkdir -p bin
+        cp "$repo_root/bin/check-shell-lint.sh" bin/
+        printf '%s\n' '#!/usr/bin/env bash
+cd /tmp
+echo hi' > bin/subject.sh
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m fixture
+    ) > /dev/null 2>&1
+    if out="$(cd "$tmp" && SHELL_LINT_SEVERITY=warning bin/check-shell-lint.sh 2>&1)"; then
+        printf 'FAIL: severity floor is decorative - SC2164 passed at severity=warning\n'
+        fail=$((fail + 1))
+    elif ! grep -qF 'SC2164' <<< "$out"; then
+        # A nonzero exit is not proof the FLOOR moved. Without this, the arm passes when the script
+        # dies early for any unrelated reason - the same "red for the wrong reason" defect this whole
+        # branch is about, and one that contaminated a forbidden-apis control arm earlier in it.
+        printf 'FAIL: exited nonzero at severity=warning but never mentioned SC2164 - red for the wrong reason\n%s\n' "$out"
+        fail=$((fail + 1))
+    else
+        printf 'ok:   the severity floor lowers (SC2164 caught at warning)\n'
+        pass=$((pass + 1))
+    fi
+    rm -rf "$tmp"
+}
+severity_case
+
+# --- Refuses to report success over an empty set -------------------------------------------------
+empty_case() {
+    local tmp rc
+    tmp="$(mktemp -d)"
+    (
+        cd "$tmp" || exit 1
+        git init -q .
+        mkdir -p bin
+        cp "$repo_root/bin/check-shell-lint.sh" bin/check-shell-lint.sh
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m fixture
+        git rm -q --cached bin/check-shell-lint.sh
+    ) > /dev/null 2>&1
+    ( cd "$tmp" && bin/check-shell-lint.sh ) > /dev/null 2>&1 && rc=0 || rc=$?
+    if [ "$rc" = "2" ]; then
+        printf 'ok:   an empty target set exits 2, not 0\n'
+        pass=$((pass + 1))
+    else
+        printf 'FAIL: empty target set exited %s, expected 2 (a vacuous run must not read as clean)\n' "$rc"
+        fail=$((fail + 1))
+    fi
+    rm -rf "$tmp"
+}
+empty_case
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/bin/test-check-shell-sigpipe.sh
+++ b/bin/test-check-shell-sigpipe.sh
@@ -14,6 +14,8 @@
 #    6. the violation appears only in a COMMENT                  -> pass (0)
 #    7. same pipe, but the script has no `pipefail`              -> pass (0)
 #    8. herestring instead of a pipe - the prescribed fix        -> pass (0)
+#    8b. `|| grep -q ... <<<` - a logical OR, NOT a pipe          -> pass (0)
+#    8c. a real pipe with an `||` earlier on the line             -> FAIL (1)
 #    9. `| grep query` - a bare word, no q-bearing FLAG          -> pass (0)
 #   10. the guard skips itself, matched on BASENAME not path     -> pass (0)
 #   11. the guard skips its OWN self-test, same reason           -> pass (0)
@@ -81,6 +83,18 @@ assert "same pipe but no pipefail in the script" 0 \
 
 assert "herestring instead of a pipe (the prescribed fix)" 0 \
     "$(run_guard 'if grep -qE "foo" <<<"$x"; then :; fi')"
+
+# `||` IS NOT A PIPE. The guard used to flag this, because the second `|` of `||` sits immediately
+# before ` grep -q` - so it fired on a line that already used the herestring it prescribes, and the
+# only way to go green was to rewrite correct code. A guard that fails on the fix it recommends is
+# worse than no guard. Found when it went red on a herestring added in the same PR.
+assert "logical OR before a herestring is not a pipe" 0 \
+    "$(run_guard 'if [ -z "$w" ] || grep -qF "$w" <<<"$out"; then :; fi')"
+
+# The other direction, so the fix above cannot be over-applied into blindness: a real pipe still
+# fails even when an `||` appears earlier on the same line.
+assert "a real pipe still fails when an || precedes it" 1 \
+    "$(run_guard 'if [ -z "$w" ] || printf "%s" "$x" | grep -qF "foo"; then :; fi')"
 
 assert "bare word containing q, not a flag" 0 \
     "$(run_guard 'printf "%s" "$x" | grep query')"

--- a/bin/test-ci-mutation-test.sh
+++ b/bin/test-ci-mutation-test.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Self-test for bin/ci-mutation-test.sh - specifically for its VERDICT, not for PIT.
+#
+# WHY THIS EXISTS. Measured 2026-08-25 over the last 40 `maven.yml` pull_request runs: the
+# "Mutation Tests (PIT, PR-scoped)" check reported success on every one of them and scored ZERO
+# mutants on every one of them. Nothing was broken - each skip was individually correct - but the
+# lane had no way to say so in the one place anybody looks, so a green tick meant "did nothing"
+# 40 times out of 40 and would have meant exactly the same thing had the scope regex been stale.
+# AGENTS.md names that shape ("exits 0 printing nothing to mutate, skipping ... indistinguishable
+# from a pass in the job summary"); this file is what makes it distinguishable and keeps it so.
+#
+# So every case below asserts an EXIT CODE, because the exit code is now the verdict:
+#
+#   0  scored at least PIT_MIN_MUTANTS mutants
+#   2  CANNOT RUN - the scope matches nothing in the tree, or PIT scored nothing when asked to
+#   3  nothing in scope - legitimate, and deliberately not 0
+#
+# A lane that cannot demonstrate a red is not evidence of anything, so the red arms come first and
+# each has a green near-miss one character away from it - the shape bin/test-check-shell-lint.sh
+# established on this branch.
+#
+# NO MAVEN RUNS HERE. Every case either exits before the build (the scoping arms) or feeds a
+# captured PIT log through PIT_DRY_RUN_LOG (the verdict arms). The whole file is seconds.
+
+set -euo pipefail
+
+pass=0
+fail=0
+
+repo_root="$(git rev-parse --show-toplevel)"
+subject="$repo_root/bin/ci-mutation-test.sh"
+
+if [ ! -x "$subject" ]; then
+    echo "test-ci-mutation-test: $subject is missing or not executable - CANNOT RUN" >&2
+    exit 2
+fi
+
+# Builds a throwaway repo that looks enough like this one for the scoping logic: a core module with
+# two main-source packages, one commit as the base, and a `refs/remotes/origin/master` pointing at
+# it. Nothing here touches the real tree.
+#
+# $1 receives the temp dir path via stdout.
+make_fixture() {
+    local tmp
+    tmp="$(mktemp -d)"
+    (
+        cd "$tmp" || exit 1
+        git init -q .
+        mkdir -p parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets
+        mkdir -p parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state
+        mkdir -p bin
+        cp "$subject" bin/ci-mutation-test.sh
+        printf 'package bz.stub.parallelconsumer.offsets;\nclass RunLengthEncoder {}\n' \
+            > parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/RunLengthEncoder.java
+        printf 'package bz.stub.parallelconsumer.state;\nclass ShardManager {}\n' \
+            > parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ShardManager.java
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m base
+        git update-ref refs/remotes/origin/master HEAD
+    ) > /dev/null 2>&1
+    printf '%s' "$tmp"
+}
+
+# Runs the subject inside a fixture and asserts the exit code.
+# $1 name, $2 expected exit code, $3 path a modification is written to (empty = no change),
+# $4 extra env assignments as a string, $5 optional substring the output must contain.
+
+# The verdict for one case, shared by all three fixture helpers below. It was written out three
+# times, and the three copies had already drifted: two said "output never said why" and one said
+# "but the output never said why". Nothing depended on the difference, which is how it survived.
+# `pass` and `fail` are script-global.
+record_result() {
+    local name="$1" want_rc="$2" rc="$3" out="$4" want="${5:-}"
+    if [ "$rc" != "$want_rc" ]; then
+        printf 'FAIL: %s (expected exit %s, got %s)\n%s\n' "$name" "$want_rc" "$rc" "$out"
+        fail=$((fail + 1))
+    elif [ -n "$want" ] && ! grep -qF "$want" <<< "$out"; then
+        # An exit code alone is not proof: a script that dies early scores the "cannot run" code for
+        # the wrong reason. Each red arm must also SAY what it caught.
+        printf 'FAIL: %s (exit %s was right, but the output never said why - wanted %s)\n%s\n' \
+            "$name" "$rc" "$want" "$out"
+        fail=$((fail + 1))
+    else
+        printf 'ok:   %s\n' "$name"
+        pass=$((pass + 1))
+    fi
+}
+
+assert_exit() {
+    local name="$1" want_rc="$2" touch_path="$3" envs="$4" want="${5:-}"
+    local tmp out rc
+    tmp="$(make_fixture)"
+    if [ -n "$touch_path" ]; then
+        (
+            cd "$tmp" || exit 1
+            printf '// edited\n' >> "$touch_path"
+            git add -A
+            git -c user.email=t@t -c user.name=t commit -q -m change
+        ) > /dev/null 2>&1
+    fi
+    # `env` rather than an exported assignment: each case must start from a clean environment, or a
+    # variable set by an earlier case silently changes a later one's scope.
+    set +e
+    # shellcheck disable=SC2086  # $envs is a deliberate word-split list of KEY=VALUE assignments
+    out="$(cd "$tmp" && env PIT_BASE_REF=master $envs bin/ci-mutation-test.sh 2>&1)"
+    rc=$?
+    set -e
+    rm -rf "$tmp"
+
+    record_result "$name" "$want_rc" "$rc" "$out" "$want"
+}
+
+# Writes a fake PIT log to $1 with the given statistics block. An empty $2 means the run died before
+# reaching the statistics stage, which is what "never completes" actually looks like in the log.
+write_pit_log() {
+    local path="$1" generated="${2:-}"
+    {
+        printf '9:00:00 pm PIT >> INFO : Sending 3 test classes to minion\n'
+        printf '9:00:01 pm PIT >> INFO : Calculated coverage in 3 seconds.\n'
+        if [ -n "$generated" ]; then
+            printf -- '- Statistics\n'
+            printf '>> Line Coverage (for mutated classes only): 100/120 (83%%)\n'
+            printf '>> Generated %s mutations Killed %s (100%%)\n' "$generated" "$generated"
+            printf '>> Mutations with no coverage 0. Test strength 100%%\n'
+            printf '>> Ran 40 tests (1.00 tests per mutation)\n'
+        fi
+    } > "$path"
+}
+
+# Writes a fake pitest mutations.xml under $1 (a fixture root) with $2 mutants all carrying status
+# $3. The log and the report are SEPARATE fixtures on purpose: a log claiming mutants alongside a
+# report where none were evaluated is precisely the state this lane must fail on, and a helper that
+# derived one from the other could not express it.
+write_pit_report() {
+    local root="$1" count="$2" status="${3:-KILLED}" i
+    mkdir -p "$root/parallel-consumer-core/target/pit-reports"
+    {
+        printf '<?xml version="1.0" encoding="UTF-8"?>\n<mutations>\n'
+        for ((i = 1; i <= count; i++)); do
+            printf "<mutation detected='true' status='%s' numberOfTestsRun='2'><sourceFile>RunLengthEncoder.java</sourceFile><lineNumber>%s</lineNumber><description>replaced return with 0</description></mutation>\n" \
+                "$status" "$((100 + i))"
+        done
+        printf '</mutations>\n'
+    } > "$root/parallel-consumer-core/target/pit-reports/mutations.xml"
+}
+
+echo "=== Scoping arms: a skip must never be reported as a pass ==="
+
+# --- RED CONTROL: the stale-scope class, exactly as AGENTS.md describes it -----------------------
+# This is the io.confluent -> bz.stub rename simulated. Before this guard existed the run below
+# printed "nothing to mutate, skipping" and exited 0 - a green tick over a scope that can never
+# match anything again.
+assert_exit "red: a decidable scope matching nothing in the tree exits 2" 2 \
+    "" "PIT_DECIDABLE_PACKAGES=^io\.confluent\.csid\.utils\.offsets\." \
+    "matches NOTHING"
+
+# --- GREEN NEAR-MISS: the same guard, one package name away --------------------------------------
+# If this went red too, the guard would be rejecting every regex rather than checking it against the
+# tree, and the control above would be proving nothing. It reaches the scoping decision and finds
+# nothing changed, so 3 - not 0, and not 2.
+assert_exit "green near-miss: a live scope with no changed classes exits 3" 3 \
+    "" "PIT_DECIDABLE_PACKAGES=^bz\.stub\.parallelconsumer\.offsets\." \
+    "nothing to mutate"
+
+# --- RED CONTROL: no core main-source classes at all ---------------------------------------------
+# A wrong checkout, a moved module, a `git ls-files` that returned nothing. Refusing to report
+# success over an empty target set is the contract bin/check-shell-lint.sh already holds.
+empty_tree_case() {
+    local tmp out rc
+    tmp="$(mktemp -d)"
+    (
+        cd "$tmp" || exit 1
+        git init -q .
+        mkdir -p bin
+        cp "$subject" bin/ci-mutation-test.sh
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m base
+        git update-ref refs/remotes/origin/master HEAD
+    ) > /dev/null 2>&1
+    set +e
+    out="$(cd "$tmp" && env PIT_BASE_REF=master bin/ci-mutation-test.sh 2>&1)"
+    rc=$?
+    set -e
+    rm -rf "$tmp"
+    if [ "$rc" = "2" ] && grep -qF "no core main-source classes found" <<< "$out"; then
+        printf 'ok:   red: an empty main-source tree exits 2, not 0\n'
+        pass=$((pass + 1))
+    else
+        printf 'FAIL: empty main-source tree exited %s (wanted 2)\n%s\n' "$rc" "$out"
+        fail=$((fail + 1))
+    fi
+}
+empty_tree_case
+
+# --- The two legitimate skips are 3, and they are told apart from each other ---------------------
+assert_exit "green: changed classes all outside the decidable scope exits 3" 3 \
+    "parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ShardManager.java" \
+    "PIT_DECIDABLE_PACKAGES=^bz\.stub\.parallelconsumer\.offsets\." \
+    "outside the decidable packages"
+
+# --- GREEN NEAR-MISS: widening the scope turns that same skip into a real run --------------------
+# Same fixture, same changed file, one extra package in the regex. It now reaches the build, which
+# in a fixture with no pom means a non-zero maven status - what matters is that it is neither 3
+# (skipped) nor 2 (vacuous), i.e. the scope decision flipped. PIT_DRY_RUN_LOG keeps maven out of it.
+widened_scope_case() {
+    local tmp out rc log
+    tmp="$(make_fixture)"
+    log="$tmp/pit.log"
+    write_pit_log "$log" 7
+    write_pit_report "$tmp" 7
+    (
+        cd "$tmp" || exit 1
+        printf '// edited\n' >> parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ShardManager.java
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m change
+    ) > /dev/null 2>&1
+    set +e
+    out="$(cd "$tmp" && env PIT_BASE_REF=master \
+        PIT_DECIDABLE_PACKAGES='^bz\.stub\.parallelconsumer\.(offsets|state)\.' \
+        PIT_DRY_RUN_LOG="$log" bin/ci-mutation-test.sh 2>&1)"
+    rc=$?
+    set -e
+    rm -rf "$tmp"
+    if [ "$rc" = "0" ] && grep -qF "PR-scoped to CHANGED decidable classes" <<< "$out"; then
+        printf 'ok:   green near-miss: widening the scope makes the same change decidable\n'
+        pass=$((pass + 1))
+    else
+        printf 'FAIL: widened scope exited %s (wanted 0 and a scoped target)\n%s\n' "$rc" "$out"
+        fail=$((fail + 1))
+    fi
+}
+widened_scope_case
+
+echo
+echo "=== Full-sweep arms: the same question for a PIT glob rather than a regex ==="
+
+# Runs the subject in full-sweep mode (no base ref) with the given target glob.
+# $1 name, $2 expected exit, $3 target glob, $4 optional substring.
+assert_sweep() {
+    local name="$1" want_rc="$2" target="$3" want="${4:-}"
+    local tmp out rc log
+    tmp="$(make_fixture)"
+    log="$tmp/pit.log"
+    write_pit_log "$log" 5
+    write_pit_report "$tmp" 5
+    set +e
+    out="$(cd "$tmp" && env PIT_FULL_SWEEP=true PIT_TARGET_CLASSES="$target" \
+        PIT_DRY_RUN_LOG="$log" bin/ci-mutation-test.sh 2>&1)"
+    rc=$?
+    set -e
+    rm -rf "$tmp"
+    record_result "$name" "$want_rc" "$rc" "$out" "$want"
+}
+
+# --- RED CONTROL: a sweep target naming a package that no longer exists --------------------------
+assert_sweep "red: a full-sweep target matching nothing exits 2" 2 \
+    'io.confluent.csid.utils.offsets.*' "matches NOTHING"
+
+# --- GREEN NEAR-MISS: the same glob against the package that does exist --------------------------
+assert_sweep "green near-miss: a live full-sweep target runs" 0 \
+    'bz.stub.parallelconsumer.offsets.*'
+
+# --- GREEN: a COMMA-SEPARATED target, which is what the PR path builds ---------------------------
+# The first version of the guard read the whole list as one string and rejected `Foo,Foo$*` - a live
+# target - so the lane exited 2 on a run that had previously scored 27 mutants. Found by running it,
+# not by this file, which is exactly why the case is here now.
+assert_sweep "green: a Foo,Foo\$* comma list is one target, not two failures" 0 \
+    'bz.stub.parallelconsumer.offsets.RunLengthEncoder,bz.stub.parallelconsumer.offsets.RunLengthEncoder$*'
+
+# --- GREEN: a bare star means everything, and must not be read as an empty prefix ----------------
+assert_sweep "green: a bare * target is not treated as matching nothing" 0 '*'
+
+echo
+echo "=== Verdict arms: PIT ran, so did it actually score anything? ==="
+
+# Runs the subject over a fixture whose changed class IS decidable, with a canned PIT log.
+# $1 name, $2 expected exit, $3 generated-mutant count ("" = no statistics block at all),
+# $4 optional substring, $5 optional extra env.
+assert_verdict() {
+    local name="$1" want_rc="$2" generated="$3" want="${4:-}" envs="${5:-}" status="${6:-KILLED}"
+    local tmp out rc log
+    tmp="$(make_fixture)"
+    log="$tmp/pit.log"
+    write_pit_log "$log" "$generated"
+    # $status of "none" writes no report at all - PIT always emits one when it runs, so its absence
+    # is itself a broken lane rather than a case to wave through.
+    if [ -n "$generated" ] && [ "$status" != "none" ]; then
+        write_pit_report "$tmp" "$generated" "$status"
+    fi
+    (
+        cd "$tmp" || exit 1
+        printf '// edited\n' >> parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/RunLengthEncoder.java
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m change
+    ) > /dev/null 2>&1
+    set +e
+    # shellcheck disable=SC2086  # $envs is a deliberate word-split list of KEY=VALUE assignments
+    out="$(cd "$tmp" && env PIT_BASE_REF=master PIT_DRY_RUN_LOG="$log" $envs bin/ci-mutation-test.sh 2>&1)"
+    rc=$?
+    set -e
+    rm -rf "$tmp"
+    record_result "$name" "$want_rc" "$rc" "$out" "$want"
+}
+
+# --- RED CONTROL: PIT was asked to mutate something and produced no statistics -------------------
+# This is the astubbs#57 sighting recorded in docs/inflight/ci-mutation-testing.md
+# ("PIT did not produce a report"). It used to exit with PIT's own status, which the workflow then
+# swallowed with continue-on-error.
+assert_verdict "red: PIT reached no statistics stage exits 2" 2 "" "scored NOTHING"
+
+# --- RED CONTROL: statistics present, zero mutants generated -------------------------------------
+# The subtler half, and the one a human reading the summary would skim past: a complete, tidy
+# statistics block over an empty mutant set. Verified by COUNT, never by the presence of the block.
+assert_verdict "red: a statistics block reporting 0 mutations exits 2" 2 "0" "scored NOTHING"
+
+# --- GREEN NEAR-MISS: one mutant is enough ------------------------------------------------------
+# One character away from the case above. If this failed too, the guard would be rejecting the log
+# format rather than reading the count out of it.
+assert_verdict "green near-miss: 1 generated mutation is a real run" 0 "1"
+
+assert_verdict "green: a normal run with 42 mutations passes" 0 "42"
+
+# --- The floor is a number and it moves ----------------------------------------------------------
+# A threshold nobody can raise is decoration. Same log, same fixture, a floor above the count.
+assert_verdict "red: PIT_MIN_MUTANTS is a real floor, not decoration" 2 "3" \
+    "scored NOTHING" "PIT_MIN_MUTANTS=10"
+
+assert_verdict "green near-miss: exactly meeting the floor passes" 0 "10" "" "PIT_MIN_MUTANTS=10"
+
+echo
+echo "=== Evaluated arms: GENERATING a mutant is not SCORING it ==="
+
+# The verdict used to turn on the generated count, which is the number of mutants PIT CREATED. A run
+# whose minions all die creates plenty and scores none, and against a generated-count floor it exited
+# 0 - a green tick over a lane that measured nothing. Not hypothetical: the plan that scoped this lane
+# recorded `state.*` hanging with minions dying, which is exactly this shape. The three arms below
+# hold the log identical at 42 generated and vary only the report, so the count cannot be what flips
+# them.
+
+# --- RED CONTROL: every mutant came back MEMORY_ERROR --------------------------------------------
+assert_verdict "red: 42 generated but every mutant MEMORY_ERROR exits 2" 2 "42" \
+    "0 EVALUATED" "" "MEMORY_ERROR"
+
+# --- RED CONTROL: the same shape via RUN_ERROR, so it is the CLASS not the one status -------------
+assert_verdict "red: every mutant RUN_ERROR is equally unscored" 2 "42" \
+    "minions died" "" "RUN_ERROR"
+
+# --- RED CONTROL: PIT reported statistics but wrote no report at all ------------------------------
+# PIT emits mutations.xml whenever it runs, so its absence alongside a statistics block means the
+# lane cannot show its working. Nothing to count is not the same as nothing to find.
+assert_verdict "red: a statistics block with no mutations.xml exits 2" 2 "42" \
+    "scored NOTHING" "" "none"
+
+# --- GREEN NEAR-MISS: identical log, identical count, mutants actually evaluated ------------------
+# One field of the report away from the first arm. If this went red too, the guard would be rejecting
+# the report format rather than reading statuses out of it, and the controls above would prove
+# nothing.
+assert_verdict "green near-miss: the same 42, this time KILLED, passes" 0 "42" \
+    "42 evaluated mutant(s)" "" "KILLED"
+
+# --- GREEN: NO_COVERAGE is an evaluated outcome, not an infrastructure failure --------------------
+# A mutant no test reaches is the lane's most valuable finding. Counting it as unevaluated would make
+# the lane fail hardest exactly when it has most to say. Exit 0 rather than 1 because this lane
+# REPORTS findings without blocking on them - the same deliberate staging spotbugs:spotbugs runs
+# under - so the survivor table is the product and the exit code only answers "did it measure".
+assert_verdict "green: NO_COVERAGE counts as evaluated - it is a finding, not a failure" 0 "42" \
+    "42 evaluated" "" "NO_COVERAGE"
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/config/racerd-known-findings.txt
+++ b/config/racerd-known-findings.txt
@@ -1,0 +1,33 @@
+# RacerD known findings - the ratchet's identity set, not a count.
+#
+# WHY IDENTITIES AND NOT A NUMBER. This lane first gated on a bare count ceiling of 13. An
+# independent cross-model review pointed out the hole in it: fix one race, introduce another, the
+# count is still 13 and the gate passes green. A ratchet that only counts cannot tell a codebase
+# that improved from one that swapped one defect for a different one - which is the exact
+# "reports green while the thing it guards changed" class this whole change exists to remove.
+#
+# KEYED ON bug type + class.method, DELIBERATELY NOT ON A LINE NUMBER. The SpotBugs baseline this
+# branch deleted was keyed on class + method + bug type and was defeated wholesale by a package
+# rename; a line number is worse still, invalidated by any edit above it. Class and method survive
+# reformatting and unrelated edits, and change when the code genuinely moves.
+#
+# THE COUNT COLUMN MATTERS. Two findings can share one class.method, so a bare identity set would
+# not notice a third appearing in the same place.
+#
+# EDITING THIS FILE IS THE RATCHET. Fixing a race means deleting its line, in the same change. The
+# gate fails BOTH ways: an identity here that no longer fires means somebody fixed something and
+# did not ratchet, which is how a ceiling quietly stops meaning anything.
+#
+# Format: <count> <bug_type> <Class.method>
+1 THREAD_SAFETY_VIOLATION AbstractParallelEoSStreamProcessor.controlLoop
+1 THREAD_SAFETY_VIOLATION AbstractParallelEoSStreamProcessor.isTimeToCommitNow
+1 THREAD_SAFETY_VIOLATION PCMetrics.gaugeFromMetricDef
+1 THREAD_SAFETY_VIOLATION PCMetrics.getCounterFromMetricDef
+1 THREAD_SAFETY_VIOLATION PCMetrics.getDistributionSummaryFromMetricDef
+1 THREAD_SAFETY_VIOLATION PCMetrics.getTimerFromMetricDef
+1 THREAD_SAFETY_VIOLATION RetryQueue$RetryQueueIterator.close
+1 THREAD_SAFETY_VIOLATION RetryQueue$RetryQueueIterator.hasNext
+2 THREAD_SAFETY_VIOLATION RetryQueue$RetryQueueIterator.next
+1 THREAD_SAFETY_VIOLATION RetryQueue.isEmpty
+1 THREAD_SAFETY_VIOLATION RetryQueue.removeAll
+1 THREAD_SAFETY_VIOLATION RetryQueue.size

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs suppression, BY RULE, deliberately coarse.
+
+  Every <Match> here MUST have a row in docs/inflight/static-spotbugs-rule-registry.md giving the
+  reason it is off and the trigger that turns it back on. A rule excluded without a row there is a
+  bug in this setup, not a decision - that registry is the whole point of suppressing this way
+  rather than through the auto-generated baseline this file replaces.
+
+  The baseline regenerated on every push to master, keyed on class + method + bug type, and recorded
+  nothing about what it swallowed. This file is worse at precision and better at everything that
+  matters: it is visible in a diff, each entry is justified, and the count only goes down.
+
+  Ordered to match the registry's tiers, so the two can be read side by side.
+-->
+<FindBugsFilter>
+
+    <!-- ============ Tier 2: off now, each with a trigger in the registry ============ -->
+
+    <!-- Bulk style. Mechanical sweeps; off so the engine's real findings are visible. -->
+    <Match><Bug pattern="USBR_UNNECESSARY_STORE_BEFORE_RETURN"/></Match>
+    <Match><Bug pattern="UMTP_UNBOUND_METHOD_TEMPLATE_PARAMETER"/></Match>
+    <Match><Bug pattern="NAB_NEEDLESS_BOOLEAN_CONSTANT_CONVERSION"/></Match>
+    <Match><Bug pattern="ENMI_EQUALS_ON_ENUM"/></Match>
+    <Match><Bug pattern="MRC_METHOD_RETURNS_CONSTANT"/></Match>
+    <Match><Bug pattern="LO_APPENDED_STRING_IN_FORMAT_STRING"/></Match>
+    <Match><Bug pattern="STT_TOSTRING_STORED_IN_FIELD"/></Match>
+    <Match><Bug pattern="UP_UNUSED_PARAMETER"/></Match>
+    <Match><Bug pattern="IPU_IMPROPER_PROPERTIES_USE"/></Match>
+    <Match><Bug pattern="IPU_IMPROPER_PROPERTIES_USE_SETPROPERTY"/></Match>
+
+    <!-- READ THESE TWO BEFORE CLEARING THEM. The exception-softening pair may be pointing at a real
+         analysis blind spot rather than at style: docs/solutions/best-practices/
+         sneaky-thrown-checked-exceptions-defeat-spotbugs-dataflow.md records that sneaky-throw
+         already defeats SpotBugs dataflow in this codebase. -->
+    <Match><Bug pattern="EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS"/></Match>
+    <Match><Bug pattern="LEST_LOST_EXCEPTION_STACK_TRACE"/></Match>
+
+    <!-- Structural, and each waits on work that is already planned. -->
+    <Match><Bug pattern="CT_CONSTRUCTOR_THROW"/></Match>          <!-- after the God-class decomposition -->
+    <Match><Bug pattern="FCCD_FIND_CLASS_CIRCULAR_DEPENDENCY"/></Match> <!-- pairs with the ArchUnit dependency-direction rule -->
+    <Match><Bug pattern="MS_SHOULD_BE_FINAL"/></Match>            <!-- with the codec work -->
+    <Match><Bug pattern="ACEM_ABSTRACT_CLASS_EMPTY_METHODS"/></Match>
+    <!-- 7 calls in 2 main classes (ProducerWrapper, AbstractParallelEoSStreamProcessor), and 5 more in 3
+         test classes. "Check both sites" is what this said before someone counted: two CLASSES, never two
+         calls, and a re-enable attempt sized against the wrong number gives up partway and looks finished. -->
+    <Match><Bug pattern="RFI_SET_ACCESSIBLE"/></Match>
+
+    <!-- 28 instances. A computed format string is how conditional log messages are built here.
+         Turns back on if a placeholder bug is ever traced to one. The two SLF4J placeholder
+         MISMATCH findings stay ON - they are real, and the registry names both. -->
+    <Match><Bug pattern="SLF4J_FORMAT_SHOULD_BE_CONST"/></Match>
+
+    <!-- ============ Tier 3: off, expected to stay off ============ -->
+
+    <!-- Storing and returning collaborators passed in IS how this library composes: PCModule holds
+         the options, BrokerPollSystem holds the ConsumerManager. Defensive copying would break the
+         DI wiring rather than fix anything. Reached independently by
+         docs/inflight/static-spotbugs-latent-findings.md on the same rules. -->
+    <Match><Bug pattern="EI_EXPOSE_REP"/></Match>
+    <Match><Bug pattern="EI_EXPOSE_REP2"/></Match>
+    <Match><Bug pattern="IMC_IMMATURE_CLASS_IDE_GENERATED_PARAMETER_NAMES"/></Match>
+
+    <!-- ============ Test code only, approximated by class name ============ -->
+    <!--
+      SCOPING LIMITATION, MEASURED NOT ASSUMED. A SpotBugs filter cannot express "test source root".
+      The XML records sourcepath as the PACKAGE-relative path - `bz/stub/parallelconsumer/mutiny/
+      MutinyPCTest.java` - so `src/test` never appears in it and a <Source> path regex matches
+      nothing at all. The first version of this file used one; it was inert, and only a sanity check
+      that PREDICTABLE_RANDOM had gone to zero caught it.
+
+      So these are scoped by class name instead, which is the weaker discriminator this repo already
+      knows is weak: it misses a helper called Fixture or Harness. That is a real gap and it is
+      recorded in the registry rather than papered over. The alternative - excluding these rules
+      globally - would drop the one REAL main-code PREDICTABLE_RANDOM finding, which is worse.
+    -->
+
+    <!-- A seeded, reproducible generator is what a test SHOULD use. The rule stays ON for main
+         code, where its one finding is real. -->
+    <Match>
+        <Class name="~.*(Test|Tests|IT|ITCase)(\$.*)?"/>
+        <Bug pattern="PREDICTABLE_RANDOM"/>
+    </Match>
+    <!-- A named local holding an intermediate value is how readable test setup is written. -->
+    <Match>
+        <Class name="~.*(Test|Tests|IT|ITCase)(\$.*)?"/>
+        <Bug pattern="DLS_DEAD_LOCAL_STORE"/>
+    </Match>
+    <Match>
+        <Class name="~.*(Test|Tests|IT|ITCase)(\$.*)?"/>
+        <Bug pattern="LSC_LITERAL_STRING_COMPARISON"/>
+    </Match>
+    <Match>
+        <Class name="~.*(Test|Tests|IT|ITCase)(\$.*)?"/>
+        <Bug pattern="CE_CLASS_ENVY"/>
+    </Match>
+
+
+    <!-- THE RED CONTROL IS SUPPOSED TO BE BROKEN, so the detector finding it is the detector working.
+         LincheckToolchainProbeTest (astubbs#347) is a deliberately torn containsKey/get/dereference on a
+         ConcurrentHashMap, kept broken on purpose: it is the arm that proves Lincheck can see the defect
+         class at all, and "fixing" it would silently turn the Lincheck lane's calibration into a green
+         lamp wired to nothing.
+
+         Scoped to that ONE class, never to the rule. MUI_CONTAINSKEY_BEFORE_GET is the finding that
+         justified adopting fb-contrib in the first place - it names ShardManager.removeWorkFromShardFor,
+         a real defect - so switching it off globally to quieten a deliberate fixture would trade the
+         headline result for silence. Any other class tripping this rule still fails.
+
+         Worth recording rather than just suppressing: the probe's own javadoc says SpotBugs reported
+         NOTHING on this shape. That was measured with STOCK detectors, and it is why the javadoc is
+         corrected in the same change - with fb-contrib the shape is detected in seconds. -->
+    <Match>
+        <Class name="bz.stub.parallelconsumer.state.LincheckToolchainProbeTest"/>
+        <Bug pattern="MUI_CONTAINSKEY_BEFORE_GET"/>
+    </Match>
+
+</FindBugsFilter>

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -335,6 +335,24 @@ one is a case in that file, and the suite goes red against the old parser.
   before pulling; the `.gitignore` comment says so at the point someone reads it.
   <!-- file-refs: N/A - the file is git-ignored by design, so it is absent from every checkout -->
 
+## NOT settled by testing - the nested cascade
+
+`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md` is placed at a **package
+root**, above the three sub-packages its rules are about - `state`, `metrics`, `internal`. That
+placement assumes a nested `CLAUDE.md` loads for a file in a **subdirectory**, not only for a file
+directly in its own directory. The layer table above says "file in that dir is touched", which does
+not answer it, and the two existing bridges (`bin/`, `docs/inflight/`) both sit directly above their
+files, so neither tests the question.
+
+**Evidence it probably cascades**, short of a test: the root `CLAUDE.md` loads for work anywhere in
+the tree, so ancestors clearly participate. Whether the root is special-cased is the open part.
+
+**How to settle it:** edit a file in `.../parallelconsumer/state/` in a fresh session and check
+whether the package-root rules arrive. If they do not, the fix is three bridges instead of one - the
+content is identical and the cost is duplication, which is why one was tried first.
+
+Until then this is an assumption, and a rule that does not arrive is a rule that does not exist.
+
 ## Settled by testing, so nobody re-opens them
 
 - **Sub-agent hooks DO fire.** Whether `.claude/settings.json` hooks apply to agents spawned via the

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -647,6 +647,18 @@ never run on our own hardware.
   (`bin/ci-mutation-test.sh -Dverbose=true -Dthreads=N`). The PR-scoped mutation job in `maven.yml`
   only covers classes changed against the base; this is its exhaustive counterpart.
 
+### A green mutation tick usually means "measured nothing" - read the exit code
+
+`bin/ci-mutation-test.sh` answers in its exit code, and the script's own header owns the contract:
+**0** scored mutants, **2** could not run (a scope regex matching nothing in the tree, or PIT
+producing no statistics / zero mutants), **3** nothing in scope. Measured over the last 40
+`maven.yml` PR runs: 40 passes, zero mutants scored - the lane is correctly narrow, not broken. Only
+a **0** is evidence about test quality. `bin/test-ci-mutation-test.sh` guards the contract and runs
+in the lane ahead of it. The scope, the exclusions and the ranked widening list are in
+[`docs/inflight/ci-mutation-testing.md`](inflight/ci-mutation-testing.md); whether a skip should
+render grey rather than green is an open decision in
+[`docs/inflight/ci-mutation-lane-skip-reads-as-a-pass.md`](inflight/ci-mutation-lane-skip-reads-as-a-pass.md).
+
 **There is no scheduled build, deliberately.** Every suite worth re-running is already a required
 check on each PR and runs again on every push to master, so a cron lane would only repeat covered
 work. **Do not add a lane for suites the gate already covers.** The repo's single cron lane,

--- a/docs/data/testing-evidence.yaml
+++ b/docs/data/testing-evidence.yaml
@@ -73,7 +73,7 @@ test_layers:
     limitation: It covers changed, decidable offset classes on a PR; a skipped or narrow run is not a project-wide coverage claim.
     inspect:
       - path: bin/ci-mutation-test.sh
-        demonstrates: PR-scoped mutation selection and an explicit warning that a green skip is not evidence.
+        demonstrates: PR-scoped mutation selection, and an exit code that separates a scored run from a skip and from a lane that could not run at all.
   - id: chaos
     proves: Rebalance, revocation and stalled-progress behavior under calibrated disruption.
     command: bin/chaos-test.sh

--- a/docs/inflight/branch-package-rename.md
+++ b/docs/inflight/branch-package-rename.md
@@ -57,8 +57,10 @@ class of failure that reports success, and the next namespace-wide change will m
   findings that govern its design, and rewrites the escaped form explicitly.
 - **The mutation gate failed open.** Stale, `bin/ci-mutation-test.sh` matched nothing, printed
   `PIT: no core main-source classes changed - nothing to mutate, skipping` and exited 0 - green
-  forever while scoring zero mutants. Its patterns now name `bz.stub.parallelconsumer`; the standing
-  instruction is unchanged - assert the lane actually scores mutants, do not accept the tick.
+  forever while scoring zero mutants. Its patterns now name `bz.stub.parallelconsumer`, and the
+  standing instruction is no longer only an instruction: the script validates its scope against the
+  tree and exits 2 when it matches nothing, exit 3 for a genuine skip
+  ([`ci-mutation-testing.md`](ci-mutation-testing.md)).
 - **An ArchUnit rule could go vacuous silently.** `TestConventionRules.java` pins a fully-qualified
   class name as a *string*; stale, the condition never fires and the rule passes, so the guard keeping
   Docker-dependent tests out of surefire quietly stops guarding. `failOnEmptyShould` does not catch it.

--- a/docs/inflight/ci-build-hardening-register.md
+++ b/docs/inflight/ci-build-hardening-register.md
@@ -1,0 +1,64 @@
+# Build-hardening register: additions ranked by what this month actually proved
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: ci -->
+
+Every entry in the first list is grounded in a failure observed in this repo in August 2026, not in
+a tool catalogue. The recurring shape behind almost all of them: **a check that dies or is blind
+reports the same green as a check that passed.** Rank order is proven-value first.
+
+**This register was written on astubbs#344's branch, which is an encoder-race fix and not a CI
+change.** It moved here so the CI work can proceed without waiting on that PR, and so that the
+register is not reviewed as part of a diff nobody opened it for.
+
+**astubbs#344 is not being edited to remove its copy, deliberately.** Both branches add this path
+with no common ancestor version, so whichever lands second hits an add/add conflict when it next
+takes master. That is the reconciliation working, not a problem to pre-empt: the conflict is
+blocking and visible, and the resolution is to take master's version, which is a superset of what
+astubbs#344 carries. Reaching onto another open PR's branch to smooth it over would be reshaping work
+to dodge a conflict, which this project does not do.
+
+## What this register was, and where its work went
+
+**All thirteen entries were struck through, which is the state this file said should end it:
+"when somebody has read the struck entries, delete them and this file becomes short again."** They
+are deleted here. The register did its job - it was a ranked backlog, every item of which has now
+landed - and what it must not become is a monument to finished work that a future reader has to read
+before discovering there is nothing in it.
+
+The reasoning behind each entry did not go into the void; it went where the work is, so the notes
+below are the successors rather than an index:
+
+| What it covered | Where it lives now |
+|---|---|
+| SpotBugs detectors, the rule filter, `-Xlint` | [`static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md) |
+| Error Prone and NullAway | [`static-error-prone-rule-registry.md`](static-error-prone-rule-registry.md) |
+| The PIT mutation lane | [`ci-mutation-testing.md`](ci-mutation-testing.md) |
+| RacerD | [`static-racerd-findings.md`](static-racerd-findings.md) |
+| The ShellCheck lane | [`static-shell-lint-severity-tiers.md`](static-shell-lint-severity-tiers.md) |
+| `forbidden-apis`, and the `parallelStream()` ban still to come | [`static-forbidden-apis-parallelstream.md`](static-forbidden-apis-parallelstream.md) |
+| The `dependencyConvergence` tail | [`deps-convergence-tail.md`](deps-convergence-tail.md) |
+| Running full rules on new code only | [`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md) |
+
+The one thing that had no successor is what remains below: the list of tools already in place or
+deliberately rejected. That is a **register** in the strict sense - consulted, never completed - and
+it is why this file still exists at all.
+
+## Already in place, and explicitly not proposed
+
+**Already in place, so not re-proposed:** the chaos lane, the quarantine lane, dup-code and
+similarity gates, CodeQL default setup, the copyright/issue-ref/file-ref/inflight-tag gates, the
+Lincheck lane (astubbs#347) and jcstress probe module (astubbs#348) once merged.
+
+**Not proposed, with reasons:** a jcstress CI lane (its only FORBIDDEN outcomes live in control arms
+that cannot go red when product code changes - a green run would assert the JVM honours `volatile`);
+Checker Framework (annotation burden across a Lombok-heavy codebase, poor fit); racing-double
+unification tooling (already tracked with the doubles themselves).
+
+**Ruled out by the survey, with reasons** - recorded so the names do not arrive a third time: LGTM
+(shut down, folded into CodeQL, already here); Sonatype Lift (shut down); OWASP dependency-check
+(duplicate of the OSS Index lane, Dependabot and `dependency-review`); SonarQube and SonarLint
+(dashboards and organisation-wide trend visibility, wrong shape here, overlaps CodeQL); Coverity and
+Checkmarx (commercial); Qodana (OSS tier exists, but largely repackages engines already listed);
+Checkstyle and Spotless (EditorConfig covers the rules; unenforced in CI is a real gap but a
+cosmetic one, and this register is about checks that report green while blind).

--- a/docs/inflight/ci-mutation-lane-skip-reads-as-a-pass.md
+++ b/docs/inflight/ci-mutation-lane-skip-reads-as-a-pass.md
@@ -24,7 +24,14 @@ looks, and on this repo's shape it is cheaper than the status quo, not dearer.
 
 ## What actually fires, and how often
 
-Three exit paths in `bin/ci-mutation-test.sh`; two of them are skips and both exit 0.
+**The two skips no longer exit 0** - they exit `3`, PIT-ran-but-measured-nothing exits `2`, and the
+step reddens on the latter. That closes the half of this problem that was a *script* defect and
+leaves the half that is a *rendering* decision, which is what this file has always owned: a `3` is
+still a green row. The contract and the measurement behind it are in `bin/ci-mutation-test.sh`'s
+header and [`ci-mutation-testing.md`](ci-mutation-testing.md). The table below is unchanged and is
+still the frequency argument.
+
+Three exit paths in `bin/ci-mutation-test.sh`; two of them are skips.
 
 | Path | Log line | Last 100 merged PRs | Since the lane landed (astubbs#111) |
 |---|---|---|---|
@@ -55,6 +62,10 @@ timeouts hang rather than dying, and the covering tests are timing-based, so a s
 told from a race that did not happen. astubbs#296 is the textbook case, a shutdown race in the
 concurrency core. **Widening to `state.` would convert honest silence into unfalsifiable survivors**,
 and the plan already fixes the price of admission: a completed `state.` sweep, measured, not argued.
+
+**That price was paid on 2026-08-25 and `state.` did not meet it** - the sweep does not complete at
+all, let alone produce decidable survivors, where the same run against `offsets.` finishes in under a
+minute. Numbers and the control arm: [`ci-mutation-testing.md`](ci-mutation-testing.md).
 
 One nuance the package filter cannot express: `internal/Documentation.java` (astubbs#289) is pure
 constants, where mutants *would* be decidable and also worthless. The filter is a proxy for
@@ -88,7 +99,11 @@ fork the decidable regex away from `bin/ci-mutation-test.sh`, which must stay it
 Both skips collapse to one grey row, which is correct - "we graded nothing" is the reader's answer
 either way, and the summary still distinguishes them.
 
-## Do this first, regardless of the decision above
+## ~~Do this first, regardless of the decision above~~ DONE
+
+The warning that would have been deleted along with `AGENTS.md`'s temporary rename section now has a
+permanent home: [`docs/ci.md`](../ci.md), "A green mutation tick usually means measured nothing".
+The `AGENTS.md` bullet points at it and will go with the section it lives in. Original text:
 
 The only always-loaded agent-facing warning -
 `Confirm the mutation lane scored mutants rather than trusting its tick` in `AGENTS.md` - is the last

--- a/docs/inflight/ci-mutation-testing.md
+++ b/docs/inflight/ci-mutation-testing.md
@@ -1,9 +1,7 @@
 # Mutation testing is deliberately narrow - re-widening is tracked here
 
-<!-- inflight-type: bug -->
+<!-- inflight-type: register -->
 <!-- inflight-impact: blind-spot -->
-<!-- inflight-state: deferred - after v6, tooling investment -->
-
 
 Shipped in astubbs#111. Recorded because it is a deliberate *reduction* in coverage, which is the kind of
 thing a future session otherwise rediscovers as a bug.
@@ -14,6 +12,70 @@ the full sweep is dispatch-only (`mutation-full-sweep.yml`). So on most PRs muta
 nothing, by design - elsewhere the mutants hang by construction and a survivor cannot be told from a
 race that did not happen. Reasoning and measurements:
 [`docs/plans/2026-08-03-002-mutation-testing-plan.md`](../plans/2026-08-03-002-mutation-testing-plan.md).
+
+## The lane was reporting green over nothing, 40 runs out of 40
+
+**Measured 2026-08-25, and the answer is *scope*, not a stale regex.** The build-hardening register
+suspected the `io.confluent` to `bz.stub` rename had staled the package regex, which `AGENTS.md`
+warns exits 0 printing "nothing to mutate, skipping". It had not: the regex, the FQCN derivation and
+the whole PIT invocation are correct post-rename, and a scoped run scores mutants normally (below).
+
+What the log read actually found is worse in one way and better in another. Over the last **40**
+`maven.yml` `pull_request` runs the `Mutation Tests (PIT, PR-scoped)` check reported **success 40
+times and scored zero mutants 40 times**:
+
+| Outcome | Runs |
+|---|---|
+| Skipped - no core main-source class changed at all | 23 |
+| Skipped - changed classes all outside `offsets.` | 14 |
+| **Scored any mutant** | **0** |
+| Still in flight when sampled | 3 |
+
+Every one of those skips was individually correct. The defect is that "correct skip", "stale scope
+that can never match again" and "185 mutants killed" were the same green tick - because *every path
+out of the script exited 0*. Red was always honest here and green never was; the check row does
+render red when the step fails, `continue-on-error` notwithstanding, which
+[`ci-mutation-lane-skip-reads-as-a-pass.md`](ci-mutation-lane-skip-reads-as-a-pass.md) measured.
+Nothing ever made the step fail.
+
+The 14 not-decidable runs are the interesting half, because they say what a widened scope would
+have bought. The classes they declined to mutate were, in order of frequency,
+`internal.admission.*` (the control-law work), `internal.*`, `state.PartitionStateManager`,
+`state.WorkManager`, `metrics.PCMetricsDef`, and the top-level `CommitFailure*` /
+`ParallelConsumerOptions` group.
+
+### What changed, and the contract that replaces the tick
+
+`bin/ci-mutation-test.sh` now answers in its **exit code**, and its header owns the contract: `0`
+scored at least `PIT_MIN_MUTANTS` mutants, `2` cannot run, `3` nothing in scope, otherwise PIT's own
+status. Three guards produce the `2`:
+
+- The decidable regex is validated against the classes that exist **before it decides anything**, on
+  every run including ones that would have skipped. A rename that stales it is caught by the next PR
+  of any kind, not by the next PR that touches the one package it names.
+- The full-sweep glob's literal prefix is checked the same way.
+- The run's verdict is the **generated-mutant count**, not the presence of a statistics block. A
+  tidy, complete block over zero mutants is the harder half of the vacuity problem to spot.
+
+`maven.yml` maps those codes: `3` posts a `::notice::` and passes, `2` and PIT's own failures fail
+the step and so redden the row, survivors gate nothing. `continue-on-error: true` stays on the job,
+so none of this gates a merge - the change is that the row now has more than one colour available to
+it. Whether a *skip* should render grey instead of green is a separate, open decision that belongs
+to [`ci-mutation-lane-skip-reads-as-a-pass.md`](ci-mutation-lane-skip-reads-as-a-pass.md).
+
+`bin/test-ci-mutation-test.sh` holds it there. Fifteen cases, six of them red controls, each with a
+green near-miss one package name or one mutant away; it feeds canned PIT logs through the verdict so
+the whole file runs in seconds without maven. **Against the pre-change script all fifteen fail**
+(0 passed, 15 failed) - including the first arm, which is the `AGENTS.md` scenario exactly: a stale
+`io.confluent` regex, over which the old script exited **0**.
+
+**The self-test did not catch everything, and saying where is the point.** The first cut of the
+full-sweep prefix guard read `TARGET_CLASSES` as one string when it is a comma-separated list, so it
+rejected `Foo,Foo$*` - a live target the PR path builds itself - and the lane exited 2 on a run that
+had scored 27 mutants minutes earlier. Nothing in the self-test saw it; running the real lane
+end-to-end did, which is the only reason the guard is not now a second inert-config bug of its own.
+Both the comma list and a bare `*` are arms now. The end-to-end run after the fix scores the same
+**27 generated, 23 killed** as the pre-change script, so the restructuring changed no PIT behaviour.
 
 ## Baseline - first completed sweep, 2026-08-05
 
@@ -38,18 +100,90 @@ worth it**: coverage is 311s of 1315s, about 24%, so the accuracy it would cost 
 Compare future sweeps against this. A score that moves without a deliberate test change is the signal
 worth acting on.
 
-To re-widen, in order:
+## `state.` is NOT the next candidate - measured 2026-08-25, and it hangs
+
+This entry used to read "`state.` is the obvious next candidate, but it earns inclusion by
+measurement, not by argument." It was measured, and the measurement refutes it.
+
+**Control arm, one term changed.** Same script, same machine (12 cores, JDK 17.0.18-tem), same
+`targetTests=bz.stub.parallelconsumer.*`, same timeouts, same everything - only `targetClasses`
+differs:
+
+| `targetClasses` | Coverage pass | Total wall clock | Mutants scored |
+|---|---|---|---|
+| `offsets.OffsetRunLength` (+ nested) | 53s | **2m10s, BUILD SUCCESS** | 27 generated, 23 killed, 4 survivors, 88% test strength |
+| `state.*` | 325s | **killed at 32m32s**, i.e. past the CI job's whole 30-minute budget | **0** - not one per-class tally line was ever printed |
+
+The `state.*` mutation phase therefore ran for about **27 minutes producing no output whatsoever**,
+where the `offsets.` one finished in well under a minute. Under `timeoutConstant=30000` with
+`timeoutFactor=3.0`, individual minion JVMs stayed alive for sixteen continuous minutes: hung, not
+slow. That is the failure mode `internal.*` is excluded for, arriving in the package that was
+supposed to be the safe step sideways - unsurprising in hindsight, since `state.` is bookkeeping
+around the same concurrency and the plan doc says so. `PartitionStateManager`, `ShardManager` and
+`WorkContainer` are exactly the classes the torn-read family lives in.
+
+So the scope stays at `offsets.` and the lane will keep skipping most PRs. **That is now visible
+rather than disguised**, which was the actual problem: a `3` and a notice, not a green tick.
+
+## Ranked: what to widen to next, and the criterion
+
+**Criterion: value over cost, where value is how close the package sits to a defect class this repo
+has paid for, and cost is the measured risk of hang-prone mutants plus runner minutes.** Each entry
+names what has to be measured before it is switched on - nothing here goes in by argument, which is
+the mistake `state.` was about to be.
+
+1. **The top-level `bz.stub.parallelconsumer.` package, non-recursive.**
+   `CommitFailurePolicies`, `CommitFailureContext`, `ParallelConsumerOptions`,
+   `OffsetCommitBudgetExceededException`. Configuration and policy objects: no locks, no timing, so
+   a survivor is decidable on the same grounds `offsets.` is. It appeared in the not-decidable list
+   above, so it is live traffic rather than a guess, and `CommitFailurePolicies` is new code from an
+   in-flight branch, which is where an unasserted branch is likeliest. **Measure first:** one
+   full-sweep run against `bz.stub.parallelconsumer.*` minus the sub-packages; it has to complete
+   inside the 30-minute job timeout with a non-zero score. A regex for the non-recursive case is
+   `^bz\.stub\.parallelconsumer\.[A-Z]`.
+2. **`metrics.`.** `PCMetricsDef` and friends are declarative, and metrics correctness has already
+   cost this repo a leak (astubbs#57). Small, so the marginal cost over the 325s coverage pass is
+   near zero. **Measure first:** same completion test. Lower than 1 only because the defect class is
+   narrower.
+3. **`state.` under a real per-mutant timeout, not under today's settings.** The hang is the
+   blocker, not the package. If `timeoutConstant` were low enough that a hung mutant died fast, the
+   survivors would still be undecidable for the timing-based tests - but `ShardKey`,
+   `ConsumerRecordId` and `WorkContainer`'s value logic are not timing-based, and a *class-level*
+   allow-list inside `state.` would sidestep the whole argument. **Measure first:** the three named
+   classes individually, one run each. Do NOT lower `timeoutConstant` to make the package finish:
+   PIT counts `TIMED_OUT` as `KILLED`, so a short timeout manufactures kills - the
+   `mutation-full-sweep.yml` header says this outright.
+
+**Deliberately left out:** `internal.` and `internal.admission.` - the largest group in the
+not-decidable list and the least usable, for the reason the plan doc gives and `state.` has now
+confirmed by measurement. Padding this list with the thing nobody should do next is how rankings
+stop being read.
+
+### Exclusions, with a reason and a re-enable trigger each
+
+Read [`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md) for what the profile
+marker means. **Every exclusion here is `profile: old`, and the reason is structural rather than a
+judgement call:** the PR lane is already diff-scoped, so it only ever mutates code somebody just
+changed. There is no "on for new code" left to switch on - PIT *is* the new-code profile - so a
+package that is off is off for new code too, permanently, until its trigger fires.
+
+| Excluded | Why | Re-enable trigger | Profile |
+|---|---|---|---|
+| `internal.`, `internal.admission.` | mutants to locks, loop conditions and timeouts hang rather than dying; covering tests are timing-based, so a survivor cannot be told from a race that did not happen | a deterministic harness for the concurrency core (Lincheck, astubbs#347) that can decide a survivor | `old` |
+| `state.` | measured above: no mutant scored inside the CI job's whole timeout | per-class allow-list for the non-timing classes, each measured on its own - ranked 3 | `old` |
+| `metrics.` | never measured, not excluded on evidence | ranked 2 - one completion measurement | `old` |
+| top-level `bz.stub.parallelconsumer.` | never measured, not excluded on evidence | ranked 1 - one completion measurement | `old` |
+| everything in other modules | SpotBugs measured zero findings across vertx, reactor and mutiny; they are six source files between them | those modules growing | `old` |
+
+## The rest of the re-widening list
 
 - ~~Run the sweep once and record the runtime~~ **DONE** - see the baseline above.
 - **Then give it a trigger** - now unblocked, at a known 22 minutes per run. Prefer
   `push: branches: [master]` over a cron: the score changes only when the code does, so a nightly
   recomputes an identical answer whenever master did not move, and blames a date rather than a merge.
   Add a `concurrency` group with `cancel-in-progress` - only the latest master state is worth scoring.
-  Still unwired - that is the next PR, and now a cost decision rather than a blocked one.
-- **Then widen `PIT_DECIDABLE_PACKAGES`** - `state.` is the obvious next candidate, but it is
-  bookkeeping around the same concurrency, so it earns inclusion by measurement, not by argument. The
-  marginal cost is smaller than it looks: the 311s coverage pass is paid whatever the target, so adding a
-  package costs only its own mutants.
+  Still unwired - now the *only* way the lane scores anything regularly, given that the PR lane
+  correctly skips most PRs, so this is a bigger lever than it looked when it was written.
 - **`excludedGroups`: verify before "fixing".** pitest-maven's `parseSurefireConfig` defaults to true
   and may already import our surefire `<excludedGroups>`; a throwaway `@Quarantined` *unit* test
   settles it. The warning comment in `bin/ci-mutation-test.sh` may be obsolete.

--- a/docs/inflight/deps-convergence-tail.md
+++ b/docs/inflight/deps-convergence-tail.md
@@ -1,0 +1,38 @@
+# Three dependency divergences block `dependencyConvergence`
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: deps-debt -->
+
+`maven-enforcer`'s `requireUpperBoundDeps` is **on** - it is the rule that catches the dangerous
+case, where resolution settles on a version lower than something in the graph asks for. That is the
+shape that made `wiremock-jre8`'s ASM 9.4 pin kill Lincheck's transformer while it reported success.
+
+Its stricter sibling `dependencyConvergence` is **off**, and this note is why. It fails on *any*
+version split, including ones where the higher version wins safely.
+
+## What it found when it was switched on
+
+Immediately, and this one is fixed: `pl.tlinkowski.unij.api` 0.1.3 pulled `slf4j-api` 1.7.28 against
+the 2.0.18 declared directly in the parent pom. Maven's nearest-wins had already resolved to 2.0.18
+so nothing was broken, but a silent version split is exactly the shape that bites later. Excluded at
+the `unij` dependency, since the API is declared directly and there is no second opinion to
+reconcile.
+
+Behind it sit three more, all in Kafka's transitive tree, measured on the same run:
+
+| Artifact | Resolved |
+|---|---|
+| `org.xerial.snappy:snappy-java` | 1.1.10.5 |
+| `org.slf4j:slf4j-api` | 1.7.36 |
+| `com.github.luben:zstd-jni` | 1.5.6-4 |
+
+## Why they are not fixed here
+
+Each needs either an exclusion or a managed pin, and pinning a version *inside* Kafka's tree is a
+decision with a blast radius - `reference_jackson_wiremock_coupling` is the standing example in this
+repo of a global pin breaking a module nobody was thinking about. The three are worth doing as their
+own change with the compatibility question answered per artifact, not as a side effect of switching
+a lint rule on.
+
+**Turning the rule back on is the definition of done for this note**, and it is a one-line change in
+the parent pom's enforcer rules next to `requireUpperBoundDeps`.

--- a/docs/inflight/static-analysis-rule-profiles.md
+++ b/docs/inflight/static-analysis-rule-profiles.md
@@ -1,0 +1,165 @@
+# Two analysis profiles: full rules on new code, a small enforced set on all of it
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: ci -->
+
+**A rule switched off because legacy code trips it is switched off for new code too.** That is the
+flaw in a single global rule set, and it is what the per-rule registries were quietly paying: rules
+like `USBR_UNNECESSARY_STORE_BEFORE_RETURN` or `CT_CONSTRUCTOR_THROW` are off not because they are
+wrong, but because the existing tree violates them. Every line written since then has been unguarded
+by a rule nobody actually disagreed with.
+
+Two profiles fix that.
+
+| Profile | Scope | Contents | A failure means |
+|---|---|---|---|
+| **old** | whole tree, every build | only rules that are clean today, plus rules genuinely WRONG for this codebase | you broke something everywhere |
+| **new** | the PR diff | the full rule set of every engine | the code you just wrote violates a rule the legacy tree also violates |
+
+The registries keep their job and lose most of their entries. What stays in a registry is the
+genuinely-wrong set - `EI_EXPOSE_REP` against this library's DI composition, `PREDICTABLE_RANDOM` in
+tests, `SLF4J_FORMAT_SHOULD_BE_CONST` against deliberately computed log formats. What leaves is
+everything currently off only because old code trips it, which moves to profile **new** and starts
+being enforced on the code being written now.
+
+## Why this is not the baseline we just deleted
+
+It is the same *idea* as the SpotBugs baseline, and the objection to that baseline was never
+ratcheting. It was that the mechanism was invisible: regenerated on every push to master, keyed on
+class plus method plus bug type, recording nothing about what it swallowed, and defeated wholesale by
+the package rename because every key changed at once. See
+[`static-spotbugs-latent-findings.md`](static-spotbugs-latent-findings.md).
+
+The difference is that a profile is **declared**, not accumulated. Profile old is a written list.
+Profile new is "everything else", computed fresh each run against the diff, with nothing stored and
+nothing to go stale.
+
+The repo already ratchets this way three times, so this is a fourth instance of an established
+pattern rather than a new idea: `newFindings(current, base)` in `.github/scripts/file-ref-gate.js`,
+whose header states the principle outright - *a red result on a branch means that branch broke
+something, not that it inherited something* - plus the duplicate-detection lane's `compare_with_base`
+and the PIT lane, which already scopes to classes changed against the PR base.
+
+## One gate, not one per engine
+
+Every engine here can emit findings with a file and a line: SpotBugs in XML, javac and Error Prone as
+warnings, `forbidden-apis` in its report, ShellCheck in JSON. So the diff filter belongs in **one**
+module that all of them feed, not five per-engine ratchets that drift apart. That is the same
+argument `file-ref-gate.js` makes for being a sibling module sharing a shape rather than a rule
+bolted into its neighbour.
+
+For the compile-time engines this needs **no second build**: run every check at *warning*, capture
+the findings, and fail on the ones inside the diff. Only a base-versus-head comparison would need
+building twice, and the diff filter makes that unnecessary.
+
+## Three things that will bite, stated before they do
+
+- **Moved code reads as new.** A refactor that relocates existing code lights up its findings as if
+  they were written today. Unavoidable with diff scoping. Expect it during the God-class
+  decomposition specifically, which is the largest planned move in the tree.
+- **Some findings have no line.** Class-level findings from SpotBugs and Error Prone cannot be
+  diff-scoped at all. They belong in profile old or nowhere; there is no third option.
+- **Line scoping misses findings reported away from the edit.** A change on line 40 can cause a
+  finding reported at line 300. This is the reason to want file scoping, and the reason it is
+  blocked below.
+
+## Scoping granularity: lines now, files later, piecemeal
+
+Profile new is scoped to changed **lines**, and that is a size problem rather than a design
+preference. `AbstractParallelEoSStreamProcessor` is 1533 lines; scoping by file would mean any PR
+touching it inherits every latent finding in it, which is a red build for reasons the author did not
+cause - the exact failure this whole scheme exists to avoid.
+
+**File scoping is strictly better and the trigger is file size, so it can be taken one file at a
+time.** As each file comes down to a reviewable size it can be promoted to file scoping on its own,
+without waiting for the decomposition to finish. `docs/refactoring.md`, under "Decompose the God
+class", carries this as a consequence of that work.
+
+Promotion list - a file moves here once it is small enough that inheriting its findings is
+reasonable:
+
+| File | Status |
+|---|---|
+| *(none yet)* | The first promotions come out of the God-class decomposition. |
+
+## Every tool's registry carries a ranked "turn these on next"
+
+A flat list of disabled rules with triggers answers *when*, and nobody ever reads it as a work order.
+So each registry also carries a **top 5 to turn back on whole-tree, ranked**, with a stated criterion
+rather than a vibe: **value divided by cost**, where value is how close the rule sits to a defect
+class this repo has actually paid for, and cost is sites plus judgement needed.
+
+The ranking is a claim, so it is written to be argued with. Each list also says what was
+**deliberately left out and why** - usually "largest and least valuable" or "gated on other work, so
+effort now is effort twice."
+
+Underneath it, the same registry groups its entries by **what clearing them takes** rather than when:
+mechanical with no judgement, read-the-sites-then-decide, blocked on other work, or permanent. That
+is the difference between an afternoon and a design decision, and it is not derivable from a count.
+
+Current lists: [`static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md) (5),
+[`static-error-prone-rule-registry.md`](static-error-prone-rule-registry.md) (3),
+[`static-shell-lint-severity-tiers.md`](static-shell-lint-severity-tiers.md) (5),
+[`static-forbidden-apis-parallelstream.md`](static-forbidden-apis-parallelstream.md) (1).
+
+**The length of the list is not five.** It is however many entries are genuinely worth doing next:
+forbidden-apis has one because it arrived with eight findings and all eight were fixed, and Error
+Prone has three because below them the list is javadoc and formatting. Padding a ranking with things
+nobody should do next is what makes rankings ignored.
+
+**A worked case for why the ranking is not just triage.** fb-contrib's `RU_INVOKE_RUN` and Error
+Prone's `DoNotCall` both landed on `ReactorTest` calling `new Thread(...).run()`, which
+`docs/test-hardening/inactive-tests-audit-2026-08-08.md` had already examined and ruled a defensible
+library scratchpad. Two independent engines disagreed with a human audit, the defect was real, and it
+is now fixed - so both exclusions are deleted rather than tiered. A manual audit reading for one
+question ("does this test assert anything?") will not see a second one ("does this thread ever
+start?"). That is the argument for running the engines at full strength somewhere, which is what the
+new profile is for.
+
+**Any registry added later carries the same two sections.** A tool whose disabled set has no ranked
+next-five is a tool whose backlog nobody will ever start.
+
+## Rules every rule registry follows
+
+**This section is the owner.** Each tool's registry restates only what is specific to that tool and
+points here for the rest - the SpotBugs and Error Prone registries had near-identical copies of these
+three, which is how two lists of the same contract start disagreeing about it.
+
+- **Off requires an entry.** A rule switched off without a row in its registry is the failure the
+  registries exist to prevent - it is indistinguishable from a rule that never fired.
+- **An entry needs a trigger, not a date.** "When the options rework happens" is a trigger. "Later"
+  is not: nothing ever arrives to make "later" true, so the entry becomes permanent by default rather
+  than by decision.
+- **The off set only shrinks.** Promoting a rule to the enforced tier deletes its row, and a registry
+  is deleted outright once nothing is left switched off. A registry that grows is a registry
+  recording a retreat.
+
+## What is done, and what is not
+
+**The classification is done. The wiring is not, deliberately.**
+
+Every suppressed rule in every registry now carries a `profile:` marker - `old` or `new`. Nothing
+about enforcement changed: the engines still run whole-tree with the same suppressions, so this PR's
+behaviour is identical with and without the markers. What the markers buy is that the split is
+recorded **while somebody has the context to make it**, which is the perishable half. Deciding that
+`EI_EXPOSE_REP` is wrong-for-this-codebase while `CT_CONSTRUCTOR_THROW` is merely blocked-by-legacy
+takes knowing why each was switched off; wiring a diff filter does not.
+
+Reading the markers:
+
+- `profile: old` - stays off **everywhere, permanently**. The rule is wrong for this codebase, not
+  merely inconvenient. These are the registry's real content.
+- `profile: new` - off only because the existing tree trips it. **Belongs on for new code** and will
+  be, the day the gate exists. Every one of these is currently unguarded on code being written today,
+  which is the cost this scheme is paying until the follow-up lands.
+
+**The gate is a separate PR** and is not in scope here. Building it means one filter module, a report
+path per engine, and each engine switched to non-failing so the gate owns the verdict. Until then
+`profile: new` is an intention with a written list behind it rather than an enforced thing, and this
+note is the tracking.
+
+**The clearest single example of what is being lost meanwhile:** `forbidden-apis` cannot ban
+`parallelStream()` because three legacy call sites exist. Under profile new it would be banned on new
+code from the first day, with those three untouched -
+[`static-forbidden-apis-parallelstream.md`](static-forbidden-apis-parallelstream.md) has the
+signature ready. That entry stops being blocked work and becomes a wiring task.

--- a/docs/inflight/static-archunit-main-code-rules.md
+++ b/docs/inflight/static-archunit-main-code-rules.md
@@ -1,4 +1,4 @@
-# ArchUnit is wired up and barely used
+# ArchUnit pins three invariants and no architecture
 
 <!-- inflight-type: bug -->
 <!-- inflight-impact: blind-spot -->
@@ -9,8 +9,8 @@ Nothing is switched off. There is no `archunit.properties`, no `FreezingArchRule
 no `allowEmptyShould` suppression anywhere in the repo. Every rule that exists runs on every PR at
 ArchUnit's defaults, and they pass because the codebase complies.
 
-The reason no findings are ever seen is simply that **there are four rules, and three of them are
-about test hygiene**:
+The reason no findings are ever seen is that the rules police **hygiene and a handful of named
+invariants**, not structure:
 
 | Rule | Where | Polices |
 |---|---|---|
@@ -18,6 +18,8 @@ about test hygiene**:
 | Tests must not use shaded libraries | `TestConventionRules` | test hygiene |
 | Test classes named so surefire collects them | `TestConventionRules` | test hygiene |
 | `WorkContainer#getFuture()` has no production readers | `WorkContainerFutureIsWriteOnlyArchTest` | one main-code invariant |
+| `ShardManager`'s shard-map setter has no production callers | `ShardMapIsNeverReplacedArchTest` | one main-code invariant |
+| `ShardManager.processingShards` is assigned only at construction | `ShardMapIsNeverReplacedArchTest` | one main-code invariant |
 
 The harness is in good shape and the hard part is already done: `TestConventionRules` is a shared
 rule library shipped in the core test-jar, and each module has a thin `TestConventionsArchTest` that
@@ -26,7 +28,8 @@ a rule is a few lines in one place and it applies everywhere.
 
 **No main-code architecture is policed.** Not layering, not package boundaries, not the dependency
 direction between `internal` and `state`, not the God-class boundaries `docs/refactoring.md` wants
-to decompose.
+to decompose. The three invariant rules above are each one named member; none of them constrains a
+shape.
 
 ## Why this is worth picking up
 
@@ -43,7 +46,8 @@ fires. That is one invariant. The class it guards has several more that nothing 
 ## Candidate rules, cheapest first
 
 Each needs its own judgement about whether it is true today; a rule that fails on arrival needs the
-code fixed or the rule narrowed, not a suppression.
+code fixed or the rule narrowed, not a suppression. Read the granularity limits below before
+costing any of them - one of the four is not expressible in ArchUnit at all.
 
 - **Dependency direction** between `internal`, `state`, `offsets` and the public API package - state
   should not reach back into the controller.
@@ -53,20 +57,56 @@ code fixed or the rule narrowed, not a suppression.
   SpotBugs findings in `docs/refactoring.md` (`lastWorkRequestWasFulfilled`,
   `ConsumerManager.commitRequested`, `RetryQueue.closed`) name the current offenders, and `state` in
   `AbstractParallelEoSStreamProcessor` is the one that makes the astubbs#209 race window
-  unpredictable.
+  unpredictable. ArchUnit can see a field's modifiers, so "these named fields must be volatile" is
+  writable; **which thread reads a field is not in the model**, so the general form is not, and
+  SpotBugs `IS2_INCONSISTENT_SYNC` is the detector for that class.
 - **Public API surface** - what may be `public` outside the documented API packages, which would have
   caught the `// todo make private` in `WorkManager` before it became a `todo`.
+
+## What ArchUnit's granularity rules out, measured
+
+**ArchUnit sees a field ACCESS - origin code unit, target field, get or set. It does not see what is
+invoked on the value that access loaded.** So no rule can distinguish a keyed `map.get(k)` from a
+bulk `map.values()`, and no rule can require that lookups of a field go through an accessor.
+
+This kills the "mandated accessor" form of the shard-map rule, and the measurement is worth keeping
+because the form reads as obviously implementable until you look at the accesses. Exactly one
+main-code access to `ShardManager.processingShards` is `getShard`; nearly all the rest are bulk
+operations over `values()`, `keySet()`, `size()` or the whole map, which `getShard(key)` cannot
+express, and the keyed ones that remain include both writes (`computeIfAbsent`, `remove`). A rule
+requiring the accessor is therefore red on arrival, and the only way to green it is an allowlist of
+the methods already there - a frozen baseline under a different name, which the trap below rules
+out.
+
+The check-then-get seam that motivated the idiom (astubbs#345) is caught instead by fb-contrib's
+`MUI_CONTAINSKEY_BEFORE_GET`, which names the method statically - see
+[`static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md). **When a candidate rule is
+about what happens to a value rather than about who may touch a member, SpotBugs is the tool and
+ArchUnit is not.**
+
+What ArchUnit could still pin about the same field is who may replace it, and that is what
+`ShardMapIsNeverReplacedArchTest` does.
+
+## Pin the names the rules depend on
+
+**ArchUnit does not check that a `String`-named target exists.** Rename the field or drop the Lombok
+annotation that generates the accessor, and the rule matches nothing, passes, and has asserted
+nothing. Measured: pointing both shard-map rules at names that do not exist leaves both **green**.
+
+Every rule naming a member as a string therefore ships with a reflective `@Test` asserting the
+member is still there. Lombok-generated targets need it most - one annotation deletes them and no
+compile error anywhere says so.
 
 ## When
 
 **After 0.6.0.0.** Adding architecture rules during a release cut turns the build red for reasons
 that have nothing to do with the release, and the God-class decomposition these rules would guard is
-itself post-v6 work. The `next-` prefix on this file is that decision.
+itself post-v6 work.
 
 **One exception, and it is already in use:** a rule that pins an invariant created by work landing
-now. `WorkContainerFutureIsWriteOnlyArchTest` was added mid-branch for exactly that reason - a
-comment saying "nothing reads this" is not enforcement. Keep doing that per-invariant; it is not the
-programme this file describes, and it does not wait for v6.
+now. `WorkContainerFutureIsWriteOnlyArchTest` and `ShardMapIsNeverReplacedArchTest` were both added
+mid-branch for exactly that reason. Keep doing that per-invariant; it is not the programme this file
+describes, and it does not wait for v6.
 
 ## The trap to avoid
 
@@ -74,3 +114,7 @@ Do not add rules in bulk and freeze the failures. `FreezingArchRule` exists and 
 land green on day one, but a frozen violation is a documented invariant nobody enforces - the exact
 pattern this repo already rejects for quarantined tests, where the registry is "enforced, not
 advisory". Add one rule at a time, green on arrival, each with a mutation check proving it can fail.
+
+**An allowlist of the methods that already violate a rule is a frozen baseline wearing a source-code
+disguise**, and it is the form the trap actually takes when `FreezingArchRule` is off the table. The
+shard-map accessor rule above is the worked example of turning one down.

--- a/docs/inflight/static-error-prone-rule-registry.md
+++ b/docs/inflight/static-error-prone-rule-registry.md
@@ -1,0 +1,207 @@
+# Error Prone rule registry: the pin, what is off, and what turns each back on
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: ci -->
+
+**Consult this before suppressing an Error Prone finding, before adding a `-Xep:` flag, and before
+asking why a check is not firing.** Every check this repo switches off is listed here with a reason
+and a re-enable trigger. A check that is off and not in this file is a bug in the setup, not a
+decision. Same contract as
+[`static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md), deliberately - two engines,
+one discipline.
+
+## The version pin, and the one thing that lifts it
+
+`error_prone_core` is held at **2.42.0** and `nullaway` at **0.12.7**. Both are pinned below current,
+and the pin is temporary rather than a preference.
+
+**2.43.0 is the first Error Prone release compiled to class file version 65 (Java 21).** 2.42.0 is
+61. This build requires JDK 17, which reads to 61, so from 2.43.0 the plugin class cannot be loaded
+at all. Raising the toolchain is not the escape: Jabel's bundled Byte Buddy refuses class file 65, so
+**no JDK satisfies both**. NullAway is a third constraint in the same knot - 0.12.7 dies against
+2.43.0 and later on a class that release removed, and because NullAway takes Error Prone as
+`compileOnly` no dependency tool can see the coupling. Move the two versions together.
+
+**The trigger is Jabel's removal**, which is tracked with the Java baseline work it belongs to:
+[`pr-53-java-baseline-kafka4.md`](pr-53-java-baseline-kafka4.md) (astubbs#53, deferred to 0.7.x).
+That note owns the Jabel story; it is not restated here.
+
+**What to do when Jabel goes:** raise `error-prone.version` and `nullaway.version` together to
+current, delete this section, and re-run the off-set verification below - a newer Error Prone renames
+and retires checks, so a `-Xep:` flag naming a check that no longer exists is silently inert rather
+than an error. The full diagnosis behind the pin, with its control arms, is settled and lives in
+[`error-prone-jabel-and-the-jdk-that-satisfies-neither-2026-08-25.md`](../solutions/build-errors/error-prone-jabel-and-the-jdk-that-satisfies-neither-2026-08-25.md).
+
+## The measurement this is built from
+
+Taken 2026-08-25 on the full reactor, `test-compile`, main and test sources, with every check on and
+javac's warning cap lifted: **951 findings across 51 checks**. After the off-set and the
+generated-source exclusion below: **251 findings across 33 checks - 63 in main code, 188 in test.**
+
+That is a dated snapshot, not a live figure. It is also only readable because of two things that are
+easy to get wrong, and both were:
+
+- **javac caps output at 100 warnings per compilation and says nothing when it truncates.** With
+  `-Xlint:all` and Error Prone feeding the same stream, the visible count was roughly a tenth of the
+  real haul and read exactly like a small one. `-Xmaxwarns` is set high in the pom for that reason.
+- **Generated sources were 54 of the findings** - the Truth generator's output, rewritten on every
+  build, so nobody can act on one and the count moves whenever a clean run regenerates them.
+  Excluded by path with `-XepExcludedPaths:`, which takes a **colon**; the equals form is rejected as
+  `invalid flag` through a Maven error path that hides the message.
+
+## Tier 1 - ON, and the three that are ERROR
+
+Everything not listed in Tier 2 is on. Three checks are ERROR severity and fail the build.
+
+**`DoNotCall` - newly enforceable, and that is the point.** `parallel-consumer-streams` annotates the
+Kafka Streams DSL overloads it refuses with `@DoNotCall`, and until now **no build in this repo could
+enforce it** - stated as a known hole in
+[`a-deprecation-without-an-explanation-misattributes-itself-to-the-wrong-party.md`](../solutions/architecture-patterns/a-deprecation-without-an-explanation-misattributes-itself-to-the-wrong-party.md).
+It is enforceable now. It arrived red on `ReactorTest.publishOn` and `.subscribeOn`, which called
+`new Thread(...).run()`; **fixed rather than demoted**, because calling `run()` on a Thread is never
+what anyone intends. The threads are started and joined, so the subscription really does happen off
+the test thread and still completes before the method returns. Those tests still assert nothing; that
+is a separate call and `docs/test-hardening/inactive-tests-audit-2026-08-08.md` owns it.
+
+**`ReturnValueIgnored` - ON, one site suppressed.** `AbstractParallelEoSStreamProcessor` forces its
+memoized worker-pool supplier at construction and discards the pool on purpose. Extracted into
+`forceWorkerPoolConstruction()` so `@SuppressWarnings` covers exactly that call. A named local was
+tried first and rejected: it satisfies Error Prone and then trips SpotBugs' `DLS_DEAD_LOCAL_STORE`,
+which trades one finding for another rather than saying what is meant. Caught by counting SpotBugs
+findings before and after, not by the build going green.
+
+**`BanJNDI` - ON globally, suppressed at three named methods.**
+`AbstractParallelEoSStreamProcessor#setupWorkerPool`, `#supervisorLoop` and `BrokerPollSystem#start`
+look up a container-managed thread factory or executor by a name the embedding application supplies
+through this library's own options, each falling back to Java SE when the lookup fails. That is the
+feature, not a lint hit. **Suppressed at the site rather than demoted globally, and the narrowness is
+proven**: a JNDI lookup added to an unannotated method in the same class fails the build at ERROR.
+
+Also ON, and these are where the value is - almost all one finding each, and concurrency-shaped:
+`WaitNotInLoop`, `UnsynchronizedOverridesSynchronized`, `LockNotBeforeTry`, `PrimitiveAtomicReference`,
+`StaticAssignmentInConstructor`, `ModifyCollectionInEnhancedForLoop`, `StreamResourceLeak`,
+`EmptyCatch`, `CatchAndPrintStackTrace`, `ModifiedButNotUsed`, `UnnecessaryAsync`, `ReferenceEquality`,
+`EqualsGetClass`, `ByteBufferBackingArray`, `NarrowCalculation`, `LongDoubleConversion`, `IntLongMath`,
+`MixedMutabilityReturnType`, `UndefinedEquals`, `StringSplitter`, `JavaTimeDefaultTimeZone`,
+`ImmutableEnumChecker`, `MissingCasesInEnumSwitch`, `JdkObsolete`, `DefaultCharset`,
+`StringCaseLocaleUsage`, `NonApiType`, `MissingOverride`, `BooleanLiteral`, `ClassCanBeStatic`,
+`EffectivelyPrivate`, `InlineMeSuggester`, `FutureReturnValueIgnored`.
+
+**`NullAway` is ON and is the deliberate exception to the bulk rule below**, at 148 findings (38 in
+main code, 110 in test). Everything else that arrives in bulk is off; this one is not, because
+nullness is the class several of this repo's tracked defects actually live in, and paying its arrival
+cost is the point of adding it. The largest group is "initializer method does not guarantee @NonNull
+fields are initialized along all control-flow paths", which is the shape of the
+fields-assigned-outside-the-constructor problem the state classes already have. Main code first.
+
+There is no source-root scoping available to hide the test half behind: NullAway's knobs are package-
+or class-keyed (`AnnotatedPackages`, `UnannotatedSubPackages`, `ExcludedClasses`,
+`ExcludedClassAnnotations`) and main and test share packages here - the same limitation the SpotBugs
+registry ran into from the other direction.
+
+## Top 3 to turn back on whole-tree, ranked
+
+Same criterion as the other registries: **value over cost**, where value is how close the check sits
+to a defect class this repo has already paid for, and cost is sites plus judgement. All three are
+`profile: new` - the check is right and only the existing tree blocks it - so clearing the sites is
+the entire job.
+
+Three rather than five, deliberately. Below these the list is javadoc and formatting, and padding a
+ranking with things nobody should do next makes the ranking worthless.
+
+| # | Check | Sites | Why this one | Effort |
+|---|---|--:|---|---|
+| 1 | `InvalidParam` | 18 | **The only javadoc check that is really a correctness check** - a `@param` naming a parameter the method does not have means the signature changed and the doc did not. All main code, and this project publishes its javadoc. | Read 18, mostly mechanical |
+| 2 | `UnusedMethod` | 58 | Dead code in a library is either genuinely dead or accidentally-public API surface, and the two need opposite fixes. High value precisely because it cannot be swept - every site is a question worth answering once. | Judgement per site |
+| 3 | `CanonicalDuration` + `JavaDurationGetSecondsToToSeconds` | 38 | One `java.time` sweep clears two checks. Mostly tests, no judgement, and `Duration` handling is load-bearing in a library whose timeouts are its contract. | Mechanical |
+
+**Deliberately not ranked:** the javadoc family minus `InvalidParam` (203 findings that are
+documentation debt, not defect risk - and the README is generated from tagged source, so a sweep
+there has a second-order effect worth doing on purpose rather than incidentally);
+`UnnecessaryParentheses` at 240, the largest and least valuable on the list; `UnusedVariable` and
+`BadImport`, both cheap but neither near a defect class.
+
+**NullAway is not in this list because it is already ON**, at 148 findings, which is the deliberate
+exception to the bulk-off rule stated above.
+
+## Tier 2 - OFF, with the trigger that turns each back on
+
+All off for one reason: **they arrive in bulk, and bulk on arrival is what makes a new engine get
+ignored.** None is off because it is wrong. Counts are from the everything-on measurement.
+
+| Check | Count | Why off | Turns back on when |
+|---|--:|---|---|
+| `UnnecessaryParentheses` | 240 | formatting opinion; this codebase parenthesises for readability, and 240 of anything drowns the hundred findings worth reading | a mechanical sweep is wanted, or a precedence bug is ever traced to parenthesisation |
+| `InvalidInlineTag` | 106 | javadoc | with the javadoc pass - and the README is generated from tagged source, so that pass has a deadline of its own |
+| `MissingSummary` | 71 | javadoc | as above |
+| `EmptyBlockTag` | 21 | javadoc | as above |
+| `InvalidParam` | 18 | javadoc, all main code. Closest of the family to a correctness check: a `@param` naming a parameter that does not exist is documentation that lies | as above, and read this one first |
+| `InvalidBlockTag` | 4 | javadoc | as above |
+| `UnrecognisedJavadocTag` | 3 | javadoc | as above |
+| `InvalidLink` | 2 | javadoc | as above |
+| `AlmostJavadoc` | 1 | javadoc | as above |
+| `NotJavadoc` | 1 | javadoc | as above |
+| `UnusedMethod` | 58 | needs judgement per site rather than a sweep: some are genuinely dead, some are public surface a library may not delete | with the God-class decomposition, or the next API review - release-gated either way |
+| `UnusedVariable` | 54 | mostly test locals | mechanical sweep |
+| `BadImport` | 34 | importing nested types; style | mechanical sweep |
+| `CanonicalDuration` | 22 | `Duration` literal style, mostly tests | mechanical sweep |
+| `JavaDurationGetSecondsToToSeconds` | 16 | `java.time` API preference | mechanical sweep, with `CanonicalDuration` |
+
+## Verify by count, never by "the build went green"
+
+
+**The rule and its evidence are owned by**
+[`an-inert-analysis-config-reads-as-a-clean-codebase.md`](../solutions/workflow-issues/an-inert-analysis-config-reads-as-a-clean-codebase.md).
+What is kept here is only the part that binds this engine.
+A `-Xep:` flag naming a check that does not exist is **silently inert**, and a suppression that
+matches nothing looks exactly like a suppression that works. After changing the off-set, run the
+reactor and assert the check you disabled reports **zero**, and that the ones you did not disable
+still report what they did.
+
+That is how both mistakes in this file's own construction were caught: the generated-source haul the
+warning cap was hiding, and the `DLS_DEAD_LOCAL_STORE` that the first `ReturnValueIgnored` fix
+introduced while removing an Error Prone finding. Both builds were green.
+
+**An ERROR-severity check reporting zero needs a positive control**, because "clean code" and
+"accidentally switched off" look identical. Both were proven by mutation on the full reactor, one term
+changed: restoring one `Thread.run()` fails the build on `DoNotCall`; adding a JNDI lookup to an
+unannotated method fails it on `BanJNDI`. Run the **whole** reactor for this - a single-module run can
+fail on the enforcer's `ReactorModuleConvergence` rule instead and read as a working control, which
+has already happened once on this branch.
+
+## The cost of running at compile, measured and accepted
+
+The Error Prone configuration is **unconditional** - not in a profile, not in `pluginManagement` -
+so it applies to every `javac` invocation in every module, main and test, with `<fork>true</fork>`
+and around ten `--add-exports`/`--add-opens` flags. Several CI jobs each do a from-scratch full
+reactor compile of the same commit, so the identical analysis runs several times per PR for the same
+result.
+
+**A simplification pass proposed gating it to one job, and it was declined.** The saving is real, but
+the fix would remove the property the engine was chosen for. The build-hardening register's entry
+says it plainly: Error Prone's advantage over SpotBugs is that its "findings block at compile rather
+than accreting into a baseline", and this registry records `BanJNDI` proven by mutation to "fail the
+build at ERROR". Gate it to one CI job and a developer's own build stops blocking - the finding still
+appears, but remotely, later, and after the code has been written on top of. That is the SpotBugs
+shape this whole change moved away from.
+
+So the redundancy is carried deliberately. **The trigger for revisiting it is CI wall-clock becoming
+a real constraint**, not tidiness - and if that happens, the lever is a profile plus one job flag,
+and the price is compile-time blocking. Whoever pulls it should say so here.
+
+## Rules for changing this file
+
+The three that bind every rule registry - off requires an entry, an entry needs a trigger rather than
+a date, and the off set only shrinks - are **owned by**
+[`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md), "Rules every rule registry
+follows". They are not restated here; a second copy is how two statements of one contract drift.
+
+Specific to this file:
+
+- **The entry point is a `-Xep:<Check>:OFF` flag in the parent pom**, so "off" here always means a
+  compiler argument somebody can see in a diff. Tier 1 is empty of rows by construction.
+- **Suppress at the narrowest scope that works, and prove the narrowness.** A site suppression plus a
+  mutation showing the check still fires elsewhere beats a global demotion, every time. `BanJNDI` is
+  the worked example: the suppression sat on three methods, one of them fifty lines long, until it
+  was moved onto a private lookup helper whose entire body is the call being excused. Removing that
+  one annotation fails the build; that is what "prove the narrowness" costs, and it is two minutes.

--- a/docs/inflight/static-forbidden-apis-parallelstream.md
+++ b/docs/inflight/static-forbidden-apis-parallelstream.md
@@ -1,0 +1,75 @@
+# `forbidden-apis` is on, but not yet banning `parallelStream()`
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: ci -->
+
+`de.thetaphi:forbiddenapis` runs over main code with the `jdk-unsafe` bundle, so the default charset,
+locale and timezone are banned and the build is green. Register item 6 asked for one more thing that
+is **not** enabled: a ban on `parallelStream()`.
+
+**`profile: new`.** Nothing is wrong with banning `parallelStream()`; only three legacy call sites
+block it. Under the two-profile scheme in
+[`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md) this is banned on new code
+from day one with those three untouched, and this entry stops being blocked work and becomes a wiring
+task. It is the clearest example in the repo of what single-profile enforcement costs.
+
+## Why not yet
+
+Three main-code call sites exist today:
+
+- `ProcessingShard`, in `slowWork.parallelStream()`
+- `PartitionState`, twice, in the accessors returning incomplete offsets
+
+The reason to remove them is real and already recorded elsewhere: the Lincheck PoC found
+`parallelStream()` breaks model-checking replay determinism, because it runs on ForkJoinPool threads
+the scheduler cannot own. But swapping to `stream()` is a **behaviour change in a hot path**, not a
+lint fix, and it belongs in a change that can measure the throughput effect. A rule that fails on
+arrival needs the code fixed or the rule narrowed, never a suppression - so the rule stays narrow
+until the sites are worked off.
+
+Note the register said "two `PartitionState` accessors". There are three sites; `ProcessingShard` was
+missed.
+
+## Top rules to turn back on whole-tree
+
+**There is exactly one, and this note is it.** `jdk-unsafe` is fully on; `parallelStream()` is the
+only signature held back, on three sites. A five-item list here would be padding - the other engines
+have backlogs because they arrived with hundreds of findings, and this one arrived with eight and
+they were all fixed.
+
+| # | Signature | Sites | Why | Effort |
+|---|---|--:|---|---|
+| 1 | `java.util.Collection#parallelStream()` | 3 | Breaks Lincheck replay determinism, runs on ForkJoinPool threads a controlled scheduler cannot own. | Behaviour change in a hot path - needs a throughput check, not a sweep |
+
+The next signatures worth *considering* once that lands are the ones this repo has been bitten by
+rather than a catalogue: `new BigDecimal(double)` and the `jdk-deprecated` bundle. Neither has a
+recorded incident here, so neither is proposed yet.
+
+## The signature, ready to paste
+
+Add to the `forbiddenapis` plugin's `<configuration>` in the parent pom, alongside
+`<bundledSignatures>`:
+
+```xml
+<signatures>
+    java.util.Collection#parallelStream() @ Runs on ForkJoinPool threads a controlled scheduler cannot own - breaks Lincheck replay determinism
+</signatures>
+```
+
+**Turning it on with the three sites still present is the definition of not-done**, and the build
+will tell you immediately.
+
+## What is already enforced, and what it cost to get there
+
+Enabling `jdk-unsafe` found eight violations, all fixed in the same change rather than suppressed:
+
+- Six in `PCMetricsDef`'s markdown generator - `toUpperCase()`, `toLowerCase()` and four
+  `String.format` calls, all default-locale. This is generated *documentation*, so the output would
+  differ on a machine with a Turkish locale. Now `Locale.ROOT`.
+- Two in the metrics example's Prometheus endpoint, and that pair was a genuine defect rather than a
+  lint hit: `response.getBytes()` was called **twice**, once for the `Content-Length` header and once
+  for the body, in the platform default charset. Now encoded once, explicitly UTF-8.
+
+Bound to the `check` goal only, not `testCheck`. Test code is its own decision with its own haul, the
+same way [`static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md) treats it, and nobody
+has measured it yet.

--- a/docs/inflight/static-polyglot-client-analysers.md
+++ b/docs/inflight/static-polyglot-client-analysers.md
@@ -1,0 +1,336 @@
+# Static analysis for the ten non-Java proxy clients, and where RacerD fits
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: blind-spot -->
+
+A survey, so it is read rather than done. It answers three questions for the polyglot proxy/sidecar
+work: what already analyses each client, what a race detector could add, and which of these
+languages CodeQL would cover for nothing.
+
+**Read the premise correction first.** This note was commissioned to find gaps. There are almost
+none: every one of the ten languages already has a bug-finder wired into a CI row and a local
+recipe, and a document already owns the per-language policy. What is left is narrow, and this note
+is mostly about that narrow part.
+
+**Scope**: Python, Ruby, TypeScript, Swift, Go, C++, Rust, C#, Scala, Kotlin. **Java is not this
+note's.** The Java core, and RacerD against it, are owned by
+[`docs/inflight/ci-build-hardening-register.md`](ci-build-hardening-register.md) and
+[`docs/inflight/static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md), which carry the
+attempt and its blocker. Cite those rather than restating them.
+
+**Everything here that names a version was checked against the real registry on 2026-08-25**, not
+recalled. Nothing was installed and no analyser was run.
+
+## The premise correction: all ten are already wired
+
+`docs/client-static-analysis.md` **owns the per-language policy** - which tool, why that one, what
+it catches, what fails the build - and `.github/workflows/clients.yml` runs one row per language
+with a `scanner` and a `scanner-cmd`. Both ship on `feats/polyglot-demos`,
+`feats/proxy-requirements` and `feats/sidecar-entry-point`, not on master, which is why this note
+does not link them as live paths.
+<!-- file-refs: N/A - clients.yml, client-static-analysis.md and every module path in this note ship on the polyglot branches; this note is cut from master, where none of them exist yet -->
+
+| Language | Already running | Recipe |
+|---|---|---|
+| Go | `go vet` + staticcheck, pinned by a `tool` directive in `go.mod` | `scripts/analyse.sh` |
+| Python | ruff (with the `S`/bandit rules) + mypy `--strict` | `make lint` |
+| Kotlin | detekt, default ruleset, no config file by decision | `detekt.sh` |
+| TypeScript | `tsc --build` + `@typescript-eslint` `recommended-type-checked` | `npm run check` |
+| Rust | `cargo clippy --all-targets -- -D warnings` | same |
+| C# | Roslyn analyzers, `latest-recommended` + `TreatWarningsAsErrors` | `dotnet build` |
+| Ruby | RuboCop weighted to `Lint/` and `Security/` | `bundle exec rubocop` |
+| C++ | cppcheck, `--check-level=exhaustive --error-exitcode=1` | `scripts/analyse.sh` |
+| Swift | Swift 6 language mode + `-warnings-as-errors`; swift-format for layout | package build |
+| Scala | `scalac -Xlint -Wunused -Werror` | `scripts/analyse.sh` |
+<!-- file-refs: N/A - every recipe named in this table lives in a client module that exists only on the polyglot branches -->
+
+Two things that read as gaps and are not:
+
+- **Swift is not unanalysed.** `docs/client-static-analysis.md` recorded "nothing mature, none
+  added" and told the Swift wave the lever was the Swift 6 language mode plus
+  `-warnings-as-errors`. That landed: `Package.swift` declares `swift-tools-version:6.0` with a
+  comment calling it load-bearing for strict concurrency, and every target carries
+  `.unsafeFlags(["-warnings-as-errors"])`. Swift's concurrency checking is a compile-time race
+  analysis, which is more than any of the other nine get for free.
+  <!-- file-refs: N/A - client-static-analysis.md and the Swift module ship on the polyglot branches, not on master -->
+
+- **Scala's compiler lint is the mature option**, not a placeholder. Its rejection of third-party
+  plugins needs one correction, below.
+
+Every one of the ten module maturity fragments reads `maturity: alpha`, so no row is skipped: these
+are started modules with real source, not skeletons.
+
+## RacerD, and the three languages it could actually reach
+
+**The support table, verified at fbinfer.com/docs/checker-racerd on 2026-08-25 rather than
+recalled, quoted verbatim:**
+
+```
+C/C++/ObjC: Yes
+C#/.Net: Yes
+Erlang: No
+Hack: No
+Java: Yes
+Python: No
+Rust: No
+Swift: No
+```
+
+Infer v1.3.0 published 2026-05-12, assets `infer-linux-x86_64-v1.3.0.tar.xz` and
+`infer-osx-arm64-v1.3.0.tar.xz`. `facebook/infer` was pushed 2026-08-24, so the project itself is
+unambiguously alive.
+
+**Why it matters here more than any linter.** These clients are thin protocol clients for a
+concurrency sidecar. Each one fans a stream of dispatches out to N executors and folds the outcomes
+back onto one transport. That is the only interesting thing they do, and it is exactly the shape a
+race detector reads and a style linter cannot see. A tool that polices application architecture is
+worth close to nothing against four hundred lines of queue and session code.
+
+**RacerD analyses a build.** It needs a compile command it can wrap, or a compilation database it
+can read. For a thin client that is a real question and not a formality, so each arm below says
+whether the build exists in this repo today.
+
+### Java core - not this note's
+
+Owned by [`docs/inflight/static-racerd-findings.md`](static-racerd-findings.md), which records that
+the calibration was attempted and what it did and did not reach. Named here
+only because it is the third arm of the one-tool-three-languages argument - an argument the C# and
+C++ findings below substantially weaken.
+
+### C++ client - buildable, and the blocker is CPU architecture, not language support
+
+**The build exists.** The module has a `CMakeLists.txt` (`set(CMAKE_CXX_STANDARD 17)`,
+`find_package(Threads REQUIRED)`), so either `infer run -- cmake --build` or a
+`CMAKE_EXPORT_COMPILE_COMMANDS=ON` compilation database would give Infer what it needs.
+
+**What it would be pointed at**: `src/dispatch_queue.cpp`, `src/session.cpp` and `src/client.cpp` -
+the executor fan-out and the transport session. That is where a race in this client lives, and
+cppcheck, which is largely pattern-based, does not model threads at all.
+
+**The blocker, stated concretely because it decides the answer.** `bin/build-client.sh` puts C++ on
+its *container* route: the host has no gRPC or protobuf dev packages, so the module builds inside a
+`debian:trixie-slim` image and nowhere else. Infer publishes **linux-x86_64 and osx-arm64 only** -
+there is no linux-arm64 binary. On an Apple Silicon dev box that container is arm64, so there is no
+Infer to install in it; and the osx-arm64 build cannot help either, because the C++ client does not
+build on the host at all. `clients.yml` runs `runs-on: ubuntu-latest`, which is x86_64, so **the CI
+row could run Infer while a local run on the dev box could not.**
+<!-- file-refs: N/A - build-client.sh and the C++ module ship on the polyglot branches, not on master -->
+
+
+That inverts this repo's rule that a check must be runnable locally before it gates. It is a
+decision to take deliberately, not a detail to discover after wiring it. The cheaper alternative if
+that decision goes the other way is `clang-tidy`, which ships with LLVM (22.1.8, 2026-06-16) and is
+already named in `docs/client-static-analysis.md` as the obvious second C++ tool; its
+`concurrency-*` and `bugprone-*` checks are path-sensitive where cppcheck is not, and it runs on any
+architecture the container already has a compiler for.
+<!-- file-refs: N/A - client-static-analysis.md ships on the polyglot branches, not on master -->
+
+
+### C# client - buildable, but the RacerD arm is dormant and I am rejecting it
+
+**The build exists and is native**: the module's pom sets `pc.foreign.build.executable` to `dotnet`,
+so `dotnet build` runs on the host with no container.
+
+**The problem is that upstream Infer has no .NET frontend.** The `C#/.Net: Yes` in the table above
+is delivered by **Infer#**, Microsoft's CIL frontend that translates built assemblies into Infer's
+IR. Checked on 2026-08-25:
+
+- `microsoft/infersharp` latest release **v1.5, 2023-05-31**
+- last commit on `main` **2023-09-07**, repository `pushed_at` **2024-01-16**, 45 open issues
+- the companion `microsoft/infersharpaction` last pushed **2023-07-19**
+
+Three years with no release, against a module targeting `net8.0` built by SDK 8/10. **Do not wire
+it.** This is the liveness trap the brief asked me to catch, and it is the more dangerous kind: the
+parent project is thriving, so the arm looks alive from the Infer side.
+
+**What covers that ground instead, and is alive**: `Microsoft.VisualStudio.Threading.Analyzers`,
+**18.7.23, published 2026-06-22 on NuGet**. It is a Roslyn analyzer package, so it drops into the
+`Directory.Build.props` that already sets `AnalysisLevel` and `TreatWarningsAsErrors` and needs no
+new CI row, no new lane and no new local command. It catches the .NET concurrency defect classes
+that actually occur - sync-over-async, `.Result`/`.Wait()` deadlock shapes, `async void`, thread
+affinity violations. **It is a rules engine, not a race detector**: it will not find an unguarded
+shared field the way RacerD would. Recommended as the pragmatic substitute, and labelled as a
+substitute rather than an equivalent.
+
+### The other seven: RacerD cannot help, and what holds that ground
+
+`No` in the table is the whole answer for Python, Rust and Swift. Go, Ruby, TypeScript, Kotlin and
+Scala are not listed at all. For none of these is the build the blocker.
+
+| Language | What covers concurrency, if anything |
+|---|---|
+| Go | The **built-in race detector**. Free, mature, and the strongest tool in this whole survey - see the gap below. |
+| Rust | The borrow checker plus `Send`/`Sync` at compile time. This is the one language where the problem is largely solved before any analyser runs. |
+| Swift | Swift 6 strict concurrency, already on with `-warnings-as-errors`. Compile-time data-race checking. |
+| TypeScript | Single-threaded event loop, so no shared-memory races. The real class is the floating promise, and typed `@typescript-eslint`'s `no-floating-promises` already covers it - which is why the type-checked config, not bare eslint, is the half that matters. |
+| Kotlin | **Nothing static.** detekt's default ruleset is not a concurrency analyser. Lincheck (JetBrains, `lincheck-3.7`, 2026-07-29) is alive but is a *testing* framework you write against, not a tool you point at code. |
+| Scala | **Nothing.** `-Xlint`/`-Wunused` does not model threads. |
+| Python | **Nothing mature exists.** The GIL prevents corruption of interpreter internals; it does not prevent a check-then-act race in client code, and no analyser looks for one. |
+| Ruby | **Nothing.** Same reasoning. |
+
+### The one concrete concurrency gap the survey found
+
+**The Go client's gating test command does not use the race detector.** The module's pom declares
+`<pc.foreign.test.args>test ./...</pc.foreign.test.args>` - no `-race`. Yet
+`docs/inflight/clients/go.md` says of a demo assertion "Covered by `go test -race`", which is a
+developer-run claim the recipe that actually gates does not make.
+<!-- file-refs: N/A - the Go module and its per-language note ship on the polyglot branches, not on master -->
+
+
+Go's race detector is built into the toolchain, costs one flag, and this is the client with the
+executor fan-out. **This is the cheapest real win in the survey** and it is worth more than adding
+any new tool to any other language. It is not free at runtime (roughly 2-10x slower, higher memory),
+so if the full suite is too slow under it, a `-race` run of the concurrency-bearing packages is
+still strictly better than none.
+
+## CodeQL: nine of the ten, and two are already paid for
+
+**This is the most useful answer in the note.**
+
+Default setup is confirmed live from the API rather than assumed:
+`gh api repos/astubbs/parallel-consumer/code-scanning/default-setup` returns
+`state: configured`, `languages: [actions, java-kotlin, python]`, `query_suite: default`,
+`threat_model: remote`, `schedule: weekly`, updated 2026-07-24. Analyses are running per pull
+request - the most recent are dated 2026-08-25 - and there are **0 open alerts**.
+
+CodeQL's supported set (codeql.github.com, supported languages and frameworks): C/C++, C#, Go,
+Java/Kotlin, JavaScript/TypeScript, Python, Ruby, Rust, Swift, GitHub Actions. **Scala is named
+explicitly as unsupported**, so it is the one language here that CodeQL will never reach.
+
+| Language | CodeQL status | Cost to add |
+|---|---|---|
+| Python | **already enabled** | none |
+| Kotlin | **already enabled** (as `java-kotlin`) | none - but see the caveat |
+| Go | supported | none; the docs say Go "does not currently require special configuration" |
+| TypeScript | supported | none; same sentence |
+| Ruby | supported | none; same sentence |
+| C++ | supported | none; default setup uses **build mode `none`** for C/C++ |
+| C# | supported | none; build mode `none` |
+| Rust | supported | none; build mode `none` |
+| Swift | supported | **the expensive one** - "Support for the analysis of Swift requires macOS", so it needs a macOS runner and `autobuild` |
+| Scala | **not supported, ever** | n/a |
+
+So: seven languages are addable by editing one list in repository settings, at the price of Actions
+minutes per pull request. Only Swift costs anything structural. That is a far better return than
+adding any per-language tool, and it is the thing to do first.
+
+**Version ceilings to check before believing the coverage**, because a language outside the
+supported version range parses badly rather than loudly: Ruby is supported "up to 3.3" while the
+Ruby module's toolchain is 4.0.x - **check this before counting Ruby as covered**. TypeScript
+2.6-7.0 (module pins 5.9.3, fine), Rust editions 2021 and 2024 (module is 2021, fine), Swift
+5.4-6.3 (module is tools 6.0, fine).
+
+**A caveat I could not discharge, stated rather than glossed.** Whether the *already enabled*
+`java-kotlin` and `python` extractors actually see the client modules is **unverified**. Python
+extraction is parse-based, so the Python client should be in scope on any branch carrying it.
+Kotlin extraction needs a build, and the Kotlin client module only builds under
+`-Dpc.foreignClients`, which a CodeQL autobuild has no reason to pass. With 0 alerts everywhere
+there is no positive evidence either way, and 0 alerts is exactly what a language that was never
+extracted also looks like. Verify before claiming Kotlin is covered.
+
+## Cross-language tools, ranked by coverage
+
+1. **Semgrep** - GA on all ten, Scala included (docs.semgrep.dev/supported-languages). Highest raw
+   coverage of anything in this note. `semgrep` 1.174.0, published 2026-08-20 on PyPI; very much
+   alive. **But coverage is not value here**: it is pattern matching, its rule library is weighted
+   to security and taint, and cross-file dataflow is the paid tier. These clients accept no
+   untrusted input beyond a sidecar they spawned themselves, so the taint rules have nothing to
+   chew on. Ranked first on reach and last on expected yield.
+2. **CodeQL** - nine of ten, two already running, seven of the rest free to enable. Genuine
+   dataflow rather than pattern matching. The recommendation.
+3. **Infer / RacerD** - three of ten on paper; **two in practice**, because the C# arm is a dormant
+   third-party frontend. Narrowest reach, deepest analysis, and the only one that answers the
+   question these clients actually raise.
+
+## Liveness, checked 2026-08-25
+
+Recommendations first, then the tools already wired, then the ones rejected. Source in brackets.
+
+| Tool | Latest | Released | Verdict |
+|---|---|---|---|
+| Infer (RacerD) | v1.3.0 | 2026-05-12 | alive; repo pushed 2026-08-24 [GitHub releases] |
+| Microsoft.VisualStudio.Threading.Analyzers | 18.7.23 | 2026-06-22 | alive [NuGet] |
+| Semgrep | 1.174.0 | 2026-08-20 | alive [PyPI] |
+| clang-tidy (LLVM) | 22.1.8 | 2026-06-16 | alive [GitHub releases] |
+| staticcheck | v0.8.1 | 2026-08-21 | alive [proxy.golang.org] |
+| ruff | 0.16.4 | 2026-08-20 | alive [PyPI] |
+| mypy | 2.3.1 | 2026-08-15 | alive [PyPI] |
+| RuboCop | 1.90.0 | 2026-08-24 | alive; module pins 1.89.0 [RubyGems] |
+| eslint | 10.9.1 | 2026-08-24 | alive; module pins 10.8.1 [npm] |
+| typescript-eslint | 8.68.0 | 2026-08-24 | alive; module pins 8.67.0 [npm] |
+| TypeScript | 7.0.2 | 2026-07-08 | alive; module pins 5.9.3, a major behind [npm] |
+| cppcheck | 2.21.0 | 2026-06-04 | alive [GitHub releases] |
+| swift-format | 603.0.0 | 2026-06-30 | alive [GitHub releases] |
+| SwiftLint | 0.65.1 | 2026-08-21 | alive, but a style linter - see below |
+| detekt | 1.23.8 stable | 2025-02-21 | **stable line is 18 months old**, but 2.0 alphas are shipping (v2.0.0-alpha.6, 2026-08-04). Alive. Module pins 1.23.7. |
+| scapegoat | v3.3.6 | 2026-06-13 | **alive** - see the correction below |
+| Infer# / InferSharp | v1.5 | 2023-05-31 | **DORMANT - rejected** |
+| WartRemover | v2.4.5 | 2020-02-25 | **DEAD** |
+| loom (Rust) | 0.7.2 | 2024-04-23 | quiet for 2 years; not recommended anyway |
+| golangci-lint | v2.13.1 | 2026-08-20 | alive; rejected on overlap, not liveness |
+| pylint | 4.0.7 | 2026-08-09 | alive; rejected on overlap |
+| Lincheck | lincheck-3.7 | 2026-07-29 | alive; a testing framework, not an analyser |
+
+**Not checked, and named so nobody assumes it was**: SonarQube Cloud's free-tier eligibility for
+public repositories, and the Miri release cadence (`rust-lang/miri` was pushed 2026-08-24, but it
+ships with the nightly toolchain rather than as a release).
+
+## A correction to a recorded rejection
+
+`docs/client-static-analysis.md` rejects **scapegoat** partly on maintenance: that it and
+WartRemover are "neither as widely adopted nor as reliably maintained across Scala versions". Half
+of that is now wrong. WartRemover's last release was **v2.4.5 on 2020-02-25** - six years, dead, and
+the rejection stands with a date on it. But `scapegoat-scala/scapegoat` released **v3.3.6 on
+2026-06-13** and v3.3.5 ten days earlier, and was pushed 2026-08-22. It is actively maintained.
+<!-- file-refs: N/A - client-static-analysis.md ships on the polyglot branches, not on master -->
+
+
+The rest of that document's argument survives untouched and is the reason to keep: a compiler plugin
+is published per Scala patch version, so gating on one makes a Scala upgrade wait on somebody else's
+release. **Rejected on release coupling, not on maintenance.** Recorded here so the question is not
+re-litigated on a premise that no longer holds.
+
+## Not worth it, with reasons
+
+Named so the same suggestions do not come back around.
+
+- **Infer# / InferSharp for the C# client.** No release since 2023-05-31, no commit to `main` since
+  2023-09-07. Reasoning in full above.
+- **SwiftLint.** Alive (0.65.1, 2026-08-21) and widely adopted, but a *style* linter. Its
+  bug-adjacent rules do not add up to a defect finder, and the Swift 6 language mode already does
+  the analysis that matters. Rejected on shape, not on liveness.
+- **WartRemover.** Dead since 2020.
+- **golangci-lint.** A meta-runner over linters, and the Go row already runs the two that earn their
+  place directly. Adopting it would add a config file and a version to pin in exchange for findings
+  the row already gets.
+- **pylint.** Overlaps ruff almost entirely, and is far slower. Nothing it finds that ruff's
+  `F`/`B`/`SIM` selections do not.
+- **loom (Rust).** Not a liveness rejection. It is an exhaustive-interleaving test harness you write
+  code *against*, so adopting it means rewriting the Rust client's concurrency to use its
+  primitives. That is a rewrite dressed as a tool, and the borrow checker has already done most of
+  the job.
+- **Lincheck (Kotlin).** Same shape as loom: a testing framework, not an analyser you point at
+  existing code.
+- **SonarQube Cloud.** A hosted dashboard, which is the opposite shape from this project's policy
+  that every check fails rather than warns and runs from the module's own recipe. Scala is listed
+  under the paid Team plan, so the one language CodeQL cannot reach is also the one Sonar would
+  charge for. Its free-tier terms for public repositories were **not checked**.
+- **A second analyser for a language that already has one**, absent a named defect class the current
+  tool provably misses. The Go row's own header records the standard this repo holds tools to:
+  staticcheck earned its place because a dead store left `go vet` at exit 0 and made staticcheck
+  exit 1. That is the bar - a demonstrated miss - and nothing in this survey clears it for any
+  language except C++ concurrency and the C# concurrency substitute.
+
+## If someone picks this up, in order
+
+1. **Add `-race` to the Go module's test args.** Free, and it is the only built-in race detector on
+   the whole polyglot surface.
+2. **Add Go, TypeScript, Ruby, C++, C#, and Rust to CodeQL default setup**, and verify Ruby's
+   version ceiling before counting it. Six languages, one settings change.
+3. **Verify whether the Kotlin client is actually extracted** by the `java-kotlin` analysis already
+   running. Zero alerts is not evidence that it is.
+4. **Add `Microsoft.VisualStudio.Threading.Analyzers`** to the .NET module's existing props. One
+   package, no new lane.
+5. **Decide the C++ question**: Infer on x86_64 CI only, breaking the run-it-locally rule, or
+   `clang-tidy` in the existing container on any architecture. Do not start wiring before this is
+   decided.

--- a/docs/inflight/static-racerd-findings.md
+++ b/docs/inflight/static-racerd-findings.md
@@ -1,0 +1,108 @@
+# RacerD: it runs, and it found thirteen races nobody had pointed it at
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: ci -->
+
+`bin/racerd-test.sh` runs RacerD (Meta's Infer) over `parallel-consumer-core`'s main code. Opt-in and
+non-gating, following `bin/lincheck-test.sh`'s precedent: the script exists and is runnable, and no
+workflow calls it.
+<!-- file-refs: N/A - bin/lincheck-test.sh ships with astubbs#347 and is named deliberately as the precedent this lane copies; it is not on this branch yet -->
+
+**Why it earns its place when four other engines are already here.** Every one of those needs to be
+told where to look - Error Prone's `@GuardedBy` only fires where somebody wrote the annotation (and
+this codebase contains none), and the racing-double seam tests can only re-prove seams already found
+by hand. RacerD infers which locks protect which state from how the program actually uses them, so it
+reports races nobody named.
+
+## The calibration, stated honestly
+
+**It does not find the four named torn-read races**, and that is not a failure - it is the wrong tool
+for them. astubbs#345 and astubbs#346 are check-then-act on a map, and astubbs#337 and astubbs#344 are
+two-read value divergence. RacerD models *unguarded access to shared state*, which is a different
+class. fb-contrib reaches the first pair; nothing static reaches the second.
+
+What it does find, from 73 source files, is thirteen findings in three groups:
+
+| Where | Count | Status |
+|---|--:|---|
+| `PCMetrics.registeredMeters` | 4 | **Refinds a known defect** - the plain `ArrayList` mutated off two threads that the Lincheck PoC turned up unprompted, tracked in [`bug-shared-collections-across-the-poll-boundary.md`](bug-shared-collections-across-the-poll-boundary.md) and fixed by astubbs#57. RacerD names all four mutating entry points statically. |
+| `RetryQueue` | 7 | **Ground nothing else covers.** `this.unique` read via `Map.size()`/`isEmpty()` racing with writes, and `RetryQueueIterator.closed` read/write. The Lincheck lane's own open-items note ranks `ProcessingShard` and `RetryQueue` as the next thing to model and says they are *not modelled at all*; `RetryQueue.closed` is separately named as a current offender in `docs/refactoring.md`. Independent corroboration plus six findings beyond it. |
+| `AbstractParallelEoSStreamProcessor.lastCommitTime` | 2 | **New. Not in any ledger.** A plain `Instant` field, written in one method and read unsynchronised by `isTimeToCommitNow()`. Checked: it appears in no inflight note and no `refactoring.md` entry - the only mention anywhere is a code excerpt inside an unrelated solutions write-up. It sits on the commit-timing path, in a repo that tracks commit-timeout flakes. |
+
+So: **one new defect, two independent corroborations of tracked ones, and seven findings in the class
+that was next on somebody's list.** None of them needed a harness, an annotation or a seam name.
+
+## Toolchain, and the trap that nearly buried this
+
+Infer v1.3.0, ~220 MB, published for **linux-x86_64 and osx-arm64 only** - no linux-arm64, which
+matters for the polyglot C++ client (see
+[`static-polyglot-client-analysers.md`](static-polyglot-client-analysers.md)).
+
+**`infer run -- ./mvnw` does not work here, and the reason is not RacerD.** Infer's Maven integration
+runs the build under a JDK of its own choosing; this project requires 17. Established with a two-arm
+control: the exact command Infer runs, including the profile it injects, succeeds standalone at JDK
+17, while Infer's captured Maven output carries JDK 24+ warnings the JDK 17 run does not emit.
+Capturing `javac` directly sidesteps the wrapper that picks the JDK, and that is what the script does.
+
+That diagnosis was recorded as "RacerD is blocked" for several hours before the javac route was tried.
+It was never blocked; the first workaround was simply not attempted. Worth remembering when the next
+tool "cannot run".
+
+## Not done
+
+- ~~**No CI lane.**~~ **Done - `static: racerd` on `ubuntu-latest`.** An earlier draft of this note
+  said the natural home was the self-hosted highcpu runner. That was a preference presented as a
+  constraint: `ubuntu-latest` is x86_64, Infer ships a linux-x86_64 binary, and the analysis is
+  **11 seconds** over core's 73 files. The only real number is the 953 MB unpacked toolchain, which
+  is why the 276 MB tarball is what gets cached and it is unpacked per run - several jobs already
+  hold `~/.m2` against a 10 GB repo budget.
+
+  It gates on an **identity set**, `config/racerd-known-findings.txt` - twelve lines, checked in, keyed on
+  bug type plus `Class.method`. **It was a bare count ceiling first, and that was wrong**: an
+  independent cross-model review pointed out that fixing one race while introducing another leaves
+  the total unchanged, so the ceiling passes green on a codebase that swapped one defect for a
+  different one. That is the same reports-green-while-it-changed class the lane exists to police.
+
+  Keyed on class and method rather than a line number on purpose: the SpotBugs baseline this branch
+  deleted was keyed on class plus method plus bug type and was defeated wholesale by a package
+  rename, and a line number is worse, invalidated by any edit above it. The count column exists
+  because two findings can share one method.
+
+  Four arms verified: unchanged tree passes; a removed identity reports a new race by name; an extra
+  identity reports a fixed-but-unratcheted race by name; and a **same-count swap fails**, which the
+  ceiling passed. A collation bug found while testing those arms is worth knowing - `comm` compares
+  sorted streams and Python's tuple order disagrees with the shell's lexical order, so the first
+  version reported known findings as new. Both sides are now sorted with `LC_ALL=C sort`.
+- **Core only.** The other reactor modules are not analysed; nobody has measured whether they add
+  anything.
+
+- **The self-test covers the preflight guards, not the verdict.** `bin/test-check-racerd.sh` has two
+  red arms and a green near-miss over the "cannot run" guards, which run before any Maven or Infer
+  work. The **ceiling arithmetic and the exit-status check are not covered**, because they sit after
+  a full analysis and the script resolves a real classpath before reaching them. Covering them needs
+  the verdict logic extracted into a function a test can call, which is a refactor rather than a
+  test. Recorded rather than left implicit, because a partial self-test that reads as complete is the
+  same failure one level up.
+
+  This gate shipped **without** any self-test while its two siblings shipped with one, and it is the
+  only one of the three that reached CI red: review found the classpath resolved over the whole
+  reactor (so the file left behind was the last module's, and the first reported count of 13 was
+  measured against the example module's dependencies plus a stale core jar) and Infer's exit status
+  captured but never checked. Both are fixed. The count is still 13 with the corrected classpath,
+  which is luck rather than design.
+- **No suppressions and therefore no registry tiering yet**, because thirteen findings need no
+  tiering. If a CI lane lands and the count grows, it acquires the same contract every other engine
+  here has: an entry with a reason and a re-enable trigger, a `profile:` marker, and a ranked
+  top-N. See [`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md).
+- **`lastCommitTime` is unfixed** and is the one genuinely new thing here. It wants a look on its own
+  account rather than as a lint entry, and until it is fixed it holds two of the thirteen ceiling
+  slots.
+
+- **`@GuardedBy` is the ratchet these findings want, and it does not exist yet.** RacerD is
+  *discovery*: it infers locks and reports races on unannotated fields. It does not stop a fixed race
+  coming back. `@GuardedBy("theLock")` on a field is a locking rule Error Prone's `GuardedBy` check
+  enforces at compile time - and that check is on and at ERROR in this build already, examining
+  nothing, because the codebase contains no such annotation. So each of these thirteen should land
+  its annotation *with* its fix, at which point the invariant is enforced by the compiler rather than
+  by whoever remembers it. Recorded as a policy in `docs/refactoring.md` rather than as a task here,
+  because it is a thing to do while fixing rather than a thing to do.

--- a/docs/inflight/static-shell-lint-severity-tiers.md
+++ b/docs/inflight/static-shell-lint-severity-tiers.md
@@ -1,0 +1,74 @@
+# ShellCheck severities below `error` are not gated, and why
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: ci -->
+
+`shell: lint` in `repo-hygiene.yml` gates on **errors only**. This note says what the other
+severities contain and what would turn each on. Same contract as
+[`docs/inflight/static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md): a severity that
+is off carries a reason and a trigger, and the off-set only shrinks.
+
+**A note on what the profile split means here.** ShellCheck's floor is a severity, not a rule list,
+so "full rules on new code" means running new or changed scripts at `warning` (or lower) while the
+corpus stays at `error`. `SC2016` is the one code that would still need silencing at any floor,
+because single-quoted `$` is deliberate wherever these scripts build awk programs and grep patterns.
+
+**There is deliberately no per-code suppression list.** `bin/check-shell-lint.sh` has one knob, the
+severity floor, overridable per-run with `SHELL_LINT_SEVERITY`. The moment a code-level allowlist
+exists it grows, and this repo has just spent a PR removing exactly that shape from SpotBugs.
+
+## Measured 2026-08-25, on the tree that introduced the lane
+
+Errors: 3, all fixed in the same change - two real (`SC1072`/`SC1073` from a prose comment parsed as
+a directive, which aborted analysis of an entire file, and `SC1087` ambiguous array expansion) and
+their knock-on. Now 0.
+
+**The warning count went UP after fixing them, from 10 to 14, and that is the directive bug's real
+size.** ShellCheck had been aborting on `bin/check-shell-sigpipe.sh` before reaching its body, so
+that file's four findings were never reported. A count taken before the fix understated the corpus,
+and nothing said so - which is the same shape as the rest of this PR.
+
+Not gated:
+
+**`profile:` splits these the same way the SpotBugs registry is split** - see
+[`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md). `new` means the severity is
+right and only the existing corpus blocks it; `old` means it stays off everywhere.
+
+| Severity | Count | Profile | Why not gated | Turns on when |
+|---|--:|---|---|---|
+| `warning` | 14 | `new` | `SC2034` (unused variable, 6) is the largest group and includes shared-library exports the linter cannot see used across a `source` boundary. Then `SC2164` (`cd` without `\|\|`, 4) and `SC2155` (declare-and-assign masking a return value, 3). Real classes; none currently causing a defect. | Somebody works the fourteen off. This is the next floor to raise and the cheapest. |
+| `info` | 40 | `new` except `SC2016`, which is `old` | Dominated by `SC2016` - single-quoted `$` in strings, overwhelmingly deliberate here because these scripts build awk programs and grep patterns - and `SC2001`, `sed` where parameter expansion would do. | Only after `warning` is clean, and probably never for `SC2016`. |
+| `style` | 18 | `old` | Preference. | Not planned. |
+
+## Top 5 to turn back on whole-tree, ranked
+
+ShellCheck's floor is a **severity**, not a rule list, so raising the floor to `warning` turns on all
+of these at once. That makes the ranking a work order rather than five separate switches: clear them
+in this order and the floor moves on its own once the list is empty. Fourteen findings total, so this
+is genuinely finishable.
+
+Ranked by how close each sits to a failure this repo has actually paid for.
+
+| # | Code | Sites | Why this one | Effort |
+|---|---|--:|---|---|
+| 1 | `SC2155` | 3 | **Declare-and-assign masks the return value** - `local x=$(cmd)` swallows `cmd`'s exit status. That is the exit-code-swallowing mechanism behind several of this month's silent false greens, in a repo whose gates are shell scripts. | Mechanical, split each line |
+| 2 | `SC2164` | 4 | `cd` without `\|\|` - the run continues in the wrong directory. Same failure shape as the BSD class: accepted, and means something else. | Mechanical |
+| 3 | `SC2010` | 1 | `ls \| grep` instead of a glob. One site, and it breaks on filenames this repo will eventually have. | Mechanical |
+| 4 | `SC2034` (shared-lib exports) | 4 | `INFLIGHT_*` in `bin/lib/inflight-tags.sh`. **Not a defect** - the linter cannot see them used across a `source` boundary. Needs a directive at the definitions, which is legitimate use of a suppression rather than silencing a finding. | One directive |
+| 5 | `SC2034` (`rc`, `out`) | 2 | The remaining two are genuinely unused locals, so unlike the four above these are real. | Read 2 sites |
+
+Clearing all five raises the floor from `error` to `warning`, which is the single biggest coverage
+gain available to this lane. **After that the next floor is `info`, and it should probably never
+move** - 34 of its findings are `SC2016`, and single-quoted `$` is deliberate everywhere these
+scripts build awk programs and grep patterns.
+
+## What this lane cannot do
+
+**ShellCheck has no bash-version awareness.** `--shell=bash` means bash of any version, so a bash-4
+builtin on a bash 3.2 platform - `mapfile`, the construct that cost this repo an exit-127 gate on
+macOS - passes clean. It is reported only under `--shell=sh` or `dash`, as POSIX portability, and
+these are bash scripts.
+
+That class belongs to the `shell: macos` lane, which runs the scripts under the real 3.2.
+`bin/test-check-shell-lint.sh` asserts this gap as a **deliberately green** case, so if a future
+ShellCheck gains version awareness the self-test goes red and tells somebody to widen this lane.

--- a/docs/inflight/static-sneaky-throws-blind-the-analysers.md
+++ b/docs/inflight/static-sneaky-throws-blind-the-analysers.md
@@ -1,0 +1,48 @@
+# `@SneakyThrows` defeats SpotBugs dataflow, and there are 21 of them in main code
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: blind-spot -->
+
+**The question this note exists to answer was asked in review and had no home:** is removing sneaky
+throws tracked anywhere, given they cost us analysis coverage? It was not. It was one row inside
+[`static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md)'s ranked next-five, which is
+the right place for a *rule* and the wrong place for a *code change spanning 21 sites*.
+
+## What is established
+
+[`docs/solutions/best-practices/sneaky-thrown-checked-exceptions-defeat-spotbugs-dataflow.md`](../solutions/best-practices/sneaky-thrown-checked-exceptions-defeat-spotbugs-dataflow.md)
+records the mechanism: a checked exception thrown without being declared is invisible to SpotBugs'
+dataflow, so any analysis that reasons about what a method can throw reasons about the wrong method.
+That write-up is the evidence; this note is the open work it implies.
+
+Counted 2026-08-26: **21 `@SneakyThrows` in main code**, 122 in test code.
+
+`EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS` fires 12 times and sits at rank 4 in the registry's
+next-five, marked *investigate first* precisely because nobody has established whether those twelve
+are style or the visible edge of this blind spot.
+
+## Why this is not simply "remove them"
+
+Lombok's `@SneakyThrows` is used here to keep checked exceptions out of lambda bodies and functional
+interfaces, which is a real constraint rather than laziness - the alternative at most sites is a
+wrapper exception, and the codebase already has `InternalRuntimeException` for that. So the work is
+a judgement per site, not a sweep:
+
+- where the sneaky throw crosses a **public API boundary**, it is a contract question, not a tidy-up;
+- where it is inside a lambda passed to the user's function, removing it changes what the user sees;
+- where it merely avoids declaring `throws` on a private method, it is free to remove.
+
+**Do not start with a global find-and-replace.** The point is analysis coverage, and coverage is
+bought back site by site.
+
+## What would settle it
+
+1. Read the 12 `EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS` sites and record which are the free case
+   above. That is the cheapest evidence about whether the other nine main-code uses matter.
+2. If the free case dominates, remove those and re-measure whether any SpotBugs finding appears that
+   was previously invisible - a finding that only shows up after the removal is the whole argument.
+3. If it does not, close this note saying so. "We looked and the blindness costs us nothing
+   measurable" is a complete answer and better than leaving it open forever.
+
+Test code is explicitly out of scope until main is settled: 122 sites, and the analysis value there
+is lower.

--- a/docs/inflight/static-spotbugs-latent-count-discrepancy.md
+++ b/docs/inflight/static-spotbugs-latent-count-discrepancy.md
@@ -1,0 +1,33 @@
+# Core's latent SpotBugs count: 30 recorded, 67 measured, nobody has reconciled them
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: blind-spot -->
+
+[`static-spotbugs-latent-findings.md`](static-spotbugs-latent-findings.md) records **30** findings in
+core, surfaced when the package rename made the baseline miss. A fresh unbaselined run of core on
+2026-08-25, stock detectors only, reports **67** at the same `Max`/`Medium` settings.
+
+**Not chased.** The plausible explanations are that the 30 was what the PR-annotation action
+displayed rather than what SpotBugs found, or that core has grown since. Both are checkable and
+neither was checked.
+
+**Why it matters enough to keep a note open.** That other note is the triage of record for core's
+latent findings. If it covers half of them, then its conclusion - "everything else here is either
+noise or cosmetic" - is a claim about a smaller set than any reader assumes, and the reader has no
+way to tell. A triage document that silently covers part of its subject is the same shape as a check
+that reports green while blind, which is what the build-hardening register exists to catch.
+
+**How to settle it:** re-run core unbaselined at `Max`/`Medium` with stock detectors only, count the
+findings in `spotbugsXml.xml` directly rather than through the annotation action, and compare against
+the 30. Whichever way it lands, correct the recorded number in
+`static-spotbugs-latent-findings.md` and delete this note.
+
+---
+
+This is what remained open when `static-spotbugs-coverage-and-extension-detectors.md` was retired.
+Everything else that note tracked - SpotBugs running in one module, test code unanalysed, no
+extension detectors, javac's own analysis switched off, RacerD unexplored, and the auto-regenerating
+baseline - was resolved by the branch that retired it. Its ruled-out survey table already lived in
+[`ci-build-hardening-register.md`](ci-build-hardening-register.md), so nothing moved; the detector
+versions are properties in `pom.xml`, and the reasoning behind each is in
+[`static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md).

--- a/docs/inflight/static-spotbugs-rule-registry.md
+++ b/docs/inflight/static-spotbugs-rule-registry.md
@@ -1,0 +1,384 @@
+# SpotBugs rule registry: what is off, why, and what turns it back on
+
+<!-- inflight-type: register -->
+<!-- inflight-impact: ci -->
+
+**Consult this before suppressing a SpotBugs finding, and before asking why a rule is not firing.**
+Every rule this repo switches off is listed here with a reason and a re-enable trigger. A rule that
+is off and not in this file is a bug in the setup, not a decision.
+
+## Why a rule registry, and not the baseline
+
+**The baseline job is gone - this branch deleted it, and the registry is what replaced it.** Written
+in the present tense below while it still existed; kept because it is the justification for the
+design, not a description of the build. If you are reading a `.spotbugs-baseline.xml` somewhere, it
+is a leftover.
+
+The baseline job regenerated on every push to master and turned the whole report into an exclude
+filter keyed on class plus method plus bug type. It was invisible, automatic, and unbounded: nothing
+recorded what it swallowed or why, and it re-swallowed on every push. That is the same shape this
+repo rejects everywhere else - `FreezingArchRule` is refused in
+[`docs/inflight/static-archunit-main-code-rules.md`](static-archunit-main-code-rules.md) because
+"a frozen violation is a documented invariant nobody enforces", and the quarantine registry is
+enforced rather than advisory for the same reason.
+
+So: **suppress by RULE, in a checked-in filter, with an entry here.** Coarser than the baseline on
+purpose. A rule that is on catches every new instance including ones in new code; a rule that is off
+is visible in a diff, has a named reason, and has something that turns it back on. The count of
+off-rules only goes down.
+
+The baseline's other defect was mechanical, and is worth carrying forward because the next cached
+artefact will have the same shape: its cache key was `hashFiles('**/src/main/**/*.java')`, so a
+pom-only change - adding a detector plugin, for one - did not invalidate it, and `restore-keys`
+served the stale one.
+
+## The lane REPORTS, it does not BLOCK - and nothing else says so
+
+The job runs `./mvnw -Pci test-compile spotbugs:spotbugs spotbugs:check -Dspotbugs.failOnError=false`.
+Both goals, and `failOnError=false` on the second: **a SpotBugs finding cannot fail a build today.**
+That is deliberate staging, not an oversight - the rule filter and this registry had to exist before
+findings could be made blocking, or the first red build would have been answered with a blanket
+suppression - but it was nowhere written down, so a reader who saw a green tick and a configured
+analyser would reasonably conclude the code was clean.
+
+**`spotbugs:check` is there for REPORTING, not for gating.** The lane originally ran
+`spotbugs:spotbugs` alone, which writes `spotbugsXml.xml` and prints not one finding: the log says
+"Skipping ... report goal" and stops. Every bit of reporting was therefore GitHub-side - annotations,
+the sticky comment, the check run - and anyone running the build locally got silence over hundreds of
+findings. Review caught it by asking the question nobody had: *do they at least get reported, and in
+the mvn build output?* They did not.
+
+What `check` adds is the thing neither the annotations nor the sticky comment carry: the **rule name**
+on every line, which is exactly what you need to tier a finding here.
+
+```
+[ERROR] Medium: JUnit test method ...testHandleStaleWorkNoSplit() passes constant to second
+        (actual) assertion parameter ... UTAO_JUNIT_ASSERTION_ODDITIES_ACTUAL_CONSTANT
+```
+
+It is not bound to a lifecycle phase: SpotBugs at `effort=Max` over the whole reactor costs minutes,
+and charging that to every local `mvn test` is how a plugin gets switched off. Run the two goals by
+hand when you want the list.
+
+**Trigger to make findings BLOCK** (drop `failOnError=false`): when Tier 2 is empty, i.e. every rule
+that is off is off permanently and for a stated reason. At that point a finding means a genuinely new
+instance of a rule the project has decided it wants, which is exactly the thing worth blocking on.
+Flipping before then makes the next unrelated PR the one that has to triage the backlog.
+
+## The measurement this is built from
+
+Taken 2026-08-25 against a tree at master, running the full reactor with fb-contrib 7.7.4 and
+find-sec-bugs 1.14.0 added to the existing `<effort>Max</effort>` / `<threshold>Medium</threshold>`
+configuration, with **no baseline applied**. Main code only - stock detectors alone: 70 findings;
+with both extensions: 225 across 58 rules. Adding `includeTests` takes it to 601. It is a dated
+snapshot, not a live figure. (A later `test-compile` run counted 228 main-code findings rather than
+225; the drift is generated sources the `compile`-only run had not produced, and is not chased.)
+
+**Three rules were checked in the source. Everything else is classified by its message**, which is
+the same standard [`static-spotbugs-latent-findings.md`](static-spotbugs-latent-findings.md) sets,
+and the reason its tier is marked *proposed* rather than settled below.
+
+## Tier 1 - ON, and the reason the extensions are worth having
+
+**`MUI_CONTAINSKEY_BEFORE_GET`, `ShardManager.removeWorkFromShardFor` - CHECKED, and it is
+astubbs#345.** The source reads `if (processingShards.containsKey(shardKey))`, then
+`processingShards.get(shardKey)`, then dereferences the result. That is the check-then-get seam of
+that bug exactly, and fb-contrib names it statically in seconds with no harness, no annotation and
+no interleaving search.
+
+**This finding has a shelf life, and the note should not outlive it.** astubbs#345 is **open, not
+merged** - the seam is still on master, which is why the detector sees it. When that PR lands the
+`containsKey`/`get` pair goes away and `MUI_CONTAINSKEY_BEFORE_GET` reports **zero**. That does not
+weaken the case for fb-contrib; it means this paragraph stops describing a live finding and starts
+describing history, and somebody should reword it rather than leave a reader hunting for a race that
+is fixed. This PR does not depend on astubbs#345, so the two can land in either order.
+
+This **narrows a standing claim** that both concurrency PoCs rest on. The evaluation note says "no
+static analysis the repo runs can see the class", which remains true - stock SpotBugs at max effort
+does not. But the register's stronger gloss, "nothing static does", is now measurably wrong for one
+member of the family. The honest rate is **one of the four known instances**: astubbs#346's seam is a
+stale-check followed by a lookup, not `containsKey` before `get`, so this detector does not fire on
+it, and the two torn-read value-divergence instances are outside what any check-then-act detector
+looks for.
+
+Also ON, each a single finding unless noted, all in code that matters:
+
+| Rule | Where | Note |
+|---|---|---|
+| `IS2_INCONSISTENT_SYNC` (2) | `DynamicLoadFactor` | CHECKED: `currentFactor` locked 71% of the time, `lastStepTime` 50%. Partial synchronisation is the reportable thing. |
+| `SUI_RETURNING_MUTABLE_STATIC_MAP` | `RemovedPartitionState` | CHECKED: `getIncompleteOffsetsBelowHighestSucceeded()` returns a mutable static set. This is the shared-collections defect already on file. |
+| `MS_EXPOSE_REP`, `NP_NONNULL_RETURN_VIOLATION`, `NP_NULL_PARAM_DEREF_NONVIRTUAL` | `RemovedPartitionState` | same class, same neighbourhood |
+| `MUI_CALLING_SIZE_ON_SUBCONTAINER` | `ShardManager` | |
+| `ICAST_INTEGER_MULTIPLY_CAST_TO_LONG` | `ProcessingShard` | int multiply widened to long after the fact - a real arithmetic class |
+| `NP_NULL_ON_SOME_PATH`, `NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE`, `NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR` | `OffsetMapCodecManager`, `AbstractParallelEoSStreamProcessor`, `PartitionState` | nullness |
+| `EQ_COMPARETO_USE_OBJECT_EQUALS` | `EncodedOffsetPair` | |
+| `DM_DEFAULT_ENCODING`, `MDM_STRING_BYTES_ENCODING` (3) | `CoreApp` | JVM-default-dependent - the class `forbidden-apis` targets, arriving from another direction |
+| `PREDICTABLE_RANDOM`, `OBJECT_DESERIALIZATION` | `JavaUtils`, `OffsetSimpleSerialisation` | the only two find-sec-bugs findings with any weight |
+| `DMC_DUBIOUS_MAP_COLLECTION`, `LUI_USE_GET0`, `OI_OPTIONAL_ISSUES_*` (3), `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE`, `UEC_USE_ENUM_COLLECTIONS`, `MOM_MISLEADING_OVERLOAD_MODEL`, `NM_FIELD_NAMING_CONVENTION`, `BED_BOGUS_EXCEPTION_DECLARATION`, `SEO_SUBOPTIMAL_EXPRESSION_ORDER`, `PSC_PRESIZE_COLLECTIONS`, `SPP_FIELD_COULD_BE_STATIC`, `PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS`, `UCPM_USE_CHARACTER_PARAMETERIZED_METHOD`, `OCP_OVERLY_CONCRETE_COLLECTION_PARAMETER` | various | one finding each; cheap to fix, so no reason to switch off |
+
+The stock rules already inventoried in `static-spotbugs-latent-findings.md` - `AT_*` (11),
+`JLM_JSR166_UTILCONCURRENT_MONITORENTER` (5), `UR_UNINIT_READ`, `SS_SHOULD_BE_STATIC`,
+`SF_SWITCH_NO_DEFAULT` (3), `DCN_NULLPOINTER_EXCEPTION` - stay ON. That note owns their triage and
+says which are real; nothing here re-decides it.
+
+## The SLF4J detectors, probed and kept
+
+`jp.skypencil.findbugs.slf4j:bug-pattern` has not been released since 2019 and still loads cleanly on
+SpotBugs 4.10.3, taking the reactor total from 601 to 643. Two of its findings are real defects in
+error paths, both **CHECKED** in the source:
+
+- `AbstractParallelEoSStreamProcessor.doClose`:
+  `log.error("PC closed due to error: {}", getFailureCause(), null)` - the cause is bound to the
+  placeholder and the trailing argument is `null` rather than the throwable, so SLF4J prints the
+  exception's `toString()` and **discards the stack trace**. That is the log line PC emits when it
+  closes because something went wrong, in a library whose hardest open bug is a silent stall.
+- `ThreadUtils.sleepLog`: `log.error("Sleep of {} interrupted", e, ms)` - arguments reversed. It
+  prints "Sleep of java.lang.InterruptedException interrupted", drops the duration, and again
+  attaches no stack trace.
+
+| Rule | Count | Profile | Tier |
+|---|--:|---|---|
+| `SLF4J_PLACE_HOLDER_MISMATCH` | 2 | - | **ON** - both are the defects above |
+| `SLF4J_ILLEGAL_PASSED_CLASS` | 3 | - | ON - all in test code, cheap |
+| `SLF4J_SIGN_ONLY_FORMAT` | 3 | - | ON |
+| `SLF4J_FORMAT_SHOULD_BE_CONST` | 28 | `old` | **OFF.** A non-constant format string is how this codebase composes conditional log messages - a deliberate idiom, not a backlog. Turns back on only if a placeholder bug is ever traced to a computed format string. |
+
+## Test code, measured separately
+
+`includeTests` is on and CI runs `test-compile`, so the test tree is analysed for the first time.
+Measured the same day, same configuration: **601 findings total - 228 in main code, 373 in test
+code**, zero unclassified (split by whether the class file lands in `target/classes` or
+`target/test-classes`, not by class name, because a name-based guess mis-sorted a third of them).
+Test code uses 75 distinct rules against main code's 59.
+
+**Three checked in the source. The rest are classified by their message.**
+
+### Test-side Tier 1 - ON
+
+- **`UTAO_JUNIT_ASSERTION_ODDITIES_ACTUAL_CONSTANT` (4) - CHECKED, and worth fixing, but not what it
+  first looked like.** All four are in
+  `AbstractParallelEoSStreamProcessorConfigurationTest.testHandleStaleWorkSplit` and
+  `.testHandleStaleWorkNoSplit`, and they are **argument-swapped**, not tautological:
+  `Assertions.assertEquals(testInstance.getMailBoxSuccessCnt(), 1)` puts the constant in JUnit's
+  *actual* slot. The assertion still tests the right thing; what breaks is the **failure message**,
+  which reports expected and actual the wrong way round. That is a signal that lies while looking
+  healthy - this directory's highest-priority impact class - and it costs most exactly when someone
+  is reading a failure under time pressure. Cheap to fix.
+- **`SWL_SLEEP_WITH_LOCK_HELD` (1)**, `MockConsumerCommitTimeoutTest$1.commitSync`. Sleeping while
+  holding a lock, inside the mock that models commit timeouts, in a repo that tracks commit-timeout
+  flakes. Not diagnosed here; worth someone's attention on that ground alone.
+- **`AT_NONATOMIC_64BIT_PRIMITIVE` (1)**, `RebalanceEoSDeadlockTest.noDeadlockOnRevoke`. A
+  non-atomic 64-bit primitive - the torn-read family's own shape - inside a deadlock test.
+- `NOS_NON_OWNED_SYNCHRONIZATION` (1) `LargeVolumeInMemoryTests`,
+  `LSYC_LOCAL_SYNCHRONIZED_COLLECTION` (1) `PartitionStateCommittedOffsetIT`,
+  `OBL_UNSATISFIED_OBLIGATION` (2) `DbTest`, `IMC_IMMATURE_CLASS_PRINTSTACKTRACE` (2).
+- find-sec-bugs, test-only, one each: `COMMAND_INJECTION`, `OVERLY_PERMISSIVE_FILE_PERMISSION`,
+  `URLCONNECTION_SSRF_FD`. Low stakes in test code, but three findings is not a reason to switch a
+  rule off.
+
+### Test-side, read before deciding
+
+**`ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` (7).** Cross-test static state is not hypothetical here -
+astubbs#101 was "uncollected tests, cross-test static state, and a timing flake". Seven instances,
+none inspected. This is the test-side equivalent of `EXS_` above: possibly style, possibly a repeat
+of a bug this repo has already paid for once.
+
+### Test-side Tier 3 - OFF, expected to stay off
+
+| Rule | Count | Profile | Reason |
+|---|--:|---|---|
+| `PREDICTABLE_RANDOM` | 10 in test code | `old` | A seeded, reproducible generator is what a test **should** use. The rule stays ON for main code, where its single finding is real. |
+| `DLS_DEAD_LOCAL_STORE` | 19 | `old` | A named local holding an intermediate value is how readable test setup is written. |
+| `ENMI_EQUALS_ON_ENUM` (12), `LSC_LITERAL_STRING_COMPARISON` (7), `CE_CLASS_ENVY` (5) | 24 | `new` | Style, and only the existing tests trip it. New test code has no reason to. |
+
+## Top 5 to turn back on whole-tree, ranked
+
+**Ranked by value divided by cost, not by count.** Value is how close the rule sits to a defect class
+this repo has actually paid for; cost is how many sites and how much judgement each needs. Every one
+is `profile: new` - the rule is right, only the existing tree blocks it - so clearing the sites is the
+whole job, and each one that clears deletes a row from this file.
+
+| # | Rule | Sites | Why this one | Effort |
+|---|---|--:|---|---|
+| 1 | `LEST_LOST_EXCEPTION_STACK_TRACE` | 5 | **Closest to a defect already found here.** This PR turned up two SLF4J calls that discard a stack trace, one of them on the line PC emits when it closes because something went wrong. Same class, different engine. | Read 5 sites |
+| 2 | `MS_SHOULD_BE_FINAL` | 5 | Mutable statics in a concurrency library. `RemovedPartitionState`'s shared mutable set - already on file as a bug - is this family. | Read 5 sites |
+| 3 | `LO_APPENDED_STRING_IN_FORMAT_STRING` | 2 | Cheapest on the list, and logs are the debugging surface for the stall family. | Mechanical |
+| 4 | `EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS` | 12 | **Read this one before deciding**, and see [`static-sneaky-throws-blind-the-analysers.md`](static-sneaky-throws-blind-the-analysers.md), which owns the code-change half. `docs/solutions/best-practices/sneaky-thrown-checked-exceptions-defeat-spotbugs-dataflow.md` records that sneaky-throw already blinds SpotBugs here, so these twelve may mark a real analysis blind spot rather than style. Highest potential value, least certain. | Investigate first |
+| 5 | `ENMI_EQUALS_ON_ENUM` | 7 | No judgement required at any site - `equals` to `==`. Clears a whole rule for near-zero risk. | Mechanical |
+
+**Deliberately not in the top 5**, so the omissions are arguable rather than accidental:
+`USBR` (28) and `UMTP` (26) are the two largest and the two least valuable - pure style. `CT_CONSTRUCTOR_THROW` and
+`FCCD` are worth having but are gated on other work (the God-class decomposition and the ArchUnit
+dependency-direction rule respectively), so effort spent now is effort spent twice.
+
+## Tier 2, grouped by what clearing it actually takes
+
+The trigger column says *when*; this says *what kind of work*. It is the difference between an
+afternoon and a design decision.
+
+- **Mechanical, no judgement** - `ENMI_EQUALS_ON_ENUM`, `NAB_NEEDLESS_BOOLEAN_CONSTANT_CONVERSION`,
+  `LO_APPENDED_STRING_IN_FORMAT_STRING`, `USBR_UNNECESSARY_STORE_BEFORE_RETURN`.
+- **Read the sites, then decide** - `LEST_LOST_EXCEPTION_STACK_TRACE`, `MS_SHOULD_BE_FINAL`,
+  `EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS`, and both `old?` rows.
+- **Blocked on other work** - `CT_CONSTRUCTOR_THROW` (God-class decomposition), `FCCD` (the ArchUnit
+  dependency rule), `MRC_METHOD_RETURNS_CONSTANT` and `UMTP` (the options rework), `IPU_*`,
+  `UP_UNUSED_PARAMETER`, `STT_TOSTRING_STORED_IN_FIELD` (next time the examples are touched).
+- **Permanent** - everything in Tier 3, and the test-side `old` rows. Not work.
+
+## Tier 2 - OFF now, with the trigger that turns each back on
+
+Proposed, not settled: none of these was checked in the source. Each is off because it arrives in
+bulk, and bulk on arrival is what makes a new engine get ignored.
+
+**`profile:` marks which of these are off for a REASON versus off for a BACKLOG** - see
+[`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md). `new` means the rule is right
+and only the legacy tree blocks it, so it goes on for new code the day the diff gate exists; `old`
+means it stays off everywhere. Almost all of Tier 2 is `new`, which is the point: these are rules
+nobody disagreed with, currently unguarding every line being written.
+
+| Rule | Count | Profile | Why off | Turns back on when |
+|---|--:|---|---|---|
+| `USBR_UNNECESSARY_STORE_BEFORE_RETURN` | 28 | `new` | pure style; a named local before `return` is often the more readable form | someone wants the sweep; it is mechanical |
+| `UMTP_UNBOUND_METHOD_TEMPLATE_PARAMETER` | 26 | `new` | generics-signature style, concentrated in `ParallelConsumerOptions` and the vertx result type | the public API surface is next revised - a major, so release-gated |
+| `NAB_NEEDLESS_BOOLEAN_CONSTANT_CONVERSION` | 14 | `new` | style | mechanical sweep |
+| `EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS` | 12 | `new` | flags wrapping a checked exception in an unchecked one, which this codebase does deliberately | **read this one first.** `docs/solutions/best-practices/sneaky-thrown-checked-exceptions-defeat-spotbugs-dataflow.md` says sneaky-throw already defeats SpotBugs dataflow here, so these 12 may be pointing at a real analysis blind spot rather than at style |
+| `CT_CONSTRUCTOR_THROW` | 9 | `new` | constructors that can throw; partially inherent to the builder-heavy design | after the God-class decomposition |
+| `FCCD_FIND_CLASS_CIRCULAR_DEPENDENCY` | 8 | `new` | circular class dependencies | pairs with the ArchUnit dependency-direction rule that note already proposes - same finding, two engines |
+| `ENMI_EQUALS_ON_ENUM` | 7 | `new` | `equals` on an enum instead of `==` | mechanical sweep |
+| `MRC_METHOD_RETURNS_CONSTANT` | 7 | `new` | all in `ParallelConsumerOptions` | with the options rework |
+| `RFI_SET_ACCESSIBLE` | 7 | `old?` | `setAccessible` in `AbstractParallelEoSStreamProcessor` (4 calls) and `ProducerWrapper` (3); the producer reflection is load-bearing | never, most likely - but the 7 findings are 7 CALLS in 2 classes, plus 5 more in 3 test classes, so size any attempt against 12 |
+| `MS_SHOULD_BE_FINAL` | 5 | `new` | mutable statics in the codec classes | with the codec work |
+| `LEST_LOST_EXCEPTION_STACK_TRACE` | 5 | `new` | same family as `EXS_`, read together | as above |
+| `IPU_IMPROPER_PROPERTIES_USE` + `_SETPROPERTY` | 6 | `new` | examples only | when the examples are next touched |
+| `UP_UNUSED_PARAMETER`, `STT_TOSTRING_STORED_IN_FIELD` | 8 | `new` | examples only (`CoreApp`) | as above |
+| `ACEM_ABSTRACT_CLASS_EMPTY_METHODS` | 3 | `old?` | deliberate no-op hooks | probably permanent; needs one look |
+| `LO_APPENDED_STRING_IN_FORMAT_STRING` | 2 | `new` | logging style | mechanical sweep |
+
+**Two rows are marked `old?` rather than `old`, and the question mark is the honest part.**
+`RFI_SET_ACCESSIBLE` covers the producer reflection, which is load-bearing (7 calls across 2 main
+classes, and 5 more in tests - the count reads as "two sites" only if you count classes), and
+`ACEM_ABSTRACT_CLASS_EMPTY_METHODS` covers deliberate no-op hooks - both look permanent, and neither
+was checked in the source. Resolve them by reading the call sites, not by ageing.
+
+## Tier 3 - OFF, expected to stay off
+
+Every row here is `profile: old`: wrong for this codebase, so off for new code too. This is the
+registry's real content, and after the diff gate lands it is close to all that should remain in it.
+
+| Rule | Count | Reason |
+|---|--:|---|
+| `EI_EXPOSE_REP` / `EI_EXPOSE_REP2` | 21 | Storing and returning collaborators passed in **is** how this library composes - `PCModule` holds the options, `BrokerPollSystem` holds the `ConsumerManager`. Defensive copying would break the DI wiring rather than fix anything. This is not a new judgement: `static-spotbugs-latent-findings.md` reached it already, on the same rules, with the same reasoning. |
+| `IMC_IMMATURE_CLASS_IDE_GENERATED_PARAMETER_NAMES` | 1 | opinion about parameter naming |
+
+## The one CLASS-scoped suppression, and why it is not a rule-scoped one
+
+`MUI_CONTAINSKEY_BEFORE_GET` is switched off for
+`bz.stub.parallelconsumer.state.LincheckToolchainProbeTest` and for nothing else.
+
+That class is astubbs#347's **red control**: a deliberately torn
+`containsKey` / `get` / dereference on a `ConcurrentHashMap`, kept broken on purpose because it is
+the arm proving Lincheck can see the defect class at all. Fixing the finding would turn that
+calibration into what its own commit message calls "a green lamp wired to nothing".
+
+**The suppression names the class, never the rule**, and the distinction is the whole point:
+`MUI_CONTAINSKEY_BEFORE_GET` is the finding that justified adopting fb-contrib - it names
+`ShardManager.removeWorkFromShardFor`, a real defect - so switching it off globally to quieten a
+deliberate fixture would trade the headline result for silence. Asserted after the change rather
+than assumed: the rule reports **0** on the probe and still reports on `ShardManager`.
+
+**It also narrowed a claim in that probe's own javadoc**, which said SpotBugs reported nothing on
+this shape. True of the stock detectors, and measured; with fb-contrib the shape is named in
+seconds. The javadoc is corrected in the same change rather than left to contradict the tool now
+analysing it - the probe is still the right red control for *Lincheck*, since a static detector
+cannot exhibit an interleaving, but "no static analysis can see this" is now "no stock detector
+could".
+
+This is the model for any future site-scoped exclusion: name the class, state why the code is
+deliberately that way, and assert the rule still fires elsewhere.
+
+## A scoping limitation you will hit, and how it was found
+
+**A SpotBugs filter cannot express "test source root".** The XML records `sourcepath` as the
+PACKAGE-relative path (`bz/stub/parallelconsumer/mutiny/MutinyPCTest.java`), so `src/test` never
+appears in it and a `<Source name="~.*src/test.*"/>` matcher **matches nothing at all**. The first
+version of `spotbugs-exclude.xml` used exactly that, and it was completely inert. It was caught only
+by asserting after the run that `PREDICTABLE_RANDOM` had actually gone to zero - the build was green
+and the file was valid XML either way, which is this repo's standard silent-green shape.
+
+The test-scoped entries therefore match on `<Class name="~.*(Test|Tests|IT|ITCase)(\$.*)?"/>`, the
+weaker discriminator. **It leaks**: a helper named `Fixture`, `Harness` or `MockSomething` is test
+code the pattern does not catch, which is why `PREDICTABLE_RANDOM` still reports ten and
+`DLS_DEAD_LOCAL_STORE` one after filtering. Excluding those rules globally instead would drop the one
+REAL main-code `PREDICTABLE_RANDOM` finding, so the leak is the better trade - but it is a leak, not
+a design.
+
+**Verify by count, never by "the build went green".** The rule and the five sightings behind it are
+owned by
+[`docs/solutions/workflow-issues/an-inert-analysis-config-reads-as-a-clean-codebase.md`](../solutions/workflow-issues/an-inert-analysis-config-reads-as-a-clean-codebase.md);
+what follows is only its application to this file. After changing this file, run the analysis and
+assert the rule you excluded reports zero. Filter typos do not fail anything.
+
+## javac's own analysis, and the inert first attempt
+
+`-Xlint:all -Xlint:-processing` is on, **without** `-Werror`, and `rawtypes` is additionally off for
+TEST compilation only. There was no `<compilerArgs>` block in this build at all before, so this is
+analysis that shipped with the compiler and was never switched on.
+
+**An earlier version of this section said "172 warnings, all in test code or against deprecated
+third-party API". Both halves were wrong, and the way it was caught is worth more than the
+correction: a human scrolled the Files Changed tab of the PR that turned the flag on.** The
+annotations there were mostly on `AbstractParallelEoSStreamProcessor` - which is main code - naming
+`isUsingTransactionalProducer()` and `WorkContainer.setFuture`, which are this project's own API, not
+a third party's.
+
+Re-measured on core plus parent, `test-compile`, deduplicated by file, line and category:
+
+| Where | Before the `rawtypes` narrowing | After |
+|---|--:|--:|
+| **main code** | 58 | **58** |
+| `src/test/` + `src/test-integration/` | 226 | 184 |
+| **generated sources** (Truth assertion generator) | **559** | 24 |
+| total | 843 | **266** |
+
+Two things that table settles. **The channel was two-thirds code nobody wrote** - 535 of the 585
+`rawtypes` were generated `List` parameters in
+`target/generated-test-sources/truth-assertions-managed`, which is why `rawtypes` is now off for test
+compilation only and untouched for main. And **the headline number is meaningless without saying
+whether generated sources are counted**, which the old text did not: the same tree is 843 or 284
+depending on that one decision, so any target derived from it was arbitrary.
+
+After the narrowing, the 266 break down as unchecked (138), deprecation (106), serial (13),
+rawtypes (8, all main), cast (1).
+
+`-Werror` is a second step, deliberately. Promote it when the inventory reaches zero, not before; a
+build that goes red on a deprecation in a TestContainers class helps nobody. The 58 main-code
+warnings are the ones worth working down first - they are our own deprecated API and our own
+generics, and unlike the test ones nobody can argue they are somebody else's problem.
+
+**The first attempt at this was inert, and the way it was caught is the reusable part.** The
+`<compilerArgs>` block was inserted into the *first* `maven-compiler-plugin` declaration in the
+parent pom - which lives inside the `intellij-idea-only` profile, and CI never activates it. The
+build was green and the run reported **6** warnings, all of them from Lombok and the Truth generator
+rather than from lint, which reads exactly like "the codebase is clean".
+
+The check that caught it was `./mvnw help:effective-pom` plus `grep -c 'Xlint:all'`, asserting the
+count is greater than zero. Green told me nothing; the effective pom told me the flag was not there.
+**Do that for any build-config change whose only evidence is an absence of output** - AGENTS.md's
+"verify your instrumentation actually reached the run", arriving in a pom rather than a log config.
+The difference between the two runs was 6 warnings and 172 - both figures superseded by the table above, and kept here because they are the evidence for the detection method rather than a current count.
+
+## Rules for changing this file
+
+The three that bind every rule registry - off requires an entry, an entry needs a trigger rather than
+a date, and the off set only shrinks - are **owned by**
+[`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md), "Rules every rule registry
+follows". They are not restated here; a second copy is how two statements of one contract drift.
+
+Specific to this file:
+
+- **The entry point is `config/spotbugs-exclude.xml`.** A rule reaches the off set by being added to that
+  filter, so "off" here always means a `<Match>` element somebody can see in a diff.
+- **Moving a rule from Tier 2 to Tier 1 deletes its row.** This file is deleted outright when Tier 2
+  and Tier 3 are both empty - which is also the trigger for making the lane blocking, above.
+- **Tier assignments marked proposed become settled by reading the source**, not by ageing. A
+  proposal that has sat unexamined for months is still a proposal.

--- a/docs/inflight/test-jcstress-probe-module-open-items.md
+++ b/docs/inflight/test-jcstress-probe-module-open-items.md
@@ -50,14 +50,18 @@ Three second-order effects follow anyway:
   CVE scan will ever see it.
 - The workflows' `hashFiles('**/pom.xml')` cache key includes this pom, busting the Maven cache once
   per edit.
-- **The exclusion costs static analysis too, and astubbs#356 is about to make that the module's own
-  distinction.** SpotBugs runs `-pl parallel-consumer-core -am` today, so this module is one of
-  several unanalysed - unremarkable. astubbs#356 widens it to the whole reactor and turns on
-  `includeTests`; a module reached through neither `<parent>` nor the root `<modules>` is outside
-  that sweep as well, which would leave the probe classes the only Java in the tree nothing
-  analyses. They are concurrency code. Recorded so a later reader sees the cost was priced rather
-  than overlooked - the containment argument still wins, and the same shape as the dependency-lane
-  bullet above.
+<!-- post-merge: checked-begin -->
+- **The exclusion costs static analysis too, and this is now the module's own distinction.** It was
+  written here while astubbs#356 was still open; that PR has since landed, so the future tense is
+  spent. SpotBugs no longer runs `-pl parallel-consumer-core -am` - it covers the whole reactor with
+  `includeTests` - and a module reached through neither `<parent>` nor the root `<modules>` is
+  outside that sweep, which leaves the probe classes **the only Java in the tree nothing analyses**.
+  They are concurrency code. The containment argument still wins and nothing here is a request to
+  change it; it is recorded so a later reader sees the cost was priced rather than overlooked, and
+  it is the same shape as the dependency-lane bullet above. If the probes ever want analysis, the
+  cheapest route is a separate SpotBugs invocation scoped at this module rather than pulling it into
+  the reactor, since joining the reactor is what the containment exists to prevent.
+<!-- post-merge: checked-end -->
 
 ## Nothing enforces reading the positive control
 
@@ -66,11 +70,13 @@ raced prints `[OK]` everywhere. The warning is durable - `jcstress-poc/pom.xml` 
 THE CALIBRATION BEFORE BELIEVING ANY ZERO` - but it is prose, and no check makes a vacuous run
 distinguishable from a clean one.
 
+<!-- post-merge: checked-begin -->
 **The mechanical closure is to assert a count, not to instruct a reader**: have the run fail unless
 the calibration arm's observation count is non-zero, which is the same standing instruction
 astubbs#356 arrived at from three unrelated instances of the class (an exclude filter matching
 nothing, a compiler flag in a profile CI never activates, a mutation control whose arms both failed
 for an unrelated reason). Until that exists, this is prose asking for discipline.
+<!-- post-merge: checked-end -->
 
 ## Nothing detects correspondence drift, or even compiles the module
 

--- a/docs/inflight/test-untracked-ci-flakes.md
+++ b/docs/inflight/test-untracked-ci-flakes.md
@@ -16,13 +16,13 @@ their diagnoses generalised, the rule is in [`docs/solutions/`](../solutions/).
 |---|---|---|
 | `OffsetEncodingBackPressureTest.backPressureShouldPreventTooManyMessagesBeingQueuedForProcessing` | 4/45 | The most frequent. UNDIAGNOSED; quarantined on its sighting ledger (rule 1) - see below. Backpressure area - compare `vacuous-await-condition-brokerpoller-backpressure-2026-07-31.md`, a *different* class in the same area, so rule it in or out rather than assuming |
 | `ProducerManagerTest.producedRecordsCantBeInTransactionWithoutItsOffsetDirect` | 1 seen (2026-08-12) | Not from the original scan - found while babysitting astubbs#287. Mechanism known and owned (astubbs#262), quarantined - see below |
-| `simpleBatchTest` in **both** `ReactorBatchTest` and `MutinyBatchTest` | 2 seen (2026-08-18, 2026-08-19) | Not from the original scan - both found while babysitting a **docs-only** branch (astubbs#308 head `d930ca98d`; astubbs#320 head `70a247184`). Same Awaitility `ConditionTimeout`, same alias 'expected number of batches' (30s), same shared `BatchTestMethods` lambda - see below, the second sighting is what makes it worth diagnosing. UNDIAGNOSED - classify (contention vs product) before touching |
+| `simpleBatchTest` in **all three** of `ReactorBatchTest`, `MutinyBatchTest` and `VertxBatchTest` | 3 seen (2026-08-18, 2026-08-19, 2026-08-25) | Not from the original scan - each found while babysitting a branch carrying **no main Java**. Same Awaitility `ConditionTimeout`, same alias 'expected number of batches' (30s), same shared `BatchTestMethods` lambda. UNDIAGNOSED, but the third sighting carries the failing batch contents and they point at the test's own randomised input - see below, and classify (contention vs product vs expectation) before touching |
 
 **Classify before touching any of them** - the same rule that governs the load-tightness family next
 door, and for the same reason: two of that family turned out to be real product bugs, and the third
 was neither tight nor a stall but a test that could not force its own trigger.
 
-### `simpleBatchTest` - the second sighting says it is the shared helper, not either wrapper
+### `simpleBatchTest` - three modules, one shared helper, and a lead nobody has tested
 
 2026-08-18 it was `ReactorBatchTest`. 2026-08-19 it was `MutinyBatchTest`, on
 astubbs/parallel-consumer#320 - and the failure is the same one, not a similar one: the alias, the
@@ -41,15 +41,44 @@ question, not a lost-work question. Two readings, and they need separating rathe
 - **Product.** The batcher can split a batch under a timing the library is supposed to tolerate,
   in which case an over-eager boundary is a real defect and the test is right to complain.
 
-**Both sightings are on branches whose diffs contain no Java at all**, which is what rules out "a PR
-broke it" and makes it master state - the same reasoning applied to `ProducerManagerTest` below.
-That is also why neither was quarantined on the branch that met it: quarantine is master-state and
-needs a diagnosis, and neither sighting has one.
+**No sighting is on a branch whose diff contains main Java**, which is what rules out "a PR broke
+it" and makes it master state - the same reasoning applied to `ProducerManagerTest` below. That is
+also why none was quarantined on the branch that met it: quarantine is master-state and needs a
+diagnosis, and no sighting has one.
 
-The 2026-08-18 sighting passed on re-run. A re-run is diagnosis here, not a way to go green - it
-distinguishes flaky from deterministic - and AGENTS.md's ban is on the automatic
-`surefire.rerunFailingTestsCount` that hid this whole ledger, not on re-running a job to learn
-something.
+The 2026-08-18 sighting passed on re-run, and so did the 2026-08-25 one - three consecutive clean
+re-runs of the same test, so **1 failure in 4 local runs, not deterministic**. A re-run is diagnosis
+here, not a way to go green - it distinguishes flaky from deterministic - and AGENTS.md's ban is on
+the automatic `surefire.rerunFailingTestsCount` that hid this whole ledger, not on re-running a job
+to learn something.
+
+#### The 2026-08-25 sighting: a third module, and the first look at what was in the batches
+
+`VertxBatchTest`, KEY ordering, on a local macOS full unit run of the branch that added
+`ShardMapIsNeverReplacedArchTest` - one new core test class plus docs, no main Java. Same
+`Expected size: 3 but was: 4`. **Three modules now, so the wrapper is definitively not the
+variable.**
+
+What is new is the payload the assertion printed. The five records carried keys `29, 36, 36, 36,
+71` - a **three-way key collision** - and arrived as `{o0, o4}`, `{o1}`, `{o2}`, `{o3}`, so every
+key-36 record came alone. Meanwhile `simpleBatchTest` computes its expectation from the record count
+and nothing else: grep `BatchTestMethods` for `expectedNumOfBatches`, which is
+`ceil(numRecsExpected / batchSizeSetting)` for every ordering except PARTITION. **The keys are
+random** - `KafkaTestUtils.getRandomKey` draws from `defaultKeys`, a hundred integers - so the shard
+distribution the batcher works against varies run to run while the expected batch count does not.
+
+That is a third reading to separate, not a diagnosis, and it displaces neither of the two above:
+
+- **Expectation-versus-input.** The test randomises the key distribution and then asserts a batch
+  count that only holds for some distributions. A rare draw would explain a rare failure without any
+  contention or product defect at all.
+
+The experiment that settles it is cheap and has a control arm, and **nobody has run it**: pin the
+keys through the Lombok setter on `KafkaTestUtils`'s `defaultKeys`, force a three-way collision
+under KEY ordering, and predict a deterministic failure; then five distinct keys, and predict it
+always passes. If both hold, this is
+the test's own input and neither the runner nor the batcher. If the collision case passes, the draw
+is a red herring and contention-versus-product stands as before.
 
 ### `ProducerManagerTest.producedRecordsCantBeInTransactionWithoutItsOffsetDirect` - a helper defect, not a test defect
 

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -143,11 +143,37 @@ Do not start one casually.
   `origin/refactor/function-runner` @3fd8caac, `origin/massive-refactor` @f96e0bc4 (the umbrella attempt).
   Registered in the manifest as `refactor-thread-model-god-class` (this doc stays the editorial owner).
 
+### Annotate every fixed race with `@GuardedBy`, as you fix it
+
+- **Owned by
+  [`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md`](../parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md)**,
+  which arrives automatically when you edit a file in the engine - the moment the rule applies. A
+  backlog entry is consulted; that one fires. Kept here as a pointer only, because this list is where
+  somebody browsing debt will look for it.
+- The short version: Error Prone's `GuardedBy` check is on at ERROR and examines nothing, because the
+  codebase contains no annotation. Every detector here is discovery and none prevents regression, so
+  the annotation is what makes a fix permanent - write it with the fix.
+
+### `AbstractParallelEoSStreamProcessor.lastCommitTime` is read unsynchronised
+
+- Plain `Instant`, written in the commit path and read by `isTimeToCommitNow()` with no
+  happens-before edge. Found by RacerD 2026-08-25; **not previously in any ledger**. The poll thread
+  can read a stale value and mis-time a commit, on a codebase that already tracks commit-timeout
+  flakes. Not diagnosed further. Fix it with `@GuardedBy` per the policy above.
+
 ### Decompose the God class - `AbstractParallelEoSStreamProcessor` (1533 lines)
 - Control loop + lifecycle/state machine + commit orchestration + threading +
   rebalance listener + deprecated options in one class. Design ref: draft
   `confluentinc#488`. Branch `origin/refactor/state-machine` @8f90da8a (extract the lifecycle
   state machine). Do alongside the [confluentinc#200](https://github.com/confluentinc/parallel-consumer/issues/200) (mirror astubbs#142) work; high risk.
+- **Landing this unblocks whole-FILE static analysis, and it can be taken piecemeal.** The
+  new-code analysis profile is scoped to changed *lines* rather than changed *files* purely because
+  of size: touching a 1533-line class would otherwise inherit every latent finding in it. Line
+  scoping is the weaker choice - it misses a finding reported away from the edit that caused it - so
+  each file that comes down to a reviewable size can be promoted to file scoping on its own, without
+  waiting for the whole decomposition.
+  [`docs/inflight/static-analysis-rule-profiles.md`](inflight/static-analysis-rule-profiles.md) owns
+  the profiles and carries the promotion list.
 
 ### Actor / IPC message bus for commits & results
 - Replace shared-state coordination with a lightweight actor/mailbox. Design refs:
@@ -281,6 +307,14 @@ Do not start one casually.
   `retryQueueOrdering`, `testRetryQueueOrdering` and `testRetryQueueOrderingMultipleTries`, all of
   which test ordering only. Nothing asserts shard/retryQueue consistency after a stale removal by
   either path.
+
+### state/RetryQueue.java
+
+- **Four `// visible for testing` accessors that no test calls.** `RetryQueue`'s `unique`, `sorted`
+  and `comparator` Lombok `@Getter(AccessLevel.PACKAGE)`s, and `ShardManager`'s `retryQueue` one,
+  have zero callers anywhere in the tree - main, test or integration. Delete them; the comment is
+  documenting an access route nobody uses, and an ArchUnit rule policing a dead accessor would pass
+  vacuously forever (see `docs/inflight/static-archunit-main-code-rules.md`).
 
 ### state/PartitionState.java (715 lines)
 - `Needs to be concurrent because`: concurrent commit-data collection exists only because

--- a/docs/solutions/best-practices/sneaky-thrown-checked-exceptions-defeat-spotbugs-dataflow.md
+++ b/docs/solutions/best-practices/sneaky-thrown-checked-exceptions-defeat-spotbugs-dataflow.md
@@ -43,6 +43,15 @@ onto the PR and re-surfaces as a new-findings warning on every push until fixed 
 job itself is report-only - `spotbugs:spotbugs`, not `spotbugs:check` - so this is recurring review
 noise rather than a hard merge block.)
 
+> **Reference repair, 2026-08-25 - the claim above stands, the machinery it names is gone.** The
+> `spotbugs-baseline` job and `.spotbugs-baseline.xml` were retired; suppression is now a checked-in
+> `spotbugs-exclude.xml` keyed by RULE, with every entry justified in
+> `docs/inflight/static-spotbugs-rule-registry.md`. Read the mechanism as this document read it with
+> `git show 4480fcf89^:.github/workflows/maven.yml`, then grep `spotbugs-baseline`. Nothing about
+> the finding or its analysis changes - only the address of the CI machinery described.
+> Why it was retired, and the failure class that motivated it:
+> [`../workflow-issues/an-inert-analysis-config-reads-as-a-clean-codebase.md`](../workflow-issues/an-inert-analysis-config-reads-as-a-clean-codebase.md).
+
 The catch-broadly-and-dispatch-on-type structure follows the shared-handler design of PR
 astubbs#207 (open, unmerged as of this writing), which proposed one handler for the whole class of
 unreadable-metadata decode failures; the structure itself entered this tree in PR astubbs#306's own

--- a/docs/solutions/build-errors/error-prone-jabel-and-the-jdk-that-satisfies-neither-2026-08-25.md
+++ b/docs/solutions/build-errors/error-prone-jabel-and-the-jdk-that-satisfies-neither-2026-08-25.md
@@ -1,0 +1,139 @@
+---
+title: "Error Prone, Jabel, and the JDK that satisfies neither"
+date: 2026-08-25
+category: build-errors
+module: build-system
+problem_type: build_error
+component: development_workflow
+severity: medium
+symptoms:
+  - "`UnsupportedClassVersionError: com/google/errorprone/ErrorProneJavacPlugin has been compiled by a more recent version of the Java Runtime (class file version 65.0)` on JDK 17"
+  - "The same build on JDK 21 dies instead with `ServiceConfigurationError: com.sun.source.util.Plugin: Provider com.github.bsideup.jabel.JabelCompilerPlugin could not be instantiated`"
+  - "`Java 21 (65) is not supported by the current version of Byte Buddy which officially supports Java 20 (64)`"
+  - "Adding error_prone_core to annotationProcessorPaths breaks compilation even with no -Xplugin:ErrorProne anywhere"
+  - "`NoClassDefFoundError: com/google/errorprone/predicates/type/DescendantOf` from NullAway, at checker construction"
+  - "Error Prone crashes in StringConcatToTextBlock with a NoSuchElementException on a class that only uses Lombok's @NonNull"
+  - "maven-compiler-plugin reports `COMPILATION ERROR` followed directly by a stack frame, with the exception message missing"
+root_cause: dependency_conflict
+resolution_type: config_change
+tags:
+  - error-prone
+  - nullaway
+  - jabel
+  - lombok
+  - jdk17
+  - javac-plugin
+  - static-analysis
+  - class-file-version
+---
+
+# Error Prone, Jabel, and the JDK that satisfies neither
+
+## Problem
+
+Adding `com.google.errorprone:error_prone_core` at its current release to a build that compiles Java
+17 source to a Java 8 target through Jabel fails, and the failure moves when you try to fix it. Three
+blockers are involved, they are independent, and two of them are mutually exclusive - so the obvious
+remedy for the first makes the second fire.
+
+Everything below was measured, each with a control arm that changes one term.
+
+## Blocker 1: Error Prone dropped JDK 17, at a nameable version
+
+`ErrorProneJavacPlugin` is compiled to class file version **65** (Java 21) from **2.43.0** onwards.
+2.42.0 is **61**. JDK 17 reads to 61, so the plugin class cannot be defined at all and javac dies
+before analysing anything.
+
+The jar states its own requirement, which is quicker than bisecting: `Build-Jdk-Spec: 21` and
+`Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=21))"` in the manifest. Reading the
+class file's version bytes across releases is the mechanical way to find the boundary, and it takes
+seconds per release.
+
+## Blocker 2: raising the JDK is not available, because Jabel refuses 21
+
+Jabel 1.0.0 bundles Byte Buddy 1.12.18, which rejects class file 65 outright:
+*"Java 21 (65) is not supported by the current version of Byte Buddy which officially supports Java
+20 (64) - update Byte Buddy or set net.bytebuddy.experimental as a VM property"*.
+
+**Control**: the same plain compile on JDK 21 with an Error-Prone-free processor path fails
+identically, so this is Jabel alone and not an interaction with Error Prone. The two constraints have
+no overlapping JDK.
+
+## Blocker 3: NullAway is version-coupled to Error Prone, and nothing says so
+
+NullAway 0.12.7 dies at checker construction against Error Prone 2.50.0 with
+`NoClassDefFoundError: com/google/errorprone/predicates/type/DescendantOf`; that release ships
+`com.google.errorprone.predicates.TypePredicate(s)` and no `predicates.type` sub-package at all. It
+works against 2.42.0.
+
+**The constraint is invisible to every dependency tool**, because NullAway takes Error Prone as
+`compileOnly` and its published pom declares only jspecify, dataflow-nullaway and guava. An enforcer
+`requireUpperBoundDeps` rule cannot see a dependency that is not declared, so this class of mismatch
+will always surface at runtime. Move the two versions together, deliberately.
+
+## Lombok is a fourth blocker, but only at the newer Error Prone
+
+**Two-arm control**, same JDK, same flags, same processor path, one term changed:
+
+- `public C(@lombok.NonNull String s) { ... }` - exit 4. `StringConcatToTextBlock` throws
+  `NoSuchElementException` out of `Iterables.getLast`, walking the tokens of a string literal Lombok
+  synthesised with no source position, inside the generated
+  `throw new NullPointerException("s is marked non-null but is null")`.
+- The same class with that null check written by hand - exit 0.
+
+It does not reproduce at 2.42.0. Worth knowing before blaming the annotation processor ordering that
+Lombok and Error Prone are famous for: this is not an ordering problem, it is one check mishandling a
+synthetic node.
+
+## The trap that costs the most time: the jar alone arms the plugin
+
+Putting `error_prone_core` on `annotationProcessorPaths` breaks compilation **with the plugin
+switched off**. `BasicJavacTask.initPlugins` enumerates every `com.sun.source.util.Plugin` service
+provider on the processor path and loads each class *before* looking at which plugin was requested.
+
+**Control**: identical javac invocation both sides - Error Prone on the processor path and not
+enabled gives `UnsupportedClassVersionError`; removed from the processor path, exit 0.
+
+So "add the dependency now, enable it in a later PR" is not a route, and a build that has never
+written `-Xplugin:ErrorProne` can still be broken by the dependency.
+
+## Diagnosing any of this: maven hides the message
+
+`maven-compiler-plugin` prints `COMPILATION ERROR` followed directly by a stack frame, with the
+exception's message line missing - it does not match the plugin's `file:line: error:` parser, so it is
+dropped. Every failure above is unreadable through Maven and obvious the moment you run the same
+`javac` by hand.
+
+Reproduce the compiler invocation directly: `dependency:build-classpath` for the compile classpath, a
+throwaway pom whose dependencies are the processor path, then `javac` with the same flags. It also
+gives you somewhere to change one term at a time, which is what all the controls above needed.
+
+## Solution
+
+Pin Error Prone to the last release on the near side of the class-file boundary, and pin NullAway with
+it. The pin is temporary: it lifts when Jabel does, and Jabel's removal is already tracked with the
+Java baseline work it belongs to. What is pinned, what is switched off, and what turns each back on
+live in `docs/inflight/static-error-prone-rule-registry.md`.
+
+Configuration that turned out to be load-bearing rather than optional:
+
+- `<fork>true</fork>` plus `-J--add-exports`/`-J--add-opens` for eight and two `jdk.compiler`
+  packages. They must reach the **compiler's** JVM, which is what `-J` and forking are for. Omit them
+  and the plugin dies with `IllegalAccessError` on `BasicJavacTask` rather than anything that names
+  the cause.
+- `-XDcompilePolicy=simple` and `--should-stop=ifError=FLOW`.
+- **NullAway needs `-XepOpt:NullAway:AnnotatedPackages=<pkg>` or `-XepOpt:NullAway:OnlyNullMarked`.**
+  With neither it does not degrade to silence; it crashes the compiler while constructing the checker.
+- `-XepExcludedPaths:` takes a **colon**, not an equals sign. The equals form is rejected as
+  `invalid flag`, through the same swallowed-message path above.
+- `-Xmaxwarns`. javac caps output at 100 warnings per compilation and says nothing when it truncates.
+
+## Prevention
+
+- **Read a javac plugin's class file version before its changelog.** It is one field, it is
+  authoritative, and it answers "will this run on our JDK" without reading a release note that may not
+  mention the bump.
+- **When a build tool swallows a message, go under it.** A stack trace whose first line is a frame is
+  a message that was filtered, not a message that does not exist.
+- **A dependency taken as `compileOnly` by a plugin you consume is a version constraint nobody
+  enforces.** Pin both ends and move them together.

--- a/docs/solutions/workflow-issues/a-check-that-reports-success-without-having-run.md
+++ b/docs/solutions/workflow-issues/a-check-that-reports-success-without-having-run.md
@@ -331,3 +331,11 @@ A guard for this class has to say *which* kind of red it is.
   guard beside it.
 - astubbs/parallel-consumer#281 - retiring the standing backlog, which is what let findings become
   fatal.
+
+## Related
+
+[`an-inert-analysis-config-reads-as-a-clean-codebase.md`](an-inert-analysis-config-reads-as-a-clean-codebase.md) owns the neighbouring case this doc's model has no slot for: the tool **ran**, and
+enforced faithfully, against a configuration that never reached it - so there is no "could not run"
+state to detect. Its instances are a SpotBugs filter that matched nothing, a compiler flag in a dead
+Maven profile, a control arm that reddened on an unrelated rule, and a mutation lane green on 40 runs
+having scored nothing. The piped `$?` trap this doc closes on is shared between them.

--- a/docs/solutions/workflow-issues/an-inert-analysis-config-reads-as-a-clean-codebase.md
+++ b/docs/solutions/workflow-issues/an-inert-analysis-config-reads-as-a-clean-codebase.md
@@ -1,0 +1,232 @@
+---
+title: "An inert analysis config reads as a clean codebase - assert a count, not a green build"
+date: 2026-08-25
+category: workflow-issues
+module: build-system
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+root_cause: config_error
+resolution_type: workflow_improvement
+status: "SOLVED for the five instances found. Each is now verified by an asserted count. No mechanical guard enforces the effective-pom check - it is a habit, not a gate."
+applies_when:
+  - Adding or changing any static-analysis tool, exclude filter, or compiler flag in a pom
+  - A tool reports zero findings, or few, and you are about to read that as a clean codebase
+  - Running a negative control arm, before believing the red arm went red for your reason
+  - Reading an exit code from a command you piped into head, tail, or grep
+  - Reviewing a CI lane that can exit zero without having graded anything
+symptoms:
+  - A SpotBugs exclude filter scoped on a source path silences nothing, because sourcepath is package-relative
+  - "`-Xlint:all` reports 6 warnings against a real 172, having landed in a profile CI never activates"
+  - A negative control where both arms exited 1 for unrelated reasons, so it proved nothing
+  - A mutation-testing lane green on 40 of 40 runs, having scored zero mutants on every one
+  - An exit code read through a pipe reports the pipe's status rather than the command's
+tags:
+  - static-analysis
+  - build-config
+  - maven
+  - effective-pom
+  - false-negative
+  - silent-green
+  - control-arm
+  - exit-codes
+related_components:
+  - tooling
+  - testing_framework
+---
+
+# An inert static-analysis config reports the same green as a clean codebase
+
+## Context
+
+Expanding static analysis on `ci/static-analysis-expansion` turned up five separate changes that
+looked applied, produced no findings, and were completely inert. In every case the build stayed
+green, and the absence of output read as a clean codebase. None of them was caught by a red build,
+because none of them could ever produce one.
+
+This is not the same failure as the tools already written up here. `docs/solutions/workflow-issues/
+a-check-that-reports-success-without-having-run.md` catalogues checks that could not run at all - a
+401, a refused action, an unresolvable fork point. What is new in this batch is that the tool **did**
+run, successfully, over the real tree, and produced a genuine and correct report; the *configuration*
+never reached it. There is no error to notice and no step to gate on. The only distinguishing
+signal is the size of the finding count, which nothing was asserting.
+
+The five, each verifiable in this repo:
+
+| Change | Why it was inert | What the run reported | What it reports applied |
+|---|---|---|---|
+| SpotBugs test-scoping filter | `<Source name="~.*src/test.*"/>` - SpotBugs records `sourcepath` package-relative, so `src/test` never appears in it | Rule still firing; XML valid, build green | Filter now scopes by class name; see the `SCOPING LIMITATION, MEASURED NOT ASSUMED` block in `spotbugs-exclude.xml` |
+| `-Xlint:all` in `maven-compiler-plugin` | Landed in the *first* of two plugin declarations, the one inside the `intellij-idea-only` profile, which CI never activates | **6** warnings, all from Lombok and the Truth generator | **172** warnings |
+| `forbidden-apis` control arm | Both arms run with `-pl parallel-consumer-core`, both exit 1 | Exit 1 both sides, read as a working control | Over the full reactor: mutated exits 1 with one forbidden-method error, reverted exits 0 with none |
+| PIT mutation lane | Every exit path returned 0, so a correct skip and a real run were the same tick | Success on 40 of the last 40 PR runs | Exit code is now the verdict; see `THE EXIT CODE IS THE VERDICT` in `bin/ci-mutation-test.sh` |
+| Measuring a gate's exit status | `bin/check-branch-self-reference.sh 2>&1 \| tail -15` then `$?` reports **tail's** status | A confident "exits 0" | The script exits **127** |
+
+The first four share one property: **green and inert are indistinguishable from outside the run.**
+The fifth is the same mistake applied to the measuring instrument rather than to the thing measured,
+and it is the one that put a wrong number into a script header comment on master before being
+corrected.
+
+## Guidance
+
+**Verify by asserting a COUNT, never by observing that the build went green.** This is the whole
+rule; everything below is it applied to a particular surface. After changing a suppression, assert
+the rule you excluded reports zero. After enabling a check, assert it reports more than zero, or
+name the positive control that proves it can. A green build is compatible with the config having
+been applied, ignored, misspelled, or dropped into a dead profile; a count is not. The two rule
+registries now carry this as a standing instruction under the same heading, `Verify by count, never
+by "the build went green"` - `docs/inflight/static-spotbugs-rule-registry.md` and
+`docs/inflight/static-error-prone-rule-registry.md`.
+
+**For build config, prove the setting reached the run before believing any result from it.** Run
+`./mvnw -Pci help:effective-pom` for the module in question and `grep -c` for the flag, asserting the
+count is greater than zero. This applies to any layered configuration where a plugin can be declared
+more than once: profiles, `pluginManagement`, module-level overrides, or a parent that a child
+silently re-declares. Reading the diff is not the check - the diff of the inert `-Xlint:all` change
+was correct XML in a real `maven-compiler-plugin` block. Only the effective pom distinguishes the
+declaration that runs from the one that does not. This is AGENTS.md's "verify your instrumentation
+actually reached the run", arriving in a pom instead of a log config.
+
+**A control arm must fail for the reason you think it failed. Check *what* went red, not that
+something did.** An arm that exits non-zero is not a control until you have read the error. Two arms
+that both exit 1 for a reason unrelated to your mutation look exactly like a control that could not
+distinguish them, which is what they were. In this reactor the specific trap is that `./mvnw -pl
+<module>` without `-am` fails the enforcer's `ReactorModuleConvergence` rule - already documented in
+`docs/investigating.md` - so a single-module control arm reddens on the enforcer and never reaches
+your check at all. Run the whole reactor for a control arm here.
+
+**Measure exit codes by redirect, never through a pipe.** `cmd 2>&1 | tail` then `$?` gives you
+`tail`'s status. Redirect to a file and read `$?` directly, or read `${PIPESTATUS[0]}`. The root
+`AGENTS.md` already documents this trap for git under worktree ownership; this is the same trap in a
+different costume, and it produced a false "exits 0" for a script that exits 127.
+
+**Two smaller rules the batch also produced.** javac caps output at 100 warnings per compilation and
+says nothing when it truncates, so a visible count can read as the total when it is a tenth of it -
+`-Xmaxwarns` is set to 100000 in the parent pom's `<compilerArgs>` block for exactly this reason.
+And "the tool could not run" must never share an exit code with "the tool ran and the code is clean";
+`bin/ci-mutation-test.sh`, `bin/check-shell-lint.sh` and `bin/lib/node-gate.sh` all reserve `2` for
+the first.
+
+## Why This Matters
+
+A check that goes red when broken gets fixed. A check that goes green when broken is worse than no
+check at all, because it also removes the prompt to add a working one - and here it does something
+further: it manufactures a *positive* claim. Six warnings instead of 172 is not silence, it is a
+report, and a report of six reads as a codebase in good shape. Forty green PIT runs read as forty
+runs of mutation testing. An exclude filter that matches nothing reads as a filter doing its job. In
+each case the wrong belief is more confident than no belief would have been.
+
+The cost compounds because these changes are the ones nobody re-checks. A new engine is enabled once,
+its output is read once, and the number recorded then becomes the baseline everything after is
+compared against. The `-Xlint` inventory would have been recorded as 6, and the next person to widen
+it would have measured their own change against a figure that was wrong by a factor of nearly thirty.
+`docs/inflight/ci-build-hardening-register.md` names the shape in its opening lines - "a check that
+dies or is blind reports the same green as a check that passed" - and this branch found five more
+instances of it in a single pass, which suggests the base rate for new analysis config is high rather
+than exceptional.
+
+It also matters for how *this* repo files things. The `mapfile` case was originally written up as a
+silent pass, which put it in the wrong class: it is the loud, harmless failure that
+`docs/solutions/workflow-issues/gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md` defines its
+subject *against*. Misfiling a loud failure as a silent one inflates the class and teaches the wrong
+lesson about it, so the measurement error mattered twice - once for the number, once for the
+taxonomy.
+
+## When to Apply
+
+- Enabling, upgrading, or reconfiguring any static-analysis engine, compiler flag, or linter.
+- Adding or editing a suppression filter, exclude file, or off-set. A suppression that matches
+  nothing is indistinguishable from one that works.
+- Editing a `pom.xml` where the same plugin appears more than once, or where a profile can supply a
+  competing configuration. Check the effective pom, not the diff.
+- Running a control arm, negative control, or mutation to prove a gate can fail.
+- Reading a green check on the PR that introduced that check. That is the single case where green
+  carries the least information.
+- Any time you are about to write down what a command exited with.
+
+## Examples
+
+**The SpotBugs filter that could never match.** `spotbugs-exclude.xml` originally scoped its
+test-only entries with a `<Source>` path regex. SpotBugs writes `sourcepath` package-relative -
+`bz/stub/parallelconsumer/mutiny/MutinyPCTest.java` - so `src/test` is not in the string being
+matched and the entry could not fire.
+<!-- file-refs: N/A - that package-relative string is the VALUE SpotBugs records, quoted as data to show why the matcher could not fire; it is not a path in this tree --> The XML was valid, the build was green, and the only thing that
+caught it was a sanity check that `PREDICTABLE_RANDOM` had gone to zero. It had not. The file now
+scopes by class name and documents the leak that choice costs, under `SCOPING LIMITATION, MEASURED
+NOT ASSUMED`; excluding those rules globally instead would have dropped the one real main-code
+`PREDICTABLE_RANDOM` finding, which is why the weaker discriminator is the better trade.
+
+**The flag in the dead profile.** The parent `pom.xml` declares `maven-compiler-plugin` twice. The
+first is inside the `intellij-idea-only` profile, activated by the `idea.maven.embedder.version`
+property, which CI never sets. `-Xlint:all` went there. The build was green and reported 6 warnings,
+all of them Lombok and Truth-generator noise rather than lint, which is precisely what a clean
+codebase looks like. `./mvnw -Pci help:effective-pom -pl parallel-consumer-core` piped through
+`grep -c 'Xlint:all'` returned zero. Moved into the real declaration, the same reactor reports 172:
+deprecated `KafkaContainer` (37), unchecked conversion and unchecked calls (50), raw types (23),
+deprecated `Truth8` (10), deprecated `RandomUtils.nextInt` (6). Recorded in
+`docs/inflight/static-spotbugs-rule-registry.md` under "javac's own analysis, and the inert first
+attempt".
+
+**The control arm that proved nothing.** Verifying that `forbidden-apis` was able to fail, both arms
+were run with `-pl parallel-consumer-core` and both exited 1. That reads as a working control: the
+mutated arm failed, and so should it have. Both had actually failed on the enforcer's
+`ReactorModuleConvergence` rule, with **zero** forbidden-method errors on either side, so the
+mutation was not what turned anything red. Re-run over the full reactor, the arms separate: mutated
+exits 1 with one forbidden-method error, reverted exits 0 with none. One term changed, outcome flips.
+The same trap is recorded from Error Prone's side in
+`docs/inflight/static-error-prone-rule-registry.md`, which notes it "has already happened once on
+this branch".
+
+**Forty green runs, zero mutants.** A sweep of the last 40 `maven.yml` `pull_request` runs found the
+`Mutation Tests (PIT, PR-scoped)` check reported success 40 times and scored zero mutants 40 times:
+23 with no core main-source change, 14 with changes outside the decidable package, none that scored a
+mutant. Every skip was individually correct. The defect is that "correct skip", "stale scope that can
+never match again" and "185 mutants killed" were the same green tick, because every path out of the
+script exited 0 - the exact shape `AGENTS.md` warns about under "Confirm the mutation lane scored
+mutants rather than trusting its tick". `bin/ci-mutation-test.sh` now answers in its exit code, the
+scope regex is validated against the classes that exist before it decides anything, and the verdict
+is the generated-mutant count rather than the presence of a statistics block.
+`bin/test-ci-mutation-test.sh` fails every case against the pre-change script.
+Measurements: `docs/inflight/ci-mutation-testing.md`.
+
+**And the self-test did not catch everything, which is worth keeping.** The first cut of the
+full-sweep prefix guard read `TARGET_CLASSES` as one string when it is a comma-separated list, so it
+rejected a target the PR path builds itself, and the lane exited 2 on a run that had scored 27
+mutants minutes earlier. Nothing in the self-test saw it; running the real lane end to end did. A
+guard written against the inert-config class is itself a config change, and gets the same treatment.
+
+**The mismeasured exit code.** `bin/check-branch-self-reference.sh 2>&1 | tail -15` followed by `$?`
+reports tail's status. A `mapfile` failure on macOS bash 3.2 was written into that script's header as
+"the script still exited 0 - a local run reporting success having checked nothing". Measured on
+Darwin 25.5.0 with bash 3.2.57 against the pre-fix version, reading `$?` directly, it exits 127: the
+script sets `set -euo pipefail` well above that line, so the missing builtin takes it down. The
+corrected header names the mismeasurement rather than just the number - grep
+`reports tail's status rather than the script's` - so the next person measuring a gate reaches for a
+redirect.
+
+## Related
+
+Three docs in this directory now describe a green signal that means nothing. They are not
+restatements of each other, and the division is deliberate - **cite the owner rather than repeating
+it**.
+
+- [`a-check-that-reports-success-without-having-run.md`](a-check-that-reports-success-without-having-run.md)
+  owns **the check could not run and said success anyway**: guard design, the third state, external
+  guards. It already carries instance 5 of this doc, the piped `$?`. Its diagnostic question is
+  "what does this check do when it cannot run", and the four config instances here answer
+  "irrelevant - it ran fine". That is the seam between the two.
+- [`negative-results-need-an-instrument-that-could-have-said-yes.md`](negative-results-need-an-instrument-that-could-have-said-yes.md)
+  owns **an investigation's negative came from a mispointed or cached instrument**: positive
+  controls, and preferring instruments that report their denominator.
+- **This doc owns the remaining case**: the setting was applied to the file and never reached the
+  run, so the tool executed correctly against a configuration that was not the one you wrote. There
+  is no error to notice and no step to gate on - only the count.
+
+Adjacent, same genus, different mechanism, and worth reading together rather than merging:
+[`gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md`](gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md)
+(a construct accepted on one platform and meaning something else on another) and
+[`gh-run-view-log-truncation.md`](gh-run-view-log-truncation.md) (a truncated log read as complete
+data, which is this shape applied to the evidence rather than the tool).
+
+`docs/investigating.md` carries the parent rule, **"Verify your instrumentation actually reached the
+run"**, and owns it. What is added here is that the rule extends to build configuration, where the
+"instrumentation" is a plugin declaration and the check is the effective pom rather than the log.

--- a/docs/solutions/workflow-issues/negative-results-need-an-instrument-that-could-have-said-yes.md
+++ b/docs/solutions/workflow-issues/negative-results-need-an-instrument-that-could-have-said-yes.md
@@ -197,3 +197,10 @@ command did**, or it proves something about a different command.
   - includes a tool whose *probe* was the broken thing while it reported this project as the problem.
 - astubbs/parallel-consumer#278 (merged) - the `gh` default-repo write-up in `AGENTS.md`: the one-time
   `set-default`, and the habits that survive it being local and uncommitted.
+
+## Related
+
+[`an-inert-analysis-config-reads-as-a-clean-codebase.md`](an-inert-analysis-config-reads-as-a-clean-codebase.md) is the build-configuration case of the same family: the instrument was pointed
+correctly and ran, but the configuration under test was not the one written, so the negative was real
+and about the wrong thing. Its remedy is the count assertion this doc calls reporting a denominator,
+applied to an effective pom.

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md
@@ -1,0 +1,48 @@
+# Editing core main code: the concurrency rules that bind here
+
+This is the engine. Two threads run through most of what follows - the **broker-poll thread** and the
+**controller thread** - and the defects this project has spent the most time on are all the same
+shape: state shared between them without a happens-before edge. What is below binds whenever you
+change a field in this tree. Everything else about the project is in the repo-root `AGENTS.md`.
+
+## Annotate a race with `@GuardedBy` in the same change that fixes it
+
+**The build already enforces `@GuardedBy` and currently checks nothing**, because this codebase does
+not contain a single one. Error Prone's `GuardedBy` check runs at ERROR: give it
+`@GuardedBy("theLock")` on a field and every access outside that lock becomes a compile error.
+
+That matters because every detector here is **discovery, not prevention**:
+
+- RacerD infers which locks protect which state and finds races nobody annotated - and it cannot stop
+  a fixed race coming back.
+- SpotBugs' `AT_*` family finds non-atomic access to shared fields, same limitation.
+- The racing-double seam tests only re-prove seams somebody already found by hand.
+
+So the annotation is the only thing that makes a fix permanent. **Write it with the fix**, not as a
+follow-up: a locking decision is obvious while you are making it and archaeology a month later. The
+check goes from inert to load-bearing one annotation at a time, and no separate project is needed.
+
+If the right fix is `volatile` or removing the sharing outright, there is no lock to name and no
+annotation to write. That is fine - the rule is "record the invariant you just established", not
+"add an annotation".
+
+## Known shared state, and where its ledger lives
+
+Do not re-derive these; they are measured and recorded.
+
+- **13 RacerD findings** across `state` (7), `metrics` (4) and `internal` (2) -
+  `docs/inflight/static-racerd-findings.md`. The CI ceiling is a number in `maven.yml`: fix one and
+  **lower `RACERD_MAX_FINDINGS`**, or the lane fails telling you to.
+- **The non-volatile offenders** `lastWorkRequestWasFulfilled`, `ConsumerManager.commitRequested`,
+  `RetryQueue.closed`, and `AbstractParallelEoSStreamProcessor.lastCommitTime` -
+  `docs/refactoring.md`.
+- **The torn-read family** - check-then-act and two-read divergence, which are a *different* class
+  from unguarded access and are not what `@GuardedBy` addresses.
+
+## `ShardManager.processingShards` is pinned by a test, on purpose
+
+`ShardMapIsNeverReplacedArchTest` forbids assigning that field outside its constructor, and forbids
+production callers of its package-private setter. The map is shared unlocked across both threads, so
+replacing the *reference* is worse than a torn read of its contents: a reader holding the old
+reference accounts work against a map nothing will ever drain. If you need to change that, change the
+rule deliberately and say why - do not add an exclusion.

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/CLAUDE.md
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+Bridge only. Claude Code lazy-loads a nested `CLAUDE.md` when it reads or writes a file in that
+directory, and does not load `AGENTS.md` at all - so this arrives with the concurrency rules while
+you are editing the engine, rather than after a detector catches you.
+
+@AGENTS.md

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -318,13 +318,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         this.dynamicExtraLoadFactor = module.dynamicExtraLoadFactor();
 
         workerThreadPool = SupplierUtils.memoize(() -> requireRejectionIsVisible(setupWorkerPool(newOptions.getMaxConcurrency())));
-        // Resolved here, not left to the first dispatch. The supplier is memoized and therefore lazy, but
-        // #requireRejectionIsVisible is a precondition on a subclass's #setupWorkerPool, and a precondition that only
-        // fires when the first batch is submitted is one a subclass can ship without ever meeting. Construction built
-        // the pool anyway - #initMetrics binds meters to it a few lines below - so this changes no startup behaviour,
-        // it only stops the precondition's timing from depending on that, and moves the failure ahead of the poller
-        // and producer manager, so nothing half built has to be unwound.
-        workerThreadPool.get();
+        forceWorkerPoolConstruction();
 
         this.wm = module.workManager();
 
@@ -371,17 +365,36 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         }
     }
 
-    protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
-        ThreadFactory defaultFactory;
+    /**
+     * Looks up a container-managed resource by JNDI name, falling back to the Java SE equivalent when there is no
+     * container to ask.
+     * <p>
+     * This method exists to be the smallest possible thing carrying {@code @SuppressWarnings("BanJNDI")}. The
+     * suppression used to sit on the callers, one of which is a fifty-line method - so a JNDI lookup added anywhere
+     * in that body later would have been waved through by a suppression written for an unrelated line. A suppression
+     * is a claim about one call, and its scope should say so.
+     */
+    // BanJNDI: the lookup name is this library's own managedThreadFactory / managedExecutorService option, set by
+    // the embedding application, and the whole point is to use the container's executor when running inside one.
+    // Suppressed here rather than demoted globally, so a new JNDI lookup anywhere else still fails the build.
+    // docs/inflight/static-error-prone-rule-registry.md carries the reasoning and the re-enable trigger.
+    @SuppressWarnings("BanJNDI")
+    private static <T> T lookupManagedResource(String jndiName, Supplier<T> javaSeFallback) {
         try {
-            defaultFactory = InitialContext.doLookup(options.getManagedThreadFactory());
+            return InitialContext.doLookup(jndiName);
         } catch (NamingException e) {
             log.debug("Using Java SE Thread", e);
-            defaultFactory = Executors.defaultThreadFactory();
+            return javaSeFallback.get();
         }
-        ThreadFactory finalDefaultFactory = defaultFactory;
+    }
+
+    protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+        // Was a non-final local plus a `finalDefaultFactory` copy, because a try/catch cannot assign to a final.
+        // The lookup returning a value rather than assigning one removes the need for both.
+        final ThreadFactory defaultFactory =
+                lookupManagedResource(options.getManagedThreadFactory(), Executors::defaultThreadFactory);
         ThreadFactory namingThreadFactory = r -> {
-            Thread thread = finalDefaultFactory.newThread(r);
+            Thread thread = defaultFactory.newThread(r);
             String name = thread.getName();
             thread.setName("pc-" + name);
             this.getMyId().ifPresent(id -> thread.setName("pc-" + name + "-" + id));
@@ -436,6 +449,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      *         substitute something else
      * @throws IllegalArgumentException if the pool would swallow a rejection
      */
+
     private ThreadPoolExecutor requireRejectionIsVisible(ThreadPoolExecutor pool) {
         RejectedExecutionHandler handler = pool.getRejectedExecutionHandler();
         if (!(handler instanceof ThreadPoolExecutor.AbortPolicy)) {
@@ -457,6 +471,24 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                     ThreadPoolExecutor.CallerRunsPolicy.class.getSimpleName()));
         }
         return pool;
+    }
+
+    /**
+     * Forces the memoized {@link #workerThreadPool} supplier at construction rather than leaving it to the first
+     * dispatch. {@link #requireRejectionIsVisible} is a precondition on a subclass's {@link #setupWorkerPool}, and a
+     * precondition that only fires when the first batch is submitted is one a subclass can ship without ever meeting.
+     * Construction built the pool anyway - {@code initMetrics} binds meters to it - so this changes no startup
+     * behaviour. It only stops the precondition's timing from depending on that, and moves the failure ahead of the
+     * poller and producer manager, so nothing half built has to be unwound.
+     * <p>
+     * The pool is discarded on purpose: the supplier keeps it and every later reader goes through
+     * {@link #workerThreadPool}. Extracted into its own method so the suppression covers exactly this one call - a
+     * named local would satisfy Error Prone and then trip SpotBugs' {@code DLS_DEAD_LOCAL_STORE} instead, which is
+     * trading one finding for another rather than saying what is meant.
+     */
+    @SuppressWarnings("ReturnValueIgnored")
+    private void forceWorkerPoolConstruction() {
+        workerThreadPool.get();
     }
 
     private void checkNotSubscribed(org.apache.kafka.clients.consumer.Consumer<K, V> consumerToCheck) {
@@ -913,13 +945,8 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         // broker poll subsystem
         brokerPollSubsystem.start(options.getManagedExecutorService());
 
-        ExecutorService executorService;
-        try {
-            executorService = InitialContext.doLookup(options.getManagedExecutorService());
-        } catch (NamingException e) {
-            log.debug("Using Java SE Thread", e);
-            executorService = Executors.newSingleThreadExecutor();
-        }
+        ExecutorService executorService =
+                lookupManagedResource(options.getManagedExecutorService(), Executors::newSingleThreadExecutor);
 
 
         // run main pool loop in thread

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/BrokerPollSystem.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/BrokerPollSystem.java
@@ -108,14 +108,28 @@ public class BrokerPollSystem<K, V> implements OffsetCommitter {
                 this.consumerManager, ConsumerManager::getPausedPartitionSize);
     }
 
-    public void start(String managedExecutorService) {
-        ExecutorService executorService;
+    /**
+     * Looks up the container-managed executor by JNDI name, falling back to a Java SE single-thread executor when
+     * there is no container to ask.
+     * <p>
+     * Split out so the {@code BanJNDI} suppression covers the lookup and nothing else. It is deliberately not shared
+     * with the near-identical lookup in {@link AbstractParallelEoSStreamProcessor}: the two log different messages
+     * under different logger names, and that text is what an operator greps for when a container executor was not
+     * picked up.
+     */
+    // BanJNDI: same managed-executor lookup as AbstractParallelEoSStreamProcessor#setupWorkerPool, same reasoning.
+    @SuppressWarnings("BanJNDI")
+    private static ExecutorService lookupManagedExecutor(String managedExecutorService) {
         try {
-            executorService = InitialContext.doLookup(managedExecutorService);
+            return InitialContext.doLookup(managedExecutorService);
         } catch (NamingException e) {
             log.debug("Couldn't look up an execution service, falling back to Java SE Thread", e);
-            executorService = Executors.newSingleThreadExecutor();
+            return Executors.newSingleThreadExecutor();
         }
+    }
+
+    public void start(String managedExecutorService) {
+        ExecutorService executorService = lookupManagedExecutor(managedExecutorService);
         Future<Boolean> submit = executorService.submit(this::controlLoop);
         this.pollControlThreadFuture = Optional.of(submit);
     }

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/metrics/PCMetricsDef.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/metrics/PCMetricsDef.java
@@ -12,6 +12,7 @@ import io.micrometer.core.instrument.Tags;
 import lombok.Getter;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static bz.stub.parallelconsumer.metrics.PCMetricsDef.MeterType.*;
@@ -116,13 +117,13 @@ public enum PCMetricsDef {
     }
 
     private static String toCamelCase(String s) {
-        return Arrays.stream(s.replace("_", " ").split(" ")).map(string -> string.substring(0, 1).toUpperCase() + string.substring(1).toLowerCase()).collect(Collectors.joining(" "));
+        return Arrays.stream(s.replace('_', ' ').split(" ")).map(string -> string.substring(0, 1).toUpperCase(Locale.ROOT) + string.substring(1).toLowerCase(Locale.ROOT)).collect(Collectors.joining(" "));
     }
 
     private static String formatMetricDef(PCMetricsDef metricsDef) {
         StringBuilder sb = new StringBuilder();
-        sb.append(String.format("**%s**%n%n", toCamelCase(metricsDef.name())));
-        sb.append(String.format("%s `%s%s`%n%n", toCamelCase(metricsDef.type.name()), metricsDef.name, formatTagsAndSubsystem(metricsDef)));
+        sb.append(String.format(Locale.ROOT, "**%s**%n%n", toCamelCase(metricsDef.name())));
+        sb.append(String.format(Locale.ROOT, "%s `%s%s`%n%n", toCamelCase(metricsDef.type.name()), metricsDef.name, formatTagsAndSubsystem(metricsDef)));
         sb.append(metricsDef.description);
         sb.append("\n\n");
         return sb.toString();
@@ -131,7 +132,7 @@ public enum PCMetricsDef {
     private static String formatTagsAndSubsystem(PCMetricsDef metricsDef) {
         String res = "";
         if (metricsDef.subsystem != null) {
-            res += String.format("%s=%s", metricsDef.subsystem.getKey(), metricsDef.subsystem.getValue());
+            res += String.format(Locale.ROOT, "%s=%s", metricsDef.subsystem.getKey(), metricsDef.subsystem.getValue());
         }
         if (metricsDef.tags != null && metricsDef.tags.length > 0) {
             if (res.length() > 0) {
@@ -161,7 +162,7 @@ public enum PCMetricsDef {
     }
 
     private static String formatSubsystem(PCMetricsSubsystem sub) {
-        return String.format("==== %s%n%n", toCamelCase(sub.name()));
+        return String.format(Locale.ROOT, "==== %s%n%n", toCamelCase(sub.name()));
     }
 
     private static String joinTagsForRendering(ParallelConsumer.Tuple<String, String>[] tags) {

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/LincheckToolchainProbeTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/LincheckToolchainProbeTest.java
@@ -24,7 +24,14 @@ import static com.google.common.truth.Truth.assertThat;
  * <p>
  * The shape is deliberately the same textbook probe SpotBugs was given in the torn-read dossier and reported
  * NOTHING on, at {@code effort=Max, threshold=Medium}, including from its nominally-relevant
- * {@code AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION} detector: a {@code containsKey} followed by a
+ * {@code AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION} detector. <b>That held for SpotBugs' STOCK
+ * detectors and no longer holds generally:</b> with fb-contrib added, {@code MUI_CONTAINSKEY_BEFORE_GET}
+ * names this very probe in seconds, and names the real {@code ShardManager} seam too. The probe is still
+ * the right red control for <em>Lincheck</em> - a static detector cannot exhibit an interleaving, and the
+ * two torn-read value-divergence cases remain outside what any check-then-act detector looks at - but
+ * "no static analysis can see this" is now "no stock detector could". The finding on this class is
+ * suppressed by name in {@code config/spotbugs-exclude.xml}, because the tear here is deliberate.
+ * The shape: a {@code containsKey} followed by a
  * {@code get} on a {@code ConcurrentHashMap}, with the result dereferenced unconditionally. That is
  * {@code ShardManager.removeWorkFromShardFor}'s bug reduced to nine lines and nothing else. If Lincheck cannot
  * see it here, no result it gives on the real classes means anything.

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/ShardMapIsNeverReplacedArchTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/ShardMapIsNeverReplacedArchTest.java
@@ -1,0 +1,106 @@
+package bz.stub.parallelconsumer.state;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * The {@code processingShards} map reference in {@link ShardManager} is installed once, at construction, and is
+ * never replaced while the consumer is running.
+ * <p>
+ * The class javadoc says the map is shared between the broker-poll thread (which adds and removes shards) and the
+ * controller thread (which reads how much work is queued). Swapping the reference underneath them is strictly worse
+ * than any torn read of its contents: a reader that already loaded the old reference keeps operating on a map the
+ * writer has abandoned, so work is silently accounted against a map nothing will ever drain. Neither side takes a
+ * lock, because the map is a {@link java.util.concurrent.ConcurrentHashMap} and identity was never expected to move.
+ * <p>
+ * Two doors lead to a replacement, and each rule below shuts one:
+ * <ul>
+ *     <li>the Lombok {@code @Setter(AccessLevel.PACKAGE)}, which exists so {@code ShardManagerTest} can install a
+ *     pre-populated map and has no other caller anywhere;</li>
+ *     <li>a direct assignment inside {@link ShardManager} itself, which would bypass the setter and therefore the
+ *     first rule.</li>
+ * </ul>
+ * Until now both were held by nothing but the reviewer noticing. Package-private plus a {@code // visible for
+ * testing} comment does not fail a build, and the neighbouring {@link RetryQueue} carries three accessors annotated
+ * exactly that way - plus a fourth on {@link ShardManager} itself - that no test anywhere calls, so the annotation
+ * is not evidence of a boundary anybody is holding.
+ * <p>
+ * Tests may replace the map, which is the setter's whole purpose, so this analyses main classes only.
+ * <p>
+ * If a rule here fails, do not delete it and do not add the new caller to an allowlist: give {@link ShardManager} a
+ * method that mutates the existing map, or - if the reference genuinely must move - work out what the poll thread
+ * and the controller thread are each holding at that moment first.
+ * <p>
+ * Scope, stated because a wider rule was considered and rejected: this does NOT police keyed reads of the map.
+ * Only one main-code access to the field is {@code getShard}; nearly all the rest are bulk operations over
+ * {@code values()}, {@code keySet()}, {@code size()} or the whole map, which {@code getShard(key)} cannot express,
+ * and the keyed ones that remain include both writes. A rule requiring the accessor is therefore red on arrival and
+ * could only be greened with an allowlist of the methods already there - a frozen baseline, which
+ * docs/inflight/static-archunit-main-code-rules.md rules out. The check-then-get seam that motivated the idiom is
+ * machine-checked instead by fb-contrib's {@code MUI_CONTAINSKEY_BEFORE_GET}; ArchUnit sees field accesses, not what
+ * is invoked on the value they load, so it could never have seen that seam.
+ */
+@AnalyzeClasses(packages = "bz.stub.parallelconsumer", importOptions = ImportOption.DoNotIncludeTests.class)
+class ShardMapIsNeverReplacedArchTest {
+
+    private static final String SHARD_MAP_FIELD = "processingShards";
+
+    private static final String SHARD_MAP_SETTER = "setProcessingShards";
+
+    @ArchTest
+    static final ArchRule shard_map_setter_has_no_production_callers =
+            noClasses()
+                    .should().callMethod(ShardManager.class, SHARD_MAP_SETTER, Map.class)
+                    .because("the shard map is shared, unlocked, between the broker-poll thread and the controller "
+                            + "thread, so replacing the reference strands whichever of them already loaded the old "
+                            + "one - the setter exists only so a test can install a pre-populated map");
+
+    @ArchTest
+    static final ArchRule shard_map_field_is_assigned_only_at_construction =
+            noClasses()
+                    .should().setFieldWhere(assignsTheShardMapAfterConstruction())
+                    .because("an assignment inside ShardManager would replace the shared map without going through "
+                            + "the setter, so it would bypass the rule above as well as every reader holding the "
+                            + "previous reference");
+
+    private static DescribedPredicate<JavaFieldAccess> assignsTheShardMapAfterConstruction() {
+        return DescribedPredicate.describe(
+                "assigns ShardManager." + SHARD_MAP_FIELD + " outside its constructor and its package-private setter",
+                access -> access.getTargetOwner().isEquivalentTo(ShardManager.class)
+                        && SHARD_MAP_FIELD.equals(access.getTarget().getName())
+                        && !access.getOrigin().isConstructor()
+                        && !SHARD_MAP_SETTER.equals(access.getOrigin().getName()));
+    }
+
+    /**
+     * Both rules name their target as a string, and ArchUnit does not check that the target exists: rename the field
+     * or drop the Lombok setter and each rule matches nothing, passes, and has asserted nothing. That is the silent
+     * false-green this repo keeps finding, so pin the names the rules depend on.
+     * <p>
+     * The setter is Lombok-generated, which is exactly why it needs pinning - removing one annotation deletes it,
+     * and no compile error anywhere says so.
+     */
+    @Test
+    void theSetterTheRulesNameStillExists() throws NoSuchMethodException {
+        assertThat(ShardManager.class.getDeclaredMethod(SHARD_MAP_SETTER, Map.class)).isNotNull();
+    }
+
+    @Test
+    void theFieldTheRulesNameStillExists() throws NoSuchFieldException {
+        assertThat(ShardManager.class.getDeclaredField(SHARD_MAP_FIELD)).isNotNull();
+    }
+}

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/src/main/java/bz/stub/parallelconsumer/examples/metrics/CoreApp.java
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/src/main/java/bz/stub/parallelconsumer/examples/metrics/CoreApp.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
@@ -84,10 +85,13 @@ public class CoreApp {
         try {
             final var server = HttpServer.create(new InetSocketAddress(7001), 0);
             server.createContext(METRICS_ENDPOINT, httpExchange -> {
-                String response = meterRegistry.scrape();
-                httpExchange.sendResponseHeaders(200, response.getBytes().length);
+                // Encoded ONCE, explicitly. It was `response.getBytes()` twice - the platform
+                // default charset, and two separate encodings for the Content-Length and the body,
+                // which can disagree the moment a metric tag is not ASCII. Prometheus expects UTF-8.
+                byte[] body = meterRegistry.scrape().getBytes(StandardCharsets.UTF_8);
+                httpExchange.sendResponseHeaders(200, body.length);
                 try (OutputStream os = httpExchange.getResponseBody()) {
-                    os.write(response.getBytes());
+                    os.write(body);
                 }
             });
             metricsEndpointExecutor.submit(server::start);

--- a/parallel-consumer-reactor/src/test/java/bz/stub/parallelconsumer/reactor/ReactorTest.java
+++ b/parallel-consumer-reactor/src/test/java/bz/stub/parallelconsumer/reactor/ReactorTest.java
@@ -12,9 +12,29 @@ import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
+/**
+ * Library scratchpads for Reactor's two scheduling operators. They assert nothing, which
+ * {@code docs/test-hardening/inactive-tests-audit-2026-08-08.md} looked at and judged defensible for
+ * this pair; that remains that document's call to revisit, not this one's.
+ * <p>
+ * What was NOT defensible was {@code new Thread(...).run()}, which invokes the body on the calling
+ * thread and never starts the thread at all - so the one thing these were demonstrating, the
+ * subscription happening off the test thread, was not happening. Error Prone's {@code DoNotCall} and
+ * fb-contrib's {@code RU_INVOKE_RUN} both report it. Now started and joined, so the subscribe call
+ * really is made off the test thread.
+ * <p>
+ * <b>The join does NOT wait for the flux.</b> {@code publishOn} and {@code subscribeOn} hand the work
+ * to a {@link reactor.core.scheduler.Scheduler}, so joining the subscribing thread waits only for the
+ * subscribe call to be issued - measured against the pinned reactor-core, nothing has been emitted
+ * when {@code join()} returns, and the two values arrive on a scheduler thread some time later. An
+ * earlier version of this comment claimed completion before the method returns; it was wrong, and a
+ * reviewer disproved it by measurement rather than by reading. Anything added here that needs the
+ * values must await them, not assume the join did.
+ */
 @Slf4j
 class ReactorTest {
 
+    @SneakyThrows
     @Test
     void publishOn(){
         Scheduler s = Schedulers.newParallel("parallel-scheduler", 4);
@@ -25,7 +45,9 @@ class ReactorTest {
                 .publishOn(s)
                 .map(i -> "value " + i);
 
-        new Thread(() -> flux.subscribe(System.out::println)).run();
+        Thread subscriber = new Thread(() -> flux.subscribe(System.out::println));
+        subscriber.start();
+        subscriber.join();
     }
 
 
@@ -40,7 +62,9 @@ class ReactorTest {
                 .subscribeOn(s)
                 .map(i -> "value " + i);
 
-        new Thread(() -> flux.subscribe(System.out::println)).run();
+        Thread subscriber = new Thread(() -> flux.subscribe(System.out::println));
+        subscriber.start();
+        subscriber.join();
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,10 @@
         <auto-service.version>1.1.1</auto-service.version>
         <surefire.version>3.5.6</surefire.version>
         <spotbugs.version>4.10.3</spotbugs.version>
+        <forbiddenapis.version>3.10</forbiddenapis.version>
+        <fb-contrib.version>7.7.4</fb-contrib.version>
+        <findsecbugs.version>1.14.0</findsecbugs.version>
+        <findbugs-slf4j.version>1.5.0</findbugs-slf4j.version>
         <spotbugs-maven-plugin.version>4.10.3.0</spotbugs-maven-plugin.version>
         <pitest.version>1.25.8</pitest.version>
         <pitest-junit5.version>1.2.3</pitest-junit5.version>
@@ -161,6 +165,15 @@
         <byte-buddy.version>1.17.7</byte-buddy.version>
         <truth-generator-maven-plugin.version>0.1.1</truth-generator-maven-plugin.version>
         <jabel.version>1.0.0</jabel.version>
+        <!-- PINNED BELOW CURRENT, and the pin is temporary. 2.43.0 is the first Error Prone
+             release compiled to class file version 65 (Java 21); JDK 17, which this build
+             requires, reads to 61 and cannot load the plugin class at all. Raising the
+             toolchain is not the escape: Jabel's bundled Byte Buddy refuses class file 65, so
+             no JDK satisfies both. 2.42.0 is the last release on the near side of that line.
+             The pin lifts when Jabel goes, which is tracked with the release 8 target it
+             exists to serve - see docs/inflight/static-error-prone-rule-registry.md. -->
+        <error-prone.version>2.42.0</error-prone.version>
+        <nullaway.version>0.12.7</nullaway.version>
         <netty.version>4.1.137.Final</netty.version>
         <logback.version>1.6.1</logback.version>
         <!-- Held at 1.13.0: keep the micrometer family version-aligned with
@@ -356,6 +369,19 @@
             <groupId>pl.tlinkowski.unij</groupId>
             <artifactId>pl.tlinkowski.unij.api</artifactId>
             <version>${version.unij}</version>
+            <exclusions>
+                <!-- unij 0.1.3 pulls slf4j-api 1.7.28 transitively, against the 2.0.18 declared
+                     directly above. Maven's nearest-wins already resolved to 2.0.18, so nothing was
+                     broken - but a silent version split is precisely the shape that made wiremock's
+                     ASM 9.4 pin kill Lincheck's transformer while it reported success. Excluded
+                     rather than managed, because the API is declared here directly and there is no
+                     second opinion to reconcile. Found by dependencyConvergence on the run that
+                     added it; it was the rule's first act. -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>pl.tlinkowski.unij</groupId>
@@ -891,6 +917,67 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
+                    <!-- javac's own analysis, which was entirely switched off: there was no
+                         <compilerArgs> block in this build at all. NOT -Werror yet - Jabel, Lombok
+                         and the release 8 target produce a first-run pile, and mutiny's 17
+                         override means the two source levels disagree about what is worth warning
+                         about. Promoting to -Werror is a second step once the inventory is at zero;
+                         until then this is a channel somebody has to actually read.
+                         -processing: the annotation processors here (Lombok, Jabel, the Truth
+                         generator) are deliberate, and their warnings drown everything else. -->
+                    <compilerArgs combine.children="append">
+                        <arg>-Xlint:all</arg>
+                        <arg>-Xlint:-processing</arg>
+                        <!-- javac caps output at 100 warnings per compilation and says nothing when it
+                             truncates. With -Xlint:all and Error Prone both feeding this stream, the cap
+                             hides most of the report and the visible count reads as the total: the same
+                             reactor reported roughly a tenth of its real haul before this was lifted.
+                             A static-analysis channel that silently truncates is worse than none. -->
+                        <arg>-Xmaxwarns</arg>
+                        <arg>100000</arg>
+                        <!-- Error Prone is a javac PLUGIN, not an annotation processor, so it is switched
+                             on with -Xplugin and is unaffected by the explicit <annotationProcessors> list
+                             below. It still has to be on the processor PATH, which is why the two
+                             coordinates are added there - and note that merely putting it there arms it:
+                             javac loads every com.sun.source.util.Plugin provider on the processor path
+                             before consulting which plugin was requested, so there is no way to stage the
+                             dependency ahead of enabling it.
+                             -XDcompilePolicy and should-stop are Error Prone's own requirements; without
+                             them javac runs the plugin against a half attributed AST. -->
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>--should-stop=ifError=FLOW</arg>
+                        <!-- The off set. Every entry has a reason and a re-enable trigger in
+                             docs/inflight/static-error-prone-rule-registry.md, and the set only ever
+                             shrinks; a check that is off and not in that file is a bug in this setup.
+                             They are off because they arrive in bulk, and bulk on arrival is what makes
+                             a new engine get ignored. NullAway is the deliberate exception and stays on
+                             despite its volume, because nullness is the class this codebase's tracked
+                             defects actually live in. AnnotatedPackages is load bearing, not tuning:
+                             with neither it nor OnlyNullMarked, NullAway does not fall silent, it
+                             crashes the compiler while constructing the checker. -->
+                        <!-- Generated sources are excluded by PATH, not by trusting the @Generated
+                             annotation: the Truth generator's output alone contributed 44 findings,
+                             all in files rewritten on every build, so nobody can act on one and the
+                             count moves when a clean run regenerates them. Verified by counting
+                             findings under target/generated to zero, not by the build going green. -->
+                        <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-[^/]*/.* -XepOpt:NullAway:AnnotatedPackages=bz.stub -Xep:UnnecessaryParentheses:OFF -Xep:InvalidInlineTag:OFF -Xep:MissingSummary:OFF -Xep:EmptyBlockTag:OFF -Xep:InvalidParam:OFF -Xep:InvalidBlockTag:OFF -Xep:UnrecognisedJavadocTag:OFF -Xep:InvalidLink:OFF -Xep:AlmostJavadoc:OFF -Xep:NotJavadoc:OFF -Xep:UnusedMethod:OFF -Xep:UnusedVariable:OFF -Xep:BadImport:OFF -Xep:CanonicalDuration:OFF -Xep:JavaDurationGetSecondsToToSeconds:OFF</arg>
+                        <!-- javac's internals are not exported on JDK 17 and Error Prone reads them.
+                             These have to reach the COMPILER's JVM, not Maven's, which is what -J does and
+                             what <fork> below is for. Omit them and the plugin dies with an
+                             IllegalAccessError on BasicJavacTask rather than anything self explanatory. -->
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                    <!-- Required by the -J args above; they configure the compiler's JVM. -->
+                    <fork>true</fork>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>com.google.auto.service</groupId>
@@ -908,6 +995,19 @@
                             <artifactId>jabel-javac-plugin</artifactId>
                             <version>${jabel.version}</version>
                         </path>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>${error-prone.version}</version>
+                        </path>
+                        <!-- NullAway rides on Error Prone and is version coupled to it: 0.12.7 dies on
+                             2.43.0 and later with a NoClassDefFoundError, because it takes Error Prone as
+                             compileOnly and no dependency declares the constraint. Move both together. -->
+                        <path>
+                            <groupId>com.uber.nullaway</groupId>
+                            <artifactId>nullaway</artifactId>
+                            <version>${nullaway.version}</version>
+                        </path>
                     </annotationProcessorPaths>
                     <!-- enable language preview features -->
                     <source>${source.version}</source>
@@ -918,6 +1018,44 @@
                         </annotationProcessor>
                     </annotationProcessors>
                 </configuration>
+                <executions>
+                    <!-- RAWTYPES IS OFF FOR TEST COMPILATION ONLY, and the reason is signal-to-noise
+                         measured rather than taste. `-Xlint:all` over core plus parent reports 843
+                         deduplicated warnings; 559 of them come from
+                         target/generated-test-sources/truth-assertions-managed, the Truth assertion
+                         generator's own output, and 535 of those are `rawtypes` on generated `List`
+                         parameters. Two thirds of the channel is therefore code nobody wrote, cannot
+                         edit, and will regenerate identically next build.
+
+                         That matters because the whole justification for turning this on was that it
+                         be read. The registry's own bar - "a warning channel nobody reads is
+                         decoration" - is not met at 66% generated noise, and the count is what makes
+                         the inventory meaningless: 843 with generated sources, 284 without.
+
+                         javac cannot scope a warning by path, so the scope available is the
+                         compilation unit. Main compilation keeps EVERY category, which is where the
+                         signal is - 58 warnings, our own deprecated API and our own generics. Test
+                         compilation drops `rawtypes` alone, which costs 42 real warnings in test code
+                         and removes 535 generated ones. Every other category stays on everywhere, so
+                         unchecked, deprecation and serial are unaffected in tests.
+
+                         This is the same trade already made one block above with `-Xlint:-processing`,
+                         for the same reason and by the same measurement.
+
+                         Appending works because javac applies -Xlint left to right: the plugin-level
+                         `-Xlint:all` is narrowed by this `-Xlint:-rawtypes`, not replaced by it. -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <arg>-Xlint:-rawtypes</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -1009,6 +1147,36 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Register item 6. Bans JVM-default-dependent API in MAIN code: the default charset, locale
+                 and timezone, whose results differ between a developer's machine and a user's JVM. This is
+                 the same class SpotBugs reaches from the other direction with DM_DEFAULT_ENCODING and
+                 MDM_STRING_BYTES_ENCODING, and for a LIBRARY it matters more than for an application: the
+                 JVM belongs to the caller.
+                 Bound to `check` only, not `testCheck`. Test code is a separate decision with its own haul,
+                 the same way the SpotBugs rule registry treats it.
+                 NOT YET banning parallelStream(): three main-code sites exist today, and the reason to
+                 remove them is real but is a behaviour change in a hot path. See
+                 docs/inflight/static-forbidden-apis-parallelstream.md, which carries the signature line
+                 ready to paste. A rule that fails on arrival needs the code fixed or the rule narrowed,
+                 never a suppression. -->
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <version>${forbiddenapis.version}</version>
+                <configuration>
+                    <targetVersion>${release.target}</targetVersion>
+                    <bundledSignatures>
+                        <bundledSignature>jdk-unsafe</bundledSignature>
+                    </bundledSignatures>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
@@ -1017,6 +1185,38 @@
                     <effort>Max</effort>
                     <threshold>Medium</threshold>
                     <xmlOutput>true</xmlOutput>
+                    <!-- Test code is main code for a concurrency library: the harnesses, the chaos
+                         suite and the Lincheck lane are where the trickiest threading lives, and
+                         until now none of it was analysed - includeTests defaults to false, and the
+                         CI goal ran `compile` rather than `test-compile`, so target/test-classes did
+                         not even exist. Which rules this switches OFF, and what turns each back on,
+                         is docs/inflight/static-spotbugs-rule-registry.md. -->
+                    <includeTests>true</includeTests>
+                    <!-- Suppression is BY RULE, in a file you can read in a diff - never the
+                         auto-generated baseline this replaces, which regenerated on every push and
+                         recorded nothing about what it swallowed. Same reasoning that refuses
+                         FreezingArchRule in docs/inflight/static-archunit-main-code-rules.md. -->
+                    <excludeFilterFile>${maven.multiModuleProjectDirectory}/config/spotbugs-exclude.xml</excludeFilterFile>
+                    <plugins>
+                        <!-- fb-contrib earns its place on measurement, not reputation: its
+                             MUI_CONTAINSKEY_BEFORE_GET names ShardManager.removeWorkFromShardFor,
+                             which is astubbs#345's check-then-get seam, with no harness. -->
+                        <plugin>
+                            <groupId>com.mebigfatguy.fb-contrib</groupId>
+                            <artifactId>fb-contrib</artifactId>
+                            <version>${fb-contrib.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>${findsecbugs.version}</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>jp.skypencil.findbugs.slf4j</groupId>
+                            <artifactId>bug-pattern</artifactId>
+                            <version>${findbugs-slf4j.version}</version>
+                        </plugin>
+                    </plugins>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -1112,6 +1312,22 @@
                                     </excludes>
                                 </bannedDependencies>
                                 <reactorModuleConvergence />
+                                <!-- Register item 5. wiremock-jre8 pinning ASM 9.4 made Lincheck's
+                                     transformer die per-class WHILE REPORTING SUCCESS - a false PASS
+                                     on every calibration verdict, caught only by a deliberately
+                                     broken control probe. This is the rule that catches THAT case:
+                                     it fires when resolution settles on a version LOWER than
+                                     something in the graph asks for, which is the shape that breaks
+                                     things silently.
+                                     Its stricter sibling, dependencyConvergence, is deliberately NOT
+                                     here. It was switched on, it immediately found a real split
+                                     (unij dragging slf4j-api 1.7.28 against the 2.0.18 declared
+                                     directly, now excluded above), and behind that sit three more in
+                                     Kafka's transitive tree. Those are tracked in
+                                     docs/inflight/deps-convergence-tail.md rather than blocking this
+                                     change, because divergence where the HIGHER version wins is
+                                     untidy, not dangerous. -->
+                                <requireUpperBoundDeps />
                                 <banDuplicatePomDependencyVersions />
                                 <requireSameVersions />
                                 <!-- Catches the "version declared only inside a profile, consumed from a child


### PR DESCRIPTION
Serves no single issue. Turns on the static analysis this repo was not running, records every rule
it switches off so they can be turned back on deliberately, and - by the end - fixes the analysis
lanes' own habit of reporting success without having measured anything.

depends on astubbs/parallel-consumer#347
depends on astubbs/parallel-consumer#348

Those land first by request, and there is a substantive reason too: this PR analyses **test code**
for the first time, and astubbs/parallel-consumer#347 adds the Lincheck harnesses. The rule registry
should be built against a tree that contains them.

## What lands

| Engine | State before | State now |
|---|---|---|
| SpotBugs | one module of five, main code only, stock detectors, invisible auto-baseline | whole reactor, main **and test** code, fb-contrib + find-sec-bugs + findbugs-slf4j, checked-in rule filter, findings printed to the build log |
| Error Prone + NullAway | absent | `error_prone_core` 2.42.0 + NullAway 0.12.7, pinned below the JDK 17 line, with a rule registry |
| javac `-Xlint` | no `<compilerArgs>` block existed at all | `-Xlint:all`, no `-Werror`, `rawtypes` off for test compilation only |
| PIT mutation | a lane that had scored zero mutants on 40 consecutive runs | revived, and its verdict now counts mutants **evaluated** rather than generated |
| RacerD | never ran | `static: racerd` on `ubuntu-latest`, digest-pinned toolchain, gated on an identity ratchet |
| ArchUnit | - | shard-map replacement rules |
| `forbidden-apis` | absent | `jdk-unsafe` over main code |
| enforcer | 4 rules | plus `requireUpperBoundDeps` |
| ShellCheck | absent | `shell: lint`, errors only, with a self-test carrying two red arms |

## The finding that justifies the detectors

fb-contrib's `MUI_CONTAINSKEY_BEFORE_GET` names `ShardManager.removeWorkFromShardFor` -
`containsKey`, then `get`, then dereference, which is astubbs/parallel-consumer#345's check-then-get
seam verbatim - statically, in seconds, with no harness and no annotation.

That **narrows a standing claim** both concurrency PoCs rest on. The register said "nothing static
does". Honestly bounded, it is **one of four known instances**: astubbs/parallel-consumer#346's seam
is a stale-check before a lookup, and the two torn-read value-divergence cases are outside what any
check-then-act detector looks at.

## Suppression is a registry, not a baseline

The `spotbugs-baseline` job regenerated an exclude filter on every push to master, keyed on class
plus method plus bug type, recording nothing about what it swallowed. **Deleted.** In its place
`config/spotbugs-exclude.xml`, where every entry has a row in
`docs/inflight/static-spotbugs-rule-registry.md` with a reason and a re-enable trigger. Coarser on
purpose: visible in a diff, and the off-count only goes down. Same argument
`static-archunit-main-code-rules.md` already makes for refusing `FreezingArchRule`. ShellCheck
severities and Error Prone checks are tiered the same way, and each registry carries a ranked
"turn these on next" so the backlog is a work order rather than a list.

643 findings unfiltered, 278 after. **The lane cannot fail a build** - it runs
`spotbugs:check -Dspotbugs.failOnError=false` - and the registry now says so outright, with the
trigger that flips it.

## The recurring defect, including in this PR's own work

**A check that dies, skips, or measures nothing reports the same green as a check that passed.**
That is the thread through everything here, and the uncomfortable part is how much of it was found
inside this branch rather than in the code it was pointed at.

- **The SpotBugs rule filter's first version was completely inert.** Test-scoped entries used
  `<Source name="~.*src/test.*"/>`, but SpotBugs records `sourcepath` package-relative. Build green,
  XML valid, zero effect. Caught by asserting the excluded rule had reached zero.
- **`-Xlint:all` did nothing for two runs**, having landed in the `intellij-idea-only` profile CI
  never activates. Caught by `help:effective-pom | grep -c`, not by the build.
- **The PIT lane had scored zero mutants on 40 consecutive green runs**, and its verdict counted
  mutants *generated* rather than *evaluated* - so a run whose minions all die would still pass.
- **The RacerD ratchet compared a count, not identities**, so fixing one race and introducing
  another passed green at 13 either way. Then its self-test's ratchet arms turned out to assert
  nothing at all while printing `ok:`.
- **The RacerD self-test's decisive arm had never run in CI**, looking only for a developer's local
  SDKMAN path and printing `skip` on a hosted runner.
- **A `head -50` in the mutation lane could kill the verdict** by SIGPIPE under `pipefail`, so a
  large but valid report would have made the lane look broken.
- **The sigpipe gate failed on the very fix it prescribes**, reading the second `|` of `||` as a pipe.
- **The `forbidden-apis` mutation arm was contaminated** - both arms exited 1 on the enforcer, with
  zero forbidden-method errors.

Each is fixed with a control arm that flips, and each fix carries the reasoning in its commit.

## Reading the analysis, which is the half that was missing

Turning a channel on is not the same as reading it, and this PR proved that on itself: `-Xlint` and
SpotBugs-over-tests both fired on files this PR was editing - including on the exact
`PCMetricsDef.toCamelCase` line it had just rewritten to satisfy a *different* detector - and the
author never looked. A human found them scrolling Files Changed.

The cause is structural: the tools report to five places that are not each other - the Maven
console, check annotations, sticky PR comments, job summaries, and files under `target/`. So
`bin/check-pr-analysis-surfaces.sh` collapses that into one command, splitting findings **on a line
your diff wrote** (yours) from those merely **in a file you touched** (inherited), and
de-duplicating the same javac warning across every compiling job. On this PR: 28 findings in 3
files, exactly 1 of them ours. It is `gh`-reads-only, so the `check-` prefix grants it to the review
agent automatically.

**`bin/check-all.sh` is the same problem one level up.** There are eighteen `check-*.sh` gates and
twenty-two self-tests in `bin/`, and an agent preparing a push had to know which applied - so it ran
whichever subset it remembered. That is not hypothetical either: a push on this branch failed
`check-branch-self-reference.sh` in CI after a local sweep of seven gates chosen by hand. The gate
was not new, not subtle, and not broken; it was not on somebody's list. `check-all.sh` globs both
sets instead, so a gate added tomorrow is swept with no edit anywhere and nobody has to register it.

Neither tool counts a skip as a pass - both exit 2 for "cannot run", and `check-all` gives exit 2
and exit 3 their own columns outside the pass count. A runner that laundered "could not measure"
into "measured and found nothing" would be this PR's own defect class, one layer up.

Both went through an independent review round of their own. It found three real defects - a gate
that bash cannot *parse* also exits 2 and so was filed as a skip; the exception list's assertion
caught renames but not a recorded reason that had expired; and findings were classified on
`start_line` alone, so one spanning a method could start on an untouched line, end on an added one,
and be misfiled as inherited. All fixed. It also overstated its headline: an unparseable gate does
normally fail the sweep, via ShellCheck at `severity=error` - the real hole is narrower, needing
ShellCheck to be absent so that two skips agree. The measured version is in the code.

Two related repairs: SpotBugs printed *nothing* to the build log until now, and two-thirds of the
`-Xlint` channel was the Truth generator's own output (843 warnings to 266, main code unchanged
at 58).

## Records corrected

Notes are injected as current state, so a stale one actively misroutes the next agent. Corrected
here: the `-Xlint` inventory (said "all in test code"; 58 are main), the SpotBugs baseline described
in the present tense after its deletion, `RFI_SET_ACCESSIBLE`'s "two sites" (twelve, in five files),
`bin/racerd-test.sh`'s header denying the CI lane the same commit added, and a coverage note whose
every claim this branch had falsified - retired, with the one genuinely open question kept.

The build-hardening register, extracted here from astubbs/parallel-consumer#344, ends with all
thirteen entries struck and is cut from 252 lines to 64.

## Deferred, with the reasoning recorded

- **Two analysis profiles** - full rules on new code, a small enforced set on all of it. The
  classification is done; the wiring is deliberately a separate PR.
- **`@SneakyThrows` blinds SpotBugs dataflow** - 21 main-code sites, now tracked with the cheapest
  experiment written down.
- **`dependencyConvergence`** measured and deferred with its tail recorded, while
  `requireUpperBoundDeps` is on and passing.
- **A polyglot client survey** for the ten non-Java clients: CodeQL supports nine of ten, and the Go
  client's gating test command has no `-race`.

## Checklist

- [x] Docs updated - the registries, plus the topic docs and `docs/inflight/` notes named above.
- [x] User-facing feature documentation data added under `docs/features/` - **N/A** - build and CI
      only. The code changes are a bug fix in an example, a locale fix in a doc generator, and a
      suppression narrowing.
- [x] Tests added/updated - self-tests for every gate added here: `bin/test-check-shell-lint.sh`,
      `bin/test-check-racerd.sh` (7 arms including the same-count swap a ceiling passes),
      `bin/test-ci-mutation-test.sh` (20 arms), `bin/test-check-pr-analysis-surfaces.sh` (7 arms),
      and two new arms on `bin/test-check-shell-sigpipe.sh`.
- [x] Title & body reflect the final content of this PR

