### PR TITLE
fix(ci): a comment inside the PIT invocation's line continuation truncated it, so the lane mutated every module

### DIFF
--- a/bin/ci-mutation-test.sh
+++ b/bin/ci-mutation-test.sh
@@ -272,14 +272,21 @@ if [ -n "${PIT_DRY_RUN_LOG:-}" ]; then
   STATUS=0
 else
   set +e
+  # -DexcludedTestClasses below: the Lincheck harnesses are excluded as PIT TESTS (astubbs#347,
+  # inherited via master) - each asserts that a violation IS found, so using them as the suite PIT
+  # mutates against is meaningless and slow. They remain mutable TARGETS; this excludes them from
+  # the test set, not from the target set.
+  #
+  # KEEP COMMENTS OUT OF THE INVOCATION BELOW. A `#` line inside a backslash continuation does not
+  # comment out one line - the continuation splices it onto the command, the shell truncates the
+  # command there, and every remaining line becomes a SEPARATE command. That is not hypothetical:
+  # it shipped, and it silently dropped `-pl parallel-consumer-core -am` so the lane mutated every
+  # module, dropped the exclusions this very comment describes, and exited 127 from the orphaned
+  # `-DexcludedTestClasses` line. `bin/test-ci-mutation-test.sh` now pins the argv against it.
   ./mvnw --batch-mode -Pci test-compile org.pitest:pitest-maven:mutationCoverage \
     -Djacoco.skip=true \
     -DtargetClasses="${TARGET_CLASSES}" \
     -DtargetTests="${TARGET_TESTS}" \
-    # The Lincheck harnesses are excluded as PIT TESTS (astubbs#347, inherited via master):
-    # each asserts that a violation IS found, so using them as the suite PIT mutates against
-    # is meaningless and slow. They remain mutable TARGETS - this excludes them from the test
-    # set, not from the target set.
     -DexcludedTestClasses="bz.stub.parallelconsumer.integrationTests.*,bz.stub.parallelconsumer.state.*Lincheck*" \
     -DjvmArgs=-Xmx2g \
     -DoutputFormats=XML,HTML \

--- a/bin/ci-mutation-test.sh
+++ b/bin/ci-mutation-test.sh
@@ -272,28 +272,34 @@ if [ -n "${PIT_DRY_RUN_LOG:-}" ]; then
   STATUS=0
 else
   set +e
-  # -DexcludedTestClasses below: the Lincheck harnesses are excluded as PIT TESTS (astubbs#347,
-  # inherited via master) - each asserts that a violation IS found, so using them as the suite PIT
-  # mutates against is meaningless and slow. They remain mutable TARGETS; this excludes them from
-  # the test set, not from the target set.
+  # BUILT AS AN ARRAY, NOT A BACKSLASH CONTINUATION, AND THAT IS THE POINT. A `#` line inside a
+  # continuation does not comment out one line: the continuation splices it onto the command, the
+  # shell truncates the command there, and every remaining line runs as a SEPARATE command. That
+  # shipped here - it silently dropped `-pl parallel-consumer-core -am` so the lane mutated every
+  # module, dropped the exclusions, and exited 127 from the orphaned argument, whose `tee` then
+  # overwrote the log this script parses for its verdict.
   #
