### PR TITLE
docs(map): archive and delete `presentation`, and record that we did

### DIFF
--- a/bin/test-check-upstream-map.sh
+++ b/bin/test-check-upstream-map.sh
@@ -35,8 +35,25 @@ pass=0
 fail=0
 
 # Run the gate against a mutated copy of the tree and assert its exit code.
-# `sed` is deliberately avoided for the mutation: these are YAML flow mappings on one long line and
-# an anchored Python replace says exactly what changed.
+#
+# TWO MUTATION FORMS, and the first is strongly preferred:
+#
+#   row:<yaml>   INSERT a synthetic entry at the top of `branch_accounting`
+#   <old>=><new> anchored replace of existing text
+#
+# PREFER `row:`. The replace form anchors on REAL manifest content, which makes the test fail
+# whenever that content legitimately changes - and it fails as "fixture anchor not found", which
+# reads like a broken test rather than a moved row. That is not hypothetical: three arms anchored on
+# `- {ref: presentation, state: ours,` and broke the day that branch was archived and its state
+# became `deleted`. Worse, `bin/check-all.sh` without `--with-tests` does not run this file, so the
+# breakage reached CI having passed a local sweep. A synthetic row depends on nothing but the schema
+# it is testing.
+#
+# The replace form is kept only for arms that must corrupt the FILE rather than an entry - the
+# unparseable-YAML case - and for asserting on the shape of a real row where that is the point.
+#
+# `sed` is deliberately avoided for either: these are YAML flow mappings on one long line and an
+# anchored Python replace says exactly what changed.
 arm() {
   local name="$1" want="$2" mutation="$3"
   local work="$TMP/$RANDOM$RANDOM"
@@ -50,11 +67,19 @@ arm() {
 import os, pathlib, sys
 work = pathlib.Path(sys.argv[1])
 p = work / os.environ["MANIFEST"]
-old, new = os.environ["MUT"].split("=>", 1)
+mut = os.environ["MUT"]
 s = p.read_text()
-if old not in s:
-    sys.exit(f"fixture anchor not found: {old!r}")
-p.write_text(s.replace(old, new, 1))
+if mut.startswith("row:"):
+    key = "branch_accounting:\n"
+    if key not in s:
+        sys.exit("fixture: no branch_accounting section to insert into")
+    i = s.index(key) + len(key)
+    p.write_text(s[:i] + "  - " + mut[len("row:"):] + "\n" + s[i:])
+else:
+    old, new = mut.split("=>", 1)
+    if old not in s:
+        sys.exit(f"fixture anchor not found: {old!r}")
+    p.write_text(s.replace(old, new, 1))
 PYTHON
   fi
 
@@ -78,38 +103,44 @@ echo "test-check-upstream-map:"
 arm "unmutated manifest is valid" 0 ""
 
 # --- controls: each of these validated CLEAN before branch_accounting was covered -------------
+#
+# Every arm below inserts its OWN row. Nothing here reads a real entry, so an ordinary manifest edit
+# - archiving a branch, retiring one, adding one - cannot turn these red.
+
 arm "bogus branch state is rejected" 1 \
-  "state: mirrored=>state: TYPO_NOT_A_STATE"
-arm "deleted branch with no date is rejected" 1 \
-  "state: deleted, deleted: 2026-08-20=>state: deleted"
-arm "non-ISO deleted date is rejected" 1 \
-  "deleted: 2026-08-20=>deleted: last tuesday"
+  "row:{ref: fixture/bad-state, tip: aaaaaaaa1, state: TYPO_NOT_A_STATE}"
+arm "missing ref is rejected" 1 \
+  "row:{tip: aaaaaaaa1, state: mirrored}"
 arm "duplicate ref is rejected" 1 \
-  "- {ref: upstream/master,=>- {ref: upstream/pyallel-consumer,"
+  "row:{ref: upstream/master, tip: aaaaaaaa1, state: mirrored}"
 arm "'see' as a bare string is rejected" 1 \
-  'see: [confluentinc#539],=>see: "confluentinc#539",'
+  "row:{ref: fixture/bad-see, tip: aaaaaaaa1, state: mirrored, see: \"astubbs#1\"}"
 
 # A tip that YAML parses as an integer never string-compares equal to `git rev-parse` output, so it
 # is silently useless rather than absent. This one bit for real, in review on astubbs#327.
 arm "integer tip is rejected" 1 \
-  "tip: 4533f6d8d,=>tip: 255916684,"
+  "row:{ref: fixture/int-tip, tip: 255916684, state: mirrored}"
+
+arm "deleted branch with no date is rejected" 1 \
+  "row:{ref: fixture/no-date, tip: aaaaaaaa1, state: deleted}"
+arm "non-ISO deleted date is rejected" 1 \
+  "row:{ref: fixture/bad-date, tip: aaaaaaaa1, state: deleted, deleted: last tuesday}"
 
 # A tip is required only where nothing else can recover it. A live branch is one `git rev-parse`
-# away, and this section's rule is "nothing a command answers" - so the pair below is the point:
-# the same omission is a finding for a deleted branch and legitimate for a live one.
+# away, and this section's rule is "nothing a command answers" - so the pairs below are the point:
+# the same omission is a finding once the branch is gone and legitimate while it is there. Both
+# terminal states are covered, because a regression to just ("deleted",) would otherwise pass.
 arm "deleted branch with no tip is rejected" 1 \
-  "tip: 9a25939d7, state: deleted=>state: deleted"
-arm "live branch with no tip is accepted" 0 \
-  "- {ref: presentation, state: ours,=>- {ref: presentation, state: ours, extra_note: fine,"
-
-# `archived` is the other half of the same rule and has no entry in the real manifest, so without
-# this arm the tuple could regress to just ("deleted",) and nothing - data or test - would notice.
+  "row:{ref: fixture/deleted-no-tip, state: deleted, deleted: 2026-08-26}"
 arm "archived branch with no tip is rejected" 1 \
-  "- {ref: presentation, state: ours,=>- {ref: presentation, state: archived,"
+  "row:{ref: fixture/archived-no-tip, state: archived}"
+arm "live branch with no tip is accepted" 0 \
+  "row:{ref: fixture/live, state: ours}"
 arm "archived branch WITH a tip is accepted" 0 \
-  "- {ref: presentation, state: ours,=>- {ref: presentation, tip: deadbeef1, state: archived,"
+  "row:{ref: fixture/archived, tip: aaaaaaaa1, state: archived}"
 
 # --- the gate must not launder "could not run" into a pass ------------------------------------
+# This one corrupts the FILE, not an entry, so it keeps the replace form.
 arm "unparseable manifest is not a pass" 2 \
   "branch_accounting:=>branch_accounting: [unclosed"
 

--- a/docs/inflight/handoff-fork-branch-audit.md
+++ b/docs/inflight/handoff-fork-branch-audit.md
@@ -96,7 +96,7 @@ and are the natural place for the `upstream` half.
 
 Design question left open deliberately, because it is a judgement call and not a detail: an archive
 tag is one of the four proposed accounting routes, and no tag convention exists yet. The owner has
-separately decided that `origin/presentation` will be archived under an `archive/` tag prefix and
+separately decided that `origin/presentation` would be archived under an `archive/` tag prefix and
 then deleted - see the related work below. Whoever builds the check should settle whether that
 prefix is the convention it recognises.
 
@@ -120,7 +120,9 @@ implying the other ~36 each had a PR. Nobody has confirmed that implication.
 `feats/classic-vertx-demo` (worktree `.claude/worktrees/classic-vertx-demo`, one unpushed commit
 `4babb1414`, off `feats/proxy-requirements`) is where this was found. It carries
 `docs/inflight/branch-classic-comparison-demo.md` - the design ledger for a per-language comparison
-demo, and the plan to rescue `Demo.java` from `origin/presentation` @ `ffda9c6a3`.
+demo, and the plan to rescue `Demo.java` from `ffda9c6a3` - which is now reachable as the annotated
+tag `archive/presentation` rather than a branch, since `origin/presentation` was archived and deleted
+on 2026-08-26. `git show archive/presentation` still resolves it.
 <!-- file-refs: N/A - that path lands on feats/classic-vertx-demo, deliberately not on this branch; the paragraph below records why the split is kept -->
 
 **The split is intentional and should be preserved:** the audit is a repo-wide concern with nothing

--- a/docs/inflight/process-fork-branch-archaeology.md
+++ b/docs/inflight/process-fork-branch-archaeology.md
@@ -11,7 +11,9 @@ missed?"*
 The trigger is `origin/presentation`, found while scoping the per-language comparison demo on
 `feats/classic-vertx-demo` (its own entry, `branch-classic-comparison-demo.md`, lands with that
 branch). It carries `Demo.java`,
-the code that produced the asciinema cast embedded in `src/docs/README_TEMPLATE.adoc`. It was never
+the code that produced the asciinema cast embedded in `src/docs/README_TEMPLATE.adoc`. (The branch
+itself was archived as the tag `archive/presentation` and deleted on 2026-08-26; the account of it
+lives in `branch_accounting`, which is the point of that section.) It was never
 merged, is 3 ahead / 631 behind, and has been untouched since 2021.
 
 ## How it was missed: every audit was keyed on the tracker, never on the artifact store

--- a/src/docs/development/upstream-map.yaml
+++ b/src/docs/development/upstream-map.yaml
@@ -192,8 +192,8 @@ branch_accounting:
 
   # --- our own branches, where a decision exists that the branch does not -----
 
-  - {ref: presentation, state: ours, see: ["docs/inflight/handoff-fork-branch-audit.md", "docs/inflight/process-fork-branch-archaeology.md"],
-     note: "Carries Demo.java, the code behind the asciinema cast embedded in the README. Unmerged since 2021 and named in no ledger - the branch that triggered the whole audit. DECIDED: archive under an archive/ tag, then delete. Not yet done, so this entry is the only record of the decision."}
+  - {ref: presentation, tip: ffda9c6a3, state: deleted, deleted: 2026-08-26, tag: archive/presentation, see: ["docs/inflight/handoff-fork-branch-audit.md", "docs/inflight/process-fork-branch-archaeology.md"],
+     note: "Carried Demo.java, the code behind the asciinema cast embedded in the README. Unmerged since 2021 and named in no ledger - the branch that triggered the whole audit. Archived and deleted 2026-08-26. Not merged, because the code is demo-grade and its own commits say so - one records an unfixed data race under load. Not dropped either, because the README still embeds the cast it produced, so the source behind a published artefact stays recoverable: git show archive/presentation."}
   - {ref: bugs/prod-tx-manager-retries, state: ours, see: ["docs/inflight/core-241-tx-commit-failure-taxonomy.md", confluentinc#144],
      note: "Attached to sweep-2023-tx-failure-taxonomy, and the prototype to start from rather than the older tx-commit-failure branch. Verified 2026-08-20, closing the open question in branch-audit-orphans.md."}
 


### PR DESCRIPTION
<!-- This PR serves no single issue, so per the template it cites none. -->

## Description

`origin/presentation` has been archived and deleted, and this records it. The branch carried
`Demo.java`, the code behind the asciinema cast embedded in the README - unmerged since 2021 and
named in no ledger, which is exactly how a published artefact came to depend on a branch nothing in
the repository knew existed. It is the branch that triggered the whole fork-branch audit.

**The decision was made in astubbs/parallel-consumer#327 and executed here.** That entry read
*"DECIDED: archive under an `archive/` tag, then delete. Not yet done, so this entry is the only
record of the decision."*

### What was done, in this order deliberately

1. Annotated tag `archive/presentation` pushed at `ffda9c6a3`
2. **Verified present on the remote**, and verified pointing at the exact branch tip
3. Only then, the branch deleted

Reversing that order risks the commit being garbage-collected between the two steps - which would
make the deletion the very thing the audit exists to prevent.

Not merged, because the code is demo-grade and its own commit messages say so (one records an
unfixed data race under load). Not dropped either, because the README still embeds the cast it
produced, so the source behind a published artefact stays recoverable: `git show archive/presentation`.

### This is the first time `branch_accounting` has done its job

The entry now carries `state: deleted` with the tip, the date and the tag. That is the whole
contract: a future audit finding no `presentation` branch can tell a deliberate deletion from an
accident without redoing the work. It also exercises the validator added alongside it, which requires
a tip precisely for this state.

### One reference was actionable and would now fail

`handoff-fork-branch-audit.md` told a reader to rescue `Demo.java` from `origin/presentation` @
`ffda9c6a3` - an instruction that silently stops working the moment the branch goes. Repointed at the
tag. The archaeology note's account of the trigger is left as history, with the archival dated in
place so nobody tries to fetch a branch that is not there.

## Second commit: the self-test broke on this very edit

Worth its own section, because a reader of the description alone would not know the self-test was
reworked.

Archiving `presentation` turned `bin/test-check-upstream-map.sh` red. Three of its arms anchored on
the literal text `- {ref: presentation, state: ours,`, which stopped existing the moment that row
became `state: deleted` - **so a correct manifest edit failed the test that guards the manifest.** It
failed as *"fixture anchor not found"*, which reads like a broken test rather than a moved row, and
sends the next person looking in the wrong place.

Fixed as a class rather than as two arms: a new `row:` mutation mode prepends a synthetic entry, so
every negative arm depends on the schema it tests and nothing else. Archiving, retiring or adding a
branch cannot turn them red again. Two arms keep the anchored-replace form deliberately - the
unparseable case has to corrupt the *file*, not an entry.

Coverage rose while converting: `missing ref is rejected` had no arm at all, and both terminal states
now carry the tip-required pair. Verified by injecting the exact regression (`("deleted", "archived")`
narrowed to `("deleted",)`) and confirming only that arm goes red.

**Why it reached CI:** `bin/check-all.sh` runs `check-*.sh`; the self-tests are `test-*.sh` and need
`--with-tests`, which is what `repo: hygiene` runs. A local sweep reporting *"15 ran, 15 passed"* had
never executed the file, and read as complete.

## Checklist

- [x] Docs updated - the manifest entry and the two notes that referenced the branch
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - no user-facing feature; a branch-lifecycle record`
- [x] Tests added/updated - the second commit reworks `bin/test-check-upstream-map.sh`: a new `row:` mutation mode, one genuinely new arm (`missing ref is rejected`), and tip-required coverage split across both terminal states. Verified by injecting the regression and watching exactly one arm go red
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - `N/A - docs only, so ce-simplify stops at its preflight. Happy to ask @claude review on the PR if you want a second pair of eyes on the ordering argument`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFRbSkHwaRw6YYFHHBWZ7p

