### PR TITLE
feat(core) astubbs#190: run the user function on virtual threads

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,6 +66,37 @@ jobs:
 
   # Default Kafka version: split suites for fast, parallel feedback.
   # Uses the same scripts as local development (ci-unit-test.sh, etc.)
+  #
+  # EXECUTION-MODE AXIS. The last entry is not a fourth suite - it is the FIRST suite again, run with a
+  # different execution mode selected. Parallel Consumer has opt-in execution paths that are meant to be
+  # BEHAVIOURALLY EQUIVALENT to the default engine, and what needs asserting is not that each one works
+  # but that each one AGREES with the default, on ordering, commits, retries, rebalance and shutdown.
+  # That is the suite we already have, run again with a different selector - so it is a matrix axis over
+  # one suite, not a suite per path. See docs/inflight/test-opt-in-engine-paths-are-unexercised.md.
+  #
+  # ADDING THE NEXT MODE IS A MATRIX ENTRY, not another job. Direct pull is the next one:
+  #     - suite: unit
+  #       name: "Unit Tests (direct pull)"
+  #       cmd: "bin/ci-unit-test.sh -Dpc.directPull=true"
+  #       mode: direct-pull
+  #       java: '17'
+  #       timeout: 20
+  # It needs a row in bin/check-execution-mode.sh's mode_marker()/mode_selector() too, and it is
+  # deliberately NOT added here - that is separate work.
+  #
+  # WHY THE VIRTUAL-THREAD ENTRY BUILDS ON 17 AND TESTS ON 21. Virtual threads are a RUNTIME capability
+  # and PC reaches them reflectively, so nothing has to compile against JDK 21 - and nothing can: Jabel
+  # 1.0.0, which is what lets this project emit Java 8 bytecode from Java 17 source, does not run on JDK
+  # 21 at all (it rewrites javac internals with a Byte Buddy that predates it, and strips
+  # Source$Feature.LAMBDA in the attempt). Surefire's fork is a separate JVM, and the pom already
+  # parameterises it as ${jvm.location}, so the lane tests the SHIPPED Java 8 bytecode on a JDK 21
+  # runtime - which is exactly what a user with this option enabled does.
+  #
+  # THE JOB IS ADVISORY AND ITS NAME IS NEW. Required status checks are matched BY NAME in the master
+  # ruleset, and a required context that no run has ever produced blocks every PR whose base predates it
+  # - so making this one required is a separate, deliberate act, after it has run on master. Note also
+  # that a JDK axis existed here once (JDK 8 and 13) and was removed for cost; re-adding one re-opens
+  # that decision (astubbs#128), and this entry is scoped to the unit suite only to keep it cheap.
   test:
     if: github.event_name == 'pull_request'
     needs: prepare-deps
@@ -89,15 +120,30 @@ jobs:
             name: "Performance Tests"
             cmd: "bin/performance-test.sh"
             timeout: 60
+          # First non-default entry on the execution-mode axis - see the header comment above.
+          - suite: unit
+            name: "Unit Tests (virtual threads)"
+            cmd: "bin/ci-unit-test.sh -Dpc.virtualThreads=true -Djvm.location=$JAVA_HOME_21_X64"
+            mode: virtual-threads
+            advisory: true
+            timeout: 20
     name: "${{ matrix.name }}"
     runs-on: ubuntu-latest
+    # Advisory entries never gate merge - see the execution-mode note in this job's header comment.
+    continue-on-error: ${{ matrix.advisory == true }}
     timeout-minutes: ${{ matrix.timeout }}
     steps:
       - uses: actions/checkout@v6
+      # 17 is LAST so it wins JAVA_HOME and stays the BUILD JDK for every entry. setup-java also
+      # exports JAVA_HOME_21_X64, which is how the virtual-thread entry points surefire's fork at a
+      # JDK 21 runtime without moving the compiler - Jabel cannot run on 21. Listing 21 is a no-op
+      # for every other entry.
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: |
+            21
+            17
       - name: Restore Maven cache
         uses: actions/cache/restore@v4
         with:
@@ -107,12 +153,28 @@ jobs:
             setup-java-Linux-x64-maven-
       - name: ${{ matrix.name }}
         run: ${{ matrix.cmd }}
+      # A suite that SKIPPED the mode it was asked for and reported green is the failure this axis
+      # exists to prevent, and it is the shape this repo has already shipped once. The guard reads the
+      # surefire XML - structural evidence, not a log string - and refuses a green verdict when the
+      # mode-proving tests did not execute. always(), so it still speaks when the suite went red.
+      - name: "Was the execution mode actually exercised?"
+        if: always() && matrix.mode != ''
+        # pipefail is NOT the default for a run: step (GitHub uses "bash -e {0}"), so a bare
+        # "guard | tee" would report tee's status and the step would be green however the guard
+        # exited - this step silently doing the exact thing it was written to catch. Explicit shell,
+        # explicit pipefail.
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash bin/check-execution-mode.sh "${{ matrix.mode }}" | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
           files: '**/target/site/jacoco/jacoco.xml,**/target/site/jacoco-it/jacoco.xml'
