### PR TITLE
fix(gates): a gate was truncating the shared clone's history on every sweep

### DIFF
--- a/.claude/hooks/check-shallow-history.sh
+++ b/.claude/hooks/check-shallow-history.sh
@@ -24,6 +24,55 @@
 # SCOPED TO COMMANDS WHOSE ANSWER ACTUALLY DEPENDS ON DEPTH. `git status`, `git diff` of the working
 # tree, `git show HEAD` and `git log -1` are all correct in a shallow clone, and blocking them would
 # make this noise - which gets hooks disabled. Only ranges, ancestry and whole-history walks qualify.
+#
+# IT ALSO GUARDS THE OTHER DIRECTION: the command that MAKES the clone shallow. `git fetch --depth`
+# and `git pull --depth` write that shared `shallow` file, and the shallowing is silent - the fetch
+# succeeds, and the bill arrives later in some other worktree's merge-base. The script that did this
+# on every gate sweep was bin/check-quarantine-owners.sh, fixed by fetching into a throwaway git dir;
+# a hand-typed `--depth=1` is the same defect with no script to fix, which is what this arm is for.
+# bin/check-shell-hazards.sh enforces the same rule on scripts in bin/ and .claude/hooks/.
+#
+# EVERY GIT CALL IN THE COMMAND IS JUDGED, NOT THE FIRST ONE THAT MATCHED. The scan used to print one
+# verdict and stop, and the two directions want OPPOSITE answers from `--is-shallow-repository` - so
+# `git merge-base HEAD origin/master; git fetch --depth=1 origin master` was classified as a QUERY,
+# found the clone was not shallow, and ALLOWED the fetch that re-shallowed it. The mirror case hid
+# the query behind a fetch. The state is still read once; each collected match is tested against it
+# separately, and a fetch that will truncate the clone also arms every query that follows it in the
+# same command, because by then the graft is already cut.
+#
+# A `--git-dir=` OR `GIT_DIR=` REDIRECT EXEMPTS IT ONLY ONCE THE TARGET IS RESOLVED AND SHOWN TO BE
+# ANOTHER REPOSITORY - that idiom is the sanctioned way to fetch a ref you only want to read, and it
+# is what this hook's own deny message recommends, so it has to keep working. Trusting the SPELLING
+# made the option a one-flag bypass: `git --git-dir=.git fetch --depth=1` (and the `GIT_DIR=.git`
+# form) names THIS clone, and writes THIS clone's shared `shallow` file. The target's common
+# directory is now compared with ours, and an exemption that cannot be verified is not granted.
+# `git clone --depth` is not the hazard either: a clone owns its own depth.
+#
+# WRAPPERS ARE WALKED THROUGH. `git` had to sit in command position, so one word in front of it -
+# `command`, `env`, `time`, `timeout`, `nohup`, `stdbuf`, `xargs`, `sudo`, `nice`, `ionice`,
+# `setsid` - skipped the entire hook, both directions, including the query arm that long predates
+# the fetch arm. The same defect reached the tokeniser: shlex splits on whitespace only, so an
+# unspaced `;`, `&` or `|` and a subshell's `(` glue to the neighbouring word and hid the call just
+# as effectively. Both are handled where they arise, in the scan below.
+#
+# THREE KNOWN, DELIBERATE IMPRECISIONS, and the third is the only one that errs towards allowing:
+#
+#   - `-C <dir>` is NOT read as a redirect, so `git -C /some/other/repo fetch --depth=1` is denied
+#     even though it is harmless. Treating it as one would be a bypass, since `-C .` names THIS
+#     repository; over-blocking costs a prefixed re-run, under-blocking costs the incident above.
+#   - Once the clone is already shallow this arm stands down entirely, so a fetch that CHANGES the
+#     depth (`--depth=5` over a depth-1 clone, a different `--shallow-since`) still rewrites the
+#     shared graft. That is accepted rather than missed: the residual is bounded, because in a clone
+#     that is already shallow the QUERY arm above is armed, so no truncated answer reaches anyone
+#     silently - and denying depth changes in an intentionally shallow CI clone is the noise that
+#     gets hooks switched off.
+#   - A redirect target only the shell can expand - `--git-dir="$(mktemp -d)"`, or the
+#     `GIT_DIR="$scratch_dir/preview"` that bin/check-quarantine-owners.sh writes - cannot be
+#     resolved without RUNNING it, which a guard inspecting an unapproved command must never do. It
+#     is judged on its text instead: exempt unless the text could name a git directory of this clone.
+#     So `--git-dir="$mystery"` is allowed while `--git-dir="$PWD/.git"` is not, and the residual is
+#     a target that reaches this clone through a variable naming none of it. Failing closed here
+#     instead would deny the alternative the deny message names, which is how a guard gets disabled.
 set -uo pipefail
 
 payload="$(cat 2>/dev/null || true)"
