### PR TITLE
feat(core): record residence time, the latency this project never measured

### DIFF
--- a/docs/features/record-residence-time.yaml
+++ b/docs/features/record-residence-time.yaml
@@ -1,0 +1,65 @@
+# Copyright (C) 2026 Antony Stubbs and contributors
+
+schema_version: 1
+kind: feature
+title: Record residence time
+category: observability
+module: parallel-consumer-core
+maturity: production-use
+availability:
+  status: planned
+  target_release: 0.6.0.0
+readme_anchor: metrics
+summary: >-
+  A timer measuring how long each record spends inside Parallel Consumer: from the moment it comes out of the
+  consumer to the moment Parallel Consumer finishes with it. Produce time and time waiting on the broker are
+  excluded - they are the environment, not the engine. Time queued in the client-side work queue, every retry
+  and every retry delay are included.
+use_this_when:
+  - You need latency rather than throughput - the p99 a caller downstream of your consumer actually experiences, which no other meter reports.
+  - Measured in-flight concurrency sits far below the configured maxConcurrency and you need to know whether records are not being fetched or are fetched and queued. This is the only meter that distinguishes the two - a rising residence time with a flat in-flight count is over-buffering, not under-fetching.
+  - You are tuning the load factor or the message buffer and want the cost of that buffering expressed as latency.
+  - Your ordering mode serialises work (PARTITION, or KEY on a skewed key distribution) and you need to see head-of-line blocking, which shows up in the upper percentiles long before it shows up in the mean.
+setup:
+  options:
+    - ParallelConsumerOptions.meterRegistry - the timer, like every other meter, only reaches a backend when a registry is supplied.
+  emits:
+    - Timer pc.record.residence.time, tagged subsystem=workmanager, from PCMetricsDef.RECORD_RESIDENCE_TIME.
+    - Percentiles are published at 0, 0.5, 0.75, 0.95, 0.99 and 0.999, the same set every Parallel Consumer timer publishes.
+opt_in:
+  mechanism: Always recorded; supply a MeterRegistry to observe it.
+  isolated_from_stable_modules: false
+boundaries:
+  - >-
+    The measure STARTS when the WorkContainer is constructed from a poll batch, which is when the record leaves
+    the consumer. It is not the record's broker timestamp, so it says nothing about producer-to-consumer latency;
+    ConsumerRecord.timestamp() is there for anyone who wants that included.
+  - >-
+    The measure ENDS when the control loop takes the delivery back, not when the user function returns. The hop
+    from the worker's mailbox to the controller is Parallel Consumer's own queueing and belongs inside the number.
+  - >-
+    A sample is recorded on EVERY outcome - success, failure and abandonment - not only on success. A record that
+    fails three times before succeeding therefore contributes four samples, each measured from the same arrival
+    instant, so the last of them covers every attempt and every retry delay. This is the surprising choice and it
+    is deliberate: sampling only successes would make the distribution look best exactly when the engine is doing
+    worst. It also means the sample count exceeds the record count whenever anything is being retried, so the
+    counter to divide by is pc.processed.records, never this timer's count.
+  - >-
+    A record whose partition is revoked while it is still out at a worker records NO sample. Its result is
+    discarded and the record will be redelivered to whichever consumer takes the partition, so counting it would
+    measure a rebalance rather than the engine.
+  - >-
+    One timer for the whole consumer - deliberately NOT tagged by topic and partition, unlike pc.processed.records
+    and pc.failed.records. A percentile histogram per partition is a far heavier meter than a counter, and
+    percentiles cannot be merged afterwards, so per-partition timers could never be combined into a consumer-wide
+    p99. To narrow a bad p99 to a partition, use the per-partition counters and offset gauges.
+  - The timer only reaches a metrics backend if a MeterRegistry is supplied; see micrometer-metrics.yaml.
+references:
+  - label: Meter definition
+    path: parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/metrics/PCMetricsDef.java
+  - label: Arrival timestamp and the residence measure
+    path: parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkContainer.java
+  - label: Where each outcome records its sample
+    path: parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkManager.java
+  - label: Metrics
+    path: README.adoc#mertics

--- a/docs/inflight/bug-a-record-is-selectable-before-its-offset-is-registered.md
+++ b/docs/inflight/bug-a-record-is-selectable-before-its-offset-is-registered.md
@@ -1,0 +1,43 @@
+# A record becomes selectable before its offset is in `incompleteOffsets`
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+Recorded 2026-08-22 on `research/market-analysis-recut`. **Latent, not observed.** It is the second
+instance of the defect class that produced the direct-pull double delivery, and it is left open here
+because closing that one did not close this one.
+
+`PartitionState#maybeRegisterNewPollBatchAsWork` does, in this order:
+
+```java
+getShardManager().addWorkContainer(epochOfInboundRecords, aRecord);
+addNewIncompleteRecord(aRecord);
+```
+
+so a record is visible to shard scanners **before** its offset is in `incompleteOffsets`. Under the
+direct-pull engine those scanners are worker threads, not the control loop.
+
+**Why it is closed today, and why that is not a guarantee.** Registration and completion both run on
+the control thread, so a worker cannot get a verdict back while registration is in progress. Nothing
+in the code states that invariant, nothing tests it, and the engine that broke every other
+single-threaded assumption in selection did not break this one only because it does not change who
+*registers* work.
+
+**It is recorded because of what it would look like.** It is the one shape that fires
+`PartitionState#onSuccess`'s `assert (removedFromIncompletes)` with **no double delivery at all** -
+so anyone meeting that assert again, and correctly ruling out the claim (now a single atomic
+transition, and covered by `WorkClaimStateMachineTest`), needs this on the list rather than in front
+of them for the first time.
+
+## What settling it looks like
+
+- **Swap the two lines**, so the offset is registered before the record is reachable. Cheap, and the
+  reverse order has no reason to be preferred - but establish first whether anything depends on the
+  container existing before the offset does.
+- **Or state the invariant and test it**: registration is control-thread-only. A test that drives
+  registration from a second thread while pullers scan would fail today, which is the honest way to
+  find out whether the ordering matters.
+
+**Do not treat the assert as proof of a double delivery.** That inference was correct for the
+2026-08-22 sightings - every one carried `deliveryCount == 2` - but it is the *evidence* that made it
+correct, not the assert.