-          flags: ${{ matrix.suite }}
+          # Distinct per matrix entry, not per suite: two entries now share the "unit" suite, and one
+          # flag for both would average the default engine's coverage with the virtual-thread run's.
+          flags: ${{ matrix.mode && format('{0}-{1}', matrix.suite, matrix.mode) || matrix.suite }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # Mutation testing (PIT). ci-mutation-test.sh scopes to the classes CHANGED vs the PR base

--- a/README.adoc
+++ b/README.adoc
@@ -1483,8 +1483,10 @@ The published modules share one answer to both. They all depend on `parallel-con
 there is no per-module reliability gradient to publish. What does differ is the experimental artifacts, which are a
 separate and explicit opt-in and cannot change an application that does not depend on one.
 
-Virtual threads, micro-batching and a dead-letter queue are intentionally deferred capabilities, not exceptions to the
-critical-defect gate.
+Micro-batching and a dead-letter queue are intentionally deferred capabilities, not exceptions to the critical-defect
+gate. Virtual threads are no longer among them: the processing function can run on virtual threads via the opt-in
+`useVirtualThreads` option, on a JDK 21 runtime. The published artifacts are unchanged Java 8 bytecode, so only the
+runtime has to move.
 
 |===
 | Module | Status | Reliability confidence | API expectation | Use this if

--- a/bin/check-execution-mode.sh
+++ b/bin/check-execution-mode.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Decides whether a test run actually EXERCISED the execution mode it was asked for, and renders what
+# it found.
+#
+# WHY THIS EXISTS
+#
+# Parallel Consumer has execution paths that are selected by a flag or a runtime and are meant to be
+# BEHAVIOURALLY EQUIVALENT to the default engine - virtual threads today, direct pull next
+# (docs/inflight/test-opt-in-engine-paths-are-unexercised.md). CI runs the existing suite again with
+# a different selector, which makes one failure mode overwhelmingly likely:
+#
+#     a suite that SKIPPED the mode's own tests, and reported green.
+#
+# That is not hypothetical here. The virtual-thread tests on the upstream PR used JUnit Assumptions,
+# and CI runs a JDK the mode is unavailable on, so they skipped and the job passed - its author said
+# so himself. This repository has shipped that shape before; the roster is in
+# docs/solutions/workflow-issues/a-check-that-reports-success-without-having-run.md.
+#
+# The Java side already inverts the assumption, so a selected-but-unavailable mode FAILS a test. This
+# script is the second half: it reads the surefire XML - structural evidence from the artifact, not a
+# string in a log - and refuses to call a run green when the mode's own tests did not execute. It also
+# states the run and skip counts in the job summary, so a skip is visible rather than absent.
+#
+# TWO REDS, AND THEY MUST NOT BE CONFUSED
+#
+#   mode not proven to have run -> exit 1  (red: the LANE is broken - a green result means nothing)
+#   mode ran, tests all passed  -> exit 0
+#   mode ran, tests failed      -> exit 2  (red: the TREE has a real disagreement to triage)
+#
+# They demand opposite responses: exit 1 means go fix the lane and learn nothing about the tree;
+# exit 2 means the lane worked and there is a genuine behavioural difference between this mode and the
+# default engine - which is the most valuable thing a mode axis produces, because it identifies tests
+# that assert implementation rather than behaviour. When both are true, exit 1 wins: failures from a
+# run that cannot be shown to have exercised the mode are not evidence in either direction.
+#
+# ADDING THE NEXT MODE is a row in MODE_TESTS below plus a matrix entry - not another script.
+#
+# Usage:  bin/check-execution-mode.sh <mode> [surefire-reports-dir ...]
+#
+#   mode                 the execution mode this run selected: `virtual-threads`, or `default`
+#   surefire-reports-dir defaults to every */target/surefire-reports in the tree
+#
+# Markdown report goes to stdout, so CI can append it to $GITHUB_STEP_SUMMARY. Progress and the
+# verdict go to stderr.
+
+set -euo pipefail
+
+# The test class that can only pass by actually exercising the mode. `default` has no marker: the
+# whole suite is its evidence, and there is nothing that could silently skip.
+mode_marker() {
+  case "$1" in
+    virtual-threads) echo "VirtualThreadExecutionModeTest" ;;
+    default) echo "" ;;
+    *) return 1 ;;
+  esac
+}
+
+# The system property a mode is selected by, quoted in the failure message so the reader can
+# reproduce the run.
+mode_selector() {
+  case "$1" in
+    virtual-threads) echo "-Dpc.virtualThreads=true" ;;
+    default) echo "(none)" ;;
+    *) return 1 ;;
+  esac
+}
+
+MODE="${1:-}"
+if [ -z "$MODE" ]; then
+  echo "usage: $0 <mode> [surefire-reports-dir ...]" >&2
+  exit 1
+fi
+shift || true
+
+if ! MARKER="$(mode_marker "$MODE")"; then
+  echo "check-execution-mode: unknown mode '$MODE'. Known modes: virtual-threads, default." >&2
+  echo "Add a row to mode_marker()/mode_selector() when you add a mode." >&2
+  exit 1
+fi
+SELECTOR="$(mode_selector "$MODE")"
+
+REPORT_DIRS=("$@")
+if [ ${#REPORT_DIRS[@]} -eq 0 ]; then
+  while IFS= read -r dir; do
+    REPORT_DIRS+=("$dir")
+  done < <(find . -type d -path '*/target/surefire-reports' -not -path './.git/*' | sort)
+fi
+
+if [ ${#REPORT_DIRS[@]} -eq 0 ]; then
+  echo "## Execution mode: \`$MODE\`"
+  echo
+  echo "**No surefire reports found.** The suite did not run, so nothing is known about this mode."
+  echo "check-execution-mode: no surefire reports - the lane did not run" >&2
+  exit 1
+fi
+
+total_tests=0
+total_failures=0
+total_errors=0
+total_skipped=0
+marker_tests=0
+marker_skipped=0
+marker_seen=0
+
+for dir in "${REPORT_DIRS[@]}"; do
+  [ -d "$dir" ] || continue
+  while IFS= read -r xml; do
+    # The <testsuite ...> attributes, read off the artifact rather than parsed out of console text -
+    # console output is truncated, reordered and localised; the XML is none of those.
+    header="$(head -c 4000 "$xml" | tr '\n' ' ')"
+    case "$header" in
+      *"<testsuite "*) : ;;
+      *) continue ;;
+    esac
+
+    # Bash's own regex, deliberately, rather than sed or grep. GNU sed accepts `s/.../.../;t;d` and
+    # BSD sed (macOS, which contributors run) rejects it with "undefined label" - on stderr, while
+    # still exiting 0, so every attribute silently read as zero and the guard called a healthy run a
+    # broken lane. Its self-test caught that; nothing else would have. No pipe either, so there is no
+    # SIGPIPE hazard for bin/check-shell-sigpipe.sh to find.
+    attr() {
+      local re="[[:space:]]$1=\"([0-9]+)\""
+      if [[ "$header" =~ $re ]]; then
+        echo "${BASH_REMATCH[1]}"
+      else
+        echo 0
+      fi
+    }
+
+    t="$(attr tests)"; f="$(attr failures)"; e="$(attr errors)"; s="$(attr skipped)"
+    total_tests=$((total_tests + t))
+    total_failures=$((total_failures + f))
+    total_errors=$((total_errors + e))
+    total_skipped=$((total_skipped + s))
+
+    if [ -n "$MARKER" ] && case "$xml" in *"$MARKER"*) true ;; *) false ;; esac; then
+      marker_seen=1
+      marker_tests=$((marker_tests + t))
+      marker_skipped=$((marker_skipped + s))
+    fi
+  done < <(find "$dir" -name 'TEST-*.xml' -type f | sort)
+done
+
+marker_executed=$((marker_tests - marker_skipped))
+
+echo "## Execution mode: \`$MODE\`"
+echo
+echo "| | |"
+echo "|---|---:|"
+echo "| Selector | \`$SELECTOR\` |"
+echo "| Tests run | $total_tests |"
+echo "| Failures | $total_failures |"
+echo "| Errors | $total_errors |"
+echo "| **Skipped** | **$total_skipped** |"
+if [ -n "$MARKER" ]; then
+  echo "| Mode-proving tests in \`$MARKER\` | $marker_tests |"
+  echo "| ...of which executed | $marker_executed |"
+  echo "| ...of which skipped | $marker_skipped |"
+fi
+echo
+
+status=0
+
+if [ "$total_tests" -eq 0 ]; then
+  echo "### Lane broken"
+  echo
+  echo "Surefire reports exist but contain no tests. Nothing was learned about \`$MODE\`."
+  echo "check-execution-mode: no tests in the reports - the lane did not run" >&2
+  exit 1
+fi
+
+if [ -n "$MARKER" ]; then
+  if [ "$marker_seen" -eq 0 ]; then
+    echo "### Lane broken"
+    echo
+    echo "The suite ran, but \`$MARKER\` produced no report at all - so nothing here proves the"
+    echo "\`$MODE\` path was taken. A green result from this run means nothing about that mode."
+    echo "check-execution-mode: $MARKER did not run - the lane cannot prove mode '$MODE' was exercised" >&2
+    exit 1
+  fi
+  if [ "$marker_executed" -le 0 ]; then
+    echo "### Lane broken"
+    echo
+    echo "Every test in \`$MARKER\` was skipped, so this run verified nothing about \`$MODE\` while"
+    echo "reporting a result. Run it on a runtime that provides the mode - for virtual threads, a"
+    echo "JDK 21+ test JVM via \`-Djvm.location=<jdk21-home>\`. The build JDK does not have to move."
+    echo "check-execution-mode: all $marker_tests tests in $MARKER skipped - mode '$MODE' was never exercised" >&2
+    exit 1
+  fi
+fi
+
+if [ "$total_failures" -gt 0 ] || [ "$total_errors" -gt 0 ]; then
+  echo "### Real findings to triage"
+  echo
+  echo "The \`$MODE\` path was exercised and $((total_failures + total_errors)) test(s) disagreed with"
+  echo "the default engine's expectations. **Do not silence these.** Each is either a behaviour worth"
+  echo "keeping in both modes, or an assertion on the current engine's implementation that should not"
+  echo "have been written - and that distinction is invisible while only one mode exists."
+  echo "check-execution-mode: mode '$MODE' ran ($marker_executed mode tests executed) and the tree has $((total_failures + total_errors)) failure(s)" >&2
+  status=2
+else
+  echo "### Exercised, and in agreement"
+  echo
+  if [ -n "$MARKER" ]; then
+    echo "\`$MARKER\` executed $marker_executed test(s) that can only pass on the \`$MODE\` path."
+  fi
+  echo "The suite agrees with the default engine."
+  echo "check-execution-mode: mode '$MODE' exercised ($marker_executed mode tests), $total_tests tests green, $total_skipped skipped" >&2
+fi
+
+exit "$status"

--- a/bin/test-check-execution-mode.sh
+++ b/bin/test-check-execution-mode.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Self-test for bin/check-execution-mode.sh.
+#
+# Each case is a gap the guard exists to catch, pinned so a regression is visible. The guard's whole
+# job is to refuse a green verdict when a mode was not exercised, so the cases that matter are the
+# ones where surefire itself is perfectly happy: a suite that ran, passed, and skipped the only tests
+# that could have proven anything.
+#
+# Run it from anywhere; it works in a temp tree and never touches the repo's own reports.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$HERE/check-execution-mode.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+passes=0
+failures=0
+
+# Writes a surefire report. Naming matters: the guard identifies the mode-proving suite by the class
+# name in the file name, exactly as surefire writes it.
+report() {
+  local dir="$1" class="$2" tests="$3" fails="$4" errors="$5" skipped="$6"
+  mkdir -p "$dir"
+  cat > "$dir/TEST-$class.xml" <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="$class" time="1.0" tests="$tests" errors="$errors" skipped="$skipped" failures="$fails">
+  <properties/>
+</testsuite>
+XML
+}
+
+expect_exit() {
+  local label="$1" expected="$2"
+  shift 2
+  local actual=0
+  "$@" > "$WORK/out.md" 2> "$WORK/out.err" || actual=$?
+  if [ "$actual" -eq "$expected" ]; then
+    echo "  ok   $label (exit $actual)"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL $label: expected exit $expected, got $actual"
+    sed 's/^/       /' "$WORK/out.err" || true
+    failures=$((failures + 1))
+  fi
+}
+
+expect_stdout_contains() {
+  local label="$1" needle="$2"
+  if grep -F -- "$needle" "$WORK/out.md" >/dev/null; then
+    echo "  ok   $label"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL $label: report did not contain '$needle'"
+    sed 's/^/       /' "$WORK/out.md" || true
+    failures=$((failures + 1))
+  fi
+}
+
+echo "check-execution-mode self-test"
+
+# ---------------------------------------------------------------------------------------------
+# THE CASE THE GUARD EXISTS FOR. Every other test passed, the mode's own tests all skipped. Surefire
+# is green. This must be exit 1 - the LANE is broken - and never exit 0.
+# ---------------------------------------------------------------------------------------------
+D="$WORK/all-skipped/target/surefire-reports"
+report "$D" "bz.stub.parallelconsumer.SomeOtherTest" 40 0 0 0
+report "$D" "bz.stub.parallelconsumer.internal.VirtualThreadExecutionModeTest" 7 0 0 7
+expect_exit "all mode tests skipped is a broken lane, not a pass" 1 "$GUARD" virtual-threads "$D"
+expect_stdout_contains "...and says so in the summary" "verified nothing"
+
+# ---------------------------------------------------------------------------------------------
+# The mode-proving suite is absent entirely - a test-selection filter, a rename, a module that did
+# not build. Indistinguishable from success in the surefire totals.
+# ---------------------------------------------------------------------------------------------
+D="$WORK/marker-missing/target/surefire-reports"
+report "$D" "bz.stub.parallelconsumer.SomeOtherTest" 40 0 0 0
+expect_exit "mode-proving suite missing is a broken lane" 1 "$GUARD" virtual-threads "$D"
+expect_stdout_contains "...and names the suite it wanted" "VirtualThreadExecutionModeTest"
+
+# ---------------------------------------------------------------------------------------------
+# No reports at all.
+# ---------------------------------------------------------------------------------------------
+D="$WORK/empty/target/surefire-reports"
+mkdir -p "$D"
+expect_exit "no reports is a broken lane" 1 "$GUARD" virtual-threads "$D"
+
+# ---------------------------------------------------------------------------------------------
+# The happy path: the mode ran and everything agreed.
+# ---------------------------------------------------------------------------------------------
+D="$WORK/green/target/surefire-reports"
+report "$D" "bz.stub.parallelconsumer.SomeOtherTest" 380 0 0 8
+report "$D" "bz.stub.parallelconsumer.internal.VirtualThreadExecutionModeTest" 7 0 0 1
+expect_exit "exercised and agreeing is a pass" 0 "$GUARD" virtual-threads "$D"
+expect_stdout_contains "...and reports the skip count rather than hiding it" "Skipped"
+
+# ---------------------------------------------------------------------------------------------
+# The mode ran and the tree disagreed - exit 2, the useful red.
+# ---------------------------------------------------------------------------------------------
+D="$WORK/findings/target/surefire-reports"
+report "$D" "bz.stub.parallelconsumer.SomeOtherTest" 380 2 1 8
+report "$D" "bz.stub.parallelconsumer.internal.VirtualThreadExecutionModeTest" 7 0 0 1
+expect_exit "exercised with disagreements is exit 2, not exit 1" 2 "$GUARD" virtual-threads "$D"
+expect_stdout_contains "...and says not to silence them" "Do not silence"
+
+# ---------------------------------------------------------------------------------------------
+# BOTH reds at once: the mode never ran AND other tests failed. Exit 1 must win - failures from a run
+# that cannot be shown to have exercised the mode are not evidence in either direction.
+# ---------------------------------------------------------------------------------------------
+D="$WORK/both/target/surefire-reports"
+report "$D" "bz.stub.parallelconsumer.SomeOtherTest" 380 3 0 8
+report "$D" "bz.stub.parallelconsumer.internal.VirtualThreadExecutionModeTest" 7 0 0 7
+expect_exit "broken lane beats real findings" 1 "$GUARD" virtual-threads "$D"
+
+# ---------------------------------------------------------------------------------------------
+# The default mode has no marker suite - the whole run is its evidence - but an empty run is still a
+# broken lane.
+# ---------------------------------------------------------------------------------------------
+D="$WORK/default-green/target/surefire-reports"
+report "$D" "bz.stub.parallelconsumer.SomeOtherTest" 380 0 0 8
+expect_exit "default mode needs no marker suite" 0 "$GUARD" default "$D"
+
+# ---------------------------------------------------------------------------------------------
+# An unknown mode is a typo in the workflow, and must not silently pass.
+# ---------------------------------------------------------------------------------------------
+expect_exit "an unknown mode is rejected" 1 "$GUARD" no-such-mode "$WORK/green/target/surefire-reports"
+
+echo
+echo "$passes passed, $failures failed"
+[ "$failures" -eq 0 ]

--- a/docs/data/module-maturity.yaml
+++ b/docs/data/module-maturity.yaml
@@ -30,7 +30,6 @@ release_validation:
       merged resolution and its named recurrence guard must pass before 0.6.0.0 is cut.
     evidence: testing-evidence.yaml#v6_stability_exception
     explicit_non_defect_deferrals:
-      - Virtual threads
       - Micro-batching
       - Dead-letter queue
   automated:

--- a/docs/data/roadmap.yaml
+++ b/docs/data/roadmap.yaml
@@ -224,7 +224,7 @@ entries:
   - id: virtual-threads
     title: Support virtual threads
     serves: [performance, flexibility]
-    horizon: next-0x
+    horizon: "0.6.0.0"
     blocks_1_0: false
     stage: idea
     stage_detail: >-

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/ParallelConsumerOptions.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/ParallelConsumerOptions.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
 
 import static bz.stub.parallelconsumer.internal.utils.StringUtils.msg;
@@ -326,6 +328,32 @@ public class ParallelConsumerOptions<K, V> {
 
     public static final int DEFAULT_MAX_CONCURRENCY = 16;
 
+    /**
+     * Runs the user's function on virtual threads (JEP 444) instead of a fixed pool of platform threads. Requires a
+     * JDK 21 runtime; the published artifact is still Java 8 bytecode, and the JDK 21 API is reached reflectively.
+     * <p>
+     * <b>What it is for.</b> A handler that blocks holds an OS thread for as long as it blocks, and this machine can
+     * only bring platform threads out of a park at a fixed rate - so reachable concurrency is
+     * {@code min(maxConcurrency, activationRate * handlerLatency)} rather than {@code maxConcurrency}. Measured on a
+     * 12-core laptop at {@code maxConcurrency} 5,000 with a 100ms handler: platform threads held 2,673 records in
+     * flight, virtual threads held all 5,000. Raising {@link #maxConcurrency} past that ceiling does nothing; making
+     * the work not hold a thread removes the term. See {@code docs/inflight/perf-platform-threads-are-the-ceiling.md}.
+     * <p>
+     * <b>What it changes.</b> The pool is unbounded, so {@link #maxConcurrency} becomes a target the control loop
+     * aims at rather than a cap the pool enforces: a burst of already-submitted work can briefly exceed it. It also
+     * takes precedence over {@link #managedExecutorService} and {@link #managedThreadFactory}, which describe a pool
+     * that no longer exists in this mode. External engines (Vert.x, Reactor, Mutiny) ignore it - their worker "pool"
+     * is a single dispatch thread by design and their concurrency lives in the external runtime.
+     * <p>
+     * Defaults from the {@code pc.virtualThreads} system property, so that a benchmark harness which cannot change
+     * its source (it compiles one template against every released version) and CI's execution-mode matrix can both
+     * select the mode without editing a test.
+     *
+     * @see #validate()
+     */
+    @Builder.Default
+    private final boolean useVirtualThreads = Boolean.getBoolean("pc.virtualThreads");
+
     public static final Duration DEFAULT_STATIC_RETRY_DELAY = Duration.ofSeconds(1);
 
     // Default backoff for SaslAuthenticationException retry durion ConsumerManager.commitSync and ConsumerManager.poll.
@@ -474,6 +502,29 @@ public class ParallelConsumerOptions<K, V> {
         Objects.requireNonNull(consumer, "A consumer must be supplied");
 
         transactionsValidation();
+        virtualThreadsValidation();
+    }
+
+    /**
+     * Fails construction rather than the first poll, and probes exactly what
+     * {@code AbstractParallelEoSStreamProcessor#setupWorkerPool} will call - not just
+     * {@code Thread.ofVirtual}. Probing a subset would let a JVM with one method and not the other pass validation
+     * and then fail later, somewhere less obviously about this option.
+     */
+    private void virtualThreadsValidation() {
+        if (!useVirtualThreads) {
+            return;
+        }
+        try {
+            Class.forName("java.lang.Thread").getMethod("ofVirtual");
+            Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class);
+        } catch (NoSuchMethodException | ClassNotFoundException e) {
+            throw new UnsupportedOperationException(msg(
+                    "useVirtualThreads is enabled, but this JVM ({} {}) does not provide virtual threads. " +
+                            "They need a JDK 21 runtime - note that the Parallel Consumer artifact itself is still " +
+                            "Java 8 bytecode, so only the runtime has to move, not your build.",
+                    System.getProperty("java.vm.name"), System.getProperty("java.version")), e);
+        }
     }
 
     private void transactionsValidation() {

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
@@ -114,10 +114,24 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     private final org.apache.kafka.clients.consumer.Consumer<K, V> consumer;
 
     /**
-     * The pool which is used for running the users' supplied function
+     * The pool which is used for running the users' supplied function.
+     * <p>
+     * Typed as {@link ExecutorService} rather than {@link ThreadPoolExecutor} because
+     * {@link ParallelConsumerOptions#isUseVirtualThreads()} selects a virtual-thread-per-task executor, which is not
+     * one. Nothing outside {@link #innerDoClose(Duration)} needs the wider type: the pool's queue depth and active
+     * count - the two figures the pressure system and the shutdown diagnostics used to read off
+     * {@link ThreadPoolExecutor} - are now counted by {@link #userFunctionTaskAccounting}.
      */
     @Getter(PROTECTED)
-    protected final Supplier<ThreadPoolExecutor> workerThreadPool;
+    protected final Supplier<ExecutorService> workerThreadPool;
+
+    /**
+     * Replaces {@code workerThreadPool.getQueue().size()} and {@code workerThreadPool.getActiveCount()}, which a
+     * virtual-thread-per-task executor does not have.
+     *
+     * @see UserFunctionTaskAccounting
+     */
+    private final UserFunctionTaskAccounting userFunctionTaskAccounting = new UserFunctionTaskAccounting();
 
     private Optional<Future<Boolean>> controlThreadFuture = Optional.empty();
 
@@ -349,9 +363,21 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         this.loadFactorGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.DYNAMIC_EXTRA_LOAD_FACTOR,
                 dynamicExtraLoadFactor, DynamicLoadFactor::getCurrentFactor);
         this.statusGauge = pcMetrics.gaugeFromMetricDef(PCMetricsDef.PC_STATUS, this, pc -> pc.state.getValue());
-        new ExecutorServiceMetrics(this.getWorkerThreadPool().get(), "pc-user-function-executor",
-                USER_FUNCTION_EXECUTOR_PREFIX,
-                pcMetrics.getCommonTags()).bindTo(pcMetrics.getMeterRegistry());
+        // Micrometer's ExecutorServiceMetrics only knows how to read a ThreadPoolExecutor (and a ForkJoinPool).
+        // Handed a virtual-thread-per-task executor it binds no meters and reports nothing - a gauge set that
+        // silently measures nothing is worse than an absent one, because a dashboard showing a flat zero reads as
+        // "no work" rather than "not instrumented". Say so once, at INFO, and leave the meters unregistered.
+        ExecutorService pool = this.getWorkerThreadPool().get();
+        if (pool instanceof ThreadPoolExecutor || pool instanceof ForkJoinPool) {
+            new ExecutorServiceMetrics(pool, "pc-user-function-executor",
+                    USER_FUNCTION_EXECUTOR_PREFIX,
+                    pcMetrics.getCommonTags()).bindTo(pcMetrics.getMeterRegistry());
+        } else {
+            log.info("Worker pool is a {}, which Micrometer's ExecutorServiceMetrics cannot introspect, so the " +
+                            "{} meters are not registered. Parallel Consumer's own in-flight and queued figures are " +
+                            "unaffected.",
+                    pool.getClass().getName(), USER_FUNCTION_EXECUTOR_PREFIX);
+        }
     }
 
     private void validateConfiguration() {
@@ -371,27 +397,6 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         }
     }
 
-    protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
-        ThreadFactory defaultFactory;
-        try {
-            defaultFactory = InitialContext.doLookup(options.getManagedThreadFactory());
-        } catch (NamingException e) {
-            log.debug("Using Java SE Thread", e);
-            defaultFactory = Executors.defaultThreadFactory();
-        }
-        ThreadFactory finalDefaultFactory = defaultFactory;
-        ThreadFactory namingThreadFactory = r -> {
-            Thread thread = finalDefaultFactory.newThread(r);
-            String name = thread.getName();
-            thread.setName("pc-" + name);
-            this.getMyId().ifPresent(id -> thread.setName("pc-" + name + "-" + id));
-            return thread;
-        };
-        ThreadPoolExecutor.AbortPolicy rejectionHandler = new ThreadPoolExecutor.AbortPolicy();
-        LinkedBlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>();
-        return new ThreadPoolExecutor(poolSize, poolSize, 0L, MILLISECONDS, workQueue,
-                namingThreadFactory, rejectionHandler);
-    }
 
     /**
      * A worker pool must announce a rejection by throwing, so any pool whose {@link RejectedExecutionHandler} is not an
@@ -436,8 +441,14 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      *         substitute something else
      * @throws IllegalArgumentException if the pool would swallow a rejection
      */
-    private ThreadPoolExecutor requireRejectionIsVisible(ThreadPoolExecutor pool) {
-        RejectedExecutionHandler handler = pool.getRejectedExecutionHandler();
+    private ExecutorService requireRejectionIsVisible(ExecutorService pool) {
+        if (!(pool instanceof ThreadPoolExecutor)) {
+            // A virtual-thread executor has no rejection handler to inspect and no bounded queue to reject from -
+            // it starts a thread per task. The guard below is a property of ThreadPoolExecutor, so narrow to it
+            // rather than refusing every pool that is not one.
+            return pool;
+        }
+        RejectedExecutionHandler handler = ((ThreadPoolExecutor) pool).getRejectedExecutionHandler();
         if (!(handler instanceof ThreadPoolExecutor.AbortPolicy)) {
             throw new IllegalArgumentException(msg(
                     "Unsupported worker pool returned by {}#setupWorkerPool: its rejected execution handler is {}, " +
@@ -457,6 +468,96 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                     ThreadPoolExecutor.CallerRunsPolicy.class.getSimpleName()));
         }
         return pool;
+    }
+
+    /**
+     * Whether this engine can run the user's function on virtual threads.
+     * <p>
+     * False for {@link ExternalEngine}: its worker "pool" is one thread that dispatches into an external runtime,
+     * and the concurrency lives out there. Replacing that one
+     * thread with an unbounded virtual-thread executor would silently make the dispatch itself concurrent, which is
+     * not what any of those engines are built on.
+     *
+     * @see ParallelConsumerOptions#isUseVirtualThreads()
+     */
+    protected boolean supportsVirtualThreads() {
+        return true;
+    }
+
+    protected ExecutorService setupWorkerPool(int poolSize) {
+        if (options.isUseVirtualThreads()) {
+            if (supportsVirtualThreads()) {
+                return setupVirtualThreadWorkerPool();
+            }
+            log.warn("useVirtualThreads is set, but {} dispatches into an external runtime rather than running the " +
+                            "user's function on its own pool, so virtual threads have nothing to do here. Using the " +
+                            "usual single dispatch thread. Concurrency for this engine is configured in the runtime " +
+                            "it dispatches to.",
+                    this.getClass().getSimpleName());
+        }
+
+        ThreadFactory defaultFactory;
+        try {
+            defaultFactory = InitialContext.doLookup(options.getManagedThreadFactory());
+        } catch (NamingException e) {
+            log.debug("Using Java SE Thread", e);
+            defaultFactory = Executors.defaultThreadFactory();
+        }
+        ThreadFactory finalDefaultFactory = defaultFactory;
+        ThreadFactory namingThreadFactory = r -> {
+            Thread thread = finalDefaultFactory.newThread(r);
+            String name = thread.getName();
+            thread.setName("pc-" + name);
+            this.getMyId().ifPresent(id -> thread.setName("pc-" + name + "-" + id));
+            return thread;
+        };
+        ThreadPoolExecutor.AbortPolicy rejectionHandler = new ThreadPoolExecutor.AbortPolicy();
+        LinkedBlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>();
+        return new ThreadPoolExecutor(poolSize, poolSize, 0L, MILLISECONDS, workQueue,
+                namingThreadFactory, rejectionHandler);
+    }
+
+    /**
+     * DO NOT "SIMPLIFY" THIS INTO DIRECT CALLS. Every JDK 21 symbol here is reached reflectively on purpose: this
+     * module compiles with {@code release.target=8} (see {@code pom.xml} and
+     * {@code docs/features/java-compatibility.yaml}), so {@code Thread.ofVirtual()} and
+     * {@code Executors.newThreadPerTaskExecutor(...)} are not on the compile-time API surface at all. Writing them
+     * directly does not fail at review time - it fails the Java 8 build, for everyone, for a capability that is
+     * opt-in and off by default.
+     * <p>
+     * {@link ParallelConsumerOptions#validate()} has already probed these same two methods, so reaching here on a
+     * JVM without them means the runtime changed underneath a constructed instance. That is a bug, not a
+     * configuration error, which is why it throws {@link IllegalStateException} rather than the
+     * {@link UnsupportedOperationException} validation raises.
+     * <p>
+     * The threads are named rather than left anonymous: at a {@code maxConcurrency} where virtual threads are worth
+     * having, a thread dump holds thousands of them, and unnamed ones make it unreadable.
+     *
+     * @see bz.stub.parallelconsumer.ParallelConsumerOptions#isUseVirtualThreads()
+     */
+    private ExecutorService setupVirtualThreadWorkerPool() {
+        try {
+            // Thread.ofVirtual().name("pc-vt-", 0).factory()
+            Object builder = Class.forName("java.lang.Thread").getMethod("ofVirtual").invoke(null);
+            Class<?> builderClass = Class.forName("java.lang.Thread$Builder");
+            String prefix = getMyId().map(id -> "pc-vt-" + id + "-").orElse("pc-vt-");
+            builderClass.getMethod("name", String.class, long.class).invoke(builder, prefix, 0L);
+            ThreadFactory factory = (ThreadFactory) builderClass.getMethod("factory").invoke(builder);
+
+            // Executors.newThreadPerTaskExecutor(factory)
+            ExecutorService executor = (ExecutorService) Executors.class
+                    .getMethod("newThreadPerTaskExecutor", ThreadFactory.class)
+                    .invoke(null, factory);
+            log.info("Running the user function on virtual threads. maxConcurrency ({}) is a target the control " +
+                            "loop aims at, not a cap the pool enforces - the pool is unbounded.",
+                    options.getMaxConcurrency());
+            return executor;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(msg(
+                    "useVirtualThreads passed validation but this JVM ({} {}) cannot create a virtual-thread " +
+                            "executor - report a bug.",
+                    System.getProperty("java.vm.name"), System.getProperty("java.version")), e);
+        }
     }
 
     private void checkNotSubscribed(org.apache.kafka.clients.consumer.Consumer<K, V> consumerToCheck) {
@@ -771,11 +872,11 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
 
         log.debug("Shutting down execution pool...");
         //Clear scheduled but not started work in execution pool
-        workerThreadPool.get().getQueue().clear();
+        discardQueuedWork();
         //request graceful shutdown
         workerThreadPool.get().shutdown();
-        if (workerThreadPool.get().getActiveCount() > 0) {
-            log.info("Inflight work in execution pool: {}, letting to finish on shutdown with timeout: {}", workerThreadPool.get().getActiveCount(), timeout);
+        if (userFunctionTaskAccounting.getActive() > 0) {
+            log.info("Inflight work in execution pool: {}, letting to finish on shutdown with timeout: {}", userFunctionTaskAccounting.getActive(), timeout);
         }
 
         log.debug("Awaiting worker pool termination...");
@@ -789,7 +890,9 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                 if (!terminationFinishedWithoutTimeout) {
                     log.warn("Thread execution pool termination await timeout ({})! Were any processing jobs dead locked (test latch locks?) or otherwise stuck? Forcing shutdown of workers.", timeout);
                     //Requesting threads shutdown immediately - inflight threads will be interrupted at this point.
-                    workerThreadPool.get().shutdownNow();
+                    // shutdownNow() hands back tasks it accepted but never ran; they have to be accounted for or
+                    // the derived queue depth never returns to zero - see UserFunctionTaskAccounting.
+                    userFunctionTaskAccounting.onTasksDiscarded(workerThreadPool.get().shutdownNow().size());
                     //Give a second for any interrupt handling / resource cleanup in user functions
                     workerThreadPool.get().awaitTermination(toSeconds(Duration.ofSeconds(1)), SECONDS);
                 }
@@ -800,8 +903,8 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         }
         awaitingInflightProcessingCompletionOnShutdown.getAndSet(false);
 
-        if (workerThreadPool.get().getActiveCount() > 0) {
-            log.warn("Clean execution pool termination failed - some threads still active despite await and interrupt - is user function swallowing interrupted exception? Threads still not done count: {}", workerThreadPool.get().getActiveCount());
+        if (userFunctionTaskAccounting.getActive() > 0) {
+            log.warn("Clean execution pool termination failed - some threads still active despite await and interrupt - is user function swallowing interrupted exception? Threads still not done count: {}", userFunctionTaskAccounting.getActive());
         }
         log.debug("Worker pool terminated.");
 
@@ -1139,7 +1242,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         queueStatsLimiter.performIfNotLimited(() -> {
             int queueSize = getNumberOfUserFunctionsQueued();
             log.debug("Stats: \n- pool active: {} queued:{} \n- queue size: {} target: {} loading factor: {}",
-                    workerThreadPool.get().getActiveCount(), queueSize, queueSize, getPoolLoadTarget(), dynamicExtraLoadFactor.getCurrentFactor());
+                    userFunctionTaskAccounting.getActive(), queueSize, queueSize, getPoolLoadTarget(), dynamicExtraLoadFactor.getCurrentFactor());
         });
 
         return gotWorkCount;
@@ -1216,11 +1319,11 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                                         Consumer<R> callback,
                                         List<WorkContainer<K, V>> workToProcess) {
         if (state.equals(CLOSING) || state.equals(CLOSED)) {
-            log.debug("Not submitting new work as Parallel Consumer is in {} state, incoming work: {}, Pool stats: {}", state, workToProcess.size(), workerThreadPool.get());
+            log.debug("Not submitting new work as Parallel Consumer is in {} state, incoming work: {}, Pool stats: {}", state, workToProcess.size(), userFunctionTaskAccounting);
             return;
         }
         if (!workToProcess.isEmpty()) {
-            log.debug("New work incoming: {}, Pool stats: {}", workToProcess.size(), workerThreadPool.get());
+            log.debug("New work incoming: {}, Pool stats: {}", workToProcess.size(), userFunctionTaskAccounting);
 
             // perf: could inline makeBatches
             var batches = makeBatches(workToProcess);
@@ -1257,13 +1360,28 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                                               final List<WorkContainer<K, V>> batch) {
         // for each record, construct dispatch to the executor and capture a Future
         log.trace("Sending work ({}) to pool", batch);
+
+        // Counted BEFORE the submit, not after. A virtual thread can be running the task before submit() has
+        // returned, and an increment placed after the call would let the task's own onTaskStarted() land first -
+        // making the derived queue depth transiently negative. See UserFunctionTaskAccounting.
+        userFunctionTaskAccounting.onSubmitting();
         Future outputRecordFuture;
         try {
             outputRecordFuture = workerThreadPool.get().submit(() -> {
-                addInstanceMDC();
-                return runUserFunction(usersFunction, callback, batch);
+                userFunctionTaskAccounting.onTaskStarted();
+                try {
+                    addInstanceMDC();
+                    return runUserFunction(usersFunction, callback, batch);
+                } finally {
+                    // Outermost, so it also covers an interrupt delivered by shutdownNow() and anything thrown
+                    // out of addInstanceMDC(). finally runs for Error too; only JVM exit skips it.
+                    userFunctionTaskAccounting.onTaskFinished();
+                }
             });
         } catch (RejectedExecutionException e) {
+            // The task will never run, so nothing downstream will ever account for it - undo the pre-submit
+            // increment before deciding what to do with the rejection.
+            userFunctionTaskAccounting.onSubmitRejected();
             // Narrow on purpose, and safe to be: #requireRejectionIsVisible refuses any pool whose handler is not an
             // AbortPolicy, so RejectedExecutionException is the only thing a rejection here can throw.
             if (!isWorkerPoolShutDown()) {
@@ -1352,13 +1470,54 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
         return getQueueTargetLoaded();
     }
 
+    /**
+     * How many records to hold out for processing.
+     * <p>
+     * <b>The load factor multiplies this only when there is an executor queue for the surplus to sit in.</b> Under
+     * the default engine, everything past {@code maxConcurrency} waits in the {@link ThreadPoolExecutor}'s queue, so
+     * a factor of N means "keep the workers N deep in queued work" - more records buffered, never more records
+     * running. A virtual-thread executor has no queue: every task it accepts gets a thread immediately, so the same
+     * multiplication would mean N times {@code maxConcurrency} records <em>running at once</em>, up to
+     * {@link DynamicLoadFactor#DEFAULT_MAX_LOADING_FACTOR}. That is not a deeper buffer, it is a hundredfold breach
+     * of the concurrency the user configured.
+     * <p>
+     * The factor is <em>not</em> disabled in this mode - it is still doing its other job. See
+     * {@link #isVirtualThreadPool()}.
+     */
     protected int getQueueTargetLoaded() {
+        if (isVirtualThreadPool()) {
+            return getPoolLoadTarget();
+        }
         //noinspection unchecked
         return getPoolLoadTarget() * dynamicExtraLoadFactor.getCurrentFactor();
     }
 
     /**
+     * Whether the worker pool hands every accepted task a thread at once, rather than queueing it.
+     * <p>
+     * Asked of the pool rather than of {@link ParallelConsumerOptions#isUseVirtualThreads()} because the two can
+     * disagree: {@link ExternalEngine} declines virtual threads via {@link #supportsVirtualThreads()} and keeps its
+     * platform dispatch thread even when the option is set.
+     */
+    private boolean isVirtualThreadPool() {
+        return !(workerThreadPool.get() instanceof ThreadPoolExecutor);
+    }
+
+    /**
      * Checks the system has enough pressure in the pipeline of work, if not attempts to step up the load factor.
+     * <p>
+     * <b>This still runs under virtual threads, deliberately.</b> The obvious move when the executor queue goes away
+     * is to no-op the pressure system with it, and that move has a measured price: {@link ExternalEngine} does
+     * exactly that, and it is the identified cause of that family's throughput regression
+     * ({@code docs/inflight/next-core-async-user-function.md}). The load factor has two jobs and only one of them is
+     * about the executor's queue. The other is sizing the buffer of records polled from the broker and held in the
+     * shards - {@code WorkManager#isSufficientlyLoaded()}, which pauses the poller when that buffer is full - and
+     * virtual threads do not remove that buffer. Left unstepped, a virtual-thread run would be fed from a buffer two
+     * deep while the default engine ran with one up to a hundred deep, and any comparison between them would be of
+     * buffer depths rather than of thread types.
+     * <p>
+     * What the mode does change is where the surplus goes, which is {@link #getQueueTargetLoaded()}'s problem, not
+     * this method's.
      */
     protected void checkPipelinePressure() {
         if (log.isTraceEnabled())
@@ -1379,6 +1538,23 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
                 log.warn("isPoolQueueLow(): Max loading factor steps reached: {}/{}", dynamicExtraLoadFactor.getCurrentFactor(), dynamicExtraLoadFactor.getMaxFactor());
             }
         }
+    }
+
+    /**
+     * The queue is below its target but the loading factor cannot grow further.
+     * <p>
+     * Silent under a virtual-thread pool: there is no dispatch queue to run dry, so "the queue is low" is that
+     * pool's permanent resting state rather than a symptom, and the advice this line gives would be actively
+     * wrong - raising the load factor buys a deeper record buffer, not more concurrency, because
+     * {@link #getQueueTargetLoaded()} deliberately stops multiplying in this mode. Raise
+     * {@link ParallelConsumerOptions#getMaxConcurrency()} instead.
+     */
+    private void maybeReportLoadFactorCeiling() {
+        if (isVirtualThreadPool()) {
+            return;
+        }
+        log.warn("isPoolQueueLow(): Max loading factor steps reached: {}/{}",
+                dynamicExtraLoadFactor.getCurrentFactor(), dynamicExtraLoadFactor.getMaxFactor());
     }
 
     /**
@@ -1432,7 +1608,7 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
             currentlyPollingWorkCompleteMailBox.getAndSet(true);
             if (log.isDebugEnabled()) {
                 log.debug("Blocking poll on work until next scheduled offset commit attempt for {}. active threads: {}, queue: {}",
-                        timeToBlockFor, workerThreadPool.get().getActiveCount(), getNumberOfUserFunctionsQueued());
+                        timeToBlockFor, userFunctionTaskAccounting.getActive(), getNumberOfUserFunctionsQueued());
             }
             // wait for work, with a timeToBlockFor for sanity
             log.trace("Blocking poll {}", timeToBlockFor);
@@ -1527,7 +1703,43 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
     }
 
     private int getNumberOfUserFunctionsQueued() {
-        return workerThreadPool.get().getQueue().size();
+        return userFunctionTaskAccounting.getQueued();
+    }
+
+    /**
+     * Package-private so tests can assert the derived figures against the executor's own, which is the only
+     * independent oracle they have - and only on the platform path, because that is the only path where the
+     * executor knows.
+     * <p>
+     * Deliberately not {@code getUserFunctionTaskAccounting()}: the Truth subject generator treats any
+     * {@code get}-prefixed method as a property and emits an assertion calling it from
+     * {@code bz.stub.parallelconsumer}, where a package-private member of {@code ...parallelconsumer.internal} is
+     * not visible - which fails test compilation, not main compilation. The no-prefix form also matches
+     * {@link PCModule}'s accessors.
+     */
+    UserFunctionTaskAccounting userFunctionTaskAccounting() {
+        return userFunctionTaskAccounting;
+    }
+
+    /**
+     * Drops tasks the executor accepted but has not begun, on the way down.
+     * <p>
+     * The only place left that needs the concrete {@link ThreadPoolExecutor}: draining a pending-task queue has no
+     * {@link ExecutorService} equivalent. It is a shutdown path rather than a hot one, and a virtual-thread
+     * executor has no such queue to drain - every task it accepted already has a thread.
+     * <p>
+     * Package-private for the same reason {@link #setLastWorkRequestWasFulfilled(boolean)} is: its only caller is
+     * {@link #innerDoClose(Duration)}, which a never-started processor never reaches (an UNUSED instance goes
+     * straight to CLOSED), so a test could not otherwise drive it without standing up a whole control loop. It has
+     * to be driveable, because removing the accounting call inside it left the entire suite green.
+     */
+    void discardQueuedWork() {
+        ExecutorService pool = workerThreadPool.get();
+        if (pool instanceof ThreadPoolExecutor) {
+            List<Runnable> discarded = new ArrayList<>();
+            ((ThreadPoolExecutor) pool).getQueue().drainTo(discarded);
+            userFunctionTaskAccounting.onTasksDiscarded(discarded.size());
+        }
     }
 
 
@@ -1554,6 +1766,23 @@ public abstract class AbstractParallelEoSStreamProcessor<K, V> implements Parall
      * Visible for testing
      */
     protected void commitOffsetsThatAreReady() throws TimeoutException, InterruptedException {
+        // DELIBERATELY STILL `synchronized`, and not migrated with the other monitors on the virtual-thread path.
+        //
+        // This one is held across retrieveOffsetsAndCommit() - a network commit - so on a JDK before 24 (JEP 491) it
+        // is the textbook pinning site, and converting it to a plain ReentrantLock is a two-line change that would
+        // look like an improvement.
+        //
+        // It is also the exact monitor in the AB-BA deadlock between the poll thread's onPartitionsRevoked and this
+        // method, diagnosed but NOT yet fixed - astubbs#29, and
+        // docs/solutions/runtime-errors/revoke-path-commit-deadlock-between-poll-and-control-threads.md. That fix
+        // needs a specific lock POLICY (tryLock with a timeout, so the cycle cannot close), not merely a lock. A
+        // plain lock() migration landing first either silently forecloses that fix or, worse, makes the file look
+        // as though it already has it.
+        //
+        // The cost of waiting is bounded: pinning here only bites on JDK 21-23, only with virtual threads enabled,
+        // and only on the control thread - which is one thread, not one per record. Whoever takes astubbs#29 should
+        // make it a ReentrantLock with the tryLock policy, and note that clearCommitCommand() is called from
+        // INSIDE this block, so reentrancy is load-bearing.
         log.trace("Synchronizing on commitCommand...");
         synchronized (commitCommand) {
             log.debug("Committing offsets that are ready...");

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/DynamicLoadFactor.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/DynamicLoadFactor.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Controls a loading factor. Is used to ensure enough messages in multiples of our target concurrency are queued ready
@@ -88,19 +89,31 @@ public class DynamicLoadFactor {
         return false;
     }
 
-    private synchronized boolean doStep() {
-        if (isMaxReached()) {
-            return false;
-        } else {
-            // compare and set
-            currentFactor = currentFactor + stepUpFactorBy;
-            long delta = currentFactor - lastSteppedFactor;
-            log.debug("Stepped up load factor by {} from {} to {}", delta, lastSteppedFactor, currentFactor);
+    private final ReentrantLock stepLock = new ReentrantLock();
 
-            //
-            lastSteppedFactor = currentFactor;
-            lastStepTime = Instant.now();
-            return true;
+    /**
+     * A {@link ReentrantLock} rather than {@code synchronized} for uniformity with the other monitors on the
+     * virtual-thread path, not because this one pins: nothing inside blocks. Kept as a lock so the whole engine
+     * reads one way.
+     */
+    private boolean doStep() {
+        stepLock.lock();
+        try {
+            if (isMaxReached()) {
+                return false;
+            } else {
+                // compare and set
+                currentFactor = currentFactor + stepUpFactorBy;
+                long delta = currentFactor - lastSteppedFactor;
+                log.debug("Stepped up load factor by {} from {} to {}", delta, lastSteppedFactor, currentFactor);
+
+                //
+                lastSteppedFactor = currentFactor;
+                lastStepTime = Instant.now();
+                return true;
+            }
+        } finally {
+            stepLock.unlock();
         }
     }
 

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ExternalEngine.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ExternalEngine.java
@@ -11,7 +11,7 @@ import bz.stub.parallelconsumer.state.WorkContainer;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ExecutorService;
 
 import static bz.stub.parallelconsumer.internal.utils.StringUtils.msg;
 
@@ -54,8 +54,18 @@ public abstract class ExternalEngine<K, V> extends AbstractParallelEoSStreamProc
      * vert.x.
      */
     @Override
-    protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+    protected ExecutorService setupWorkerPool(int poolSize) {
         return super.setupWorkerPool(1);
+    }
+
+    /**
+     * @return false - see {@link AbstractParallelEoSStreamProcessor#supportsVirtualThreads()}. The single thread
+     *         this engine's pool holds only starts asynchronous work; making it virtual buys nothing and making it
+     *         unbounded breaks the dispatch model.
+     */
+    @Override
+    protected boolean supportsVirtualThreads() {
+        return false;
     }
 
     /**

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ProducerManager.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static bz.stub.parallelconsumer.internal.utils.StringUtils.msg;
@@ -69,6 +70,11 @@ public class ProducerManager<K, V> extends AbstractOffsetCommitter<K, V> impleme
      */
     @Getter
     private ReentrantReadWriteLock producerTransactionLock;
+
+    /**
+     * @see #syncBeginTransaction()
+     */
+    private final ReentrantLock beginTransactionLock = new ReentrantLock();
 
     /**
      * Installed on every send. Built once, because whether this manager uses transactions is already decided before
@@ -187,14 +193,27 @@ public class ProducerManager<K, V> extends AbstractOffsetCommitter<K, V> impleme
     }
 
     /**
-     * Pessimistic lock (synchronized method) on beginning a transaction
+     * Pessimistic lock on beginning a transaction.
      * <p>
      * Thread safe.
+     * <p>
+     * A {@link ReentrantLock} rather than {@code synchronized} because this is the only monitor on the user
+     * function's own hot path: {@code produceMessages} -> {@code lazyMaybeBeginTransaction} -> here runs on the
+     * worker thread, once per produce. On a JDK before 24 (JEP 491), a virtual thread that blocks inside
+     * {@code synchronized} pins its carrier, so with
+     * {@link bz.stub.parallelconsumer.ParallelConsumerOptions#isUseVirtualThreads()} and transactions this would
+     * take carriers out of circulation under exactly the contention it exists to manage. {@code ReentrantLock}
+     * parks the virtual thread instead and releases the carrier.
      */
-    private synchronized void syncBeginTransaction() {
-        boolean txNotBegunAlready = !producerWrapper.isTransactionOpen();
-        if (txNotBegunAlready) {
-            beginTransaction();
+    private void syncBeginTransaction() {
+        beginTransactionLock.lock();
+        try {
+            boolean txNotBegunAlready = !producerWrapper.isTransactionOpen();
+            if (txNotBegunAlready) {
+                beginTransaction();
+            }
+        } finally {
+            beginTransactionLock.unlock();
         }
     }
 

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/UserFunctionTaskAccounting.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/UserFunctionTaskAccounting.java
@@ -1,0 +1,177 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * The worker pool's queue depth and active count, derived by conservation from counters Parallel Consumer keeps
+ * itself rather than read off the executor.
+ *
+ * <pre>
+ *     queued = submitted - started - neverStarted      (replaces ThreadPoolExecutor.getQueue().size())
+ *     active = started   - finished                    (replaces ThreadPoolExecutor.getActiveCount())
+ * </pre>
+ * <p>
+ * <b>Why this exists.</b> Those two {@link ThreadPoolExecutor} methods drive the pressure system
+ * ({@code isPoolQueueLow}, {@code checkPipelinePressure}, {@link DynamicLoadFactor}), the shutdown diagnostics, and
+ * the {@code pool active: {} queued: {}} log line. A virtual-thread-per-task executor is not a
+ * {@link ThreadPoolExecutor} and exposes neither, so under
+ * {@link bz.stub.parallelconsumer.ParallelConsumerOptions#isUseVirtualThreads()} there is nothing to read. Counting
+ * here serves both modes from one code path, with no {@code instanceof} fork - and on the platform path the
+ * executor's own figures remain available as an independent oracle to test these against, which a fork returning a
+ * hardcoded zero for virtual threads could never have.
+ * <p>
+ * <b>A task is a batch, not a record.</b> {@code getQueue().size()} counted submitted {@code Runnable}s, and one
+ * submission carries one batch, so these counts mean exactly what they replaced. Records are counted elsewhere, by
+ * {@code WorkManager#getNumberRecordsOutForProcessing()}.
+ *
+ * <h2>Every path that can move a counter</h2>
+ * <p>
+ * Nothing here is ever decremented, so there is no removal site with a predicate to get wrong - the defect shape
+ * behind {@code docs/solutions/logic-errors/counter-clamp-hid-a-conditional-decrement-bug-2026-08-21.md} and the
+ * clamp it removed. The complete enumeration, which is the point of this class:
+ *
+ * <table>
+ *     <caption>Counter transitions</caption>
+ *     <tr><th>Counter</th><th>Moved by</th></tr>
+ *     <tr><td>{@code submitted}</td>
+ *         <td>{@link #onSubmitting()}, called immediately <em>before</em> handing a task to the executor. Before,
+ *             not after: a virtual thread can begin running before {@code submit()} returns, and incrementing
+ *             afterwards would let {@code started} overtake {@code submitted} and make the derived queue depth
+ *             negative.</td></tr>
+ *     <tr><td>{@code neverStarted}</td>
+ *         <td>{@link #onSubmitRejected()}, when {@code submit()} threw - the platform pool's
+ *             {@link ThreadPoolExecutor.AbortPolicy}, or any executor rejecting after shutdown. The task will never
+ *             run, so nothing else will ever account for it.</td></tr>
+ *     <tr><td>{@code neverStarted}</td>
+ *         <td>{@link #onTasksDiscarded(long)}, for tasks drained out of the executor's queue at close, and for the
+ *             list {@code shutdownNow()} hands back. Both are shutdown paths that today return zero or near-zero -
+ *             counted anyway, because an unaccounted path is a drift path whether or not it fires.</td></tr>
+ *     <tr><td>{@code started}</td>
+ *         <td>{@link #onTaskStarted()}, the first statement inside the submitted task.</td></tr>
+ *     <tr><td>{@code finished}</td>
+ *         <td>{@link #onTaskFinished()}, in that task's outermost {@code finally} - so it covers a normal return, a
+ *             user-function exception, and the {@code InterruptedException} that {@code shutdownNow()} delivers.
+ *             {@code finally} also runs for an {@link Error}; only JVM exit skips it, and that is terminal.</td></tr>
+ * </table>
+ * <p>
+ * The relationship between them is an invariant a test can assert directly once the pool is quiet:
+ * {@code submitted == started + neverStarted} and {@code started == finished}. See
+ * {@link #getSubmittedTotal()} and its siblings.
+ *
+ * @author Antony Stubbs
+ * @see bz.stub.parallelconsumer.state.RecordPopulation the same conservation shape, applied to records in shards
+ */
+public class UserFunctionTaskAccounting {
+
+    private final LongAdder submitted = new LongAdder();
+
+    private final LongAdder started = new LongAdder();
+
+    private final LongAdder neverStarted = new LongAdder();
+
+    private final LongAdder finished = new LongAdder();
+
+    /**
+     * A task is about to be handed to the executor. Must be called before the submit, not after - see the class
+     * javadoc.
+     */
+    void onSubmitting() {
+        submitted.increment();
+    }
+
+    /**
+     * The submit threw, so the task will never run.
+     */
+    void onSubmitRejected() {
+        neverStarted.increment();
+    }
+
+    /**
+     * Tasks that were accepted by the executor but will never run: drained from its queue on shutdown, or handed
+     * back by {@code shutdownNow()}.
+     */
+    void onTasksDiscarded(long count) {
+        if (count > 0) {
+            neverStarted.add(count);
+        }
+    }
+
+    /**
+     * First statement inside the submitted task.
+     */
+    void onTaskStarted() {
+        started.increment();
+    }
+
+    /**
+     * Outermost {@code finally} of the submitted task.
+     */
+    void onTaskFinished() {
+        finished.increment();
+    }
+
+    /**
+     * @return tasks handed to the executor that have not begun running - the figure
+     *         {@code ThreadPoolExecutor.getQueue().size()} used to supply
+     */
+    public int getQueued() {
+        // Subtrahends first, for the reason RecordPopulation#getInSystem states: every counter here only
+        // increases, and no task can start (or be discarded) without having been submitted first, so a start
+        // observed here always has its submission already committed. Reading this way round makes the difference
+        // non-negative by construction rather than by clamp.
+        long startedSoFar = started.sum();
+        long neverStartedSoFar = neverStarted.sum();
+        long submittedSoFar = submitted.sum();
+        return (int) Math.min(Integer.MAX_VALUE, submittedSoFar - startedSoFar - neverStartedSoFar);
+    }
+
+    /**
+     * @return tasks currently running the user's function - the figure {@code ThreadPoolExecutor.getActiveCount()}
+     *         used to supply
+     */
+    public int getActive() {
+        long finishedSoFar = finished.sum();
+        long startedSoFar = started.sum();
+        return (int) Math.min(Integer.MAX_VALUE, startedSoFar - finishedSoFar);
+    }
+
+    /**
+     * @return running total, for asserting on conservation in tests
+     */
+    public long getSubmittedTotal() {
+        return submitted.sum();
+    }
+
+    /**
+     * @return running total, for asserting on conservation in tests
+     */
+    public long getStartedTotal() {
+        return started.sum();
+    }
+
+    /**
+     * @return running total, for asserting on conservation in tests
+     */
+    public long getNeverStartedTotal() {
+        return neverStarted.sum();
+    }
+
+    /**
+     * @return running total, for asserting on conservation in tests
+     */
+    public long getFinishedTotal() {
+        return finished.sum();
+    }
+
+    @Override
+    public String toString() {
+        return "queued=" + getQueued() + ", active=" + getActive()
+                + " (submitted=" + submitted.sum() + ", started=" + started.sum()
+                + ", neverStarted=" + neverStarted.sum() + ", finished=" + finished.sum() + ")";
+    }
+}

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/utils/SupplierUtils.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/utils/SupplierUtils.java
@@ -9,23 +9,36 @@ import lombok.experimental.UtilityClass;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 @UtilityClass
 public class SupplierUtils {
 
+    /**
+     * A {@link ReentrantLock} rather than {@code synchronized} because the monitor is held across whatever the
+     * delegate does, and one caller's delegate is
+     * {@code AbstractParallelEoSStreamProcessor#setupWorkerPool(int)} - which performs a JNDI
+     * {@code InitialContext.doLookup}, i.e. potentially remote I/O. Before JDK 24 (JEP 491) a virtual thread that
+     * blocks inside {@code synchronized} pins its carrier, so this generic-looking utility was the least obvious
+     * of the pinning sites. The double-checked read is unchanged.
+     */
     public static <T> Supplier<T> memoize(Supplier<T> delegate) {
         Objects.requireNonNull(delegate);
         AtomicReference<T> value = new AtomicReference<>();
+        ReentrantLock lock = new ReentrantLock();
         return () -> {
             T val = value.get();
             if (val == null) {
-                synchronized (value) {
+                lock.lock();
+                try {
                     val = value.get();
                     if (val == null) {
                         val = Objects.requireNonNull(delegate.get());
                         value.set(val);
                     }
+                } finally {
+                    lock.unlock();
                 }
             }
             return val;

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/AbstractParallelEoSStreamProcessorConfigurationTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -81,6 +82,12 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
                 .batchSize(batchSize)
                 .maxConcurrency(concurrency)
                 .consumer(consumer)
+                // The multiplication asserted below is specific to the pre-loaded-queue engine: the load factor
+                // sizes the executor's QUEUE, so a factor of 2 means twice as many records buffered, not twice as
+                // many running. A virtual-thread pool has no queue, so it deliberately does not multiply, and this
+                // assertion would be asserting a defect there. The virtual-thread half of the contract is pinned
+                // in VirtualThreadExecutionModeTest#theInFlightTargetIsNotMultipliedByTheLoadFactorInThisMode.
+                .useVirtualThreads(false)
                 .build();
         try (final TestParallelEoSStreamProcessor<String, String> testInstance = new TestParallelEoSStreamProcessor<>(testOptions)) {
             final int defaultLoad = 2;
@@ -205,10 +212,10 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
      */
     @Test
     void theDefaultPoolIsAcceptedUnchanged() {
-        var built = new AtomicReference<ThreadPoolExecutor>();
+        var built = new AtomicReference<ExecutorService>();
         try (var testInstance = new TestParallelEoSStreamProcessor<String, String>(testOptions) {
             @Override
-            protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+            protected ExecutorService setupWorkerPool(int poolSize) {
                 var pool = super.setupWorkerPool(poolSize);
                 built.set(pool);
                 return pool;
@@ -217,7 +224,7 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
             assertThat(built.get())
                     .as("the default pool must be built during construction - the check cannot be deferred to first use")
                     .isNotNull();
-            assertThat(built.get().getRejectedExecutionHandler())
+            assertThat(((ThreadPoolExecutor) built.get()).getRejectedExecutionHandler())
                     .as("the pool must be handed on exactly as setupWorkerPool built it")
                     .isInstanceOf(ThreadPoolExecutor.AbortPolicy.class);
         }
@@ -238,7 +245,7 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
         var landmarkWhenPoolWasBuilt = new AtomicReference<Object>("the pool was never built");
         try (var testInstance = new TestParallelEoSStreamProcessor<String, String>(testOptions) {
             @Override
-            protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+            protected ExecutorService setupWorkerPool(int poolSize) {
                 landmarkWhenPoolWasBuilt.set(getWm());
                 return super.setupWorkerPool(poolSize);
             }
@@ -332,7 +339,7 @@ class AbstractParallelEoSStreamProcessorConfigurationTest {
     private TestParallelEoSStreamProcessor<String, String> processorBackedBy(ThreadPoolExecutor pool) {
         return new TestParallelEoSStreamProcessor<String, String>(testOptions) {
             @Override
-            protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+            protected ExecutorService setupWorkerPool(int poolSize) {
                 return pool;
             }
         };

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/ParallelEoSStreamProcessorPauseResumeTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/ParallelEoSStreamProcessorPauseResumeTest.java
@@ -204,11 +204,21 @@ class ParallelEoSStreamProcessorPauseResumeTest extends ParallelEoSStreamProcess
         // unlock the user function
         testUserFunction.unlockProcessing();
 
-        // in flight messages + buffered messages should get processed now (exact number is based on dynamic load factor)
+        // In-flight messages, plus whatever was buffered ahead of the workers, should get processed now.
+        //
+        // The bound is >= rather than > because the surplus is engine-specific, and asserting on it was asserting
+        // an implementation detail rather than the property this test is named for. Under the pre-loaded-queue
+        // engine the load factor keeps a multiple of maxConcurrency sitting in the executor's queue, so more than
+        // `degreeOfParallelism` records drain here. Under virtual threads there is no such queue - every submitted
+        // record is already running - so exactly `degreeOfParallelism` drain, and `isGreaterThan` failed for a
+        // system behaving correctly. See AbstractParallelEoSStreamProcessor#getQueueTargetLoaded.
+        //
+        // What the test is actually for - that pausing finishes in-flight work successfully and commits its
+        // offsets - is asserted below and is unchanged in both modes.
         Awaitility
                 .waitAtMost(defaultTimeout)
                 .alias("at least " + degreeOfParallelism + " records should be processed")
-                .untilAsserted(() -> assertThat(testUserFunction.numProcessedRecords.get()).isGreaterThan(degreeOfParallelism));
+                .untilAsserted(() -> assertThat(testUserFunction.numProcessedRecords.get()).isAtLeast(degreeOfParallelism));
 
         // overall committed offset should reach the same value
         awaitForCommit(testUserFunction.numProcessedRecords.get());

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/ParallelEoSStreamProcessorPauseResumeTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/ParallelEoSStreamProcessorPauseResumeTest.java
@@ -215,6 +215,15 @@ class ParallelEoSStreamProcessorPauseResumeTest extends ParallelEoSStreamProcess
         //
         // What the test is actually for - that pausing finishes in-flight work successfully and commits its
         // offsets - is asserted below and is unchanged in both modes.
+        //
+        // WHERE THE LOST STRICTNESS GOES. Loosening this line deletes a real property of the shipped engine:
+        // strictly MORE than maxConcurrency records must drain, because the load factor keeps a multiple of it
+        // already committed to running in the executor's queue. That half cannot be asserted on this branch - it
+        // has to be skipped for the queue-less engine, and a skip needs a per-engine predicate that only arrives
+        // with the direct-pull work. It is restored, at full strength and in its own skippable method, on
+        // perf/shard-occupancy-scan-v2 (astubbs#361), as
+        // ParallelEoSStreamProcessorPauseResumeTest#pausingDrainsThePreLoadedExecutorQueueAsWellAsTheInFlightRecords.
+        // Do not read the loosening as a decision that the property stopped mattering.
         Awaitility
                 .waitAtMost(defaultTimeout)
                 .alias("at least " + degreeOfParallelism + " records should be processed")
@@ -226,6 +235,12 @@ class ParallelEoSStreamProcessorPauseResumeTest extends ParallelEoSStreamProcess
         // shouldn't have anymore in flight records now
         assertThat(testUserFunction.numInFlightRecords.get()).isEqualTo(0);
         assertThat(parallelConsumer.getWm().getNumberRecordsOutForProcessing()).isEqualTo(0);
+
+        // The bound the original assertion never had, and the part of the lost strictness that CAN be asserted
+        // here: whatever was already dispatched drains, but the pause stops the rest, so this must be nowhere near
+        // the whole set. Without it, an engine that ignored the pause entirely would satisfy everything above.
+        // Engine-independent, so no skip is needed and it holds under virtual threads too.
+        assertThat(testUserFunction.numProcessedRecords.get()).isLessThan(numTestRecordsPerSet);
 
         // resume parallel consumer ->
         parallelConsumer.resumeIfPaused();

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/SubmitWorkToPoolShutdownRaceTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/SubmitWorkToPoolShutdownRaceTest.java
@@ -115,7 +115,7 @@ class SubmitWorkToPoolShutdownRaceTest {
         pc.setWm(wm);
 
         // the pool is a lazy supplier - resolve it up front so each test acts on the same instance
-        pool = pc.workerThreadPool.get();
+        pool = (ThreadPoolExecutor) pc.workerThreadPool.get();
     }
 
     @AfterEach

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/UserFunctionTaskAccountingTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/UserFunctionTaskAccountingTest.java
@@ -1,0 +1,186 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Pins the conservation arithmetic in {@link UserFunctionTaskAccounting} - that the four counters only ever move the
+ * way its javadoc enumerates, and that the two derived figures cannot go negative.
+ * <p>
+ * The counters replace {@code ThreadPoolExecutor.getQueue().size()} and {@code getActiveCount()}, so the important
+ * property is not that they hold some value but that <b>every path in and out is counted</b>. A missed increment on
+ * one side drifts the derived figure permanently, and the figure gates how much work Parallel Consumer fetches from
+ * the broker - so drift stalls the consumer while it still looks alive.
+ * <p>
+ * The agreement with a real executor's own figures is asserted separately, in
+ * {@link WorkerPoolAccountingAgreementTest}, which is the only independent oracle these numbers have.
+ */
+class UserFunctionTaskAccountingTest {
+
+    @Test
+    void aFreshAccountingReadsZeroOnBothDerivedFigures() {
+        var accounting = new UserFunctionTaskAccounting();
+
+        // What PipelinePressureLoggingTest depends on: a processor that has been constructed but never started must
+        // report an empty pool, not an unknown one.
+        assertThat(accounting.getQueued()).isEqualTo(0);
+        assertThat(accounting.getActive()).isEqualTo(0);
+    }
+
+    @Test
+    void aSubmittedTaskIsQueuedUntilItStartsAndActiveUntilItFinishes() {
+        var accounting = new UserFunctionTaskAccounting();
+
+        accounting.onSubmitting();
+        assertThat(accounting.getQueued()).isEqualTo(1);
+        assertThat(accounting.getActive()).isEqualTo(0);
+
+        accounting.onTaskStarted();
+        assertThat(accounting.getQueued()).isEqualTo(0);
+        assertThat(accounting.getActive()).isEqualTo(1);
+
+        accounting.onTaskFinished();
+        assertThat(accounting.getQueued()).isEqualTo(0);
+        assertThat(accounting.getActive()).isEqualTo(0);
+    }
+
+    @Test
+    void aRejectedSubmitLeavesNothingQueued() {
+        var accounting = new UserFunctionTaskAccounting();
+
+        accounting.onSubmitting();
+        accounting.onSubmitRejected();
+
+        // The defect this guards: without onSubmitRejected(), a pool that starts rejecting - AbortPolicy, or any
+        // executor after shutdown - leaves the queue depth permanently high by one per rejection, and the pressure
+        // system reads a backlog that does not exist.
+        assertThat(accounting.getQueued()).isEqualTo(0);
+        assertThat(accounting.getActive()).isEqualTo(0);
+        assertThat(accounting.getNeverStartedTotal()).isEqualTo(1);
+    }
+
+    @Test
+    void tasksDiscardedOnShutdownLeaveNothingQueued() {
+        var accounting = new UserFunctionTaskAccounting();
+
+        for (int i = 0; i < 5; i++) {
+            accounting.onSubmitting();
+        }
+        accounting.onTaskStarted();
+        accounting.onTaskFinished();
+
+        // the four that never ran, drained out of the executor's queue on the way down
+        accounting.onTasksDiscarded(4);
+
+        assertThat(accounting.getQueued()).isEqualTo(0);
+        assertThat(accounting.getActive()).isEqualTo(0);
+    }
+
+    @Test
+    void discardingNothingIsNotCountedAsSomething() {
+        var accounting = new UserFunctionTaskAccounting();
+        accounting.onSubmitting();
+
+        // Both shutdown paths routinely hand back an empty list - a virtual-thread executor always does, because
+        // every task it accepted already has a thread. That must not move the counter.
+        accounting.onTasksDiscarded(0);
+
+        assertThat(accounting.getQueued()).isEqualTo(1);
+        assertThat(accounting.getNeverStartedTotal()).isEqualTo(0);
+    }
+
+    @Test
+    void theConservationInvariantHoldsOnceTheWorkIsDone() {
+        var accounting = new UserFunctionTaskAccounting();
+
+        for (int i = 0; i < 10; i++) {
+            accounting.onSubmitting();
+        }
+        for (int i = 0; i < 7; i++) {
+            accounting.onTaskStarted();
+            accounting.onTaskFinished();
+        }
+        accounting.onSubmitRejected();
+        accounting.onTasksDiscarded(2);
+
+        // The whole point of deriving rather than maintaining: the relationship between the counters is a statement
+        // a test can check, where "is this running total correct?" is not.
+        assertThat(accounting.getSubmittedTotal())
+                .isEqualTo(accounting.getStartedTotal() + accounting.getNeverStartedTotal());
+        assertThat(accounting.getStartedTotal()).isEqualTo(accounting.getFinishedTotal());
+        assertThat(accounting.getQueued()).isEqualTo(0);
+        assertThat(accounting.getActive()).isEqualTo(0);
+    }
+
+    /**
+     * The ordering hazard the class exists to rule out. A virtual thread can be running its task before
+     * {@code submit()} has returned, so the submit side must increment first; and both derived figures read their
+     * subtrahends first so that a start observed against a not-yet-visible submission still reads as zero rather
+     * than as minus one.
+     */
+    @Test
+    void neitherDerivedFigureEverGoesNegativeUnderConcurrentSubmitAndRun() throws Exception {
+        var accounting = new UserFunctionTaskAccounting();
+        int tasks = 20_000;
+        var random = new Random(20260822L);
+        var sawNegative = new AtomicBoolean();
+        var readerStarted = new CountDownLatch(1);
+        var done = new AtomicBoolean();
+
+        ExecutorService workers = Executors.newFixedThreadPool(8);
+        Thread reader = new Thread(() -> {
+            readerStarted.countDown();
+            while (!done.get()) {
+                if (accounting.getQueued() < 0 || accounting.getActive() < 0) {
+                    sawNegative.set(true);
+                }
+            }
+        }, "accounting-reader");
+        reader.start();
+        readerStarted.await();
+
+        try {
+            var latch = new CountDownLatch(tasks);
+            for (int i = 0; i < tasks; i++) {
+                accounting.onSubmitting();
+                int spin = random.nextInt(4);
+                workers.execute(() -> {
+                    accounting.onTaskStarted();
+                    try {
+                        // Vary how long each task holds "started but not finished" so the reader below observes
+                        // real interleavings rather than a lock-step submit/run/finish rhythm.
+                        for (int s = 0; s < spin; s++) {
+                            Thread.yield();
+                        }
+                    } finally {
+                        accounting.onTaskFinished();
+                        latch.countDown();
+                    }
+                });
+            }
+            assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            done.set(true);
+            reader.join(TimeUnit.SECONDS.toMillis(10));
+            workers.shutdownNow();
+        }
+
+        assertThat(sawNegative.get()).isFalse();
+        assertThat(accounting.getQueued()).isEqualTo(0);
+        assertThat(accounting.getActive()).isEqualTo(0);
+        assertThat(accounting.getSubmittedTotal()).isEqualTo(tasks);
+        assertThat(accounting.getFinishedTotal()).isEqualTo(tasks);
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/VirtualThreadExecutionModeTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/VirtualThreadExecutionModeTest.java
@@ -1,0 +1,211 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Proves the virtual-thread path <b>ran</b>, rather than proving it exists.
+ *
+ * <h2>Why an assumption would have been the wrong tool</h2>
+ * <p>
+ * The natural way to write these is {@code Assumptions.assumeTrue(virtualThreadsAvailable())}, and it is the
+ * failure mode this repository has already shipped once: a test that skips on the JDK CI runs and <em>passes</em>
+ * reports green having verified nothing
+ * ({@code docs/solutions/workflow-issues/a-check-that-reports-success-without-having-run.md}).
+ * <p>
+ * So the assumption is inverted and keyed on <b>intent</b> rather than on capability. When
+ * {@code -Dpc.virtualThreads=true} selects the mode - which is how CI's execution-mode matrix runs the suite - a
+ * runtime that cannot provide virtual threads is a <b>failure</b>, because the lane was asked for a thing it did
+ * not deliver. An assumption remains only for the developer running the default suite on a JDK 17 with no mode
+ * selected, where nothing was asked for and nothing is owed.
+ *
+ * @see ParallelConsumerOptions#isUseVirtualThreads()
+ */
+class VirtualThreadExecutionModeTest {
+
+    /**
+     * The system property {@link ParallelConsumerOptions} defaults {@code useVirtualThreads} from, and the one
+     * CI's execution-mode axis sets. Its presence is what turns a skip into a failure below.
+     */
+    private static final String MODE_PROPERTY = "pc.virtualThreads";
+
+    /**
+     * Mirrors {@code ParallelConsumerOptions#virtualThreadsValidation()} exactly - both reflective targets, not
+     * just {@code Thread.ofVirtual}. Probing a subset here would let the test and production disagree about what
+     * "supported" means on some future JVM that has one and not the other.
+     */
+    private static boolean virtualThreadsAvailable() {
+        try {
+            Class.forName("java.lang.Thread").getMethod("ofVirtual");
+            java.util.concurrent.Executors.class
+                    .getMethod("newThreadPerTaskExecutor", java.util.concurrent.ThreadFactory.class);
+            return true;
+        } catch (ReflectiveOperationException e) {
+            return false;
+        }
+    }
+
+    private static boolean isVirtual(Thread thread) {
+        try {
+            Method isVirtual = Thread.class.getMethod("isVirtual");
+            return (boolean) isVirtual.invoke(thread);
+        } catch (ReflectiveOperationException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Fails - never skips - when the mode was selected but the runtime cannot serve it.
+     */
+    private static void requireVirtualThreadsWhenModeSelected() {
+        boolean modeSelected = Boolean.getBoolean(MODE_PROPERTY);
+        if (modeSelected && !virtualThreadsAvailable()) {
+            throw new AssertionError(String.format(
+                    "-D%s=true selected the virtual-thread execution mode, but this JVM (%s %s) cannot provide "
+                            + "virtual threads. This run has verified nothing about that mode. Run it on a JDK 21+ "
+                            + "runtime - the build JDK does not have to move, only the test JVM (-Djvm.location).",
+                    MODE_PROPERTY, System.getProperty("java.vm.name"), System.getProperty("java.version")));
+        }
+        Assumptions.assumeTrue(virtualThreadsAvailable(),
+                "No execution mode was selected and this JVM has no virtual threads - nothing was asked for. "
+                        + "Set -D" + MODE_PROPERTY + "=true to make this a failure instead.");
+    }
+
+    private static ParallelConsumerOptions.ParallelConsumerOptionsBuilder<String, String> options() {
+        return ParallelConsumerOptions.<String, String>builder()
+                .consumer(new MockConsumer<>(OffsetResetStrategy.EARLIEST));
+    }
+
+    @Test
+    void theUserFunctionRunsOnANamedVirtualThread() throws Exception {
+        requireVirtualThreadsWhenModeSelected();
+
+        try (var pc = new TestParallelEoSStreamProcessor<>(options().useVirtualThreads(true).build())) {
+            ExecutorService pool = pc.getWorkerThreadPool().get();
+            var seen = new AtomicReference<Thread>();
+            var ran = new CountDownLatch(1);
+
+            pool.execute(() -> {
+                seen.set(Thread.currentThread());
+                ran.countDown();
+            });
+            assertThat(ran.await(30, TimeUnit.SECONDS)).isTrue();
+
+            assertThat(isVirtual(seen.get())).isTrue();
+            // Named, because a thread dump at the concurrency where virtual threads earn their place holds
+            // thousands of them and anonymous ones make it unreadable.
+            assertThat(seen.get().getName()).startsWith("pc-vt-");
+        }
+    }
+
+    @Test
+    void thePoolIsNotAThreadPoolExecutorInThisMode() {
+        requireVirtualThreadsWhenModeSelected();
+
+        try (var pc = new TestParallelEoSStreamProcessor<>(options().useVirtualThreads(true).build())) {
+            // The premise of the whole change: the executor the pressure system used to introspect is gone.
+            assertThat(pc.getWorkerThreadPool().get()).isNotInstanceOf(ThreadPoolExecutor.class);
+        }
+    }
+
+    @Test
+    void theInFlightTargetIsNotMultipliedByTheLoadFactorInThisMode() {
+        requireVirtualThreadsWhenModeSelected();
+
+        var withVirtualThreads = options().useVirtualThreads(true).maxConcurrency(7).batchSize(3).build();
+        var withPlatformThreads = options().useVirtualThreads(false).maxConcurrency(7).batchSize(3).build();
+
+        try (var vt = new TestParallelEoSStreamProcessor<>(withVirtualThreads);
+             var platform = new TestParallelEoSStreamProcessor<>(withPlatformThreads)) {
+
+            int target = withVirtualThreads.getTargetAmountOfRecordsInFlight();
+
+            // There is no executor queue for the surplus to wait in, so multiplying would put N x maxConcurrency
+            // records RUNNING rather than N x maxConcurrency records buffered.
+            assertThat(vt.getTargetLoad()).isEqualTo(target);
+
+            // ...and the default engine is untouched: still target x the factor.
+            assertThat(platform.getTargetLoad()).isGreaterThan(target);
+        }
+    }
+
+    @Test
+    void aPoolWithNoQueueReportsAnEmptyQueueRatherThanAnUnknownOne() {
+        requireVirtualThreadsWhenModeSelected();
+
+        try (var pc = new TestParallelEoSStreamProcessor<>(options().useVirtualThreads(true).build())) {
+            var accounting = pc.userFunctionTaskAccounting();
+
+            // Not a hardcoded zero standing in for "cannot tell": nothing has been submitted, so the derived
+            // figure is genuinely zero and would move if something were.
+            assertThat(accounting.getQueued()).isEqualTo(0);
+            assertThat(accounting.getActive()).isEqualTo(0);
+
+            accounting.onSubmitting();
+            assertThat(accounting.getQueued()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void aVirtualThreadWorkerIsInterruptedByShutdown() {
+        requireVirtualThreadsWhenModeSelected();
+
+        var pc = new TestParallelEoSStreamProcessor<>(options().useVirtualThreads(true).build());
+        pc.getWorkerThreadPool().get().execute(() -> {
+            try {
+                Thread.sleep(TimeUnit.MINUTES.toMillis(5));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        long start = System.nanoTime();
+        pc.close();
+        // An unbounded pool still has to come down promptly; shutdownNow() must reach a parked virtual thread.
+        assertThat(TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start)).isLessThan(60L);
+    }
+
+    /**
+     * The negative half, and it runs on every JDK - including the JDK 17 default lane, where it is the only one of
+     * these that executes. Without it, "the virtual-thread tests all passed on 17" would be true and meaningless.
+     */
+    @Test
+    void enablingTheModeOnAJvmWithoutVirtualThreadsFailsAtConstructionWithACause() {
+        if (virtualThreadsAvailable()) {
+            // Cannot be provoked on this JVM - it has them. The complementary case is covered above.
+            return;
+        }
+
+        assertThatThrownBy(() -> options().useVirtualThreads(true).build().validate())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("useVirtualThreads")
+                .hasMessageContaining("JDK 21")
+                .hasCauseInstanceOf(ReflectiveOperationException.class);
+    }
+
+    @Test
+    void theOptionIsOffByDefault() {
+        // The default must stay platform threads whatever else changes here.
+        Assumptions.assumeFalse(Boolean.getBoolean(MODE_PROPERTY),
+                "the execution-mode axis has selected virtual threads for this run");
+
+        assertThat(options().build().isUseVirtualThreads()).isFalse();
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/VirtualThreadExecutionModeTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/VirtualThreadExecutionModeTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Proves the virtual-thread path <b>ran</b>, rather than proving it exists.
@@ -35,6 +34,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * runtime that cannot provide virtual threads is a <b>failure</b>, because the lane was asked for a thing it did
  * not deliver. An assumption remains only for the developer running the default suite on a JDK 17 with no mode
  * selected, where nothing was asked for and nothing is owed.
+ *
+ * <p>
+ * <b>Every test in this class requires the mode.</b> That is a contract, not a coincidence:
+ * {@code bin/check-execution-mode.sh} counts how many tests in this class actually executed and calls a lane broken
+ * when the answer is zero, so a test that can pass without virtual threads would inflate that count and let a JDK 17
+ * run claim it had exercised the mode. The option-level tests that run on any JDK live in
+ * {@link VirtualThreadOptionTest}.
  *
  * @see ParallelConsumerOptions#isUseVirtualThreads()
  */
@@ -182,30 +188,4 @@ class VirtualThreadExecutionModeTest {
         assertThat(TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start)).isLessThan(60L);
     }
 
-    /**
-     * The negative half, and it runs on every JDK - including the JDK 17 default lane, where it is the only one of
-     * these that executes. Without it, "the virtual-thread tests all passed on 17" would be true and meaningless.
-     */
-    @Test
-    void enablingTheModeOnAJvmWithoutVirtualThreadsFailsAtConstructionWithACause() {
-        if (virtualThreadsAvailable()) {
-            // Cannot be provoked on this JVM - it has them. The complementary case is covered above.
-            return;
-        }
-
-        assertThatThrownBy(() -> options().useVirtualThreads(true).build().validate())
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessageContaining("useVirtualThreads")
-                .hasMessageContaining("JDK 21")
-                .hasCauseInstanceOf(ReflectiveOperationException.class);
-    }
-
-    @Test
-    void theOptionIsOffByDefault() {
-        // The default must stay platform threads whatever else changes here.
-        Assumptions.assumeFalse(Boolean.getBoolean(MODE_PROPERTY),
-                "the execution-mode axis has selected virtual threads for this run");
-
-        assertThat(options().build().isUseVirtualThreads()).isFalse();
-    }
 }

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/VirtualThreadOptionTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/VirtualThreadOptionTest.java
@@ -1,0 +1,88 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The half of the virtual-threads contract that holds on <b>every</b> JDK: the option's default, and what happens
+ * when it is enabled on a runtime that cannot serve it.
+ * <p>
+ * Deliberately a separate class from {@link VirtualThreadExecutionModeTest}, which
+ * {@code bin/check-execution-mode.sh} uses as its evidence that the mode was exercised at all. That guard counts
+ * executed tests in the marker class, so a test living there that passes <em>without</em> virtual threads would
+ * inflate the count and let a JDK 17 run report the mode as exercised - the guard committing the exact defect it
+ * exists to catch. Found by pointing the guard at a real JDK 17 report and reading what it claimed.
+ *
+ * @see ParallelConsumerOptions#isUseVirtualThreads()
+ */
+class VirtualThreadOptionTest {
+
+    private static final String MODE_PROPERTY = "pc.virtualThreads";
+
+    private static boolean virtualThreadsAvailable() {
+        try {
+            Class.forName("java.lang.Thread").getMethod("ofVirtual");
+            Executors.class.getMethod("newThreadPerTaskExecutor", ThreadFactory.class);
+            return true;
+        } catch (ReflectiveOperationException e) {
+            return false;
+        }
+    }
+
+    private static ParallelConsumerOptions.ParallelConsumerOptionsBuilder<String, String> options() {
+        return ParallelConsumerOptions.<String, String>builder()
+                .consumer(new MockConsumer<>(OffsetResetStrategy.EARLIEST));
+    }
+
+    /**
+     * The negative half of the contract. On a JDK without virtual threads, asking for them must fail at
+     * construction with a message that names the option and a cause worth reading - not at the first poll, and not
+     * silently on the platform path.
+     */
+    @Test
+    void enablingTheModeOnAJvmWithoutVirtualThreadsFailsAtConstructionWithACause() {
+        Assumptions.assumeFalse(virtualThreadsAvailable(),
+                "this JVM has virtual threads, so the unsupported path cannot be provoked here - "
+                        + "VirtualThreadExecutionModeTest covers the complementary case");
+
+        assertThatThrownBy(() -> options().useVirtualThreads(true).build().validate())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("useVirtualThreads")
+                .hasMessageContaining("JDK 21")
+                .hasCauseInstanceOf(ReflectiveOperationException.class);
+    }
+
+    /**
+     * The default must stay platform threads whatever else changes here.
+     */
+    @Test
+    void theOptionIsOffByDefault() {
+        Assumptions.assumeFalse(Boolean.getBoolean(MODE_PROPERTY),
+                "the execution-mode axis has selected virtual threads for this run");
+
+        assertThat(options().build().isUseVirtualThreads()).isFalse();
+    }
+
+    /**
+     * The system property is the seam the benchmark harness and CI's matrix both use, so an explicit builder call
+     * has to win over it - otherwise a test cannot pin itself to the platform path inside a virtual-thread lane,
+     * which several now do.
+     */
+    @Test
+    void anExplicitBuilderValueBeatsTheSystemProperty() {
+        assertThat(options().useVirtualThreads(false).build().isUseVirtualThreads()).isFalse();
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/WorkerPoolAccountingAgreementTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/WorkerPoolAccountingAgreementTest.java
@@ -1,0 +1,285 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import bz.stub.parallelconsumer.state.ModelUtils;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.junit.jupiter.api.Test;
+import pl.tlinkowski.unij.api.UniLists;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * The only independent check the derived pool figures have: on the platform path the executor keeps the same two
+ * numbers itself, so {@link UserFunctionTaskAccounting} can be held against them.
+ * <p>
+ * This matters because {@code getNumberOfUserFunctionsQueued()} is load-bearing for the default engine that every
+ * user runs, not only for the opt-in virtual-thread mode. The alternative design - branching on
+ * {@code instanceof ThreadPoolExecutor} and returning a hardcoded zero for a virtual-thread pool - has no oracle at
+ * all, because the branch that would be wrong is the branch with nothing to compare against.
+ * <p>
+ * A virtual-thread pool has no queue and no active count to compare with, which is the whole reason the counters
+ * exist; its correctness rests on {@link UserFunctionTaskAccountingTest}'s conservation invariant instead.
+ */
+class WorkerPoolAccountingAgreementTest {
+
+    private static final int POOL_SIZE = 2;
+
+    private static final int TASKS = 6;
+
+    @Test
+    void theDerivedFiguresMatchTheExecutorsOwnWhileWorkIsHeldUp() throws Exception {
+        var options = ParallelConsumerOptions.<String, String>builder()
+                .consumer(new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST))
+                .maxConcurrency(POOL_SIZE)
+                // Pinned, not inherited. This test IS the platform path's oracle, so it has to keep running on the
+                // platform path even when CI's execution-mode axis sets -Dpc.virtualThreads=true for the suite -
+                // otherwise the one test that can check these figures against an independent source quietly stops
+                // checking them in the very run that changed them.
+                .useVirtualThreads(false)
+                .build();
+
+        try (var pc = new TestParallelEoSStreamProcessor<>(options)) {
+            ExecutorService pool = pc.getWorkerThreadPool().get();
+            assertThat(pool).isInstanceOf(ThreadPoolExecutor.class);
+            var tpe = (ThreadPoolExecutor) pool;
+            var accounting = pc.userFunctionTaskAccounting();
+
+            var release = new CountDownLatch(1);
+            var running = new CountDownLatch(POOL_SIZE);
+
+            // Submitted through the accounting the way submitWorkToPoolInner does - counted before the submit,
+            // started inside the task, finished in a finally.
+            for (int i = 0; i < TASKS; i++) {
+                accounting.onSubmitting();
+                pool.execute(() -> {
+                    accounting.onTaskStarted();
+                    try {
+                        running.countDown();
+                        release.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        accounting.onTaskFinished();
+                    }
+                });
+            }
+
+            assertThat(running.await(30, TimeUnit.SECONDS)).isTrue();
+            awaitExecutorQuiescence(tpe, TASKS - POOL_SIZE);
+
+            // The comparison this test exists for. Both figures, both sources, at a point where neither is zero.
+            assertThat(accounting.getQueued()).isEqualTo(tpe.getQueue().size());
+            assertThat(accounting.getActive()).isEqualTo(tpe.getActiveCount());
+            assertThat(accounting.getQueued()).isEqualTo(TASKS - POOL_SIZE);
+            assertThat(accounting.getActive()).isEqualTo(POOL_SIZE);
+
+            release.countDown();
+            awaitDrained(accounting);
+
+            assertThat(accounting.getQueued()).isEqualTo(tpe.getQueue().size());
+            assertThat(accounting.getActive()).isEqualTo(tpe.getActiveCount());
+            assertThat(accounting.getSubmittedTotal())
+                    .isEqualTo(accounting.getStartedTotal() + accounting.getNeverStartedTotal());
+            assertThat(accounting.getStartedTotal()).isEqualTo(accounting.getFinishedTotal());
+        }
+    }
+
+    /**
+     * The executor's own queue size lags the submits by however long the pool takes to pick tasks up, so comparing
+     * immediately would be comparing against a value still in motion. Wait for it to settle at the expected depth
+     * rather than sleeping a guessed interval.
+     */
+    private static void awaitExecutorQuiescence(ThreadPoolExecutor tpe, int expectedQueueDepth) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        while (tpe.getQueue().size() != expectedQueueDepth && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        assertThat(tpe.getQueue().size()).isEqualTo(expectedQueueDepth);
+    }
+
+    /**
+     * Closing with work still in the executor's queue must leave the accounting balanced.
+     * <p>
+     * Those tasks are dropped rather than run, so nothing downstream will ever count them: no
+     * {@code onTaskStarted()}, no {@code onTaskFinished()}. Left unaccounted, the derived queue depth stays high by
+     * the number discarded, forever. Today nothing reads it after close, which is exactly why the gap would sit
+     * there unnoticed until something did - and that is the shape of a drift defect, not a harmless omission.
+     * <p>
+     * Found by sabotage: removing the {@code onTasksDiscarded} call in
+     * {@code AbstractParallelEoSStreamProcessor#discardQueuedWork()} left the whole suite green until this test
+     * existed.
+     */
+    @Test
+    void queuedWorkDiscardedOnCloseIsAccountedFor() throws Exception {
+        var options = ParallelConsumerOptions.<String, String>builder()
+                .consumer(new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST))
+                .maxConcurrency(1)
+                .useVirtualThreads(false)
+                // The occupied worker never finishes on its own, so close() has to reach the interrupt path.
+                // Two seconds rather than the ten-second default keeps this test quick without changing what it
+                // exercises.
+                .shutdownTimeout(java.time.Duration.ofSeconds(2))
+                .build();
+
+        var pc = new TestParallelEoSStreamProcessor<>(options);
+        var accounting = pc.userFunctionTaskAccounting();
+        ExecutorService pool = pc.getWorkerThreadPool().get();
+
+        var running = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+
+        // One task occupies the single worker; the rest pile up in the queue and will never run.
+        for (int i = 0; i < TASKS; i++) {
+            accounting.onSubmitting();
+            pool.execute(() -> {
+                accounting.onTaskStarted();
+                try {
+                    running.countDown();
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    accounting.onTaskFinished();
+                }
+            });
+        }
+        assertThat(running.await(30, TimeUnit.SECONDS)).isTrue();
+        int queuedBeforeDiscard = accounting.getQueued();
+        assertThat(queuedBeforeDiscard).isGreaterThan(0);
+
+        // Driven directly rather than through close(). A processor that was never started transitions UNUSED ->
+        // CLOSED without going through innerDoClose(), so close() here would drain nothing and the test would pass
+        // whether or not the accounting call existed - which is precisely how the first version of this test
+        // stayed green under sabotage.
+        pc.discardQueuedWork();
+
+        release.countDown();
+        pc.close();
+
+        assertThat(accounting.getQueued()).isEqualTo(0);
+        assertThat(accounting.getSubmittedTotal())
+                .isEqualTo(accounting.getStartedTotal() + accounting.getNeverStartedTotal());
+    }
+
+    /**
+     * The hazard that only exists once the pool is virtual, made deterministic.
+     * <p>
+     * On a {@link ThreadPoolExecutor}, {@code submit()} enqueues and returns; a worker picks the task up later, so
+     * counting the submission after that call is <em>almost</em> always fine, and a race test does not reliably
+     * catch it - verified: reversing the read order and running 20,000 concurrent tasks stayed green. A
+     * virtual-thread-per-task executor starts the task immediately, so the task's own {@code onTaskStarted()} can
+     * land <b>before</b> the submit call returns, and a submission counted after that call would make the derived
+     * queue depth negative.
+     * <p>
+     * This makes it deterministic on any JDK, including the JDK 17 default lane where no real virtual thread exists
+     * to demonstrate it: the accounting is read at the instant the executor is handed the task, which is strictly
+     * before {@code submit()} returns. Counted correctly, one task is queued at that moment; counted after the
+     * submit, none is.
+     */
+    @Test
+    void theSubmissionIsCountedBeforeTheExecutorEverSeesTheTask() {
+        var options = ParallelConsumerOptions.<String, String>builder()
+                .consumer(new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST))
+                .useVirtualThreads(false)
+                .build();
+
+        var observedAtHandover = new ArrayList<Integer>();
+        var mu = new ModelUtils();
+
+        try (var pc = new TestParallelEoSStreamProcessor<String, String>(options) {
+            @Override
+            protected ExecutorService setupWorkerPool(int poolSize) {
+                return new ObservingInlineExecutorService(observedAtHandover);
+            }
+        }) {
+            pc.setWm(mu.getModule().workManager());
+            // The observer needs the accounting, which is only reachable once the processor exists.
+            ObservingInlineExecutorService.accounting = pc.userFunctionTaskAccounting();
+            observedAtHandover.clear();
+
+            pc.submitWorkToPool(
+                    context -> UniLists.of("done"),
+                    ignored -> {
+                    },
+                    UniLists.of(mu.createWorkFor(0)));
+        } finally {
+            ObservingInlineExecutorService.accounting = null;
+        }
+
+        assertThat(observedAtHandover).hasSize(1);
+        // The discriminator: 1 if the submission was counted before the hand-over, 0 if it was counted after.
+        assertThat(observedAtHandover.get(0)).isEqualTo(1);
+    }
+
+    /**
+     * Records the derived queue depth at the moment the executor is handed a task, then runs it inline.
+     */
+    private static final class ObservingInlineExecutorService extends AbstractExecutorService {
+
+        static volatile UserFunctionTaskAccounting accounting;
+
+        private final List<Integer> observations;
+
+        private volatile boolean shutdown;
+
+        ObservingInlineExecutorService(List<Integer> observations) {
+            this.observations = observations;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            UserFunctionTaskAccounting current = accounting;
+            if (current != null) {
+                observations.add(current.getQueued());
+            }
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return UniLists.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return true;
+        }
+    }
+
+    private static void awaitDrained(UserFunctionTaskAccounting accounting) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        while (accounting.getActive() + accounting.getQueued() > 0 && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        assertThat(accounting.getActive() + accounting.getQueued()).isEqualTo(0);
+    }
+}

--- a/parallel-consumer-vertx/src/main/java/bz/stub/parallelconsumer/vertx/VertxParallelEoSStreamProcessor.java
+++ b/parallel-consumer-vertx/src/main/java/bz/stub/parallelconsumer/vertx/VertxParallelEoSStreamProcessor.java
@@ -32,7 +32,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -137,7 +137,7 @@ public class VertxParallelEoSStreamProcessor<K, V> extends ExternalEngine<K, V>
      * vert.x.
      */
     @Override
-    protected ThreadPoolExecutor setupWorkerPool(int poolSize) {
+    protected ExecutorService setupWorkerPool(int poolSize) {
         return super.setupWorkerPool(1);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,28 @@
         <included.groups></included.groups>
         <excluded.groups>performance,chaos,quarantined</excluded.groups>
 
+        <!-- EXECUTION-MODE AXIS. Parallel Consumer has opt-in execution paths that are meant to be
+             BEHAVIOURALLY EQUIVALENT to the default engine, and the thing worth asserting is not that each
+             one works but that each one AGREES with the default - on ordering, commits, retries, rebalance and
+             shutdown. That is the existing suite, run again with a different selector, so these are a matrix
+             axis over one suite rather than a suite each.
+
+             Each is a plain system property (rather than only a builder option) because the option has to be
+             selectable without editing source: bench/Bench.java.template compiles against every released
+             version in a sweep and cannot reference an option that did not exist in 0.3.0.2, and a CI matrix
+             entry should be a line of config.
+
+             Surefire forks a JVM, and a -D on the Maven command line does NOT reach that fork - it has to be
+             forwarded, which is what the systemPropertyVariables block below does. Without the forwarding,
+             `mvn test -Dpc.virtualThreads=true` runs the entire suite on the DEFAULT engine and reports
+             green: the silent-green shape in
+             docs/solutions/workflow-issues/a-check-that-reports-success-without-having-run.md.
+
+             ADDING THE NEXT MODE IS A LINE HERE PLUS A LINE IN THE FORWARDING BLOCK - not a second job.
+             docs/inflight/test-opt-in-engine-paths-are-unexercised.md is why that matters. -->
+        <pc.virtualThreads>false</pc.virtualThreads>
+        <pc.directPull>false</pc.directPull>
+
         <!-- version numbers -->
         <!-- plugins -->
         <lombok.version>1.18.46</lombok.version>
@@ -897,6 +919,11 @@
                     </excludes>
                     <jvm>${jvm.location}/bin/java</jvm>
                     <skipTests>${skipUTs}</skipTests>
+                    <!-- Execution-mode axis - see the pc.* properties above. -->
+                    <systemPropertyVariables>
+                        <pc.virtualThreads>${pc.virtualThreads}</pc.virtualThreads>
+                        <pc.directPull>${pc.directPull}</pc.directPull>
+                    </systemPropertyVariables>
                     <!-- Same group filtering as failsafe below - without this binding, surefire ignores
                          the quarantine/performance tags entirely and a @Quarantined UNIT test would
                          still run (and fail) in the gating Unit Tests lane (ce-review P1 finding). -->

--- a/src/docs/README_TEMPLATE.adoc
+++ b/src/docs/README_TEMPLATE.adoc
@@ -1223,8 +1223,10 @@ The published modules share one answer to both. They all depend on `parallel-con
 there is no per-module reliability gradient to publish. What does differ is the experimental artifacts, which are a
 separate and explicit opt-in and cannot change an application that does not depend on one.
 
-Virtual threads, micro-batching and a dead-letter queue are intentionally deferred capabilities, not exceptions to the
-critical-defect gate.
+Micro-batching and a dead-letter queue are intentionally deferred capabilities, not exceptions to the critical-defect
+gate. Virtual threads are no longer among them: the processing function can run on virtual threads via the opt-in
+`useVirtualThreads` option, on a JDK 21 runtime. The published artifacts are unchanged Java 8 bytecode, so only the
+runtime has to move.
 
 |===
 | Module | Status | Reliability confidence | API expectation | Use this if


### PR DESCRIPTION
Closes astubbs/parallel-consumer#190.

## Description

**Run the user function on virtual threads (opt-in, JDK 21+), and stop the pressure system reading the executor's queue.**

A handler that blocks holds an OS thread for as long as it blocks, and a machine can only bring platform threads out of a park at a fixed rate. Reachable concurrency is therefore `min(maxConcurrency, activationRate × handlerLatency)`, not `maxConcurrency`. Measured on a 12-core laptop at `maxConcurrency` 5,000 with a 100ms handler: **platform threads held 2,673 records in flight; virtual threads held all 5,000.** Raising `maxConcurrency` past that ceiling does nothing — the term only disappears if the work stops holding a thread.

`useVirtualThreads` (defaulting from the `pc.virtualThreads` system property) runs the user function on `Executors#newVirtualThreadPerTaskExecutor`, reached reflectively because the published artifact is still Java 8 bytecode. It fails loudly on an older JDK rather than silently falling back to platform threads — a silent fallback would make the two modes indistinguishable and every comparison meaningless.

**What the pool change forced, and this is the reviewable core of the PR.** `setupWorkerPool` now returns `ExecutorService`, because a virtual-thread executor is not a `ThreadPoolExecutor`. Two subsystems read the concrete type:

- `requireRejectionIsVisible` inspects a rejection handler only `ThreadPoolExecutor` has. It now applies to that case and passes any other pool through — a virtual-thread executor starts a thread per task, so there is no bounded queue to reject from and nothing for the guard to protect.
- The pressure system read the executor's queue depth to decide whether to step the load factor. There is no queue under virtual threads, so `UserFunctionTaskAccounting` derives the same figure from submissions minus completions. **Counted before the submit, not after:** a virtual thread can be running the task before `submit()` returns, and an increment placed afterwards lets the task's own start land first, making the derived depth transiently negative.

`WorkerPoolAccountingAgreementTest` pins the derived depth against the executor's own figure for the platform pool — that agreement is what stops the two accountings drifting apart silently.

The load-factor ceiling report is silent under a virtual-thread pool: "the queue is low" is that pool's permanent resting state rather than a symptom, and the line's advice would be actively wrong there (raising the load factor buys a deeper record buffer, not more concurrency).

**External engines opt out** via `supportsVirtualThreads()`: Vert.x, Reactor and Mutiny have a single dispatch thread by design with concurrency living in the external runtime, so an unbounded executor would silently make dispatch itself concurrent.

**CI lane.** `bin/check-execution-mode.sh` runs the suite under a chosen mode and **refuses a green run that skipped the mode's tests** — the failure this exists to prevent is a matrix leg that passes by running nothing. It has its own self-test (`bin/test-check-execution-mode.sh`, 12 assertions) because a guard nobody tests is a guard nobody can trust.

**Verification.** Full `parallel-consumer-core` unit suite: **403 tests, 0 failures** (13 skipped, of which 5 are the JDK-21-only virtual-thread cases — the project builds on JDK 17, where delombok requires it, so those run in the CI execution-mode lane).

**Provenance, and two things deliberately not reverted.** Adapted from `b6083f5ef` on `perf/engine-concurrency`. That commit predates two changes now on master, and this PR keeps master's versions rather than the branch's: the shutdown guards in `submitWorkToPool` (the closing-state early return, and the shut-down-pool rejection that drops the batch and stops the poll instead of escaping to the control thread — `SubmitWorkToPoolShutdownRaceTest` covers both, and it fails without them), and the load-factor ceiling reporting, which belongs to astubbs/parallel-consumer#201 and is left in master's form here.

## Checklist

- [x] Docs updated - the option, the accounting class and the capability hook all carry their reasoning in javadoc
- [ ] User-facing feature documentation data added under `docs/features/` - N/A - `ExecutionMode` is opt-in and preview-grade; the feature record lands with the engine-comparison documentation once the mode is out of experimental status
- [x] Tests added/updated - `VirtualThreadExecutionModeTest`, `UserFunctionTaskAccountingTest`, `WorkerPoolAccountingAgreementTest`, plus the CI lane's own self-test
- [x] Title & body reflect the final content of this PR