@@ -54,11 +103,19 @@ command -v python3 >/dev/null 2>&1 || {
 
 # Only pay for the git call if the command really is a history query. TOKENS, NOT SUBSTRINGS - the
 # rule the sibling hooks state - so `git commit -m "rev-list notes"` does not fire. An unbalanced
-# quote makes shlex raise, and that fails open.
-verdict="$(printf '%s' "$payload" | python3 -c '
+# quote makes shlex raise, and that fails open. One record per match, in command order: KIND, the
+# `--git-dir`/`GIT_DIR` target as written, and the text the deny message quotes. THE SEPARATOR IS
+# US (\x1f), not a tab, because tab is an IFS *whitespace* character: `read` collapses a run of them,
+# so a record with no redirect target silently shifted its description one field left and every
+# QUERY verdict came back empty - a guard that allowed everything while reporting nothing.
+verdicts="$(printf '%s' "$payload" | python3 -c '
 import json, re, shlex, sys
 
 DEPTH_DEPENDENT = {"rev-list", "merge-base", "blame", "describe", "bisect", "shortlog", "cherry"}
+
+# The other direction: these do not READ a truncated history, they CREATE one, for every worktree.
+SHALLOWING = {"fetch", "pull"}
+DEPTH_FLAGS = ("--depth", "--shallow-since", "--shallow-exclude")
 
 # git own options that sit BEFORE the subcommand. The two that take a separate value must consume it,
 # or the value is mistaken for the subcommand - which is how `git -C DIR rev-list` read as subcommand
@@ -69,9 +126,34 @@ GLOBAL_WITH_VALUE = {"-C", "-c", "--exec-path", "--git-dir", "--work-tree", "--n
 # `git` means the word is prose - a heredoc body, an echo argument, a commit message - not a call.
 SEPARATORS = {";", "&&", "||", "|", "(", "{", "&", "then", "do", "else", "!"}
 
-def report(v):
-    print(v)
-    sys.exit(0)
+# A WRAPPER RUNS ITS TAIL AS A COMMAND, so `command git fetch --depth=1` is a git call with a word in
+# front of it - and every name here used to put `git` out of command position and skip the whole
+# hook. Each maps to ITS OWN options that take a SEPARATE value, which have to be stepped over or
+# `nice -n 10 git ...` stops on "10" and the call is missed again. Per-wrapper on purpose: `env -i`
+# takes no value while `stdbuf -i` does, so one shared list would have `env -i git fetch --depth=1`
+# swallow the very `git` it is looking for.
+WRAPPERS = {
+    "command": (),
+    "env": ("-u", "--unset", "-S", "--split-string", "-C", "--chdir"),
+    "time": ("-o", "--output", "-f", "--format"),
+    "nohup": (),
+    "stdbuf": ("-i", "--input", "-o", "--output", "-e", "--error"),
+    "xargs": ("-n", "--max-args", "-I", "--replace", "-P", "--max-procs", "-L", "-s",
+              "--max-chars", "-d", "--delimiter", "-E", "-a", "--arg-file"),
+    "sudo": ("-u", "--user", "-g", "--group", "-p", "--prompt", "-C", "--close-from",
+             "-h", "--host", "-r", "--role", "-t", "--type"),
+    "nice": ("-n", "--adjustment"),
+    "ionice": ("-c", "--class", "-n", "--classdata", "-p", "--pid"),
+    "setsid": (),
+    "timeout": ("-s", "--signal", "-k", "--kill-after"),
+}
+
+# `timeout` is the one wrapper here that takes a MANDATORY POSITIONAL before the command it runs, so
+# the option walk stops on "60" and `timeout 60 git fetch --depth=1 origin master` is missed exactly
+# the way the bare wrappers were. Only a duration is stepped over, so nothing else is consumed.
+POSITIONAL = {"timeout": re.compile(r"^[0-9]+(\.[0-9]+)?[smhd]?$")}
+
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
 
 try:
     data = json.load(sys.stdin)
@@ -79,20 +161,70 @@ try:
     # shlex glues `$(` onto the following word, so `X=$(git log a..b)` never yields a bare `git`
     # token. Pad the substitution openers so the command inside is tokenised as a command.
     cmd = cmd.replace("$(", "$( ").replace("`", " ` ")
+    # AND SO DOES AN UNSPACED CONTROL OPERATOR. shlex splits on whitespace only, so
+    # `git merge-base HEAD origin/master; git fetch --depth=1 origin master` tokenises as
+    # `origin/master;` followed by `git` - which is not in command position, and the fetch was
+    # therefore never seen. Padding is safe in a way the `(` glue is not: these three cannot appear
+    # unquoted inside a path or an argument, and a quoted one stays inside its single token.
+    cmd = cmd.replace(";", " ; ").replace("&", " & ").replace("|", " | ")
     toks = shlex.split(cmd)
 except Exception:
     sys.exit(0)
 
-def in_command_position(i):
+def starts_a_command(i):
     if i == 0:
         return True
     prev = toks[i - 1]
-    if prev in SEPARATORS:
-        return True
-    # `X=$( git ...` and a leading `VAR=value git ...` assignment prefix
-    if prev.endswith("(") or re.match(r"^[A-Za-z_][A-Za-z_0-9]*=", prev):
-        return True
-    return False
+    # `X=$( git ...` opens a command too; a leading `VAR=value` prefix is consumed by the walk below,
+    # which is where wrappers and assignments are handled together.
+    return prev in SEPARATORS or prev.endswith("(")
+
+def walk_to_command(start):
+    """Step over assignment prefixes and wrappers to the word actually executed."""
+    j, assigns = start, []
+    while j < len(toks):
+        t = toks[j]
+        if ASSIGNMENT.match(t):
+            assigns.append(j)
+            j += 1
+            continue
+        if t in WRAPPERS:
+            with_value = WRAPPERS[t]
+            positional = POSITIONAL.get(t)
+            j += 1
+            if positional is not None and j < len(toks) and positional.match(toks[j]):
+                j += 1
+            while j < len(toks):
+                w = toks[j]
+                if w == "--":
+                    j += 1
+                    break
+                if w.startswith("-"):
+                    j += 2 if w in with_value else 1
+                    continue
+                break
+            continue
+        break
+    return j, assigns
+
+def stitch(idx, value):
+    """Re-join a `$(...)` target the opener padding split, so the bash half sees the whole text."""
+    if not value.endswith("$("):
+        return value
+    parts, depth, k = [value], 1, idx + 1
+    while k < len(toks) and depth > 0:
+        t = toks[k]
+        parts.append(t)
+        if t.endswith("$("):
+            depth += 1
+        elif t.endswith(")"):
+            depth -= 1
+        k += 1
+    return " ".join(parts)
+
+def clean(s):
+    # One record per line, US-separated, so a field may hold neither.
+    return s.replace("\x1f", " ").replace("\n", " ").replace("\r", " ")
 
 # THE OVERRIDE IS A LEADING ASSIGNMENT PREFIX, not any occurrence. Matching it anywhere meant
 # `git log -S "SHALLOW_HISTORY_ACCEPTED=1"` - searching history for the name of the escape hatch -
@@ -101,10 +233,21 @@ for i, t in enumerate(toks):
     if t == "SHALLOW_HISTORY_ACCEPTED=1" and (i == 0 or toks[i - 1] in SEPARATORS or toks[i - 1].endswith("(")):
         sys.exit(0)
 
-for i, t in enumerate(toks):
-    if t != "git" or not in_command_position(i):
+seen = set()
+for i in range(len(toks)):
+    if not starts_a_command(i):
         continue
-    rest = toks[i + 1:]
+    g, assigns = walk_to_command(i)
+    # `BASE=$( git ...` starts a command twice over - at the assignment and at the padded opener - so
+    # the same call would otherwise be reported once per entry point.
+    # A subshell glues its `(` to the command word - `(git fetch --depth=1 origin master)` - and the
+    # padding trick used for `;` cannot be reused here without breaking the `$(` stitching below, so
+    # the opener is stripped off the word instead. Same defect as the wrappers: the call is there and
+    # the scanner cannot see it.
+    if g >= len(toks) or toks[g].lstrip("(") != "git" or g in seen:
+        continue
+    seen.add(g)
+    rest = toks[g + 1:]
     # walk past git own global options to find the real subcommand
     j = 0
     while j < len(rest):
@@ -121,34 +264,160 @@ for i, t in enumerate(toks):
     # a pathspec after `--` is a FILE PATH: `git diff -- ../docs` is not a commit range
     if "--" in args:
         args = args[:args.index("--")]
+    # Report the redirect target rather than deciding on it: whether it names another repository is a
+    # question only git can answer, and this half runs no subprocess. `--git-dir` beats `GIT_DIR=`
+    # here because it beats it in git.
+    target = ""
+    for idx in assigns:
+        if toks[idx].startswith("GIT_DIR="):
+            target = stitch(idx, toks[idx][len("GIT_DIR="):])
+    for m in range(j):
+        idx = g + 1 + m
+        o = toks[idx]
+        if o.startswith("--git-dir="):
+            target = stitch(idx, o[len("--git-dir="):])
+        elif o == "--git-dir" and idx + 1 < len(toks):
+            target = stitch(idx + 1, toks[idx + 1])
+    if sub in SHALLOWING:
+        depth_flag = next((a for a in args if a.startswith(DEPTH_FLAGS)), None)
+        if depth_flag:
+            print("SHALLOWING\x1f" + clean(target) + "\x1f" + clean("git " + sub + " " + depth_flag))
     if sub in DEPTH_DEPENDENT:
-        report("git " + sub)
+        print("QUERY\x1f\x1fgit " + sub)
     if sub in ("log", "diff") and any(".." in a and not a.startswith("-") for a in args):
-        report("git " + sub + " over a commit range")
+        print("QUERY\x1f\x1fgit " + sub + " over a commit range")
 sys.exit(0)
 ')"
 
-[ -n "$verdict" ] || exit 0
+[ -n "$verdicts" ] || exit 0
 
-# Now, and only now, ask git. Cheap, but not free enough to run on every Bash call.
-[ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ] || exit 0
+# Absolute and physical, without `readlink -f` (GNU-only, and bin/check-shell-hazards.sh bans it),
+# and TOLERANT OF A PATH THAT DOES NOT EXIST YET: a fetch into a directory git is about to create
+# cannot truncate this clone, so failing to resolve one must not deny it.
+abs_path() {
+    local p="$1" dir base dir_abs
+    [ -n "$p" ] || return 1
+    case "$p" in /*) ;; *) p="$PWD/$p" ;; esac
+    if [ -d "$p" ]; then
+        ( cd "$p" 2>/dev/null && pwd -P )
+        return 0
+    fi
+    dir="$(dirname "$p")"
+    base="$(basename "$p")"
+    if dir_abs="$( cd "$dir" 2>/dev/null && pwd -P )" && [ -n "$dir_abs" ]; then
+        printf '%s/%s\n' "$dir_abs" "$base"
+    else
+        printf '%s\n' "$p"
+    fi
+}
 
-export VERDICT="$verdict"
+# Does a `--git-dir=`/`GIT_DIR=` target really name a repository OTHER than this clone? Answering by
+# spelling made the option a bypass - see the header - so the target is resolved and compared, and
+# anything that cannot be shown to differ is not exempt.
+redirect_is_elsewhere() {
+    local t="$1" abs resolved
+    [ -n "$t" ] || return 1
+    [ -n "$self_common" ] || return 1
+    case "$t" in
+        *'$'*|*'`'*)
+            # Only the shell can expand this, and expanding it means running it. Judged on its text -
+            # the third imprecision in the header, and the one that errs towards allowing.
+            case "$t" in
+                .git|.git/*|*/.git|*/.git/*|*PWD*|*GIT_DIR*|*GIT_COMMON_DIR*|*git-common-dir*|*rev-parse*)
+                    return 1 ;;
+                *) return 0 ;;
+            esac
+            ;;
+    esac
+    abs="$(abs_path "$t")" || return 1
+    [ -n "$abs" ] || return 1
+    # `git --git-dir=X rev-parse --git-common-dir` follows a gitfile and a linked worktree back to
+    # the SHARED directory - which is the file `--depth` writes - so a sibling worktree's `.git`
+    # compares equal to ours, as it has to. A target that is not a repository at all resolves to
+    # nothing and is compared as the plain path it is.
+    resolved="$(git --git-dir="$abs" rev-parse --git-common-dir 2>/dev/null)"
+    if [ -n "$resolved" ]; then
+        abs="$(abs_path "$resolved")"
+    fi
+    [ "$abs" = "$self_common" ] && return 1
+    return 0
+}
+
+# Now, and only now, ask git - once, however many matches there are. Cheap, but not free enough to
+# run on every Bash call. THE TWO KINDS WANT OPPOSITE ANSWERS: a query is wrong only when the clone
+# is ALREADY shallow, while a shallowing fetch is only worth stopping while it is not - once the
+# clone is shallow, that fetch changes nothing, and denying it would block the CI-shaped case for no
+# gain. That opposition is exactly why the state has to be tested per match rather than once for a
+# single winning verdict.
+shallow="$(git rev-parse --is-shallow-repository 2>/dev/null)"
+self_common="$(git rev-parse --git-common-dir 2>/dev/null)"
+if [ -n "$self_common" ]; then
+    self_common="$(abs_path "$self_common")"
+fi
+
+query_verdict=""
+shallowing_verdict=""
+# A fetch that truncates the clone arms every query AFTER it in the same command, even though the
+# clone is still full at the moment the hook runs.
+truncated="$shallow"
+while IFS=$'\x1f' read -r kind target desc; do
+    [ -n "$kind" ] || continue
+    if [ "$kind" = "SHALLOWING" ]; then
+        [ "$truncated" = "true" ] && continue
+        redirect_is_elsewhere "$target" && continue
+        [ -n "$shallowing_verdict" ] || shallowing_verdict="$desc"
+        truncated="true"
+    else
+        [ "$truncated" = "true" ] || continue
+        [ -n "$query_verdict" ] || query_verdict="$desc"
+    fi
+done <<< "$verdicts"
+
+[ -n "$query_verdict" ] || [ -n "$shallowing_verdict" ] || exit 0
+
+export QUERY_VERDICT="$query_verdict"
+export SHALLOWING_VERDICT="$shallowing_verdict"
 python3 -c '
 import json, os
+query_reason = (
+    "THE CLONE IS SHALLOW, and `" + os.environ["QUERY_VERDICT"] + "` will answer anyway - from the "
+    "truncated graft, without erroring. Measured here: a branch reported 836 commits against a "
+    "true 29, and merge-base returned a commit that was not the merge base.\n\n"
+    "Run `git fetch --unshallow` first, then re-run. If you are mid-merge-prep this is not "
+    "optional: `git reset --mixed $(git merge-base ...)` against a wrong base silently reverts "
+    "whatever master gained.\n\n"
+    "It re-shallows because the `shallow` file lives in the shared --git-common-dir, so any "
+    "sibling worktree doing a depth-limited fetch re-shallows this one too. Expect to need it "
+    "more than once in a session.\n\n"
+    "If the truncated answer genuinely does not matter, re-run prefixed with "
+    "SHALLOW_HISTORY_ACCEPTED=1.")
+shallowing_reason = (
+    "`" + os.environ["SHALLOWING_VERDICT"] + "` WOULD TRUNCATE THIS CLONE, and not just for you. The `shallow` "
+    "file lives in the shared --git-common-dir, so one depth-limited fetch re-shallows EVERY "
+    "worktree of this clone at once - including sessions that unshallowed a minute ago.\n\n"
+    "Nothing goes red afterwards. `git merge-base` starts returning empty, ahead/behind counts read "
+    "in the hundreds, and commits that plainly landed report as not ancestors of master - all of "
+    "which read as a rewritten history rather than as missing objects.\n\n"
+    "Drop `--depth` (an ordinary fetch is incremental and cheap here), or fetch into a throwaway "
+    # hazard-ok: the guidance text this hook prints, naming the safe alternative - not a command.
+    "repository if you only want to read a ref: `git --git-dir=\"$(mktemp -d)\" fetch --depth=1 "
+    "<url> <ref>`, then read it back with `git --git-dir=... show FETCH_HEAD:<path>`.\n\n"
+    "If you really do want this clone shallow, re-run prefixed with SHALLOW_HISTORY_ACCEPTED=1.")
+# Chained commands hid one hazard behind the other, so when both are live both get named: fixing the
+# half you were told about and re-running the rest is how the second one used to land.
+both_reason = (
+    "TWO SEPARATE HAZARDS in one command, and chaining them is what used to hide the second: `"
+    + os.environ["SHALLOWING_VERDICT"] + "` truncates the clone, and `" + os.environ["QUERY_VERDICT"]
+    + "` then reads the truncated graft it leaves behind. Both are below.\n\n"
+    + shallowing_reason + "\n\n" + query_reason)
+if os.environ["QUERY_VERDICT"] and os.environ["SHALLOWING_VERDICT"]:
+    reason = both_reason
+elif os.environ["SHALLOWING_VERDICT"]:
+    reason = shallowing_reason
+else:
+    reason = query_reason
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": (
-        "THE CLONE IS SHALLOW, and `" + os.environ["VERDICT"] + "` will answer anyway - from the "
-        "truncated graft, without erroring. Measured here: a branch reported 836 commits against a "
-        "true 29, and merge-base returned a commit that was not the merge base.\n\n"
-        "Run `git fetch --unshallow` first, then re-run. If you are mid-merge-prep this is not "
-        "optional: `git reset --mixed $(git merge-base ...)` against a wrong base silently reverts "
-        "whatever master gained.\n\n"
-        "It re-shallows because the `shallow` file lives in the shared --git-common-dir, so any "
-        "sibling worktree doing a depth-limited fetch re-shallows this one too. Expect to need it "
-        "more than once in a session.\n\n"
-        "If the truncated answer genuinely does not matter, re-run prefixed with "
-        "SHALLOW_HISTORY_ACCEPTED=1.")}}))
+    "permissionDecisionReason": reason}}))
 '
 exit 0

--- a/bin/check-quarantine-owners.sh
+++ b/bin/check-quarantine-owners.sh
@@ -34,28 +34,94 @@ cd "${QUARANTINE_CHECK_ROOT:-$(dirname "$0")/..}"
 source "${BASH_SOURCE[0]%/*}/lib/quarantine-common.sh" 2>/dev/null || source bin/lib/quarantine-common.sh
 
 # this repo is a fork - pin gh to the origin remote's repo, or it resolves PR numbers upstream
-REPO=$(git remote get-url origin | sed -E 's#\.git$##; s#.*[:/]([^/]+/[^/]+)$#\1#')
+ORIGIN_URL=$(git remote get-url origin)
+REPO=$(sed -E 's#\.git$##; s#.*[:/]([^/]+/[^/]+)$#\1#' <<<"$ORIGIN_URL")
 fail=0
+
+# REF PREVIEWS ARE FETCHED INTO A THROWAWAY GIT DIR, NEVER INTO THIS CLONE.
+#
+# The preview check below needs two remote refs - the owner PR's base, and its merge preview - and
+# it used to reach them with `git fetch --depth=1` right here. A depth-limited fetch writes the
+# `shallow` file, and that file lives in the SHARED --git-common-dir, so one run truncated history
+# for every worktree of the clone at once. This gate is swept by bin/check-all.sh, which made the
+# mandated pre-push sweep an instruction to corrupt the clone.
+#
+# The damage lands on OTHER commands and nothing goes red: `git merge-base` returns empty,
+# ahead/behind counts read in the hundreds, and a commit that plainly landed reports "not an
+# ancestor of master" - all of which read as a rewritten history rather than as missing objects.
+# .claude/hooks/check-shallow-history.sh denies those queries while shallow; this is the other half.
+#
+# FETCHING ELSEWHERE RATHER THAN FETCHING DEEPER HERE is what makes that unconditional. Choosing the
+# depth from `git rev-parse --is-shallow-repository` would still SAMPLE shared state a sibling
+# worktree can change between the sample and the fetch. A scratch git dir has no shared state to
+# race on; it deepens nothing when the clone arrived shallow on purpose (CI checks out at depth 1);
+# and if this script is killed mid-fetch the clone is exactly as it was, because it was never the
+# fetch target. Cost of the isolation, measured on this repo: ~1.4s and ~2.3MB for the first fetch,
+# and the dir is reused for the rest of the run.
+#
+# ONE SCRATCH DIR FOR THE WHOLE RUN, created eagerly below and removed by a single trap. Lazily is
+# what it wants to be, and cannot: gh_query runs inside `$(...)`, so a dir it created would be
+# recorded in a subshell and leak on every exit. It also holds gh_query stderr capture, which used
+# to be a per-call `mktemp` that survived an interrupted run.
+scratch_dir=""
+# IDEMPOTENT, AND IT DISARMS FIRST: a second signal arriving during teardown re-enters the handler
+# and abandons the `rm -rf` half-done.
+scratch_cleanup() { trap '' INT TERM; [ -n "$scratch_dir" ] && rm -rf "$scratch_dir"; scratch_dir=""; return 0; }
+trap scratch_cleanup EXIT
+# THE SIGNAL HANDLERS CLEAN UP THEMSELVES rather than relying on `exit` to reach the EXIT trap.
+# `exit` from inside a trap handler is documented to run the EXIT trap and MEASURABLY does not
+# always: instrumented, the TERM handler ran in the main shell and the EXIT trap did not follow, on
+# roughly one run in five of the self-test's interrupt arm. Calling it directly is one word and
+# removes the question. Nothing about the CLONE depends on any of this - it was never the fetch
+# target - so this is tidiness, not correctness.
+trap 'scratch_cleanup; exit 130' INT
+trap 'scratch_cleanup; exit 143' TERM
+
+# Fetch one ref for inspection. The result is FETCH_HEAD *in the scratch repo*, read back by
+# preview_show/preview_has - never by a bare `git show FETCH_HEAD`, which would read this clone's.
+#
+# `GIT_DIR=` AS A COMMAND PREFIX, NOT `--git-dir`, THOUGH THEY MEAN THE SAME THING. The global-option
+# spelling pushes the subcommand out of `$1`, and CheckQuarantineOwnersScriptTest stubs `git` on PATH
+# with a `case "$1" in fetch|show|cat-file)` dispatcher - so `git --git-dir=X show` matched nothing,
+# the stub printed nothing, and three of its assertions failed with the script behaving perfectly.
+# The stub is naive, but the property is worth keeping for free: the subcommand stays where every
+# wrapper looks for it. Same walk-past that let `git -C DIR rev-list` through
+# .claude/hooks/check-shallow-history.sh, and `git -c k=v fetch` through the hazard row.
+preview_git() { GIT_DIR="$scratch_dir/preview" git "$@"; }
+preview_fetch() { # $1 = ref to fetch from origin
+    [ -d "$scratch_dir/preview" ] || git init -q --bare "$scratch_dir/preview" || return 1
+    # The scratch repo is thrown away with its `shallow` file, which is the entire point of the
+    # indirection. The marker must be the line IMMEDIATELY above; the gate reads one line back.
+    # hazard-ok: fetches into the scratch repo above, never into this clone.
+    preview_git fetch --quiet --depth=1 --no-tags "$ORIGIN_URL" "$1" 2>/dev/null
+}
+preview_show() { preview_git show "FETCH_HEAD:$1" 2>/dev/null; }
+preview_has()  { preview_git cat-file -e "FETCH_HEAD:$1" 2>/dev/null; }
 
 # gh with retry + error classification: echoes the value, or MISSING (confirmed not-found), or
 # TRANSIENT (still failing after retries - infra weather, never an ERROR).
 gh_query() { # $1=pr  $2=jq field (e.g. .state)
-    local err out rc attempt
-    err=$(mktemp)
+    # A FIXED PATH IN THE RUN SCRATCH DIR, not a per-call `mktemp`. This function runs inside
+    # `$(...)`, so it cannot register anything for cleanup; every redirect below truncates the file,
+    # and the trap above removes the directory, interrupted run included.
+    local err out attempt
+    err="$scratch_dir/gh-stderr"
     for attempt in 1 2 3; do
         if out=$(gh pr view "$1" -R "$REPO" --json "${2#.}" -q "$2" 2>"$err"); then
-            rm -f "$err"; echo "$out"; return 0
+            echo "$out"; return 0
         fi
         if grep -qiE 'could not resolve|not found|no pull requests' "$err"; then
-            rm -f "$err"; echo MISSING; return 0
+            echo MISSING; return 0
         fi
         sleep "$attempt"
     done
-    rm -f "$err"; echo TRANSIENT
+    echo TRANSIENT
 }
 
 entries=$(registry_entries)
 [ -z "$entries" ] && { echo "Registry has no entries - nothing to verify."; exit 0; }
+
+scratch_dir=$(mktemp -d) || { echo "ERROR: cannot create a scratch directory." >&2; exit 1; }
 
 for t in $entries; do
     cls=${t%%.*}
@@ -111,26 +177,26 @@ for t in $entries; do
                 echo "ADVISORY: $t owner PR #$pr is open; could not resolve its base branch - skipping preview check."
                 continue
             fi
-            if ! git fetch --quiet --depth=1 origin "$base" 2>/dev/null; then
+            if ! preview_fetch "$base"; then
                 echo "ADVISORY: $t owner PR #$pr is open; could not fetch its base '$base' to verify - skipping preview check."
                 continue
             fi
             # Herestring: `git show | grep -q` under pipefail turns a MATCH into a failure once
             # the file exceeds the 64 KiB pipe buffer. The largest source file here is already
             # within a few hundred bytes of that.
-            if ! grep -qE "$QUARANTINE_ANNOTATION_ERE" <<<"$(git show "FETCH_HEAD:$relpath" 2>/dev/null)"; then
+            if ! grep -qE "$QUARANTINE_ANNOTATION_ERE" <<<"$(preview_show "$relpath")"; then
                 echo "ADVISORY: $t owner PR #$pr is open, but the quarantine is not yet on its base '$base' - preview check n/a, re-check after the base updates."
                 continue
             fi
-            if ! git fetch --quiet --depth=1 origin "pull/$pr/merge" 2>/dev/null; then
+            if ! preview_fetch "pull/$pr/merge"; then
                 echo "ADVISORY: $t owner PR #$pr is open but has no merge preview (conflicts?) - cannot verify it removes the quarantine."
                 continue
             fi
-            if ! git cat-file -e "FETCH_HEAD:$relpath" 2>/dev/null; then
+            if ! preview_has "$relpath"; then
                 echo "ADVISORY: $t owner PR #$pr merge preview does not contain $relpath (file renamed/moved?) - cannot verify removal; check manually."
                 continue
             fi
-            if grep -qE "$QUARANTINE_ANNOTATION_ERE" <<<"$(git show "FETCH_HEAD:$relpath" 2>/dev/null)"; then
+            if grep -qE "$QUARANTINE_ANNOTATION_ERE" <<<"$(preview_show "$relpath")"; then
                 echo "ADVISORY: $t owner PR #$pr is open and does NOT yet remove the quarantine - it must delete the @Quarantined annotation + registry entry before merging."
             else
                 echo "OK: $t owner PR #$pr is open and its merge result removes the quarantine - loop closed."

--- a/bin/check-shell-hazards.sh
+++ b/bin/check-shell-hazards.sh
@@ -17,6 +17,21 @@
 # control flow. The first category is GNU-vs-BSD coreutils divergence; the shape suits anything with
 # the same signature: silent, platform- or version-dependent, invisible to a linter.
 #
+# THE SECOND CATEGORY IS SHARED-GIT-STATE, and it is what the generic shape was for. `git fetch
+# --depth` is portable and correct on every platform; what it does silently is write the `shallow`
+# file in the shared --git-common-dir, truncating history for every worktree of the clone. Same
+# signature - no error, wrong answers elsewhere, unreachable by a linter - so it is a table row.
+#
+# ONE PIECE OF CONTROL FLOW EARNS ITS PLACE, and it is deliberately not a table row: before anything
+# is matched, backslash continuations are joined so every regex above sees LOGICAL commands rather
+# than physical lines. No regex can be written that sees across a newline, which is why this cannot
+# be data - and without it the table is quietly optional. `git fetch \` on one line with
+# `--depth=1 origin master` on the next is the ordinary way to format that command, and the
+# physical-line scanner reported SUCCESS over it: the subcommand and the flag never appeared in the
+# same haystack. Every other row has the same hole (`sed \` then `-i ...`), so the join strengthens
+# all of them at once. A finding on a joined command reports the line the command STARTS on, because
+# that is where a reader has to edit and the flag's own line means nothing without it.
+#
 # check-shell-sigpipe.sh BELONGS IN HERE, and has not moved yet. It is the same class by every test
 # that matters: a silent wrong answer, invisible to ShellCheck, found the hard way. It predates this
 # file, which is the only reason it is separate - and this file is named for the class rather than
@@ -32,13 +47,17 @@
 # The corpus resolution both gates share already lives in bin/lib/shell-corpus.sh, so they cannot
 # drift about WHAT they scan while they remain separate. They already had.
 #
-# ZERO FINDINGS TODAY, ON PURPOSE. Every existing use in this repo is already correct: `stat` sits
-# behind a probe-then-choose, `sed -i` and `date -d` were deliberately avoided. This gate fixes
-# nothing; it stops the next script from re-learning it, which makes it free to adopt.
+# ZERO FINDINGS TODAY, ON PURPOSE - for the gnu-bsd rows. Every existing use in this repo is already
+# correct: `stat` sits behind a probe-then-choose, `sed -i` and `date -d` were deliberately avoided.
+# Those rows fix nothing; they stop the next script from re-learning it, which makes them free to
+# adopt. The shared-git-state row is the exception and had two live findings when it landed, both in
+# bin/check-quarantine-owners.sh, fixed in the same change.
 #
 # THE MARKER, not an allowlist in this file. A use that is genuinely correct carries
 # `hazard-ok: <reason>` on the line or the line above, so the reason travels with the code instead
-# of rotting in a list here. `hazard-ok-file: <reason>` anywhere in a file exempts all of it.
+# of rotting in a list here - and on a continued command, ANY of its physical lines counts, because
+# the natural place to write the excuse is beside the flag being excused rather than up on the first
+# line. `hazard-ok-file: <reason>` anywhere in a file exempts all of it.
 set -uo pipefail
 
 # shellcheck source=lib/shell-corpus.sh
@@ -47,20 +66,32 @@ shell_corpus_init "${1:-}" || exit 1
 
 # <category><TAB><extended-regex><TAB><what actually happens on the other platform>
 #
+# THE COMMAND WORD MAY BE A WRAPPER, hence the `([[:alnum:]_]*[_-])?` after every row's leading
+# boundary. `git` is routinely wrapped to redirect it, and a refactor here proved the point: the
+# quarantine gate's `git --git-dir=X fetch --quiet --depth=1` became `preview_git fetch --quiet
+# --depth=1` behind a one-line wrapper, the row stopped matching, and that file's coverage silently
+# went to zero - while the `hazard-ok:` marker above the call went on looking load-bearing. Applied
+# to EVERY row rather than just the git one: a `my_sed` wrapper is less idiomatic than a `preview_git`
+# one, but a row whose command-word class differs from its neighbours is its own trap, and the header
+# above already argues that a row finding nothing today earns its place by stopping the next script.
+# THE `[_-]` IS LOAD-BEARING - it demands a separator, so `digit` and `parsed` are not calls to `git`
+# and `sed`, and a command word can never begin with `-` (`diff --git a/x` is not a wrapper).
+#
 # A FLAG THAT TAKES AN ATTACHED VALUE NEEDS A LOOSER TAIL. `-i([[:space:]]|$)` misses `sed -i.bak`
 # and `-w([[:space:]]|$)` misses `base64 -w0` - and in both cases the attached spelling is the
 # GNU-only one, so the strict pattern let exactly the dangerous form through while catching the
 # benign one. Caught by the self-test, which is why it carries an attached-value arm.
 HAZARDS=$(cat <<'HZ'
-gnu-bsd	(^|[^[:alnum:]_-])sed[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-i[^[:space:]]*([[:space:]]|$)	GNU takes the backup suffix ATTACHED (-i.bak); BSD takes it as the NEXT ARGUMENT, so `sed -i` silently consumes whatever follows. Write a temp file and move it.
-gnu-bsd	(^|[^[:alnum:]_-])stat[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-c([[:space:]]|$)	`stat -c` is GNU; BSD/macOS rejects it. Probe with `if stat -c %Y . >/dev/null 2>&1` and fall back to `stat -f %m`.
-gnu-bsd	(^|[^[:alnum:]_-])stat[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-f([[:space:]]|$)	`stat -f` is BSD; on GNU it exits 1 while PRINTING filesystem prose to stdout, so a caller capturing it gets prose, not a number.
-gnu-bsd	(^|[^[:alnum:]_-])date[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-d([[:space:]]|$)	`date -d` is GNU; BSD date reads -d as a daylight-saving flag. Use python3 for date arithmetic.
-gnu-bsd	(^|[^[:alnum:]_-])readlink[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-f([[:space:]]|$)	`readlink -f` is GNU and absent from older macOS. Use `cd ... && pwd -P`, or python3 realpath.
-gnu-bsd	(^|[^[:alnum:]_-])grep[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-P([[:space:]]|$)	`grep -P` needs PCRE and is absent from BSD grep. Use -E.
-gnu-bsd	(^|[^[:alnum:]_-])sort[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-V([[:space:]]|$)	`sort -V` is GNU; BSD sort has no version sort and treats it as an error.
-gnu-bsd	(^|[^[:alnum:]_-])base64[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-w[0-9]*([[:space:]]|$)	`base64 -w` is GNU; BSD base64 does not wrap and rejects -w.
-gnu-bsd	(^|[^[:alnum:]_-])sed[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-r([[:space:]]|$)	`sed -r` is GNU; -E works on both and means the same thing.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?sed[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-i[^[:space:]]*([[:space:]]|$)	GNU takes the backup suffix ATTACHED (-i.bak); BSD takes it as the NEXT ARGUMENT, so `sed -i` silently consumes whatever follows. Write a temp file and move it.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?stat[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-c([[:space:]]|$)	`stat -c` is GNU; BSD/macOS rejects it. Probe with `if stat -c %Y . >/dev/null 2>&1` and fall back to `stat -f %m`.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?stat[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-f([[:space:]]|$)	`stat -f` is BSD; on GNU it exits 1 while PRINTING filesystem prose to stdout, so a caller capturing it gets prose, not a number.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?date[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-d([[:space:]]|$)	`date -d` is GNU; BSD date reads -d as a daylight-saving flag. Use python3 for date arithmetic.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?readlink[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-f([[:space:]]|$)	`readlink -f` is GNU and absent from older macOS. Use `cd ... && pwd -P`, or python3 realpath.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?grep[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-P([[:space:]]|$)	`grep -P` needs PCRE and is absent from BSD grep. Use -E.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?sort[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-V([[:space:]]|$)	`sort -V` is GNU; BSD sort has no version sort and treats it as an error.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?base64[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-w[0-9]*([[:space:]]|$)	`base64 -w` is GNU; BSD base64 does not wrap and rejects -w.
+gnu-bsd	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?sed[[:space:]]+(-[[:alnum:]]+[[:space:]]+)*-r([[:space:]]|$)	`sed -r` is GNU; -E works on both and means the same thing.
+shared-git-state	(^|[^[:alnum:]_-])([[:alnum:]_]*[_-])?git[[:space:]]+((-[^[:space:]]+)([[:space:]]+[^-[:space:]][^[:space:]]*)?[[:space:]]+)*(fetch|pull)([[:space:]]+[^[:space:]]+)*[[:space:]]+--(depth|shallow-since|shallow-exclude)	`git fetch --depth` (and `git pull --depth`) writes the `shallow` file, which lives in the SHARED --git-common-dir - so it truncates history for EVERY worktree of the clone at once, and merge-base and ahead/behind then answer confidently wrong instead of erroring. Fetch into a throwaway git dir and read FETCH_HEAD there; mark it hazard-ok when the fetch target really is disposable.
 HZ
 )
 
@@ -79,12 +110,60 @@ for f in $(shell_corpus_files); do
     # and any file whose prose merely mentioned the marker got a free pass on every hazard in it.
     # Anchored to a comment line with a reason after it, so writing ABOUT the marker cannot disarm it.
     grep -qE '^[[:space:]]*#[[:space:]]*hazard-ok-file:[[:space:]]*[^[:space:]]' "$f" && continue
+    # LOGICAL COMMANDS, ONE PER RECORD, as `<first-physical-line>:<joined text>` - see the header for
+    # why this one transformation is control flow rather than a table row. Three things it must get
+    # right, each of which has its own self-test arm:
+    #   - a COMMENT ends at the newline, so a `\` inside one continues nothing. bash agrees: `# x \`
+    #     followed by `echo hi` runs the echo.
+    #   - a HEREDOC BODY is data, so its lines are emitted one per record and never joined - splicing
+    #     two lines of fixture text into a command the file never runs is the false-positive class
+    #     that gets a gate switched off. Emitting them with their true line numbers is also what
+    #     keeps the heredoc-range check below working unchanged.
+    #   - the joined text keeps every physical line, which is what lets a `hazard-ok:` marker written
+    #     beside the offending flag suppress the whole command.
+    # The heredoc opener is recognised exactly as the range scan further down recognises it, so the
+    # two cannot disagree about where a body starts.
+    norm=$(awk '
+        delim != "" {
+            print NR ":" $0
+            if ($0 ~ "^[[:space:]]*" delim "[[:space:]]*$") delim = ""
+            next
+        }
+        {
+            line = $0
+            if (pending == 0) { start = NR; buf = "" }
+            if (line ~ /\\$/ && !(pending == 0 && line ~ /^[[:space:]]*#/)) {
+                sub(/\\$/, "", line); buf = buf line; pending = 1; next
+            }
+            buf = buf line
+            print start ":" buf
+            pending = 0
+            if ($0 ~ /<<-?[\x27"]?[A-Za-z_][A-Za-z_0-9]*[\x27"]?$/) {
+                d = $0; sub(/.*<<-?/, "", d); gsub(/[\x27"]/, "", d); delim = d
+            }
+        }
+        END { if (pending) print start ":" buf }' "$f")
+    # MATCHED AGAINST THE COMMAND TEXT ALONE - the line number travels alongside, never inside the
+    # haystack. A row is DATA that someone will add, and `^` is the natural way to write "at the
+    # start of a command"; a haystack still carrying its `NNN:` prefix would make every such row
+    # match nothing, for ever, with the gate reporting success - this file's own subject matter,
+    # turned inward. The stripped copy is derived FROM $norm rather than produced by a second awk
+    # run, so the two cannot drift into disagreeing about how many records there are, which is what
+    # the index mapping below depends on.
+    norm_text=$(sed 's/^[0-9][0-9]*://' <<<"$norm")
     while IFS= read -r hz; do
         [ -n "$hz" ] || continue
         cat_name="${hz%%	*}"; rest="${hz#*	}"
         pat="${rest%%	*}"; why="${rest#*	}"
-        while IFS=: read -r lineno text; do
-            [ -n "$lineno" ] || continue
+        # FED FROM THE STRIPPED RECORDS (a herestring, not a pipe - `printf | grep` under pipefail
+        # inverts its own answer, the rule bin/check-shell-sigpipe.sh enforces). `idx` is grep's
+        # RECORD index, which is the same index in $norm because norm_text is $norm line for line, so
+        # the prefixed copy hands back the physical line the command starts on. `text` is the whole
+        # joined command, which is what the marker and comment tests want, while the heredoc-range
+        # test still gets a real physical line because heredoc bodies are emitted one per record.
+        while IFS=: read -r idx text; do
+            [ -n "$idx" ] || continue
+            rec=$(sed -n "${idx}p" <<<"$norm"); lineno="${rec%%:*}"
             # A COMMENT ABOUT A HAZARD IS NOT A USE OF IT, and this repo is full of comments warning
             # about exactly these flags - they are how the knowledge survived before this gate. A
             # scanner that flagged its own documentation would be abandoned within a day.
@@ -113,7 +192,7 @@ EOF
             printf '    %s\n' "$(printf '%s' "$text" | sed 's/^[[:space:]]*//' | cut -c1-110)" >&2
             problems=$((problems + 1))
         done <<EOF
-$(grep -nE "$pat" "$f" 2>/dev/null || true)
+$(grep -nE "$pat" <<<"$norm_text" 2>/dev/null || true)
 EOF
     done <<EOF
 $HAZARDS

--- a/bin/test-check-quarantine-owners.sh
+++ b/bin/test-check-quarantine-owners.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Self-test for bin/check-quarantine-owners.sh.
+#
+# THE LOAD-BEARING ARM IS THE DEPTH INVARIANT: running this gate must leave the clone exactly as
+# shallow as it found it. The gate reached an owner PR's base and merge preview with
+# `git fetch --depth=1`, which writes the `shallow` file - and that file lives in the SHARED
+# --git-common-dir, so one run truncated history for EVERY worktree of the clone. bin/check-all.sh
+# sweeps `bin/check-*.sh`, so the mandated pre-push sweep was also an instruction to corrupt the
+# clone, and the damage showed up in OTHER commands: empty merge-bases, ahead/behind counts in the
+# hundreds, landed commits reported as "not an ancestor of master". Nothing went red.
+#
+# So the invariant is ASSERTED HERE rather than described in a comment there, and it is asserted
+# from both sides - a full clone must stay full, and a clone that arrived shallow on purpose (CI
+# checks out at depth 1) must not be deepened either. Verified red against the unfixed script before
+# it landed: the full-clone arm reported `is-shallow=true`.
+#
+# HERMETIC BY CONSTRUCTION. The gate needs `gh` and the network; both are replaced - a fake `gh` on
+# PATH answers the two queries it makes, and "origin" is a local file:// repository carrying real
+# `refs/pull/N/merge` refs. So this runs offline, deterministically, and against the real gate rather
+# than a copy of it.
+set -uo pipefail
+
+GATE="$(cd "$(dirname "$0")/.." && pwd)/bin/check-quarantine-owners.sh"
+pass=0; fail=0
+
+check() { # <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then printf 'ok:   %s\n' "$1"; pass=$((pass + 1))
+    else printf 'FAIL: %s (expected %s, got %s)\n' "$1" "$2" "$3"; fail=$((fail + 1)); fi
+}
+check_contains() { # <name> <needle> <haystack>
+    case "$3" in *"$2"*) printf 'ok:   %s\n' "$1"; pass=$((pass + 1)) ;;
+        *) printf 'FAIL: %s (no "%s" in output)\n%s\n' "$1" "$2" "$3"; fail=$((fail + 1)) ;; esac
+}
+
+scratch="$(mktemp -d)"; trap 'rm -rf "$scratch"' EXIT
+origin="$scratch/origin"
+
+# ---------------------------------------------------------------------------- the fake remote
+# Three commits, so "depth 1" is distinguishable from "all of it" by counting.
+mkdir -p "$origin/src/test/java"
+git init -q "$origin"
+git -C "$origin" symbolic-ref HEAD refs/heads/master   # not `init -b`, which needs git >= 2.28
+git -C "$origin" config user.email t@t
+git -C "$origin" config user.name t
+quarantined() { cat > "$origin/src/test/java/FlakyThingTest.java" <<'JAVA'
+class FlakyThingTest {
+    @Test
+    @Quarantined(fixedBy = "PR astubbs#7", reason = "fixture")
+    void someMethod() {}
+}
+JAVA
+}
+released() { cat > "$origin/src/test/java/FlakyThingTest.java" <<'JAVA'
+class FlakyThingTest {
+    @Test
+    void someMethod() {}
+}
+JAVA
+}
+quarantined
+for i in 1 2 3; do
+    echo "$i" > "$origin/filler"
+    git -C "$origin" add -A && git -C "$origin" commit -qm "c$i"
+done
+
+# refs/pull/7/merge REMOVES the quarantine - the loop closes, the gate must say OK.
+released
+git -C "$origin" add -A && git -C "$origin" commit -qm "pr7 releases the quarantine"
+git -C "$origin" update-ref refs/pull/7/merge HEAD
+git -C "$origin" reset -q --hard HEAD~1
+
+# refs/pull/8/merge STILL CARRIES it - the gate must say no. A gate that can only say yes is not a
+# gate, and "still works" is half the point of this fix.
+echo touched > "$origin/filler2"
+git -C "$origin" add -A && git -C "$origin" commit -qm "pr8 leaves the quarantine in place"
+git -C "$origin" update-ref refs/pull/8/merge HEAD
+git -C "$origin" reset -q --hard HEAD~1
+
+# ---------------------------------------------------------------------------- the fake gh
+fakebin="$scratch/fakebin"; mkdir -p "$fakebin"
+cat > "$fakebin/gh" <<'GH'
+#!/usr/bin/env bash
+# Answers the two queries gh_query makes: `gh pr view <n> -R <repo> --json <field> -q <path>`.
+n=""; field=""
+while [ $# -gt 0 ]; do
+    case "$1" in view) n="$2" ;; --json) field="$2" ;; esac
+    shift
+done
+case "$field" in
+    state)
+        # PR 9 exists only to be interrupted: it blocks until the caller kills the gate. `exec`, so
+        # this process BECOMES sleep - a forked child would keep the command substitution's pipe
+        # open after its parent was killed, and the gate would stay blocked anyway.
+        # `exec`, so this process BECOMES sleep and keeps this pid: a forked child would hold the
+        # command substitution's pipe open after its parent died, and outlive the test as an orphan.
+        # The pid goes in the marker so the caller can reap it rather than wait out the sleep.
+        if [ "$n" = "9" ]; then echo $$ > "${FAKE_GH_BLOCKED_MARKER:-/dev/null}"; exec sleep 30; fi
+        echo OPEN ;;
+    baseRefName) echo master ;;
+    *) exit 1 ;;
+esac
+GH
+chmod +x "$fakebin/gh"
+
+registry() { # <workdir> <entries...>
+    local w="$1"; shift
+    mkdir -p "$w/docs"
+    { echo "# Quarantined tests"; echo; printf '%s\n' "$@"; } > "$w/docs/quarantined-tests.md"
+}
+run_gate() { # <workdir> ; echoes the gate's output, TMPDIR pinned so leaks are observable
+    local w="$1"
+    rm -rf "$scratch/tmp"; mkdir -p "$scratch/tmp"
+    ( cd "$w" && PATH="$fakebin:$PATH" TMPDIR="$scratch/tmp" QUARANTINE_CHECK_ROOT="$w" \
+        bash "$GATE" 2>&1 )
+}
+
+# ============================================================ 1. a FULL clone must stay full
+full="$scratch/full"
+git clone -q "file://$origin" "$full"
+registry "$full" "- [ ] \`FlakyThingTest.someMethod\` - fixture entry." "  Owner: PR astubbs#7"
+out="$(run_gate "$full")"
+
+check "a full clone is NOT left shallow by the gate" \
+    "false" "$(git -C "$full" rev-parse --is-shallow-repository)"
+check "no shallow file is written into the shared git dir" \
+    "absent" "$([ -e "$full/.git/shallow" ] && echo present || echo absent)"
+check "the clone still has its whole history" \
+    "3" "$(git -C "$full" rev-list --count HEAD)"
+check "the scratch fetch dir is cleaned up" \
+    "" "$(ls -A "$scratch/tmp" 2>/dev/null)"
+
+# THE GATE MUST STILL CHECK. Removing the side effect by removing the check would pass every
+# assertion above and be a worse script than the one it replaced.
+check_contains "the merge preview that removes the quarantine reads as OK" \
+    "OK: FlakyThingTest.someMethod owner PR #7 is open and its merge result removes the quarantine" "$out"  # issue-refs: exempt - the gate's own output format, not a reference to anything
+
+# ============================================================ 2. and it must still be able to say no
+full2="$scratch/full2"
+git clone -q "file://$origin" "$full2"
+registry "$full2" "- [ ] \`FlakyThingTest.someMethod\` - fixture entry." "  Owner: PR astubbs#8"
+out2="$(run_gate "$full2")"
+check_contains "a merge preview that keeps the quarantine is reported" \
+    "does NOT yet remove the quarantine" "$out2"
+check "saying no does not shallow the clone either" \
+    "false" "$(git -C "$full2" rev-parse --is-shallow-repository)"
+
+# ============================================================ 3. a DELIBERATELY shallow clone
+# CI checks out at depth 1 on purpose. Unshallowing it would make every job slower for no benefit,
+# so the fix must not "repair" what it did not break.
+shallow="$scratch/shallow"
+git clone -q --depth=1 "file://$origin" "$shallow"
+registry "$shallow" "- [ ] \`FlakyThingTest.someMethod\` - fixture entry." "  Owner: PR astubbs#7"
+out3="$(run_gate "$shallow")"
+check "a deliberately shallow clone stays shallow" \
+    "true" "$(git -C "$shallow" rev-parse --is-shallow-repository)"
+check "a deliberately shallow clone is not deepened" \
+    "1" "$(git -C "$shallow" rev-list --count HEAD)"
+check_contains "the gate still verifies from a shallow clone" \
+    "owner PR #7" "$out3"  # issue-refs: exempt - matches the gate's printed output, not a real PR
+
+# ============================================================ 4. interrupted mid-run
+# The first entry completes, so the scratch fetch dir exists; the second blocks in `gh` until we
+# kill the gate. The clone must be untouched, because it was never the fetch target.
+killable="$scratch/killable"
+git clone -q "file://$origin" "$killable"
+registry "$killable" \
+    "- [ ] \`FlakyThingTest.someMethod\` - fixture entry." \
+    "  Owner: PR astubbs#7" \
+    "" \
+    "- [ ] \`OtherThingTest.blocks\` - fixture entry that blocks." \
+    "  Owner: PR astubbs#9"
+marker="$scratch/blocked"
+rm -rf "$scratch/tmp"; mkdir -p "$scratch/tmp"
+# `exec`, so the backgrounded subshell BECOMES the gate and $! is the gate's own pid. Without it,
+# $! is the wrapper and the signal lands on the wrong process - which is how this arm first passed
+# its kill and then failed its assertion.
+( cd "$killable" || exit 1
+  export PATH="$fakebin:$PATH" TMPDIR="$scratch/tmp" QUARANTINE_CHECK_ROOT="$killable"
+  export FAKE_GH_BLOCKED_MARKER="$marker"
+  exec bash "$GATE" >/dev/null 2>&1 ) &
+gate_pid=$!
+# BOUNDED WAIT, and the bound is a failure, not a timeout to sleep through. `-s`, not `-e`: an
+# existing but still-empty marker would hand the kill below an empty pid.
+waited=0
+while [ ! -s "$marker" ] && [ "$waited" -lt 200 ]; do sleep 0.1; waited=$((waited + 1)); done
+check "the gate reached the blocking entry" "yes" "$([ -s "$marker" ] && echo yes || echo no)"
+# The gate is parked in a foreground child, and bash defers a trap until that child returns - so
+# everything below it has to go too, or the TERM is never serviced and this arm just times out.
+# The blocked `gh` is a GRANDchild (command substitution forks its own subshell), which is why its
+# pid is passed out through the marker rather than reached with `pkill -P`.
+kill -TERM "$(cat "$marker")" 2>/dev/null
+pkill -TERM -P "$gate_pid" 2>/dev/null
+kill -TERM "$gate_pid" 2>/dev/null
+wait "$gate_pid" 2>/dev/null
+
+# THE CLONE IS THE ASSERTION THAT MATTERS, and it is instantaneous: the clone was never the fetch
+# target, so no ordering of the teardown can leave it shallow.
+check "an interrupted gate leaves the clone unshallowed" \
+    "false" "$(git -C "$killable" rev-parse --is-shallow-repository)"
+
+# CLEANUP IS THE SECOND ASSERTION, and it is instantaneous on purpose. It was flaky at three passes
+# in five while the gate reached its EXIT trap by `exit`-ing from the signal handler, and the fix
+# for that is in the gate, not a poll here - a bounded wait would have hidden a real defect behind
+# a timeout. The handlers now do their own cleanup, so by the time `wait` returns it has happened.
+check "an interrupted gate cleans up its scratch dir" \
+    "" "$(ls -A "$scratch/tmp" 2>/dev/null)"
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/bin/test-check-shallow-history.sh
+++ b/bin/test-check-shallow-history.sh
@@ -7,7 +7,17 @@
 # The hook's whole value is PRECISION: it must fire on the queries a shallow clone answers wrongly
 # and stay silent on the ones it answers correctly, because a hook that fires on `git status` gets
 # switched off and then protects nothing. Most arms here are therefore negative.