-  # KEEP COMMENTS OUT OF THE INVOCATION BELOW. A `#` line inside a backslash continuation does not
-  # comment out one line - the continuation splices it onto the command, the shell truncates the
-  # command there, and every remaining line becomes a SEPARATE command. That is not hypothetical:
-  # it shipped, and it silently dropped `-pl parallel-consumer-core -am` so the lane mutated every
-  # module, dropped the exclusions this very comment describes, and exited 127 from the orphaned
-  # `-DexcludedTestClasses` line. `bin/test-ci-mutation-test.sh` now pins the argv against it.
-  ./mvnw --batch-mode -Pci test-compile org.pitest:pitest-maven:mutationCoverage \
-    -Djacoco.skip=true \
-    -DtargetClasses="${TARGET_CLASSES}" \
-    -DtargetTests="${TARGET_TESTS}" \
-    -DexcludedTestClasses="bz.stub.parallelconsumer.integrationTests.*,bz.stub.parallelconsumer.state.*Lincheck*" \
-    -DjvmArgs=-Xmx2g \
-    -DoutputFormats=XML,HTML \
-    -DtimeoutConstant=30000 -DtimeoutFactor=3.0 \
-    -Dthreads="${THREADS}" \
-    -pl parallel-consumer-core -am \
-    "$@" 2>&1 | tee "$PIT_LOG"
+  # An array element cannot do that, because there is no continuation to splice through - so a
+  # comment may sit beside any element below, safely. This is a structural guard rather than a
+  # warning somebody has to remember: reintroducing the defect now requires converting this back
+  # to a continuation first. `bin/test-ci-mutation-test.sh` pins the argv either way.
+  pit_args=(
+    --batch-mode -Pci test-compile org.pitest:pitest-maven:mutationCoverage
+    -Djacoco.skip=true
+    -DtargetClasses="${TARGET_CLASSES}"
+    -DtargetTests="${TARGET_TESTS}"
+    # The Lincheck harnesses are excluded as PIT TESTS (astubbs#347, inherited via master): each
+    # asserts that a violation IS found, so using them as the suite PIT mutates against is
+    # meaningless and slow. They remain mutable TARGETS - this excludes them from the test set,
+    # not from the target set. This is the comment whose placement broke the lane; here it is inert.
+    -DexcludedTestClasses="bz.stub.parallelconsumer.integrationTests.*,bz.stub.parallelconsumer.state.*Lincheck*"
+    -DjvmArgs=-Xmx2g
+    "-DoutputFormats=XML,HTML"
+    -DtimeoutConstant=30000 -DtimeoutFactor=3.0
+    -Dthreads="${THREADS}"
+    -pl parallel-consumer-core -am
+  )
+  ./mvnw "${pit_args[@]}" "$@" 2>&1 | tee "$PIT_LOG"
   STATUS=${PIPESTATUS[0]}
   set -e
 fi

--- a/bin/test-ci-mutation-test.sh
+++ b/bin/test-ci-mutation-test.sh
@@ -23,8 +23,14 @@
 # each has a green near-miss one character away from it - the shape bin/test-check-shell-lint.sh
 # established on this branch.
 #
-# NO MAVEN RUNS HERE. Every case either exits before the build (the scoping arms) or feeds a
-# captured PIT log through PIT_DRY_RUN_LOG (the verdict arms). The whole file is seconds.
+# NO REAL MAVEN RUNS HERE, and note the word REAL - the earlier wording was "NO MAVEN RUNS HERE",
+# which described a blind spot as a feature. Every case used to either exit before the build (the
+# scoping arms) or feed a captured PIT log through PIT_DRY_RUN_LOG (the verdict arms), so NOTHING
+# exercised the branch that actually invokes Maven. A comment inside that invocation's backslash
+# continuation then truncated the command - dropping `-pl parallel-consumer-core -am` so the lane
+# mutated every module, dropping the exclusions, and exiting 127 from the orphaned argument - and
+# every arm in this file stayed green through it. The argv arms at the end close that: they run the
+# real branch against a STUB `./mvnw` that records what it was handed. Still seconds.
 
 set -euo pipefail
 
@@ -369,6 +375,87 @@ assert_verdict "green near-miss: the same 42, this time KILLED, passes" 0 "42" \
 # under - so the survivor table is the product and the exit code only answers "did it measure".
 assert_verdict "green: NO_COVERAGE counts as evaluated - it is a finding, not a failure" 0 "42" \
     "42 evaluated" "" "NO_COVERAGE"