--- a/docs/inflight/core-a-lost-claim-means-two-different-things.md
+++ b/docs/inflight/core-a-lost-claim-means-two-different-things.md
@@ -1,0 +1,28 @@
+# A lost claim is invisible, and it means opposite things on the two engines
+
+<!-- inflight-type: feature -->
+<!-- inflight-impact: blind-spot -->
+
+Recorded 2026-08-22 on `research/market-analysis-recut`, left open by the change that made the claim
+one atomic transition (`WorkContainer.ExecutionState`).
+
+`WorkContainer#onQueueingForExecution()` returning `false` is a `trace` log and nothing else. That is
+the right amount of noise for **one** of the two engines and the wrong amount for the other:
+
+- **Direct pull** - every worker selects, so a lost claim is *normal*. It is the mechanism working.
+  A rate worth having as a number, because it is the contention signal for the engine whose measured
+  behaviour collapses at high worker counts, but not an event.
+- **The default engine** - the control loop is the only selector, so a claim can never be contested.
+  A lost claim there means the single-selector invariant has been broken, which is a serious and
+  currently **silent** condition.
+
+One counter, two meanings. The open question is whether to have one metric read differently per
+engine, two, or a metric plus an assertion on the default engine - and whether the default engine's
+case should be loud (log at `warn`) rather than merely countable.
+
+**What makes it worth doing rather than shrugging at:** the single-selector assumption is what every
+safety property of selection was originally written under, and it is stated nowhere. An engine change
+that quietly introduced a second selector would produce exactly this signal and nothing else.
+
+Related: the opt-in engine paths are exercised by no CI lane (that note travels with the direct-pull
+branch), so a counter nobody reads in CI buys less than it looks.

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/metrics/PCMetricsDef.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/metrics/PCMetricsDef.java
@@ -29,6 +29,7 @@ public enum PCMetricsDef {
     PROCESSED_RECORDS("processed.records", "Total number of records successfully processed", PCMetricsSubsystem.WORK_MANAGER, COUNTER, topicPartitionTags()),
     FAILED_RECORDS("failed.records", "Total number of records failed to be processed", PCMetricsSubsystem.WORK_MANAGER, COUNTER, topicPartitionTags()),
     SLOW_RECORDS("slow.records", "Total number of records that spent more than the configured time threshold in the waiting queue. This setting defaults to 10 seconds", PCMetricsSubsystem.WORK_MANAGER, COUNTER, topicPartitionTags()),
+    RECORD_RESIDENCE_TIME("record.residence.time", "Time from a record leaving the consumer to Parallel Consumer finishing with it - INCLUDING time queued in the client-side work queue and every retry, and EXCLUDING produce time and time waiting on the broker. Recorded on success, on failure and on abandonment, so a record that is retried three times contributes a sample per attempt and its last sample covers the whole of it", PCMetricsSubsystem.WORK_MANAGER, TIMER),
 
     PC_POLLER_STATUS("poller.status", "PC Broker Poller Status, reported as number with following mapping - " + getStateToValueListing(), PCMetricsSubsystem.BROKER_POLLER, GAUGE),
     PC_STATUS("status", "PC Status, reported as number with following mapping - " + getStateToValueListing(), PCMetricsSubsystem.PROCESSOR, GAUGE),

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ProcessingShard.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ProcessingShard.java
@@ -88,6 +88,18 @@ public class ProcessingShard<K, V> {
         }
     }
 