+#
+# IT GUARDS TWO OPPOSITE THINGS, so there are two fixtures. A depth-dependent QUERY is wrong only in
+# a clone that is already shallow; a SHALLOWING fetch is only worth stopping in one that is not. Get
+# the fixture wrong and an arm passes for the wrong reason - `fire` uses the shallow clone, and
+# `fire_full` the full one, and the last two arms below assert each kind stays silent in the other's
+# fixture.
 set -uo pipefail
+# hazard-ok-file: every git command in here is a FIXTURE - a string handed to the hook to judge,
+# never executed. Several are literally `git fetch --depth=1`, because the hook's job is to block
+# that; check-shell-hazards.sh cannot tell a fixture from a use, and its own self-test carries the
+# same exemption for the same reason.
 HOOK="$(cd "$(dirname "$0")/.." && pwd)/.claude/hooks/check-shallow-history.sh"
 problems=0
 
@@ -19,14 +29,43 @@ git -C "$scratch" init -q origin-repo 2>/dev/null
   git config user.email t@t; git config user.name t
   for i in 1 2 3; do echo "$i" > f; git add f; git commit -qm "c$i"; done ) >/dev/null 2>&1
 git clone -q --depth=1 "file://$scratch/origin-repo" "$scratch/shallow" 2>/dev/null