+
+echo
+echo "=== Argv arms: the lane is only PR-scoped if the flags survive the invocation ==="
+
+# The only arms that reach the real `./mvnw` branch. They do not run Maven: the fixture drops an
+# executable `mvnw` stub at its root which records its argv and prints a canned statistics block, so
+# the run still reaches a verdict. What is under test is not PIT - it is whether the flags this lane
+# depends on arrive at all.
+#
+# $1 name, $2 the flag the recorded argv must contain, $3 optional following argv word.
+assert_mvn_argv() {
+    local name="$1" want="$2" want_next="${3:-}"
+    local tmp argv out rc
+    tmp="$(make_fixture)"
+    argv="$tmp/argv.txt"
+    (
+        cd "$tmp" || exit 1
+        printf '// edited\n' >> parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/RunLengthEncoder.java
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m change
+        cat > mvnw <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$PIT_STUB_ARGV"
+printf -- '- Statistics\n'
+printf '>> Generated 42 mutations Killed 42 (100%%)\n'
+STUB
+        chmod +x mvnw
+        mkdir -p parallel-consumer-core/target/pit-reports
+        printf '<mutations><mutation status="KILLED"/></mutations>\n' \
+            > parallel-consumer-core/target/pit-reports/mutations.xml
+    ) > /dev/null 2>&1
+
+    set +e
+    out="$(cd "$tmp" && env PIT_BASE_REF=master PIT_STUB_ARGV="$argv" bin/ci-mutation-test.sh 2>&1)"
+    rc=$?
+    set -e
+
+    if [ ! -s "$argv" ]; then
+        printf 'FAIL: %s (the stub mvnw was never invoked - the run never reached the build branch)\n%s\n' \
+            "$name" "$out"
+        fail=$((fail + 1))
+        rm -rf "$tmp"
+        return
+    fi
+
+    local got=""
+    if grep -qxF -- "$want" "$argv"; then
+        if [ -z "$want_next" ]; then
+            got="yes"
+        elif grep -qxF -- "$want_next" <<< "$(grep -A1 -xF -- "$want" "$argv")"; then
+            got="yes"
+        fi
+    fi
+
+    if [ "$got" = "yes" ]; then
+        printf 'ok:   %s\n' "$name"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL: %s (argv did not carry %s%s). Recorded argv:\n%s\n' \
+            "$name" "$want" "${want_next:+ followed by $want_next}" "$(cat "$argv")"
+        fail=$((fail + 1))
+    fi
+    rm -rf "$tmp"
+}
+
+# --- The flag whose loss made the lane mutate every module ----------------------------------------
+# Without this the run is not PR-scoped at all: it walks the whole reactor, spends ~24 minutes on
+# core and then dies in a module the PR never touched. That is what shipped.
+assert_mvn_argv "argv: the module scope reaches Maven" "-pl" "parallel-consumer-core"
+assert_mvn_argv "argv: -am reaches Maven so core's deps build" "-am"
+
+# --- The exclusions the truncated comment was describing ------------------------------------------
+# The comment explaining why the Lincheck harnesses are excluded is what deleted the exclusion.
+assert_mvn_argv "argv: the Lincheck test exclusions reach Maven" \
+    "-DexcludedTestClasses=bz.stub.parallelconsumer.integrationTests.*,bz.stub.parallelconsumer.state.*Lincheck*"
+
+# --- The rest of the tail, which went the same way ------------------------------------------------
+# These were dropped by the same truncation. Individually minor; collectively they are the evidence
+# that everything after the comment was gone, not just the next line.
+assert_mvn_argv "argv: the report formats reach Maven" "-DoutputFormats=XML,HTML"
+assert_mvn_argv "argv: the timeout factor reaches Maven" "-DtimeoutFactor=3.0"
 
 printf '\n%s passed, %s failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/bin/test-ci-mutation-test.sh
+++ b/bin/test-ci-mutation-test.sh
@@ -71,6 +71,20 @@ make_fixture() {
     printf '%s' "$tmp"
 }
 
+# Commits an edit to one file inside a fixture, which is how a case becomes "a PR that changed X".
+# Written out four times before this existed, exactly like the verdict block below it - and the same
+# drift had started, so it is one helper for the same reason.
+# $1 fixture root, $2 path to edit, relative to that root.
+commit_edit() {
+    local root="$1" path="$2"
+    (
+        cd "$root" || exit 1
+        printf '// edited\n' >> "$path"
+        git add -A
+        git -c user.email=t@t -c user.name=t commit -q -m change
+    ) > /dev/null 2>&1
+}
+
 # Runs the subject inside a fixture and asserts the exit code.
 # $1 name, $2 expected exit code, $3 path a modification is written to (empty = no change),
 # $4 extra env assignments as a string, $5 optional substring the output must contain.
