### PR TITLE
docs(ci): record which checks are required, and why several deliberately are not

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -154,6 +154,46 @@ hand-written matrix has to re-declare `actions` and `python`, which default setu
 and then be maintained. astubbs#1 was exactly that proposal, opened in 2021 against
 `github/codeql-action@v1`; it was overtaken by default setup and closed by becoming this section.
 
+### Which checks are required, and why several deliberately are not
+
+**The required list is repository settings, not tree state**, so no PR can change it and nothing goes
+red when it drifts. Read it rather than trusting any list written down here:
+
+```bash
+gh api repos/astubbs/parallel-consumer/rulesets --jq '.[] | "\(.id) \(.name)"'
+gh api repos/astubbs/parallel-consumer/rulesets/<id> \
+  --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
+```
+
+**A required context that no run produces leaves every PR pending until it merges master**, so a new
+check is only promoted once the job that emits it is already on master. The same ordering governs a
+renamed job: the ruleset keeps the old name, which then blocks nothing visibly and passes never. That
+is how a bare `spotbugs` context outlived the job that became `static: spotbugs` and sat required with
+no producer until 2026-08-26. **A skip does not satisfy a required check either** - it waits - so a
+job that can legitimately have nothing in scope should report success rather than skip before anyone
+requires it.
+
+**These are deliberately NOT required, and each would break something if promoted:**
+
+| Check | Why not |
+|---|---|
+| `Mutation Tests (PIT, PR-scoped)` | **Requiring it would be vacuous.** The job is `continue-on-error: true`, so its check-run *conclusion* is success even when the step fails - the row reddens, and a required check reads the conclusion. The property worth gating is that the lane could not measure anything, which `bin/ci-mutation-test.sh` signals through its own exit codes rather than by finding survivors. Gating that means removing `continue-on-error` first, which is a code change, not a ruleset edit |
+| `Performance (optional)` | The self-hosted lane is dispatch-only, so this context is never produced on a PR. Requiring it would block every PR permanently |
+| `compat: kafka 4.x (experimental)` | Disabled with `if: false` |
+| `full build (master)` | Push-only; never produced on a PR |
+| `Analyze (actions)`, `Analyze (java-kotlin)`, `Analyze (python)` | The `CodeQL` aggregate above is already required and covers all three |
+
+This table is the durable half of a note that has been retired: the three ruleset edits it tracked -
+adding `Chaos Pain Suite` once it reached master, adding `static: infer`, and removing the orphaned
+`spotbugs` - were made on 2026-08-26. The reasoning survives it, because the failure it prevents is
+someone re-proposing one of the rows above and re-deriving why it does not work.
+
+**`Chaos Pain Suite` was promoted without waiting for a bake-in period**, deliberately and against
+the advice recorded at the time: it had been red for much of 2026-08-25 on a timing bound, and the
+detector responsible was demoted to non-gating only the day after. The owner's call was that a red
+chaos check is a real finding and will be fixed as one. Read a red there as a bug to investigate, not
+as the gate misbehaving.
+
 ### The three `claude*` workflows, and which is which
 
 Their filenames do not distinguish them well - `claude-code-review.yml` is the one file that does


### PR DESCRIPTION
<!-- This PR serves no single issue, so per the template it cites none. -->

## Description

Three edits were made to the `master` ruleset on 2026-08-26, after
astubbs/parallel-consumer#366 merged: `Chaos Pain Suite` promoted to required once its job reached
master, `static: infer` promoted, and a bare `spotbugs` context removed. **Those are repository
settings - no commit can carry them, and nothing goes red when the list drifts.** What a commit can
carry is the reasoning, and that is all this PR is.

### Why the reasoning, and not the list

The required contexts are one `gh api` call away, so they are deliberately *not* written down. What
no command answers is why four checks are deliberately **not** required - each of which looks like an
obvious promotion until you try it:

- **`Mutation Tests (PIT, PR-scoped)`** is `continue-on-error: true`, so its check-run *conclusion*
  is success even when the step fails. The row reddens; a required check reads the conclusion.
  Requiring it today gates nothing at all. The property worth gating - that the lane could not
  measure anything - is signalled by `bin/ci-mutation-test.sh`'s exit codes, so gating it means
  removing `continue-on-error` first. A code change, not a ruleset edit.
- **`Performance (optional)`** sits on a dispatch-only lane, so the context never appears on a PR.
  Requiring it would block every PR permanently.
- **`compat: kafka 4.x (experimental)`** is `if: false`.
- **`full build (master)`** is push-only.
- The three **`Analyze (...)`** jobs are already covered by the required `CodeQL` aggregate.

### Three ordering traps, all of which have happened here

- **A required context that no run produces leaves every PR pending** until it merges master - which
  is why a check is promoted only after its job is on master.
- **The ruleset keeps the OLD name when a job is renamed.** That is how a bare `spotbugs` outlived
  the job that became `static: spotbugs`, sitting required with no producer: blocking nothing
  visibly, and passing never.
- **A skip does not satisfy a required check - it waits.** `static: infer` has skipped on some runs
  and is now required, so this is live rather than hypothetical. A job that can legitimately have
  nothing in scope should report success rather than skip before anyone requires it.

### One decision recorded because it contradicts its own advice

`Chaos Pain Suite` was promoted **without** the bake-in period the retired note advised. It had been
red for much of 2026-08-25 on a timing bound, and the detector responsible was demoted to non-gating
only the day after. The owner's call was that a red chaos check is a real finding and will be fixed
as one. Written down so a future reader finding it red investigates the bug rather than assuming the
gate was promoted too early.

### What this retires, and why it was at risk

`docs/inflight/ci-required-status-checks-need-updating.md`, whose three edits are now made. That note
**never reached master**: it was excluded from astubbs/parallel-consumer#366 because it described
work that PR was landing, which `docs/inflight/AGENTS.md` forbids - correct at the time. But the
reason expired on merge, and it then existed only as an untracked file behind a local
`.git/info/exclude` entry. One `rm -rf` of a worktree would have destroyed the only copy of it.

## Checklist

- [x] Docs updated - this PR *is* the documentation change
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - internal CI documentation, no user-facing feature`
- [x] Tests added/updated - `N/A - documentation only. The change it records is a repository setting, which no test in this tree can reach`
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - `N/A - docs only, so ce-simplify stops at its preflight (no executable lines in the diff). Asking @claude review on the PR instead, which is the route that can open inline threads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFRbSkHwaRw6YYFHHBWZ7p