+# A LINKED WORKTREE OF THE FULL CLONE. Its `.git` is a different path that resolves to the SAME
+# common directory - the exact reason this hook exists - so a redirect naming it is not a redirect.
+git -C "$scratch/origin-repo" worktree add -q -b wt "$scratch/wt" 2>/dev/null
+
+# ONE PAYLOAD BUILDER FOR ALL THREE HELPERS. python does the quoting because half the arms below are
+# about quoting - a fixture carrying a quote, a `;` or a `$(` has to reach the hook exactly as typed.
+payload_for() { python3 -c 'import json,sys;print(json.dumps({"tool_input":{"command":sys.argv[1]}}))' "$1"; }
 
 fire() { # <name> <expect fire|silent> <command>
     local name="$1" expect="$2" cmd="$3" out
-    out="$(printf '%s' "{\"tool_input\":{\"command\":$(python3 -c 'import json,sys;print(json.dumps(sys.argv[1]))' "$cmd")}}" \
-        | ( cd "$scratch/shallow" && bash "$HOOK" ) 2>/dev/null)"
+    out="$(payload_for "$cmd" | ( cd "$scratch/shallow" && bash "$HOOK" ) 2>/dev/null)"
     local got="silent"; [ -n "$out" ] && got="fire"
     if [ "$got" = "$expect" ]; then printf 'ok:   %s\n' "$name"
     else printf 'FAIL: %s (expected %s, got %s)\n' "$name" "$expect" "$got"; problems=$((problems + 1)); fi
+}
+
+# The same, in the FULL clone - the fixture the shallowing arms need.
+fire_full() { # <name> <expect fire|silent> <command>
+    local name="$1" expect="$2" cmd="$3" out
+    out="$(payload_for "$cmd" | ( cd "$scratch/origin-repo" && bash "$HOOK" ) 2>/dev/null)"
+    local got="silent"; [ -n "$out" ] && got="fire"
+    if [ "$got" = "$expect" ]; then printf 'ok:   %s\n' "$name"
+    else printf 'FAIL: %s (expected %s, got %s)\n' "$name" "$expect" "$got"; problems=$((problems + 1)); fi
+}
+
+# SOME ARMS CARE WHICH HAZARD THE DENY NAMES, not merely that it denied. A chained command that
+# reports only its first git command still denies, so `fire` cannot tell the fixed scanner from the
+# broken one - the deny text is the only place the second hazard becomes visible.
+mentions() { # <name> <command> <needle>...
+    local name="$1" cmd="$2"; shift 2
+    local out missing="" needle
+    out="$(payload_for "$cmd" | ( cd "$scratch/origin-repo" && bash "$HOOK" ) 2>/dev/null)"
+    for needle in "$@"; do
+        case "$out" in *"$needle"*) ;; *) missing="$missing [$needle]" ;; esac
+    done
+    if [ -z "$missing" ]; then printf 'ok:   %s\n' "$name"
+    else printf 'FAIL: %s (deny did not name:%s)\n' "$name" "$missing"; problems=$((problems + 1)); fi
 }
 
 # MUST fire - every one of these answers wrongly from a truncated graft.