+    /**
+     * Which container currently occupies an offset, or null.
+     * <p>
+     * Read-only, and package-private for tests that need to assert WHICH container won a contested offset rather
+     * than merely how many are tracked. A read cannot break the invariants that keep {@link #entries} private -
+     * only a write can, which is why there is no corresponding setter and why {@link #addWorkContainer} remains
+     * the only way in.
+     */
+    WorkContainer<K, V> getWorkContainerAt(long offset) {
+        return entries.get(offset);
+    }
+
     public void onSuccess(WorkContainer<?, ?> wc) {
         // remove work from shard's queue
         entries.remove(wc.offset());
@@ -157,10 +169,15 @@ public class ProcessingShard<K, V> {
             var workContainer = iterator.next().getValue();
 
             if (pm.couldBeTakenAsWork(workContainer)) {
-                if (workContainer.isAvailableToTakeAsWork()) {
+                // ONE call, deliberately. This used to read `isAvailableToTakeAsWork()` and then call
+                // onQueueingForExecution() separately, and the gap between the two is what could let a record be
+                // delivered twice: the check read three terms and the act re-validated none of them, so a decision
+                // made before another worker completed the record could still win. onQueueingForExecution() now
+                // evaluates the whole decision and claims from the state it evaluated. Do not reintroduce a guard
+                // in front of it.
+                if (workContainer.onQueueingForExecution()) {
                     log.trace("Taking {} as work", workContainer);
 
-                    workContainer.onQueueingForExecution();
                     workTaken.add(workContainer);
                 } else {
                     log.trace("Skipping {} as work, not available to take as work", workContainer);

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkContainer.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkContainer.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static bz.stub.parallelconsumer.internal.utils.KafkaUtils.toTopicPartition;
 import static java.util.Optional.of;
@@ -38,6 +39,113 @@ import static java.util.Optional.of;
 public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
 
     static final String DEFAULT_TYPE = "DEFAULT";
+
+    /**
+     * Where a record is in its execution lifecycle, as one value.
+     * <p>
+     * <pre>
+     *     AVAILABLE  --claim-->  IN_FLIGHT  --verdict-->  IN_FLIGHT_SUCCEEDED  --land-->  SUCCEEDED (terminal)
+     *          ^                     |                    IN_FLIGHT_FAILED     --land-->  FAILED
+     *          |                     +--no verdict------------------------------land-->  AVAILABLE (abandoned)
+     *          +----------------------------------------claim, once the retry delay passes-----------+
+     * </pre>
+     * <p>
+     * <b>Two dimensions, one value.</b> A record is either out at a worker or it is not, and it either carries a
+     * verdict or it does not; those two questions used to be answered by two fields, and a claim that re-validated
+     * only one of them is what let an already-succeeded record be delivered again. These six states are that pair
+     * of questions crossed, and every one of them is a situation the code already reaches - in particular the two
+     * {@code IN_FLIGHT_*} states, which is where a record sits between the worker recording its verdict and the
+     * controller returning it. Collapsing those would make an outstanding record look parked to the revocation
+     * sweep.
+     * <p>
+     * <b>The retry delay is deliberately NOT a state.</b> A delay expires because a clock passed a point, and
+     * nothing fires a transition when that happens - so {@link #FAILED} covers both "waiting" and "due", and
+     * {@link WorkContainer#isDelayPassed()} separates them at the moment of asking. That term is safe to read
+     * outside the atomic: only the holder of a claim can write the retry deadline, a {@link #FAILED} record has no
+     * holder, and time only ever moves one way.
+     *
+     * @author Antony Stubbs
+     * @see WorkContainer#onQueueingForExecution()
+     */
+    public enum ExecutionState {
+
+        /** Free, carrying no verdict: a fresh record, or one returned without a verdict at all. Claimable. */
+        AVAILABLE(false, null),
+
+        /** Out at a worker, which has not reported yet. */
+        IN_FLIGHT(true, null),
+
+        /** The user function succeeded; the controller has not taken the record back yet. */
+        IN_FLIGHT_SUCCEEDED(true, Boolean.TRUE),
+
+        /** The user function failed; the controller has not taken the record back yet. */
+        IN_FLIGHT_FAILED(true, Boolean.FALSE),
+
+        /** Succeeded and returned. <b>Terminal</b> - a claim from here is always refused. */
+        SUCCEEDED(false, Boolean.TRUE),
+
+        /** Failed and returned. Claimable again, but only once its retry delay has passed. */
+        FAILED(false, Boolean.FALSE);
+
+        private final boolean inFlight;
+
+        private final Optional<Boolean> verdict;
+
+        ExecutionState(boolean inFlight, Boolean verdict) {
+            this.inFlight = inFlight;
+            this.verdict = Optional.ofNullable(verdict);
+        }
+
+        /** @return true while the record is out at a worker and has not been returned to the controller */
+        public boolean isInFlight() {
+            return inFlight;
+        }
+
+        /**
+         * @return true, false, or empty when the user function has not reported on this delivery
+         */
+        public Optional<Boolean> getVerdict() {
+            return verdict;
+        }
+
+        /**
+         * @return true when a claim may be attempted from this state - the state half of the decision; the retry
+         *         delay is the other half
+         */
+        boolean isClaimable() {
+            return this == AVAILABLE || this == FAILED;
+        }
+
+        /**
+         * @return the state this delivery leaves behind when it is returned to the controller, keeping whatever
+         *         verdict it carries. Only meaningful while {@link #isInFlight()}.
+         */
+        ExecutionState afterFlightEnds() {
+            switch (this) {
+                case IN_FLIGHT:
+                    return AVAILABLE;
+                case IN_FLIGHT_SUCCEEDED:
+                    return SUCCEEDED;
+                case IN_FLIGHT_FAILED:
+                    return FAILED;
+                default:
+                    return this;
+            }
+        }
+
+        /**
+         * @return this state with a verdict attached, preserving whether the record is in flight. Total, because a
+         *         verdict may legitimately be recorded against a record that was never claimed - retry-delay
+         *         arithmetic is built that way in tests, and the failure history it drives is independent of the
+         *         claim.
+         */
+        ExecutionState withVerdict(boolean succeeded) {
+            if (inFlight) {
+                return succeeded ? IN_FLIGHT_SUCCEEDED : IN_FLIGHT_FAILED;
+            }
+            return succeeded ? SUCCEEDED : FAILED;
+        }
+    }
 
     /**
      * Instance reference to otherwise static state, for access to the instance type parameters of WorkContainer as
@@ -76,10 +184,35 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
     @Getter
     private Optional<Throwable> lastFailureReason;
 
-    private boolean inFlight = false;
+    /**
+     * Where this record is in its execution lifecycle: whether it is out at a worker, and what verdict it carries.
+     * <p>
+     * <b>One field, because two were the bug.</b> This used to be a plain {@code boolean inFlight} plus a separate
+     * {@code Optional<Boolean> maybeUserFunctionSucceeded}: selection read both, and then claimed in a separate
+     * step that re-validated neither. Under a single selector the gap is unreachable; give the engine two
+     * concurrent selectors and a claim whose availability decision predated another worker's completion could
+     * still win on an already-succeeded record - and the claim then cleared the verdict, erasing the term that
+     * should have refused it. The record would be delivered, and its offset committed, twice. Diagnosis and the
+     * state machine that closes it: the commit and PR that introduced {@link ExecutionState}, and
+     * {@code docs/inflight/core-a-lost-claim-means-two-different-things.md}.
+     * <p>
+     * Atomic because the direct-pull engine (in development) lets every worker select work straight from the
+     * shards, so the "is it free? then take it" pair has to be one indivisible step. Under the shipped engine only
+     * the control loop selects work and a plain field would do; making it atomic for both keeps one code path, and
+     * the cost is one uncontended compare-and-set per delivery.
+     *
+     * @see ExecutionState
+     * @see #onQueueingForExecution()
+     */
+    private final AtomicReference<ExecutionState> state = new AtomicReference<>(ExecutionState.AVAILABLE);
 
+    /**
+     * How many times this record has been handed to a worker. Incremented only by a WON claim, so a refused
+     * claim leaves it untouched - which is one of the properties {@code WorkClaimStateMachineTest} pins. Written
+     * only by the claim winner, read anywhere: the state field's compare-and-set orders the increment.
+     */
     @Getter
-    private Optional<Boolean> maybeUserFunctionSucceeded = Optional.empty();
+    private long deliveryCount = 0;
 
     @Getter
     @Setter(AccessLevel.PUBLIC)
@@ -108,9 +241,27 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
         this(epoch, cr, module, DEFAULT_TYPE);
     }
 
+    /**
+     * This delivery has been handed back to the controller: the record leaves flight, keeping whatever verdict it
+     * came back with, and releases its shard's in-flight charge.
+     * <p>
+     * A no-op when the record is not in flight. That is not a legal transition, but it has always been silently
+     * idempotent here and the callers rely on it - {@link WorkManager#handleFutureResult} reaches this from the
+     * revoked-partition branch, which does not know how far the delivery got.
+     */
     public void endFlight() {
-        log.trace("Ending flight {}", this);
-        inFlight = false;
+        while (true) {
+            ExecutionState current = state.get();
+            if (!current.isInFlight()) {
+                log.trace("Flight already ended, nothing to release {}", this);
+                return;
+            }
+            if (state.compareAndSet(current, current.afterFlightEnds())) {
+                log.trace("Ending flight {}", this);
+                return;
+            }
+            // the worker's verdict landed between the read and the write - re-read and end the flight it left
+        }
     }
 
     public boolean isDelayPassed() {
@@ -187,13 +338,57 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
     }
 
     public boolean isInFlight() {
-        return inFlight;
+        return state.get().isInFlight();
     }
 
-    public void onQueueingForExecution() {
+    /**
+     * @return where this record currently is in its lifecycle
+     */
+    public ExecutionState getExecutionState() {
+        return state.get();
+    }
+
+    /**
+     * Claims this record for execution. <b>One compare-and-set: the check IS the act.</b>
+     * <p>
+     * The whole decision - not in flight, no success verdict, retry delay passed - is evaluated against a single
+     * observed {@link ExecutionState}, and the claim then compares against <em>that exact state</em>. Anything that
+     * moved the record in between makes the compare fail, so there is no window in which a decision can outlive the
+     * facts it was made on. That window is what could let an already-completed record be claimed and delivered a
+     * second time, and it is why callers must NOT pre-filter with {@link #isAvailableToTakeAsWork()} and then call
+     * this: the two-step form is the defect, restated.
+     * <p>
+     * A won claim starts a new delivery, and the new delivery carries no verdict - not because anything is
+     * cleared, but because {@link ExecutionState#IN_FLIGHT} has none.
+     *
+     * @return {@code true} if this caller won the claim; {@code false} if the record was not claimable, or another
+     *         caller moved it first, in which case this caller must not process it. Never expected under the
+     *         shipped engine, where the control loop is the only selector; an engine with concurrent selectors
+     *         (the direct-pull engine, in development) loses claims routinely and relies on the refusal.
+     */
+    public boolean onQueueingForExecution() {
+        ExecutionState observed = state.get();
+        if (!isClaimableFrom(observed)) {
+            log.trace("Not claimable from {}: {}", observed, this);
+            return false;
+        }
+        if (!state.compareAndSet(observed, ExecutionState.IN_FLIGHT)) {
+            log.trace("Lost the race to claim {}", this);
+            return false;
+        }
         log.trace("Queueing for execution: {}", this);
-        inFlight = true;
+        deliveryCount++;
         timeTakenAsWorkMs = of(System.currentTimeMillis());
+        return true;
+    }
+
+    /**
+     * The claim decision, over one observed state. Read the state FIRST and the delay second: the state read is
+     * the volatile one, so its acquire semantics make the retry deadline written by the previous holder visible.
+     * Doing it the other way round would open a second, independent hole.
+     */
+    private boolean isClaimableFrom(ExecutionState observed) {
+        return observed.isClaimable() && isDelayPassed();
     }
 
     public TopicPartition getTopicPartition() {
@@ -202,7 +397,7 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
 
     public void onUserFunctionSuccess() {
         this.succeededAt = of(module.clock().instant());
-        this.maybeUserFunctionSucceeded = of(true);
+        recordVerdict(true);
     }
 
     public void onUserFunctionFailure(Throwable cause) {
@@ -210,7 +405,26 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
 
         updateFailureHistory(cause);
 
-        this.maybeUserFunctionSucceeded = of(false);
+        recordVerdict(false);
+    }
+
+    /**
+     * Attaches the user function's verdict to the current state, without ending the flight - the worker that ran
+     * the function still holds the record until the controller takes it back through
+     * {@link WorkManager#handleFutureResult}.
+     * <p>
+     * The failure history behind {@link #getDelayUntilRetryDue()} is written before this, so the state write is
+     * what publishes it: a thread that observes {@link ExecutionState#FAILED} has, by the same happens-before
+     * edge, observed the retry deadline that goes with it.
+     */
+    private void recordVerdict(boolean succeeded) {
+        while (true) {
+            ExecutionState current = state.get();
+            ExecutionState next = current.withVerdict(succeeded);
+            if (current == next || state.compareAndSet(current, next)) {
+                return;
+            }
+        }
     }
 
     private void updateFailureHistory(Throwable cause) {
@@ -219,6 +433,16 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
         lastFailureReason = Optional.ofNullable(cause);
         Duration retryDelay = getRetryDelayConfig();
         retryDueAt = of(lastFailedAt.get().plus(retryDelay));
+    }
+
+    /**
+     * The user function's verdict on the current delivery, or empty if it has not reported yet.
+     * <p>
+     * Derived from {@link #getExecutionState()} rather than stored beside it. Keeping it as its own field is what
+     * made a claim able to contradict it.
+     */
+    public Optional<Boolean> getMaybeUserFunctionSucceeded() {
+        return state.get().getVerdict();
     }
 
     public boolean isUserFunctionComplete() {
@@ -252,13 +476,20 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
     }
 
     /**
-     * Checks the work is not already in flight, it's retry delay has passed and that it's not already been succeeded.
+     * Whether a claim would be accepted <em>at the instant this is asked</em> - the record is not in flight, has no
+     * success verdict, and its retry delay has passed.
+     * <p>
+     * <b>Answering true here does not reserve anything, and callers that intend to take the record must NOT use
+     * this as a pre-filter.</b> Call {@link #onQueueingForExecution()} directly: it evaluates exactly this
+     * predicate and claims from the state it evaluated, in one step. Testing here and claiming afterwards is
+     * precisely the check-then-act that delivered records twice. This survives for the callers that only want to
+     * know - metrics, diagnostics, and tests.
      * <p>
      * Checking that there's no back pressure for the partition it belongs to is covered by
      * {@link PartitionStateManager#isAllowedMoreRecords(WorkContainer)}.
      */
     public boolean isAvailableToTakeAsWork() {
-        return isNotInFlight() && !isUserFunctionSucceeded() && isDelayPassed();
+        return isClaimableFrom(state.get());
     }
 
     /**

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkContainer.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkContainer.java
@@ -172,6 +172,28 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
     @Getter
     private final ConsumerRecord<K, V> cr;
 
+    /**
+     * When this record ARRIVED in Parallel Consumer - the instant this container was constructed, which is the
+     * moment the record came out of the consumer and entered the engine's own queues.
+     * <p>
+     * <b>Deliberately not {@link #timeTakenAsWorkMs}</b>, which is stamped when a delivery is <em>claimed</em>.
+     * That one measures time in flight, so it cannot see the interval this exists for: how long a record sits in
+     * the shards after being fetched and before anything picks it up. Under a backlog that interval is Little's
+     * law applied to Parallel Consumer's own buffers - buffered depth divided by throughput - so it is the only
+     * quantity that separates "not fetched yet" from "fetched and queued behind other work", which no other
+     * meter distinguishes.
+     * <p>
+     * Produce time and time waiting on the broker are deliberately EXCLUDED: they are the environment, not the
+     * engine, and {@link ConsumerRecord#timestamp()} is there for anyone who wants them included.
+     * <p>
+     * Taken from the module clock, like {@link #succeededAt}, so a test driving a fake clock sees a residence
+     * time consistent with everything else it observes.
+     *
+     * @see #getResidenceTime()
+     */
+    @Getter
+    private final Instant arrivedAt;
+
     @Getter
     private int numberOfFailedAttempts = 0;
 
@@ -235,6 +257,7 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
         this.cr = cr;
         this.workType = workType;
         this.module = module;
+        this.arrivedAt = module.clock().instant();
     }
 
     public WorkContainer(long epoch, ConsumerRecord<K, V> cr, PCModule<K, V> module) {
@@ -457,6 +480,21 @@ public class WorkContainer<K, V> implements Comparable<WorkContainer<K, V>> {
     @Override
     public String toString() {
         return "WorkContainer(tp:" + toTopicPartition(cr) + ":o:" + cr.offset() + ":k:" + cr.key() + ")";
+    }
+
+    /**
+     * How long this record has been inside Parallel Consumer: from {@link #getArrivedAt()} to now.
+     * <p>
+     * Asked at the moment the controller takes a delivery back, this is the record's RESIDENCE TIME - the
+     * quantity behind {@link bz.stub.parallelconsumer.metrics.PCMetricsDef#RECORD_RESIDENCE_TIME}. Because
+     * arrival is stamped once, at construction, a record that failed and was retried carries every one of those
+     * attempts and every retry delay in this figure, which is the point: excluding them would flatter exactly
+     * the case the metric exists to expose.
+     *
+     * @return the interval between this record entering Parallel Consumer and now, on the module clock
+     */
+    public Duration getResidenceTime() {
+        return Duration.between(arrivedAt, module.clock().instant());
     }
 
     public Duration getTimeInFlight() {

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/WorkManager.java
@@ -12,6 +12,7 @@ import bz.stub.parallelconsumer.metrics.PCMetricsDef;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -75,6 +76,21 @@ public class WorkManager<K, V> implements ConsumerRebalanceListener {
     private Gauge inflightRecordsNumberGauge;
     private Map<TopicPartition, Counter> succeededRecordsCounters = new HashMap<>();
     private Map<TopicPartition, Counter> failedRecordsCounters = new HashMap<>();
+
+    /**
+     * How long each record spent inside Parallel Consumer, from arrival to the controller finishing with it.
+     * <p>
+     * <b>One timer for the whole consumer, deliberately NOT tagged by topic-partition</b>, unlike the two
+     * counters above. Two reasons, and the second is the binding one. A percentile histogram per partition is a
+     * far heavier meter than a counter - an instance assigned a hundred partitions would carry a hundred of
+     * them. And percentiles cannot be merged after the fact: per-partition timers can never be combined into a
+     * consumer-wide p99, whereas an operator hunting a slow partition still has the per-partition counters and
+     * offset gauges to narrow it with. A per-partition breakdown, if it is ever wanted, has to be an additional
+     * meter rather than a re-tagging of this one.
+     *
+     * @see WorkContainer#getResidenceTime()
+     */
+    private Timer recordResidenceTimer;
 
     private final PCMetrics pcMetrics;
 
@@ -163,6 +179,7 @@ public class WorkManager<K, V> implements ConsumerRebalanceListener {
         log.trace("Work success ({}), removing from processing shard queue", wc);
 
         incrementCounterIfPresent(succeededRecordsCounters, wc.getTopicPartition());
+        recordResidenceTime(wc);
 
         wc.endFlight();
 
@@ -188,6 +205,7 @@ public class WorkManager<K, V> implements ConsumerRebalanceListener {
     public void onFailureResult(WorkContainer<K, V> wc) {
         // error occurred, put it back in the queue if it can be retried
         incrementCounterIfPresent(failedRecordsCounters, wc.getTopicPartition());
+        recordResidenceTime(wc);
         wc.endFlight();
         pm.onFailure(wc);
         sm.onFailure(wc);
@@ -317,6 +335,26 @@ public class WorkManager<K, V> implements ConsumerRebalanceListener {
                 this, WorkManager::getNumberOfWorkQueuedInShardsAwaitingSelection);
         inflightRecordsNumberGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.INFLIGHT_RECORDS,
                 this, WorkManager::getNumberRecordsOutForProcessing);
+        recordResidenceTimer = pcMetrics.getTimerFromMetricDef(PCMetricsDef.RECORD_RESIDENCE_TIME);
+    }
+
+    /**
+     * Records how long this record has been inside Parallel Consumer, at the moment the controller finishes with
+     * the delivery.
+     * <p>
+     * <b>Called from every outcome - success, failure and abandonment - not only success.</b> A record that is
+     * failing and being retried is precisely the case a residence-time metric exists to expose, and sampling only
+     * the successes would make the distribution look best exactly when the engine is doing worst.
+     * <p>
+     * The instant taken is the CONTROLLER's, not the worker's {@link WorkContainer#getSucceededAt()}. The hop
+     * from the worker's mailbox back to the control loop is Parallel Consumer's own queueing, so it belongs
+     * inside the number rather than outside it - and taking it here is the one point that is common to all three
+     * outcomes, two of which stamp no completion instant at all.
+     */
+    private void recordResidenceTime(WorkContainer<K, V> wc) {
+        if (recordResidenceTimer != null) {
+            recordResidenceTimer.record(wc.getResidenceTime());
+        }
     }
 
     private void initTopicPartitionSpecificMetrics(Collection<TopicPartition> partitions) {

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/PCMetricsTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/PCMetricsTest.java
@@ -260,6 +260,67 @@ class PCMetricsTest extends ParallelEoSStreamProcessorTestBase {
     }
 
 
+    /**
+     * Residence time is the interval from a record leaving the consumer to Parallel Consumer finishing with it,
+     * and the assertions here pin the two properties that make it worth having.
+     * <p>
+     * <b>The sample COUNT is asserted exactly, not "greater than zero".</b> Every outcome records one - the 999
+     * records that succeed first time, plus the failing delivery, plus that record's successful retry - so the
+     * count is one more than the record count. An implementation that recorded only successes would produce
+     * exactly the record count and would pass a "greater than zero" assertion, which is precisely the mistake
+     * this metric exists to avoid.
+     * <p>
+     * <b>The MAXIMUM is asserted against the retry delay</b>, which is the only observable that separates a
+     * residence time from a time-in-flight. The redelivered record spends the default one-second retry delay
+     * parked, doing nothing, and that second is in its residence time because arrival is stamped once, at
+     * construction. A measure taken from the claim instant instead cannot exceed the handler's own runtime.
+     */
+    @Test
+    @SneakyThrows
+    void recordResidenceTimeCoversRetriesAndFailures() {
+        final int quantity = 1000;
+        final int offsetToFailOnce = 5;
+
+        ktu.send(consumerSpy, ktu.generateRecords(0, quantity));
+
+        AtomicInteger succeeded = new AtomicInteger();
+        AtomicBoolean alreadyFailedOnce = new AtomicBoolean(false);
+        parallelConsumer.poll(recordContexts -> recordContexts.forEach(recordContext -> {
+            if (recordContext.offset() == offsetToFailOnce && !alreadyFailedOnce.getAndSet(true)) {
+                throw new RuntimeException("Failing offset " + offsetToFailOnce + " once, to prove its retry "
+                        + "delay lands inside its residence time");
+            }
+            succeeded.incrementAndGet();
+        }));
+
+        // The retried record cannot succeed before its one second retry delay expires, so the budget has to
+        // clear that with room for the commit cycle behind it.
+        await().atMost(Duration.ofSeconds(60)).untilAsserted(() ->
+                assertThat(succeeded.get()).isEqualTo(quantity));
+
+        // Short budget deliberately: the await above already established that every record finished, so the
+        // samples are in the timer by now. This only covers the meter publishing behind the counter.
+        await().atMost(Duration.ofSeconds(20)).untilAsserted(() -> {
+            assertThat(registeredTimerCountFor(PCMetricsDef.RECORD_RESIDENCE_TIME))
+                    .as("one sample per outcome: %d successes, one failure, one retried success", quantity - 1)
+                    .isEqualTo(quantity + 1);
+            assertThat(registeredTimerMaxMillisFor(PCMetricsDef.RECORD_RESIDENCE_TIME))
+                    .as("the retried record was parked for the default one second retry delay, which is inside "
+                            + "its residence time and could not be inside a time-in-flight")
+                    .isGreaterThanOrEqualTo(ParallelConsumerOptions.DEFAULT_STATIC_RETRY_DELAY.toMillis());
+        });
+    }
+
+    private long registeredTimerCountFor(PCMetricsDef metricsDef, String... tags) {
+        return Optional.ofNullable(registry.find(metricsDef.getName()).tags(tags).timer())
+                .map(Timer::count).orElse(-1L);
+    }
+
+    private double registeredTimerMaxMillisFor(PCMetricsDef metricsDef, String... tags) {
+        return Optional.ofNullable(registry.find(metricsDef.getName()).tags(tags).timer())
+                .map(timer -> timer.max(TimeUnit.MILLISECONDS)).orElse(-1.0);
+    }
+
     private double registeredGaugeValueFor(PCMetricsDef metricsDef, String... filterTags) {
         return Optional.ofNullable(registry.find(metricsDef.getName()).tags(filterTags).gauge()).map(Gauge::value).orElse(-1.0);
     }

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/WorkClaimStateMachineTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/WorkClaimStateMachineTest.java
@@ -1,0 +1,349 @@
+package bz.stub.parallelconsumer.state;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.FakeRuntimeException;
+import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import bz.stub.parallelconsumer.internal.EpochAndRecordsMap;
+import bz.stub.parallelconsumer.internal.PCModuleTestEnv;
+import bz.stub.parallelconsumer.state.WorkContainer.ExecutionState;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniLists;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The claim on a record is one atomic transition, and every other move a record makes is one too.
+ * <p>
+ * WHY THIS EXISTS, and it is a real defect rather than a hypothetical. Selection used to be two steps:
+ * {@code isAvailableToTakeAsWork()} evaluated three terms - not in flight, no success verdict, retry delay
+ * passed - and {@code onQueueingForExecution()} then acted, re-validating <b>none of them</b>. Nothing makes
+ * that <em>decision</em> atomic. The shipped engine has a single selector, the control loop, so the gap is
+ * unreachable today; give the engine concurrent selectors - the direct-pull engine, in development, where
+ * every worker selects work - and a puller whose availability decision predated another puller's completion
+ * could still act on an already-completed record. The record was delivered twice and its offset committed
+ * twice; with assertions enabled the second completion surfaces as an {@code AssertionError} from
+ * {@link PartitionState#onSuccess(long)}.
+ * <p>
+ * {@link #aClaimDecidedBeforeAnotherPullerCompletedTheRecordIsRefused()} is that interleaving, played out by
+ * hand with no threads at all. The concurrent reproduction of the same defect needed of the order of 14
+ * million record completions to land four occurrences, so it is a soak and not a gate; this runs in
+ * milliseconds and is exact. The reproduction numbers come from the branch that develops the direct-pull
+ * engine; the follow-up the fix left open is
+ * {@code docs/inflight/core-a-lost-claim-means-two-different-things.md}.
+ * <p>
+ * THE FIX THIS PINS is {@link ExecutionState}: one atomic field carrying both the flight and the verdict, so
+ * a claim is a single compare-and-set from a state that was <em>observed</em> to be claimable. The check IS
+ * the act. A claim attempted against a record that has since succeeded finds {@link ExecutionState#SUCCEEDED}
+ * rather than the {@code false} of a boolean that no longer answers the question that was asked.
+ *
+ * @author Antony Stubbs
+ * @see WorkContainer#onQueueingForExecution()
+ * @see ExecutionState
+ */
+@Slf4j
+class WorkClaimStateMachineTest {
+
+    static final String TOPIC = "claim-state-topic";
+    static final TopicPartition TP = new TopicPartition(TOPIC, 0);
+
+    PCModuleTestEnv module;
+    WorkManager<String, String> wm;
+
+    void setup(ParallelConsumerOptions.ProcessingOrder ordering) {
+        module = new PCModuleTestEnv(ParallelConsumerOptions.<String, String>builder()
+                .ordering(ordering)
+                .build());
+        wm = module.workManager();
+        wm.onPartitionsAssigned(UniLists.of(TP));
+    }
+
+    void register(int fromOffset, int count) {
+        List<ConsumerRecord<String, String>> recs = new ArrayList<>(count);
+        for (int i = fromOffset; i < fromOffset + count; i++) {
+            recs.add(new ConsumerRecord<>(TOPIC, 0, i, "the-key", "value-" + i));
+        }
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> m = new HashMap<>();
+        m.put(TP, recs);
+        wm.registerWork(new EpochAndRecordsMap<>(new ConsumerRecords<>(m), wm.getPm()));
+    }
+
+    /**
+     * The container the shard is holding at an offset, reached the way a concurrent scanner reaches it - through
+     * the shard - so the test holds the same reference a losing puller would still be holding after the winner
+     * completed the record and it left the shard.
+     */
+    WorkContainer<String, String> containerInShardAt(long offset) {
+        var sm = wm.getSm();
+        var shard = sm.getShard(sm.computeShardKey(new ConsumerRecord<>(TOPIC, 0, offset, "the-key", "v")));
+        assertWithMessage("the shard for offset %s must exist for this test to prove anything", offset)
+                .that(shard.isPresent()).isTrue();
+        var wc = shard.get().getWorkContainerAt(offset);
+        assertWithMessage("the shard must still hold offset %s", offset).that(wc).isNotNull();
+        return wc;
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // The defect, deterministically
+    // -----------------------------------------------------------------------------------------------------
+
+    /**
+     * THE INTERLEAVING, step by step, with no threads - each step is a plain method call in program order:
+     * <ol>
+     *   <li>Puller <b>A</b> scans the shard and evaluates availability for offset 0: true. A is descheduled
+     *       here, between its check and its claim.</li>
+     *   <li>Puller <b>B</b> evaluates the same guard, wins, and takes offset 0.</li>
+     *   <li>The control thread runs B's verdict: success, then {@link WorkManager#handleFutureResult}. That
+     *       ends the flight, removes the offset from the incomplete set and the container from the shard.</li>
+     *   <li>A resumes and performs the second half of its guard - the claim.</li>
+     * </ol>
+     * Under the old boolean CAS step 4 returned {@code true}, because step 3 had reset the flag; the claim then
+     * cleared the success verdict, and feeding the container back through {@code handleFutureResult} tripped
+     * {@link PartitionState#onSuccess(long)}'s assert on an offset that was already gone. With one atomic state
+     * the claim compares against {@link ExecutionState#SUCCEEDED} and is refused.
+     * <p>
+     * A holds the container reference from its own iteration, which is why moving the flight-end after the
+     * shard removal does not close this - see the control arm recorded in the diagnosis note.
+     */
+    @Test
+    void aClaimDecidedBeforeAnotherPullerCompletedTheRecordIsRefused() {
+        setup(ParallelConsumerOptions.ProcessingOrder.UNORDERED);
+        register(0, 1);
+
+        // 1. puller A decides, and is descheduled holding the container
+        var containerHeldByA = containerInShardAt(0L);
+        boolean aSawItAvailable = containerHeldByA.isAvailableToTakeAsWork();
+        assertWithMessage("A must have seen it available, or the interleaving under test never starts")
+                .that(aSawItAvailable).isTrue();
+
+        // 2. puller B takes it
+        var takenByB = wm.getWorkIfAvailable(1);
+        assertThat(takenByB).hasSize(1);
+        assertThat(takenByB.get(0)).isSameInstanceAs(containerHeldByA);
+
+        // 3. the control thread completes B's delivery
+        takenByB.get(0).onUserFunctionSuccess();
+        wm.handleFutureResult(takenByB.get(0));
+        assertWithMessage("the record really did complete, so there is nothing left to deliver")
+                .that(wm.getNumberOfIncompleteOffsets()).isEqualTo(0L);
+
+        // 4. A resumes and attempts the claim it decided on in step 1
+        boolean aWonTheClaim = containerHeldByA.onQueueingForExecution();
+
+        assertWithMessage("P1 - a claim whose availability decision predates another puller's completion must "
+                + "be REFUSED. Winning it here delivers an already-committed record a second time, and in "
+                + "production - where assertions are off - the only surviving evidence is the duplicate.")
+                .that(aWonTheClaim).isFalse();
+        assertWithMessage("P1b - and the record must still say it succeeded. The old claim cleared the verdict, "
+                + "erasing the very term that should have refused it.")
+                .that(containerHeldByA.isUserFunctionSucceeded()).isTrue();
+        assertWithMessage("the delivery count must not move for a claim that was refused")
+                .that(containerHeldByA.getDeliveryCount()).isEqualTo(1L);
+    }
+
+    /**
+     * P2 - the observable consequence of losing the test above, asserted separately so that a regression tells
+     * you which half broke. A second delivery is returned as a second success, and
+     * {@link PartitionState#onSuccess(long)} removes an offset that is already gone.
+     * <p>
+     * Written as "if the claim were ever won, this is what follows", so it exercises the return path rather than
+     * merely restating the claim assertion.
+     */
+    @Test
+    void asecondSuccessfulReturnForAnAlreadyCompletedRecordWouldTripTheIncompleteOffsetsAssert() {
+        setup(ParallelConsumerOptions.ProcessingOrder.UNORDERED);
+        register(0, 1);
+
+        var wc = containerInShardAt(0L);
+        var taken = wm.getWorkIfAvailable(1);
+        assertThat(taken).hasSize(1);
+        wc.onUserFunctionSuccess();
+        wm.handleFutureResult(wc);
+
+        // the record is now SUCCEEDED and out of the shard. Force the second return the lost claim would have
+        // produced, without going through the claim - so this test still means something if the claim changes.
+        wc.onUserFunctionSuccess();
+
+        assertWithMessage("assertions must be enabled for this test to prove anything - run with -ea")
+                .that(WorkClaimStateMachineTest.class.desiredAssertionStatus()).isTrue();
+        assertThatThrownBy(() -> wm.handleFutureResult(wc))
+                .as("a second success for an offset already removed from the incomplete set is the recorded "
+                        + "sighting: PartitionState#onSuccess asserts the removal actually removed something")
+                .isInstanceOf(AssertionError.class);
+    }
+
+    /**
+     * The in-flight control from the same proof: a claim attempted while the record is still out at a worker is
+     * refused too. Without this, a fix that simply refused every second claim would look correct.
+     */
+    @Test
+    void aClaimOnARecordStillInFlightIsRefused() {
+        setup(ParallelConsumerOptions.ProcessingOrder.UNORDERED);
+        register(0, 1);
+
+        var wc = containerInShardAt(0L);
+        assertThat(wm.getWorkIfAvailable(1)).hasSize(1);
+
+        assertWithMessage("P3 - a record already out at a worker may not be claimed again")
+                .that(wc.onQueueingForExecution()).isFalse();
+        assertThat(wc.getDeliveryCount()).isEqualTo(1L);
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // The transitions the state machine makes explicit
+    // -----------------------------------------------------------------------------------------------------
+
+    @Test
+    void aFreshRecordIsAvailableAndAClaimTakesItInFlight() {
+        setup(ParallelConsumerOptions.ProcessingOrder.UNORDERED);
+        register(0, 1);
+
+        var wc = containerInShardAt(0L);
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.AVAILABLE);
+        assertThat(wc.isAvailableToTakeAsWork()).isTrue();
+
+        assertThat(wc.onQueueingForExecution()).isTrue();
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.IN_FLIGHT);
+        assertThat(wc.getDeliveryCount()).isEqualTo(1L);
+        assertThat(wc.isAvailableToTakeAsWork()).isFalse();
+    }
+
+    /**
+     * The verdict is recorded by the thread that ran the user function, which still holds the record - so a
+     * verdict does not end the flight, and the container stays in flight until the controller returns it.
+     * Getting that wrong would let the revocation sweep treat an outstanding record as if it were parked.
+     */
+    @Test
+    void averdictIsRecordedWithoutEndingTheFlight() {
+        setup(ParallelConsumerOptions.ProcessingOrder.UNORDERED);
+        register(0, 2);
+
+        var succeeding = containerInShardAt(0L);
+        var failing = containerInShardAt(1L);
+        assertThat(wm.getWorkIfAvailable(2)).hasSize(2);
+
+        succeeding.onUserFunctionSuccess();
+        assertThat(succeeding.getExecutionState()).isEqualTo(ExecutionState.IN_FLIGHT_SUCCEEDED);
+        assertThat(succeeding.isInFlight()).isTrue();
+
+        failing.onUserFunctionFailure(new FakeRuntimeException("deliberate"));
+        assertThat(failing.getExecutionState()).isEqualTo(ExecutionState.IN_FLIGHT_FAILED);
+        assertThat(failing.isInFlight()).isTrue();
+    }
+
+    /**
+     * SUCCEEDED is terminal. This is the illegal transition that the whole state machine exists to make
+     * assertable - and it is exactly the one the old boolean could not express, because "not in flight" and
+     * "already succeeded" were two different fields.
+     */
+    @Test
+    void aClaimFromSucceededIsRefusedForever() {
+        setup(ParallelConsumerOptions.ProcessingOrder.UNORDERED);
+        register(0, 1);
+
+        var wc = containerInShardAt(0L);
+        assertThat(wm.getWorkIfAvailable(1)).hasSize(1);
+        wc.onUserFunctionSuccess();
+        wm.handleFutureResult(wc);
+
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.SUCCEEDED);
+        assertThat(wc.isAvailableToTakeAsWork()).isFalse();
+        assertWithMessage("a succeeded record can never be claimed again, however often it is asked")
+                .that(wc.onQueueingForExecution()).isFalse();
+        assertThat(wc.onQueueingForExecution()).isFalse();
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.SUCCEEDED);
+        assertThat(wc.getDeliveryCount()).isEqualTo(1L);
+    }
+
+    /**
+     * FAILED is not terminal, but it is not immediately claimable either: the retry delay is time, and it lives
+     * outside the state because no transition can be scheduled to fire when a clock passes a point.
+     */
+    @Test
+    void aFailedRecordIsRefusedUntilItsRetryDelayPassesAndThenClaimable() {
+        setup(ParallelConsumerOptions.ProcessingOrder.UNORDERED);
+        register(0, 1);
+
+        var wc = containerInShardAt(0L);
+        assertThat(wm.getWorkIfAvailable(1)).hasSize(1);
+        wc.onUserFunctionFailure(new FakeRuntimeException("deliberate"));
+        wm.handleFutureResult(wc);
+
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.FAILED);
+        assertWithMessage("still inside its retry delay, so not claimable - the state alone does not decide")
+                .that(wc.isAvailableToTakeAsWork()).isFalse();
+        assertThat(wc.onQueueingForExecution()).isFalse();
+        assertThat(wc.getDeliveryCount()).isEqualTo(1L);
+
+        module.getMutableClock().add(module.options().getDefaultMessageRetryDelay().plus(Duration.ofSeconds(1)));
+
+        assertThat(wc.isAvailableToTakeAsWork()).isTrue();
+        assertThat(wc.onQueueingForExecution()).isTrue();
+        assertThat(wc.getExecutionState())
+                .isEqualTo(ExecutionState.IN_FLIGHT);
+        assertWithMessage("the retry is a second delivery, and it carries no verdict from the first")
+                .that(wc.getDeliveryCount()).isEqualTo(2L);
+        assertThat(wc.getMaybeUserFunctionSucceeded()).isEmpty();
+        assertWithMessage("the failure history survives the redelivery - the attempt happened")
+                .that(wc.getNumberOfFailedAttempts()).isEqualTo(1);
+    }
+
+    /**
+     * Fail, retry, then succeed: one walk that crosses every state the machine has, in the order production
+     * reaches them, on one record - rather than three fragments that each start from a fresh container.
+     * <p>
+     * The FAILED verdict of the first delivery must not leak into the second: a won claim moves the record to
+     * {@link ExecutionState#IN_FLIGHT}, which carries no verdict, so the second delivery reports on its own
+     * outcome alone.
+     */
+    @Test
+    void aRecordThatFailsThenRetriesThenSucceedsCrossesEveryState() {
+        setup(ParallelConsumerOptions.ProcessingOrder.UNORDERED);
+        register(0, 1);
+
+        var wc = containerInShardAt(0L);
+
+        // AVAILABLE -> IN_FLIGHT
+        assertThat(wm.getWorkIfAvailable(1)).hasSize(1);
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.IN_FLIGHT);
+
+        // IN_FLIGHT -> IN_FLIGHT_FAILED -> FAILED
+        wc.onUserFunctionFailure(new FakeRuntimeException("deliberate"));
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.IN_FLIGHT_FAILED);
+        wm.handleFutureResult(wc);
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.FAILED);
+        assertWithMessage("a failed record is not selectable until its retry delay passes")
+                .that(wc.isAvailableToTakeAsWork()).isFalse();
+
+        // FAILED -> IN_FLIGHT, once the delay has passed
+        module.getMutableClock().add(module.options().getDefaultMessageRetryDelay().plus(Duration.ofSeconds(1)));
+        var retried = wm.getWorkIfAvailable(1);
+        assertThat(retried).hasSize(1);
+        assertThat(retried.get(0)).isSameInstanceAs(wc);
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.IN_FLIGHT);
+        assertWithMessage("the FAILED verdict of the first delivery must not survive into the second")
+                .that(wc.getMaybeUserFunctionSucceeded()).isEmpty();
+        assertThat(wc.getNumberOfFailedAttempts()).isEqualTo(1);
+
+        // IN_FLIGHT -> IN_FLIGHT_SUCCEEDED -> SUCCEEDED
+        wc.onUserFunctionSuccess();
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.IN_FLIGHT_SUCCEEDED);
+        wm.handleFutureResult(wc);
+        assertThat(wc.getExecutionState()).isEqualTo(ExecutionState.SUCCEEDED);
+        assertThat(wm.getNumberOfIncompleteOffsets()).isEqualTo(0L);
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/WorkManagerTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/WorkManagerTest.java
@@ -593,8 +593,13 @@ public class WorkManagerTest {
         var records = ktu.generateRecords(i);
 
         var treeMap = new TreeMap<Long, WorkContainer<String, String>>();
+        // The class's own PCModuleTestEnv, not a mock of it. PCModuleTestEnv is already a test double
+        // with a working MutableClock; mocking it stubbed that clock out to null, which went unnoticed
+        // only while nothing in WorkContainer's constructor read the module. Stamping the arrival
+        // instant does read it, and every sibling test that mocks PCModule for this purpose stubs
+        // clock() by hand - see ShardManagerTest#retryQueueOrdering. The real one needs no stubbing.
         for (ConsumerRecord<String, String> record : records) {
-            treeMap.put(record.offset(), new WorkContainer<>(0, record, mock(PCModuleTestEnv.class)));
+            treeMap.put(record.offset(), new WorkContainer<>(0, record, module));
         }
 
         // read back, assert correct order


### PR DESCRIPTION
depends on astubbs/parallel-consumer#335 - the atomic work claim

## Description

**Record how long a record spends inside Parallel Consumer, end to end — the first latency measurement this project has had.**

Every metric until now has described throughput or queue depth. Neither answers the question an operator actually has: *how long does a record take to get through?* A run that finishes in the same wall-clock time can have put one record in a hundred through a queue ten times as long, and nothing in `PCMetrics` would have moved.

`pc.record.residence.time` is a `Timer`: the clock starts when the `WorkContainer` is built from a poll batch, and stops when the control loop finishes with that delivery — success, failure, or abandonment, **including every retry in between**. That last part is deliberate: a record that failed twice and succeeded on the third attempt took as long as it took, and a measure that restarted per attempt would flatter the engine exactly where users feel the pain.

**What it deliberately excludes:** produce time and broker wait. Those are the environment, not the engine. (The bench harness carries a separate end-to-end measure that *does* charge the wait, precisely because residence cannot see coordinated omission — but that belongs to the harness, not to the library's own meter.)

**Why it is worth a metric rather than a benchmark number:** it is the only quantity that distinguishes an engine holding N records because it fetched N from one holding N because they are queued behind a slow key. Throughput cannot tell those apart, and it is the difference between "tune your concurrency" and "your key distribution is the ceiling".

**Verification.** `PCMetricsTest` covers the timer's registration and that it records on the completion path. `WorkManagerTest` and `WorkClaimStateMachineTest` green alongside (36 tests total locally) — the second matters because the arrival instant is stamped in `WorkContainer`'s constructor, which astubbs/parallel-consumer#335 also touches.

**One test fix travels with this change, and is not incidental:** stamping the arrival instant made the constructor read the module's clock for the first time, which surfaced a latent defect in a *test double* — `WorkManagerTest` built containers from `mock(PCModuleTestEnv.class)`, a mock of a class that is already a test double, whose working `MutableClock` the mock replaced with null. The fix uses the class's own `PCModuleTestEnv` instead, which needs no stubbing. The test that errored (`treeMapOrderingCorrect`) was never testing the clock; it was testing TreeMap ordering, and its double had been wrong all along.

**Provenance.** Extracted from the engine-performance campaign on `perf/engine-concurrency`. Stacked on astubbs/parallel-consumer#335 because both touch `WorkContainer`; the branch's verdict-free abandonment path (which also records residence) belongs to the proxy work and is deliberately excluded here.

## Checklist

- [x] Docs updated - `PCMetricsDef` carries the metric's contract in javadoc
- [x] User-facing feature documentation data added under `docs/features/` - `docs/features/record-residence-time.yaml`
- [x] Tests added/updated - `PCMetricsTest`, plus the test-double repair described above
- [x] Title & body reflect the final content of this PR