@@ -101,12 +115,7 @@ assert_exit() {
     local tmp out rc
     tmp="$(make_fixture)"
     if [ -n "$touch_path" ]; then
-        (
-            cd "$tmp" || exit 1
-            printf '// edited\n' >> "$touch_path"
-            git add -A
-            git -c user.email=t@t -c user.name=t commit -q -m change
-        ) > /dev/null 2>&1
+        commit_edit "$tmp" "$touch_path"
     fi
     # `env` rather than an exported assignment: each case must start from a clean environment, or a
     # variable set by an earlier case silently changes a later one's scope.
@@ -218,12 +227,7 @@ widened_scope_case() {
     log="$tmp/pit.log"
     write_pit_log "$log" 7
     write_pit_report "$tmp" 7
-    (
-        cd "$tmp" || exit 1
-        printf '// edited\n' >> parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ShardManager.java
-        git add -A
-        git -c user.email=t@t -c user.name=t commit -q -m change
-    ) > /dev/null 2>&1
+    commit_edit "$tmp" parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ShardManager.java
     set +e
     out="$(cd "$tmp" && env PIT_BASE_REF=master \
         PIT_DECIDABLE_PACKAGES='^bz\.stub\.parallelconsumer\.(offsets|state)\.' \
@@ -297,12 +301,7 @@ assert_verdict() {
     if [ -n "$generated" ] && [ "$status" != "none" ]; then
         write_pit_report "$tmp" "$generated" "$status"
     fi
-    (
-        cd "$tmp" || exit 1
-        printf '// edited\n' >> parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/RunLengthEncoder.java
-        git add -A
-        git -c user.email=t@t -c user.name=t commit -q -m change
-    ) > /dev/null 2>&1
+    commit_edit "$tmp" parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/RunLengthEncoder.java
     set +e
     # shellcheck disable=SC2086  # $envs is a deliberate word-split list of KEY=VALUE assignments
     out="$(cd "$tmp" && env PIT_BASE_REF=master PIT_DRY_RUN_LOG="$log" $envs bin/ci-mutation-test.sh 2>&1)"
@@ -387,14 +386,12 @@ echo "=== Argv arms: the lane is only PR-scoped if the flags survive the invocat
 # $1 name, $2 the flag the recorded argv must contain, $3 optional following argv word.
 assert_mvn_argv() {
     local name="$1" want="$2" want_next="${3:-}"
-    local tmp argv out rc
+    local tmp argv out
     tmp="$(make_fixture)"
     argv="$tmp/argv.txt"
+    commit_edit "$tmp" parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/RunLengthEncoder.java
     (
         cd "$tmp" || exit 1
-        printf '// edited\n' >> parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/offsets/RunLengthEncoder.java
-        git add -A
-        git -c user.email=t@t -c user.name=t commit -q -m change
         cat > mvnw <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$PIT_STUB_ARGV"
@@ -402,14 +399,18 @@ printf -- '- Statistics\n'
 printf '>> Generated 42 mutations Killed 42 (100%%)\n'
 STUB
         chmod +x mvnw
-        mkdir -p parallel-consumer-core/target/pit-reports
-        printf '<mutations><mutation status="KILLED"/></mutations>\n' \
-            > parallel-consumer-core/target/pit-reports/mutations.xml
     ) > /dev/null 2>&1
+    # The report must AGREE with the count the stub's log claims, and must be written by
+    # write_pit_report rather than by hand: the subject only recognises the single-quoted
+    # `status='...'` that helper emits. A hand-rolled `status="KILLED"` parses as zero evaluated
+    # mutants, which ends the run on the "scored NOTHING" verdict instead of the clean one this
+    # helper's comment describes - invisibly, because these arms judge the argv and not the exit code.
+    write_pit_report "$tmp" 42 KILLED
 
+    # The exit code is deliberately NOT asserted here: these arms answer "did the flags arrive",
+    # which the verdict arms above cannot, and the verdict itself is already their subject.
     set +e
     out="$(cd "$tmp" && env PIT_BASE_REF=master PIT_STUB_ARGV="$argv" bin/ci-mutation-test.sh 2>&1)"
-    rc=$?
     set -e
 
     if [ ! -s "$argv" ]; then

--- a/docs/inflight/static-shell-lint-severity-tiers.md
+++ b/docs/inflight/static-shell-lint-severity-tiers.md
@@ -52,14 +52,19 @@ the command there and every following line became a separate command. The lane t
 and thread count - then exited 127 from the orphaned argument, whose `tee` also overwrote the PIT log
 the script parses for its verdict.
 
-ShellCheck names this exactly - *"This flag is used as a command name. Bad line break?"* - and
-`shellcheck --severity=error` does not report it. Reproduce the gap:
+ShellCheck names this exactly - *"This flag is used as a command name. Bad line break or missing
+[ .. ]?"* - and `shellcheck --severity=error` does not report it. Reproduce the gap:
 
 ```bash
-printf 'foo --a \\\n  --b \\\n  # comment\n  --c\n' > /tmp/probe.sh
+printf '#!/usr/bin/env bash\nfoo --a \\\n  --b \\\n  # comment\n  --c\n' > /tmp/probe.sh
 shellcheck /tmp/probe.sh                    # SC2215, exit 1
 shellcheck --severity=error /tmp/probe.sh   # silent, exit 0
 ```
+
+**The shebang in that probe is load-bearing, not boilerplate.** Without it the file also trips
+`SC2148` (*"Tips depend on target shell and yours is unknown"*), which IS an error - so the second
+command reports a finding and exits 1, and the snippet appears to disprove the gap it is
+demonstrating.
 
 **This did not become a per-code promotion, deliberately.** The one-knob rule above is the reason:
 the moment `--include=SC2215` is added, the next incident adds another code, and the list is the
@@ -67,13 +72,19 @@ shape this repo has already removed from SpotBugs once. The floor is the knob. W
 changes is the *argument* for raising it - the warning tier is no longer a tidiness backlog, it is a
 tier with a shipped defect in it.
 
-A whole-tree class sweep found **one** other instance of this exact shape: none. `SC2215` matched
-only the one site, across all 82 scripts in `bin/`, `.claude/hooks/` and `.github/`.
+**A whole-tree sweep for the class found no other instance** - `SC2215` matched the one site and
+nothing else. Re-run it over every script in `bin/`, `.claude/hooks/` and `.github/`:
+
+```bash
+find bin .claude/hooks .github -type f -name '*.sh' -print0 \
+  | xargs -0 shellcheck -f gcc --severity=warning 2>/dev/null | grep SC2215
+```
 
 The gap is covered behaviourally in the meantime: `bin/test-ci-mutation-test.sh` gained argv arms
 that run the real invocation branch against a stub `mvnw` and assert the flags arrive. They are
-proven red against the pre-fix script - 5 of them flip, the other 20 arms stay green either way,
-which is what shows the existing arms could never have caught it.
+**proven red against the pre-fix script** - restore master's `bin/ci-mutation-test.sh` over the
+fixed one and re-run the self-test: every argv arm flips and every other arm stays green either
+way, which is what shows the pre-existing arms could never have caught it.
 
 ## Top 5 to turn back on whole-tree, ranked
 

--- a/docs/inflight/static-shell-lint-severity-tiers.md
+++ b/docs/inflight/static-shell-lint-severity-tiers.md
@@ -37,9 +37,43 @@ right and only the existing corpus blocks it; `old` means it stays off everywher
 
 | Severity | Count | Profile | Why not gated | Turns on when |
 |---|--:|---|---|---|
-| `warning` | 14 | `new` | `SC2034` (unused variable, 6) is the largest group and includes shared-library exports the linter cannot see used across a `source` boundary. Then `SC2164` (`cd` without `\|\|`, 4) and `SC2155` (declare-and-assign masking a return value, 3). Real classes; none currently causing a defect. | Somebody works the fourteen off. This is the next floor to raise and the cheapest. |
+| `warning` | 14 | `new` | `SC2034` (unused variable, 6) is the largest group and includes shared-library exports the linter cannot see used across a `source` boundary. Then `SC2164` (`cd` without `\|\|`, 4) and `SC2155` (declare-and-assign masking a return value, 3). **"None currently causing a defect" stopped being true - see below.** | Somebody works the remainder off. This is the next floor to raise and the cheapest, and it now has an incident behind it rather than only tidiness. |
 | `info` | 40 | `new` except `SC2016`, which is `old` | Dominated by `SC2016` - single-quoted `$` in strings, overwhelmingly deliberate here because these scripts build awk programs and grep patterns - and `SC2001`, `sed` where parameter expansion would do. | Only after `warning` is clean, and probably never for `SC2016`. |
 | `style` | 18 | `old` | Preference. | Not planned. |
+
+## The warning floor has now missed a real defect: SC2215
+
+**`SC2215` is a `warning`, so the gate at `error` passed a script that had been silently broken for
+weeks.** `bin/ci-mutation-test.sh` carried a comment *inside* the backslash continuation of its
+`./mvnw` invocation. The continuation splices the `#` onto the command line, so the shell truncated
+the command there and every following line became a separate command. The lane therefore ran without
+`-pl parallel-consumer-core -am` (mutating every module instead of the PR's), without the Lincheck
+`-DexcludedTestClasses` the deleted comment was explaining, and without its output formats, timeouts
+and thread count - then exited 127 from the orphaned argument, whose `tee` also overwrote the PIT log
+the script parses for its verdict.
+
+ShellCheck names this exactly - *"This flag is used as a command name. Bad line break?"* - and
+`shellcheck --severity=error` does not report it. Reproduce the gap:
+
+```bash
+printf 'foo --a \\\n  --b \\\n  # comment\n  --c\n' > /tmp/probe.sh
+shellcheck /tmp/probe.sh                    # SC2215, exit 1
+shellcheck --severity=error /tmp/probe.sh   # silent, exit 0
+```
+
+**This did not become a per-code promotion, deliberately.** The one-knob rule above is the reason:
+the moment `--include=SC2215` is added, the next incident adds another code, and the list is the
+shape this repo has already removed from SpotBugs once. The floor is the knob. What this incident
+changes is the *argument* for raising it - the warning tier is no longer a tidiness backlog, it is a
+tier with a shipped defect in it.
+
+A whole-tree class sweep found **one** other instance of this exact shape: none. `SC2215` matched
+only the one site, across all 82 scripts in `bin/`, `.claude/hooks/` and `.github/`.
+
+The gap is covered behaviourally in the meantime: `bin/test-ci-mutation-test.sh` gained argv arms
+that run the real invocation branch against a stub `mvnw` and assert the flags arrive. They are
+proven red against the pre-fix script - 5 of them flip, the other 20 arms stay green either way,
+which is what shows the existing arms could never have caught it.
 
 ## Top 5 to turn back on whole-tree, ranked
 


### PR DESCRIPTION
## Description

`bin/ci-mutation-test.sh` explained its `-DexcludedTestClasses` flag with a comment placed **inside** the backslash continuation of its `./mvnw` invocation. A backslash-newline splices the next line onto the command, so the `#` terminated it: Maven received everything up to `-DtargetTests` and nothing after, and each remaining line ran as a **separate command**.

### What the lane lost, on every run

- **`-pl parallel-consumer-core -am`** — so it was not PR-scoped at all. It walked the whole reactor: ~24 minutes on core, then died in `parallel-consumer-vertx` with *"No mutations found"*, a module no PR had touched. That is how this was noticed.
- **`-DexcludedTestClasses`** — the Lincheck harness exclusion *the truncating comment was itself describing*. Those harnesses assert a violation **is** found, so mutating against them is meaningless and slow; astubbs/parallel-consumer#347 added the flag for exactly that, and it never arrived.
- `-DjvmArgs`, `-DoutputFormats`, both timeouts, `-Dthreads`, and `"$@"`.

Then the orphaned `-DexcludedTestClasses=...` line executed as a command — *command not found*, **exit 127**. Its own `2>&1 | tee "$PIT_LOG"` **overwrote the log the script parses for its verdict**, and `STATUS=${PIPESTATUS[0]}` read that orphan pipeline rather than Maven's. So the lane's report was computed from a clobbered log, with a status from the wrong command.

### The fix is structural, not a warning

The arguments are now built as an **array** and passed as `./mvnw "${pit_args[@]}" "$@"`. There is no continuation to splice a `#` through, so a comment beside any element is inert — reintroducing this defect now requires converting back to a continuation first. Verified rather than assumed: a probe array carrying a comment mid-literal yields every element, exit 0, shellcheck clean.

The first draft of this PR instead hoisted the comment and left a *"keep comments out of the invocation below"* warning. Review pointed out that is a rule someone has to remember, and that the argv arms only catch a truncation if the dropped flag happens to be one they assert. The array removes the mechanism instead. A pleasant consequence: the Lincheck comment can go back to sitting immediately above the flag it explains — where it originally was, and what broke the lane.

The array form initially tripped `SC2054` (shellcheck reading the comma in `-DoutputFormats=XML,HTML` as an element separator). The element is quoted rather than suppressed — this PR's argument is that per-code exceptions are what to avoid.

### The self-test could not have caught it, and said so in its own header

`bin/test-ci-mutation-test.sh` opened with *"NO MAVEN RUNS HERE"* — a blind spot described as a feature. Every arm took the `PIT_DRY_RUN_LOG` branch, so nothing exercised the branch that invokes Maven, and the suite stayed green through a broken invocation.

Five argv arms now run the **real** branch against a stub `mvnw` that records what it was handed. **Proven red against master's script: exactly those 5 fail, the pre-existing arms pass either way** — which is the evidence they were never capable of catching this.

A simplify pass then found a second-order bug in those new arms: the fixture wrote `status="KILLED"` while the subject only greps `status='...'`, so the arms were silently landing on the exit-2 *"scored NOTHING"* verdict and passing anyway, because they assert argv and never the exit code. A fixture quietly disagreeing with the thing it tests — the same defect class this PR exists to fix. Now routed through the existing `write_pit_report`.

### Why this is not a new ShellCheck rule

ShellCheck names it — `SC2215`, *"This flag is used as a command name. Bad line break or missing [ .. ]?"* (verified verbatim) — but it is a **`warning`**, and `bin/check-shell-lint.sh` gates at `error`. Promoting the single code was **rejected**: the severity register has a deliberate one-knob rule because per-code lists grow, and this repo already removed that shape from SpotBugs. The incident is instead recorded as the argument for raising the floor tier-wide, which stays its own work.

`docs/inflight/static-shell-lint-severity-tiers.md` carries that, and two corrections the simplify pass caught in it: its reproduce snippet had no shebang, so `shellcheck --severity=error` returned `SC2148`/exit 1 rather than the "silent, exit 0" printed beside it — the snippet disproved its own point — and raw counts were replaced by the commands that yield them, per the counts rule in `docs/inflight/AGENTS.md`.

### Defect-class sweep

`shellcheck --include=SC2215` across `bin/`, `.claude/hooks/` and `.github/` matches **no** sites now, and matched only the one fixed here before. **No siblings.**

### Verification

Note what this PR's own CI does **not** prove: it changes no Java, so the mutation lane correctly reports *"nothing in scope"* and exits before the invocation. The green tick is the scoping arm working, **not** evidence the fixed invocation runs. That evidence is behavioural and local:

- `bin/test-ci-mutation-test.sh` — 25 passed, 0 failed
- `bin/check-all.sh` — 15 passed, 0 failed, 0 could not run
- Red control, re-run after the array change: restoring master's script fails exactly the 5 argv arms and passes the rest; 25/25 on restore

## Checklist

- [x] Docs updated — `docs/inflight/static-shell-lint-severity-tiers.md` gains the SC2215 incident, the (corrected) reproduction of the severity gap, and why a per-code promotion was rejected.
- [x] User-facing feature documentation data added under `docs/features/` — **N/A** — CI tooling, no user-facing behaviour.
- [x] Tests added/updated — five argv arms, proven red against the pre-fix script, plus the fixture-parity fix.
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally — `ce-simplify` **was** run (it found the fixture/subject `status=` mismatch and two errors in the note). `ce-code-review` was **not** run locally; `@claude review this` was used on the PR instead, which is cheaper and is the only route that opens inline review threads. Its array suggestion is what produced the structural fix above.