@@ -60,8 +99,8 @@ fire "git -c k=v rev-list is caught"      fire   'git -c core.pager=cat rev-list
 fire "git --no-pager log RANGE is caught" fire   'git --no-pager log origin/master..HEAD'
 # COMMAND SUBSTITUTION. shlex glues `$(` to the next word, so no bare `git` token existed - and this
 # is the idiom AGENTS.md itself prescribes for finding the merge base.
-fire "X=$(git merge-base ...) is caught"  fire   'BASE=$(git merge-base HEAD origin/master)'
-fire "echo $(git rev-list) is caught"     fire   'echo $(git rev-list --count origin/master..HEAD)'
+fire 'X=$(git merge-base ...) is caught'  fire   'BASE=$(git merge-base HEAD origin/master)'
+fire 'echo $(git rev-list) is caught'     fire   'echo $(git rev-list --count origin/master..HEAD)'
 # THE OVERRIDE IS A LEADING PREFIX, NOT ANY OCCURRENCE. Searching history for the name of the escape
 # hatch used to disable the escape hatch.
 fire "override in a -S pattern is caught" fire   'git log -S "SHALLOW_HISTORY_ACCEPTED=1" origin/master..HEAD'
@@ -72,6 +111,92 @@ see git log old..new for the story
 EOF'
 fire "a pathspec containing .. is ok"     silent 'git diff -- ../docs'
 fire "prose in an echo is ok"             silent 'echo "run git log a..b next"'
+
+# THE OTHER DIRECTION - the command that CREATES the truncation, in a clone that is still full.
+# `bin/check-quarantine-owners.sh` did this on every sweep of bin/check-all.sh; hand-typed, there is
+# no script to fix, which is what these arms are for.
+fire_full "git fetch --depth=1 is blocked"     fire   'git fetch --quiet --depth=1 origin master'
+fire_full "git fetch --depth 1 is blocked"     fire   'git fetch --depth 1 origin master'
+fire_full "git pull --depth is blocked"        fire   'git pull --depth=1 origin master'
+fire_full "--shallow-since is blocked"         fire   'git fetch --shallow-since=2026-01-01 origin master'
+fire_full "a global option cannot hide it"     fire   'git -c core.pager=cat fetch --depth=1 origin master'
+# NOT THE HAZARD. `--git-dir` names another repository - the sanctioned way to fetch a ref you only
+# want to read; a clone owns its own depth; and an unrestricted fetch writes no `shallow` file.
+fire_full "--git-dir elsewhere is allowed"     silent 'git --git-dir=/tmp/x fetch --depth=1 https://h/r ref'
+# The same redirect as an assignment prefix - what bin/check-quarantine-owners.sh actually writes,
+# so denying it would block the alternative this hook's own deny message recommends.
+fire_full "GIT_DIR= prefix is allowed"         silent 'GIT_DIR=/tmp/x git fetch --depth=1 https://h/r ref'
+fire_full "an unrelated env prefix is not"     fire   'FOO=bar git fetch --depth=1 origin master'
+fire_full "git clone --depth=1 is allowed"     silent 'git clone -q --depth=1 https://h/r dir'
+fire_full "an undepthed fetch is allowed"      silent 'git fetch --no-tags origin master'
+fire_full "--unshallow is allowed"             silent 'git fetch --unshallow origin'
+fire_full "the override is honoured"           silent 'SHALLOW_HISTORY_ACCEPTED=1 git fetch --depth=1 origin master'
+fire_full "prose about it does not fire"       silent 'echo "never git fetch --depth=1 in a worktree"'
+# THE TWO KINDS ARE GATED OPPOSITELY, and each must stay silent in the other's fixture - otherwise an
+# arm above could be passing on the wrong condition entirely.
+fire_full "a history query is fine when full"  silent 'git merge-base HEAD origin/master'
+fire      "shallowing an already-shallow clone is a no-op" silent 'git fetch --depth=1 origin master'
+
+# CHAINED GIT COMMANDS. The scanner reported the FIRST git call it matched and stopped, and the two
+# directions want opposite answers from --is-shallow-repository - so the query's verdict was used to
+# clear the fetch, and the chain re-shallowed the clone with the guard reporting safe.
+fire_full "a fetch chained after a query" fire 'git merge-base HEAD origin/master; git fetch --depth=1 origin master'
+fire      "a query chained after a fetch" fire 'git fetch --depth=1 origin master && git merge-base HEAD origin/master'
+# ...and the deny has to NAME both, or a reader fixes the half it was told about and re-runs the rest.
+mentions  "the chained deny names both" 'git fetch --depth=1 origin master && git merge-base HEAD origin/master' \
+          'TWO SEPARATE HAZARDS' 'git fetch --depth=1' 'git merge-base'
+# Chaining must not INVENT a hazard either: a redirected fetch truncates nothing, so the query after
+# it is still answering from a full clone.
+fire_full "a redirected fetch taints nothing" silent \
+          'git --git-dir=/tmp/x fetch --depth=1 https://h/r ref && git merge-base HEAD origin/master'
+
+# A REDIRECT IS TRUSTED ONLY AFTER IT IS RESOLVED. `--git-dir` was exempt on its spelling alone, so
+# naming THIS clone's own git directory - which is precisely where the shared `shallow` file lives -
+# was a one-flag bypass of the arm above.
+fire_full "--git-dir=.git is not a redirect"         fire 'git --git-dir=.git fetch --depth=1 origin master'
+fire_full "GIT_DIR=.git is not a redirect"           fire 'GIT_DIR=.git git fetch --depth=1 origin master'
+fire_full "--git-dir naming this clone"    fire "git --git-dir=$scratch/origin-repo/.git fetch --depth=1 origin master"
+fire_full "--git-dir with a separate value is caught" fire 'git --git-dir .git fetch --depth=1 origin master'
+# A SIBLING WORKTREE'S `.git` IS A DIFFERENT PATH AND THE SAME REPOSITORY. Comparing the spelling, or
+# even the git dir, would clear this one - it is the COMMON dir that holds the `shallow` file, and
+# truncating through a sibling is precisely the incident this hook was written for.
+fire_full "a sibling worktree's .git is caught"      fire "git --git-dir=$scratch/wt/.git fetch --depth=1 origin master"
+# A target only the shell can expand is judged on its text, so the two spellings that name THIS
+# clone through a substitution stay denied while an opaque one is allowed.
+fire_full "a \$PWD/.git redirect is caught"           fire 'git --git-dir="$PWD/.git" fetch --depth=1 https://h/r ref'
+fire_full "a rev-parse redirect is caught" fire \
+          'git --git-dir="$(git rev-parse --git-common-dir)" fetch --depth=1 https://h/r ref'
+# The genuine article still has to pass, or the hook denies the alternative its own message names -
+# and bin/check-quarantine-owners.sh writes the second of these.
+fire_full "a mktemp scratch dir is ok"  silent 'git --git-dir="$(mktemp -d)" fetch --depth=1 https://h/r ref'
+fire_full "a \$scratch_dir GIT_DIR is ok" silent 'GIT_DIR="$scratch_dir/preview" git fetch --depth=1 https://h/r ref'
+
+# COMMAND WRAPPERS. `git` was required to sit in command position, so one word in front of it -
+# `command`, `env`, `time`, `nohup`, `stdbuf`, `xargs`, `sudo`, `nice`, `ionice`, `setsid` - skipped
+# the whole hook, the pre-existing query arm included.
+fire_full "command git fetch --depth is caught"      fire 'command git fetch --depth=1 origin master'
+fire_full "env git fetch --depth is caught"          fire 'env git fetch --depth=1 origin master'
+fire_full "nohup git fetch --depth is caught"        fire 'nohup git fetch --depth=1 origin master'
+fire_full "sudo -u ci git fetch --depth is caught"   fire 'sudo -u ci git fetch --depth=1 origin master'
+fire_full "nice -n 10 git fetch --depth is caught"   fire 'nice -n 10 git fetch --depth=1 origin master'
+fire_full "stacked wrappers cannot hide it"          fire 'env command git fetch --depth=1 origin master'
+fire      "time git merge-base is caught"            fire 'time git merge-base HEAD origin/master'
+fire      "stdbuf -oL git rev-list is caught"        fire 'stdbuf -oL git rev-list --count a..b'
+fire      "xargs -I {} git blame is caught"          fire 'xargs -I {} git blame README.adoc'
+# `env -i` takes NO value: a shared option table would have it swallow the very `git` it looks for.
+fire_full "timeout 60 git fetch is caught"  fire 'timeout 60 git fetch --depth=1 origin master'
+# A SUBSHELL GLUES ITS `(` TO THE COMMAND WORD, which is the wrapper defect by another route.
+fire_full "a subshell cannot hide it"       fire '(git fetch --depth=1 origin master)'
+fire      "a subshell around a query too"   fire '(git merge-base HEAD origin/master)'
+fire      "env -i git merge-base is caught"          fire 'env -i git merge-base HEAD origin/master'
+# Walking wrappers must not widen what counts as a call: these are still prose and a non-git command.
+fire      "a heredoc naming a wrapper is ok"         silent 'cat <<EOF
+run command git blame README.adoc yourself
+EOF'
+fire      "a wrapper running echo is ok"              silent 'command echo git blame README.adoc'
+# Unspaced control operators are padded before tokenising so `...master; git fetch --depth=1` is seen
+# at all - a quoted one must still be text, or every commit message describing a command denies.
+fire      "a ; inside a commit message is ok"        silent 'git commit -m "fix; then git blame f"'
 
 if [ "$problems" -gt 0 ]; then
     echo "check-shallow-history self-test: $problems failure(s)" >&2; exit 1

--- a/bin/test-check-shell-hazards.sh
+++ b/bin/test-check-shell-hazards.sh
@@ -44,6 +44,30 @@ arm "base64 -w0 (attached) is caught" fire  'base64 -w0 < f'
 # Flags bunched before the hazardous one must still be seen.
 arm "a preceding flag does not hide it" fire 'grep -n -P "x" f'
 
+# SHARED GIT STATE - portable on every platform, and still a silent wrong answer everywhere else in
+# the clone. Two of these shipped in bin/check-quarantine-owners.sh and re-shallowed the whole
+# repository on every sweep of bin/check-all.sh.
+arm "git fetch --depth= is caught"    fire  'git fetch --quiet --depth=1 origin master'
+arm "git fetch --depth 1 is caught"   fire  'git fetch --depth 1 origin master'
+arm "--shallow-since is caught"       fire  'git fetch --shallow-since=2026-01-01 origin master'
+# `pull` is `fetch` plus a merge, and writes the same file. Matching only `fetch` would have left the
+# obvious next spelling uncovered.
+arm "git pull --depth is caught"      fire  'git pull --depth=1 origin master'
+# A GLOBAL OPTION BEFORE THE SUBCOMMAND is the exact walk-past that let `git -C DIR rev-list` through
+# .claude/hooks/check-shallow-history.sh, and `git --git-dir=... fetch` is the spelling the FIX uses.
+arm "git --git-dir=X fetch --depth caught" fire 'git --git-dir=/tmp/x fetch --depth=1 https://h/r ref'
+# A global option whose VALUE does not start with `-`: the element has to step over BOTH tokens, or
+# the pattern is looking for `fetch` and finding `core.pager=cat`. This arm was written because the
+# first version of the row missed exactly this - the hook's own header documents the same walk-past.
+arm "git -c k=v fetch --depth caught" fire 'git -c core.pager=cat fetch --depth=1 origin master'
+arm "git -C dir fetch --depth caught" fire 'git -C /tmp/x fetch --depth=1 origin master'
+# NOT THE HAZARD. A clone creates its own repository, so its depth is nobody else's; and an
+# unrestricted fetch never writes the `shallow` file.
+arm "git clone --depth=1 is fine"     clean 'git clone -q --depth=1 "file://$o" "$d"'
+arm "an undepthed git fetch is fine"  clean 'git fetch --no-tags origin master'
+arm "hazard-ok allows a scratch fetch" clean '# hazard-ok: fetches into a throwaway git dir
+git --git-dir="$scratch" fetch --depth=1 "$url" "$ref"'
+
 # NOT A USE - this repo is full of prose about exactly these flags.
 arm "a comment about sed -i is fine"  clean '# Not sed -i: GNU takes the suffix attached, BSD as the next arg'
 arm "an indented comment is fine"     clean '    # stat -c is GNU and BSD rejects it'
@@ -69,9 +93,80 @@ arm "a hazard AFTER a heredoc still fires" fire 'cat <<EOF
 harmless prose
 EOF
 sed -i "s/a/b/" f'
+# LINE CONTINUATIONS. The scanner reads LOGICAL commands, not physical lines, because no regex can
+# see across a newline: `git fetch \` on one line and `--depth=1` on the next is one command to the
+# shell and two unrelated lines to grep, so the physical-line scanner reported SUCCESS over exactly
+# the fetch this category exists to stop. Every other row has the same hole, hence a gnu-bsd arm too.
+arm "a continued git fetch --depth is caught" fire 'git fetch \
+    --depth=1 origin master'
+arm "a continued sed -i is caught"     fire 'sed \
+    -i "s/a/b/" f'
+# THE MARKER TRAVELS WITH THE COMMAND, so it counts on ANY physical line of it - the natural place to
+# write it is beside the flag being excused, which is rarely the first line.
+arm "hazard-ok on a later line of a continued command" clean 'git fetch \
+    --depth=1 "$url" "$ref"   # hazard-ok: fetches into a throwaway git dir'
+arm "hazard-ok above a continued command" clean '# hazard-ok: fetches into a throwaway git dir
+git fetch \
+    --depth=1 "$url" "$ref"'
+# A HEREDOC BODY IS DATA EVEN WHEN IT LOOKS LIKE A CONTINUATION - joining inside one splices two
+# lines of fixture text into a command the file never runs, which is the false-positive class that
+# gets a gate switched off. The NESTED opener is why this arm is a control and not a restatement of
+# "a hazard inside a heredoc is data": the range check further down is confused by an opener inside a
+# body (it re-arms on `cat <<EOF` and then pairs the WRONG terminator), so lines 3-4 here are outside
+# every range it computes. The joiner refusing to join them is the only thing left. Verified red
+# against a heredoc-blind joiner, which reports `sed -i` at line 3 of a file that never runs sed.
+arm "a continuation inside a heredoc is data" clean 'cat <<OUTER
+sed \
+    -i "s/a/b/" f
+cat <<EOF
+EOF
+OUTER'
+# A WRAPPER FUNCTION IS STILL A USE. `git` is routinely wrapped to redirect it - GIT_DIR, -C,
+# credentials - and this PR's own commit 4 did exactly that: `git --git-dir=X fetch --quiet --depth=1`
+# became `preview_git fetch --quiet --depth=1` in bin/check-quarantine-owners.sh, and gate coverage of
+# that file silently dropped to zero while its `hazard-ok:` marker went on looking load-bearing. A
+# check that quietly stops checking is the worst failure available to one, so the command word may
+# now carry a `<name>_` or `<name>-` prefix on EVERY row.
+arm "a _git wrapper fetch is caught"   fire  'preview_git fetch --quiet --depth=1 --no-tags "$u" "$r"'
+arm "a _sed wrapper is caught"         fire  'my_sed -i "s/a/b/" f'
+# THE SEPARATOR IS WHAT KEEPS THE WIDENING HONEST. Requiring the prefix to end in `_` or `-` is what
+# stops an ordinary word that merely ENDS in the tool name from reading as a call to it - `digit` here
+# and `parsed` below are the two halves of the same control. It also keeps `-` out of the front of a
+# command word, so the `diff --git a/x b/x` in bin/test-check-pr-analysis-surfaces.sh cannot read as
+# a wrapper named `--git`.
+arm "a word merely ending in git is fine" clean 'digit fetch --depth=1 origin master'
 # Similar-looking words must not trip it.
 arm "a word ending in sed is fine"     clean 'parsed -i something'
 arm "no hazards at all is clean"       clean 'echo hello'
+
+# A FINDING ON A CONTINUED COMMAND POINTS AT THE LINE THE COMMAND STARTS ON, not the line the flag
+# happens to sit on. That is where the reader has to edit, and the flag's own line is meaningless
+# without the subcommand above it. The fixture's shebang is line 1, so the command starts at line 2.
+d="$scratch/continued_lineno"; mkdir -p "$d"
+printf '#!/usr/bin/env bash\ngit fetch \\\n    --depth=1 origin master\n' > "$d/subject.sh"
+out="$(bash "$GATE" "$d" 2>&1)"; rc=$?
+case "$out" in
+    *"subject.sh:2 "*) printf 'ok:   a continued finding reports its first line\n'; pass=$((pass + 1)) ;;
+    *) printf 'FAIL: continued finding did not report the start line (rc=%s)\n%s\n' "$rc" "$out"; fail=$((fail + 1)) ;;
+esac
+
+# A ROW'S REGEX IS MATCHED AGAINST THE COMMAND, NOT AGAINST A LINE-NUMBERED RECORD. This is a
+# ROW-LEVEL contract, and `arm` cannot express it: it drives the whole gate, whose table is fixed. So
+# the probe appends one row of its own to a COPY of the gate and runs that - the only way to assert
+# what an author of a future row is entitled to assume. `^` is the natural way to write "at the start
+# of a command", and the whole premise of this file is that people will add rows; a haystack carrying
+# a `NNN:` prefix would make every such row match nothing, for ever, silently. That is this gate's own
+# subject matter turned inward, so it is tested rather than commented.
+mkdir -p "$scratch/lib"; cp "$(dirname "$GATE")/lib/shell-corpus.sh" "$scratch/lib/"
+probe="$scratch/anchor-probe.sh"
+awk '/^HZ$/ && !seen { print "gnu-bsd\t^anchored_probe\tprobe row: a ^-anchored pattern must see the"; seen = 1 }
+     { print }' "$GATE" > "$probe"
+d="$scratch/anchor_probe"; mkdir -p "$d"
+printf '#!/usr/bin/env bash\nanchored_probe --now\n' > "$d/subject.sh"
+out="$(bash "$probe" "$d" 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ]; then printf 'ok:   a ^-anchored row matches a command at the start of a line\n'; pass=$((pass + 1))
+else printf 'FAIL: a ^-anchored row matched nothing - the haystack is not the command (rc=%s)\n%s\n' \
+    "$rc" "$out"; fail=$((fail + 1)); fi
 
 # CANNOT RUN is not a pass - an empty scan directory must exit 2, not 0.
 empty="$scratch/empty"; mkdir -p "$empty"

--- a/docs/inflight/ci-networked-checker-in-reviewer-grant.md
+++ b/docs/inflight/ci-networked-checker-in-reviewer-grant.md
@@ -7,12 +7,15 @@
 `bin/AGENTS.md` states the rule for the two granted prefixes: **do not give that prefix to a script
 that writes, publishes, deploys, or reaches the network beyond `gh` reads.** One script breaks it.
 
-`bin/check-quarantine-owners.sh` fetches twice and reads through `FETCH_HEAD`:
+`bin/check-quarantine-owners.sh` fetches twice - the owning PR's base, and its merge preview - and
+reads each through `FETCH_HEAD`:
 
 ```
-if ! git fetch --quiet --depth=1 origin "$base" 2>/dev/null; then
-if ! git fetch --quiet --depth=1 origin "pull/$pr/merge" 2>/dev/null; then
+git --git-dir="$scratch_dir/preview" fetch --quiet --depth=1 --no-tags "$ORIGIN_URL" "$1"
 ```
+
+(That fetch used to target the working clone, which re-shallowed every worktree of it; fixed by
+routing it into a throwaway git dir. The *network* reach this note is about is unchanged.)
 
 It carries the `check-` prefix, so `Bash(bin/check-*.sh:*)` grants it to the reviewer in both
 `.github/workflows/claude.yml` and `.github/workflows/claude-code-review-dispatch.yml` - a job

--- a/docs/solutions/workflow-issues/a-gate-truncated-the-shared-clone-2026-08-26.md
+++ b/docs/solutions/workflow-issues/a-gate-truncated-the-shared-clone-2026-08-26.md
@@ -1,0 +1,107 @@
+---
+title: "A read-only gate truncated the shared clone - `git fetch --depth` writes state every worktree reads"
+date: 2026-08-26
+category: workflow-issues
+module: tooling
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+status: "Fixed in bin/check-quarantine-owners.sh, and the class is now gated by the shared-git-state row in bin/check-shell-hazards.sh."
+applies_when:
+  - Writing a check or hook that needs a ref it does not have
+  - Reaching for `git fetch --depth=1` because the check only needs one commit
+  - Diagnosing a repository that appears to have lost history, or a merge-base that returns nothing
+  - Running several agent sessions against worktrees of one clone
+---
+
+# A read-only gate truncated the shared clone
+
+`bin/check-quarantine-owners.sh` verifies that an owning PR's merge preview really removes the
+quarantine it claims to fix. To see the preview it needed two remote refs, and it fetched them the
+cheap way:
+
+```bash
+git fetch --quiet --depth=1 origin "$base"
+git fetch --quiet --depth=1 origin "pull/$pr/merge"
+```
+
+**A depth-limited fetch writes the `shallow` file, and that file lives in the `--git-common-dir`.**
+It is not per-worktree. One run of this gate truncated history for every worktree of the clone at
+once - including worktrees whose sessions had unshallowed a minute earlier, and one of which failed
+its repair with *"shallow file has changed since we read it"* because a sibling was fetching
+concurrently.
+
+## Why it cost so much more than a 4-line script bug should
+
+- **It fired from the sweep everyone is told to run.** `bin/check-all.sh` globs `bin/check-*.sh`, so
+  the mandated pre-push sweep was also an instruction to corrupt the clone.
+- **The damage landed on other commands, and none of them errored.** `git merge-base` returned
+  empty, ahead/behind counts read 295 and 835 against true values in the tens, and commits that had
+  demonstrably landed reported "NOT an ancestor of master". Read naively, that says master was
+  rewritten and a day's work is gone. Two sessions nearly acted on it.
+- **The gates that depend on history degraded to `CANNOT RUN`**, so the first half of the sweep
+  weakened the second half.
+
+## The fix, and why it is not a conditional depth
+
+The obvious repair is to pass `--depth=1` only when the clone is already shallow. It is not enough:
+it still *samples* shared state, and a sibling worktree can change that state between the sample and
+the fetch. The gate now fetches into a throwaway git dir (`git --git-dir=<mktemp -d> fetch ...`) and
+reads `FETCH_HEAD` there, so:
+
+- the working clone is never a fetch target, under any interleaving - nothing to race on;
+- a clone that arrived shallow on purpose (CI checks out at depth 1) is not deepened either, because
+  its depth is neither read nor written;
+- an interrupted run leaves the clone exactly as it was, because it was never touched.
+
+Measured cost of the isolation on this repository: **~1.4s and ~2.3MB** for the first fetch, with the
+dir reused for the rest of the run.
+
+Two things surfaced while proving it, both worth keeping:
+
+- **`exit` from inside a signal handler is documented to run the `EXIT` trap and measurably does not
+  always.** Instrumented, the `TERM` handler ran in the main shell and the `EXIT` trap did not
+  follow, on roughly one run in five. Signal handlers that must clean up should call the cleanup
+  themselves.
+- **A second signal during teardown re-enters the handler and abandons a half-finished `rm -rf`.**
+  Disarm `INT`/`TERM` as the first act of cleanup.
+
+## The generalisation
+
+The class is **a check that writes state its callers read**, and `bin/check-shell-hazards.sh` now
+carries it as the `shared-git-state` row - the second category in a table built for GNU-vs-BSD
+divergence ([`gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md`](gnu-only-constructs-fail-silently-on-bsd-2026-08-25.md)),
+because both have the same signature: no error, a wrong answer somewhere else, unreachable by a
+linter. `git clone --depth` is not the hazard - a clone owns its own depth. `git fetch --depth` is.
+
+## Three vectors, and all three are now closed
+
+Fixing the script only removes the instance. The class has three entrances, and each needed its own
+guard, because none of them can see the others:
+
+| Vector | Guard |
+|---|---|
+| A script in `bin/` or `.claude/hooks/` fetches with `--depth` | `bin/check-shell-hazards.sh`, `shared-git-state` row - fails the build |
+| An agent or human types it into a shell | `.claude/hooks/check-shallow-history.sh` - denies the command before it runs, and names the throwaway-git-dir alternative |
+| The clone is already truncated and a query answers from the graft | `.claude/hooks/check-shallow-history.sh` - denies `merge-base`, `rev-list` and range queries while shallow |
+
+The last of those already existed and could only ever deny the *symptom*. The first two are the
+cause, and the hook's two directions are deliberately gated in opposite senses: a depth-dependent
+query is wrong only in a clone that is **already** shallow, while a shallowing fetch is only worth
+stopping in one that is **not** - denying it in an intentionally shallow CI clone would be noise, and
+noise is what gets a hook switched off.
+
+## What was checked and ruled out
+
+- **`.github/workflows/pr-checklist.yml`** runs `git fetch --no-tags --depth=1 origin <base>` from a
+  JS step. It is a CI runner's own workspace, checked out shallow on purpose, with no worktrees
+  sharing it. Not an instance - and out of the hazard gate's corpus, which is `bin/` plus
+  `.claude/hooks/`.
+- **`actions/checkout` with `fetch-depth: 1`** in several workflows: a fresh per-job clone, not a
+  fetch into a shared one.
+- **`bin/ci-mutation-test.sh`** fetches its base ref with **no** `--depth`, so it writes no `shallow`
+  file. A plain fetch is additive.
+- **`git clone --depth=1`** in `bin/test-check-shallow-history.sh` and in this fix's own self-test:
+  building a shallow *fixture*, in a scratch directory that owns its depth.
+- **Every other `git` mutation in `bin/`** - `update-ref`, `reset`, `checkout` in the self-tests -
+  targets a `mktemp -d` fixture repository, not the working clone. Checked individually.


### PR DESCRIPTION
It serves no single issue, so it cites none.

## Description

`bin/check-quarantine-owners.sh` reached the owning PR's base and merge preview with
`git fetch --quiet --depth=1`. A depth-limited fetch writes the `shallow` file, and **that file
lives in the shared `--git-common-dir`** - so one run truncated history for *every worktree of the
clone at once*, not just the caller's. `bin/check-all.sh` globs `bin/check-*.sh`, so the mandated
pre-push sweep was also an instruction to corrupt the clone.

Nothing goes red. The damage lands on other commands, and it fired three times in one session:
`git merge-base` returned empty, ahead/behind counts read 295 and 835 against true values in the
tens, and commits that had demonstrably landed reported "NOT an ancestor of master". Read naively
that says master was rewritten and a day's work is gone - two sessions nearly acted on it. One
repair even failed with *"shallow file has changed since we read it"*, because a sibling worktree
was fetching concurrently.

### The fix

Ref previews are fetched into a **throwaway git dir** and read back through `FETCH_HEAD` there:

```
git --git-dir="$scratch_dir/preview" fetch --quiet --depth=1 --no-tags "$ORIGIN_URL" "$1"
```

**Rejected: a conditional depth** - passing `--depth=1` only when
`git rev-parse --is-shallow-repository` says the clone is already shallow. It is the obvious repair
and it still *samples* shared state a sibling worktree can change between the sample and the fetch.
Fetching elsewhere needs no sample.

How each requirement is met:

1. **Never leaves the clone shallower than it found it.** The working clone is never a fetch target,
   so its `shallow` file is never written. Asserted by
   `bin/test-check-quarantine-owners.sh` from both directions, and confirmed live: a real run against
   GitHub takes 3.5s, produces the same three verdicts, and leaves `is-shallow=false` with no
   `shallow` file in `.git/`.
2. **The gate still checks.** Both fetches survive; only their target moved. The self-test asserts
   the `OK: ... its merge result removes the quarantine` verdict *and* the
   `does NOT yet remove the quarantine` verdict, against `refs/pull/7/merge` and `refs/pull/8/merge`
   fixtures - so the side effect cannot be removed by removing the check. Both of those arms are
   **green against the unfixed script**, which is what shows this preserves behaviour.
3. **Does not deepen an intentionally shallow clone.** The clone's depth is neither read nor
   written, so a CI checkout at depth 1 is untouched. Arm: *a deliberately shallow clone stays
   shallow* plus *is not deepened* (`rev-list --count HEAD` stays 1).
4. **Concurrency-safe, and interrupt-safe.** There is no shared state to race on - not the `shallow`
   file, and not `FETCH_HEAD`, which the old code also clobbered for every other worktree. An
   interrupted run leaves the clone exactly as it was, because it was never the fetch target. Arm:
   the gate is killed mid-run and the clone is asserted unshallowed, with its scratch dir gone.
5. **Proved with a self-test, red control first.** See below.

Two bash findings came out of proving requirement 4, both fixed here:

- **`exit` from inside a signal handler is documented to run the `EXIT` trap and measurably does not
  always.** Instrumented, the `TERM` handler ran in the main shell (`$$` == `$BASHPID`) and the
  `EXIT` trap did not follow, on roughly one run in five. The handlers now call the cleanup
  themselves.
- **A second signal during teardown re-enters the handler and abandons a half-finished `rm -rf`.**
  Cleanup disarms `INT`/`TERM` as its first act.

The scratch dir also replaces `gh_query`'s per-call `mktemp`, which leaked a file on every
interrupted run.

### Gating the class, not the instance

Three entrances, none of which can see the others:

| Vector | Guard |
|---|---|
| A script in `bin/` or `.claude/hooks/` fetches with `--depth` | `bin/check-shell-hazards.sh`, new `shared-git-state` row - fails the build |
| An agent or human types it into a shell | `.claude/hooks/check-shallow-history.sh` - denies it, and names the throwaway-git-dir alternative |
| The clone is already truncated and a query answers from the graft | `.claude/hooks/check-shallow-history.sh` - already existed; denies `merge-base`, `rev-list`, ranges |

`git clone --depth` is deliberately **not** the hazard (a clone owns its own depth); `git pull
--depth` is, and is matched. The hook's two directions are gated in **opposite** senses: a query is
wrong only when the clone is *already* shallow, a shallowing fetch only worth stopping while it is
*not* - denying it in an intentionally shallow CI clone would be noise, and noise is what gets a
hook switched off.

### Red controls

Every new assertion was run against the previous code first.

| Suite | Against the old code |
|---|---|
| `bin/test-check-quarantine-owners.sh` (new, 13 arms) | **6 red**, including all three depth arms; both behaviour arms green |
| `bin/test-check-shallow-history.sh` (**67 arms** after both rounds) | **5 red** in the first round, no false positives among the 33 existing arms |
| `bin/test-check-shell-hazards.sh` (**44 arms** after both rounds) | 2 live findings in the gate's real corpus; **2 red** for the walk-past forms against the looser first pattern |

Each original was restored byte-identically afterwards and verified with `cmp` plus
`git hash-object`.

The `shared-git-state` pattern's first version read `core.pager=cat` as the subcommand and missed
`git -c k=v fetch --depth=1` entirely - the same walk-past the hook's own header documents for
`git -C DIR rev-list`. It was found by an arm, and both forms are covered now.

### Defect-class sweep - checked and dismissed

- **`.github/workflows/pr-checklist.yml`** runs `git fetch --no-tags --depth=1 origin <base>` from a
  JS step: a CI runner's own workspace, deliberately shallow, with no worktrees sharing it. Not an
  instance, and outside the hazard gate's corpus (`bin/` + `.claude/hooks/`).
- **`actions/checkout` with `fetch-depth: 1`** in `claude.yml`, `claude-code-review.yml`: a fresh
  per-job clone, not a fetch into a shared one.
- **`bin/ci-mutation-test.sh`** fetches its base ref with **no** `--depth` - a plain fetch is
  additive and writes no `shallow` file.
- **`git clone --depth=1`** in `bin/test-check-shallow-history.sh` and in this PR's own self-test:
  building a shallow *fixture* in a scratch directory that owns its depth.
- **Every other git mutation in `bin/`** - `update-ref`, `reset`, `checkout` in
  `test-ci-mutation-test.sh`, `test-check-file-refs.sh`, `test-check-branch-self-reference.sh`,
  `test-check-agent-hooks.sh` - targets a `mktemp -d` fixture repo, verified individually, not the
  working clone.
- **`bin/rename-packages.sh`'s `git fetch origin` / `git checkout origin/master -- ...`** are inside
  its `--help` text, printed as instructions, never executed.

Result: **one instance, now fixed; nothing else in the class.**

### A regression this PR caused and fixed

`CheckQuarantineOwnersScriptTest` - a Java behavioural test of this shell script, which the prior-art
search missed - stubs `git` on PATH with a `case "$1" in fetch|show|cat-file)` dispatcher. The first
version of the fix wrote `git --git-dir=X show ...`, putting a global option in `$1`, so the stub
matched nothing, printed nothing, and **3 of its 12 assertions failed while the script behaved
perfectly**.

Fixed in the **code, not the test**: `GIT_DIR=<dir> git <subcommand>` means exactly the same thing
and leaves the subcommand where every wrapper looks for it. All 12 pass locally. That is the third
instance of this walk-past in a week - `git -C DIR rev-list` past the hook, `git -c k=v fetch` past
the new hazard row, and now a global option past a test stub - so the script states the reason rather
than leaving the next editor to rediscover it. The hook learned the same idiom (`GIT_DIR=` prefix
counts as a redirect alongside `--git-dir`), or it would deny the very alternative its own deny
message recommends.

### Two deliberate imprecisions in the hook, raised in review

Both now recorded in the hook's header, and both err towards denial:

- **`-C <dir>` is not read as a redirect**, so `git -C /other/repo fetch --depth=1` is denied though
  harmless. Treating it as one would be a *bypass*, since `-C .` names this repository.
- **Once the clone is already shallow the arm stands down**, so a fetch that *changes* the depth
  (`--depth=5` over a depth-1 clone) still rewrites the shared graft. Bounded rather than missed: in
  an already-shallow clone the query arm is armed, so no truncated answer reaches anyone silently -
  and denying depth changes in an intentionally shallow CI clone is the noise that gets hooks
  switched off.

### Codex review round (`1d7759b9b`)

Codex found **four real bypasses, all in code this PR added**. All four are fixed, with every new
assertion verified red against the pre-change file first.

| | Finding | Fix |
|---|---|---|
| P1 | The hook reported one verdict and exited, so `git merge-base …; git fetch --depth=1 …` classified as a QUERY and the fetch was then allowed in a full clone | One record per git call, all tested against a single state read; a shallowing fetch arms the queries that follow it |
| P2 | `--git-dir=.git` / `GIT_DIR=.git` were exempted from their spelling, making the escape hatch a bypass | Target resolved via `rev-parse --git-common-dir` and compared with this clone's — which correctly denies a sibling worktree's `.git` |
| P2 | `command git` / `env git` / `timeout 60 git` left `git` out of command position, skipping the hook entirely — including the pre-existing query arm | Tokeniser walks assignments and eleven wrappers with per-wrapper option tables, plus a subshell's `(` |
| P2 | `bin/check-shell-hazards.sh` matched physical lines, so `git fetch \` + `--depth=1 …` read clean — a hole in *every* row | Continuations joined into logical commands before matching; findings report the command's first line |

**Two more of the same class surfaced while validating, both fixed here:**

- **The hazard row had stopped seeing this repo's own fetch.** Commit 4 refactored it to
  `preview_git fetch --depth=1 …`, and the `_` before `git` falls outside the row's prefix class —
  so coverage of `bin/check-quarantine-owners.sh` silently dropped to zero and its `hazard-ok:`
  marker was excusing nothing. The row now matches a command word ending in `git`. Proven both ways:
  marker removed → the gate fires on that line; marker present → the corpus is clean.
- **The continuation joiner matched each row against a record carrying its own `NNN:` prefix.**
  Harmless today, but rows are data contributors add, and one anchored with a bare `^` would have
  matched nothing, silently, forever. The regex now sees command text only.

Arms: 38 → 67 (`check-shallow-history`), 34 → 44 (`check-shell-hazards`).

**One deliberate imprecision, stated in the hook's header rather than left implicit:** a redirect
target only the shell can expand is judged on its text and errs towards *allowing*, because
resolving it would mean running it, and failing closed would deny `--git-dir="$(mktemp -d)"` — the
idiom the deny message itself recommends.

### Verification

- `bin/check-all.sh --with-tests`: 39 ran, 37 passed, 0 failed. The two `CANNOT RUN` are the
  shellcheck-dependent lanes - shellcheck is Ansible-managed and not installed - so the lane's exact
  invocation was run through the cached `koalaman/shellcheck:stable` image instead: **clean at
  `--severity=error`** over the whole corpus, and clean at `--severity=warning` over every file this
  PR touches.
- `bin/check-all.sh` before and after: `is-shallow=false` both times. That is the whole point - the
  sweep no longer truncates the clone it is checking.

### Note for astubbs/parallel-consumer#338

`docs/inflight/ci-check-quarantine-owners-reshallows-the-clone.md` records this bug and lives on
that PR's branch, not on master, so it cannot be deleted from here. **It should be dropped from
astubbs/parallel-consumer#338 before that merges**, or master gains a note describing a fixed bug.
Its durable replacement is
`docs/solutions/workflow-issues/a-gate-truncated-the-shared-clone-2026-08-26.md`, added here.

`docs/inflight/ci-networked-checker-in-reviewer-grant.md` quoted the two removed lines; its
quotation is refreshed and its argument - the script still reaches the network inside the reviewer's
grant - is unchanged, so the note correctly stays open.

## Checklist

- [x] Docs updated - `docs/solutions/workflow-issues/a-gate-truncated-the-shared-clone-2026-08-26.md`
      added; `docs/inflight/ci-networked-checker-in-reviewer-grant.md` citation refreshed
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - repo tooling, no
      user-facing behaviour changes`
- [x] Tests added/updated - `bin/test-check-quarantine-owners.sh` (new, 13 arms), plus 13 arms on
      `bin/test-check-shallow-history.sh` and 5 on `bin/test-check-shell-hazards.sh`; every new
      assertion shown red against the old code first
- [x] Title & body reflect the final content of this PR



