### PR TITLE
ci(hooks): fetch every remote at session start, and refuse a merge onto a stale branch

### DIFF
--- a/.claude/hooks/check-branch-behind-its-own-remote.sh
+++ b/.claude/hooks/check-branch-behind-its-own-remote.sh
@@ -55,6 +55,13 @@
 #   - A DELETED REMOTE BRANCH KEEPS DENYING until something prunes. The per-merge fetch of a ref
 #     origin no longer has fails into silence, and this arm does not prune. The SessionStart arm
 #     does, and the deny message names `git fetch --all --prune`, so it self-heals within a session.
+#   - `-s ours` DEFEATS THE REMEDY EXEMPTION. `git merge -s ours origin/master origin/<branch>`
+#     carries the exemption token, so it is allowed - and `-s ours` then discards the content of
+#     both parents. It does not reproduce the incident (the merge still records `origin/<branch>` as
+#     an ancestor, so the push is a fast-forward and nothing is silently lost at the remote), but
+#     the branch's CONTENT drops the very commits the exemption existed to let in. Documented
+#     rather than fixed: an agent does not reach for `-s ours` unprompted, and a strategy-aware
+#     check would be more machinery than the case earns.
 #   - A BRANCH THIS CHECKOUT HAS NEVER FETCHED IS INVISIBLE. With no `origin/<branch>` locally the
 #     hook exits silent - which is the state where the cache is MOST stale. That is the SessionStart
 #     arm's job, and it is why the stamp key below is a correctness matter rather than a tidy-up.
@@ -191,7 +198,7 @@ for line in sys.stdin:
         continue
     guarded = True
 print("guarded" if guarded else "exempt")
-' 2>/dev/null || true)"
+' || true)"
 [ "$exempt" = "guarded" ] || exit 0
 
 bounded_fetch --quiet origin "$branch"

--- a/.claude/hooks/check-branch-behind-its-own-remote.sh
+++ b/.claude/hooks/check-branch-behind-its-own-remote.sh
@@ -11,8 +11,8 @@
 # THE INCIDENT. On 2026-08-26 a session picked up astubbs/parallel-consumer#205, fetched
 # `origin/master`, and merged it in. It never fetched the BRANCH's own ref, which had been two weeks
 # stale since the package-rename sweep pushed five commits to it. So the session re-did the rename
-# from scratch - taking the tooling, clearing the legacy-token residue, moving 239 files - resolved
-# 43 merge conflicts on top of it, and only found out at `git push`, which rejected the
+# from scratch - taking the tooling, clearing the legacy-token residue, moving the package tree -
+# resolved the merge conflicts on top of it, and only found out at `git push`, which rejected the
 # non-fast-forward. Everything after the first command was wasted, and the recovery was to throw the
 # local work away and start again from the published tip.
 #
@@ -29,52 +29,109 @@
 # cannot be pushed without discarding somebody else's commits, so there is no outcome the agent
 # wanted. Denying costs one fetch; allowing cost an hour, once, measurably.
 #
-# IT ONLY DENIES WHAT IT CAN PROVE. No branch, no upstream, no network, a detached HEAD, a fetch
-# that fails - every one of those exits silent. The deny fires on exactly one answer: the
-# remote-tracking ref contains commits HEAD does not. `git push` is deliberately NOT an arm, because
-# git already refuses that case itself and the refusal is legible.
+# WHAT IT MUST NEVER DENY, because a guard that blocks its own remedy gets switched off:
 #
-# NOT `git fetch` ITSELF ON EVERY TOOL CALL. The SessionStart arm is throttled on a stamp file so
-# that a session which starts, stops and resumes does not turn into a fetch loop; the PreToolUse arm
-# fetches ONE ref, which is cheap enough to pay for every merge.
+#   - THE RECONCILIATION ITSELF. `git merge origin/<this-branch>`, `git rebase origin/<this-branch>`,
+#     `@{upstream}`, `FETCH_HEAD` - the commands the deny message tells you to run. Review found the
+#     first version denying all of them, so the only way to obey the message was to lie to the
+#     override, whose documented meaning is the opposite. It also meant that ON `master`,
+#     `origin/<branch>` IS `origin/master`, so `git merge origin/master` - the most routine command
+#     in this repo - was denied every time master advanced.
+#   - THE WAY OUT OF A CONFLICTED TREE. `--abort`, `--continue`, `--skip`, `--quit`. A sibling
+#     session pushing mid-rebase must not trap the agent between a rebase it cannot finish and one it
+#     cannot abandon. check-history-rewrite.sh already exempts these; this departed from it.
+#
+# IT ONLY DENIES WHAT IT CAN PROVE. No branch, no `origin/<branch>`, a detached HEAD, a fetch that
+# fails - every one of those exits silent. The deny fires on one answer: the remote-tracking ref
+# contains commits HEAD does not, and the command is not one of the two exemptions above.
+# `git push` is deliberately NOT an arm, because git already refuses that case itself and legibly.
+#
+# KNOWN IMPRECISIONS, stated the way check-shallow-history.sh states its own, because an
+# undocumented one reads as a bug to the next person who trips it:
+#
+#   - `git -C <dir>` IS NOT READ AS A REDIRECT. A merge aimed at another repository is judged
+#     against this one. The tokeniser skips the flag so the SUBCOMMAND is found correctly; nothing
+#     re-points the comparison.
+#   - A DELETED REMOTE BRANCH KEEPS DENYING until something prunes. The per-merge fetch of a ref
+#     origin no longer has fails into silence, and this arm does not prune. The SessionStart arm
+#     does, and the deny message names `git fetch --all --prune`, so it self-heals within a session.
+#   - A BRANCH THIS CHECKOUT HAS NEVER FETCHED IS INVISIBLE. With no `origin/<branch>` locally the
+#     hook exits silent - which is the state where the cache is MOST stale. That is the SessionStart
+#     arm's job, and it is why the stamp key below is a correctness matter rather than a tidy-up.
+#
+# FAIL LOUDLY, NOT OPEN, WHEN THE GUARD ITSELF IS BROKEN. Missing `python3` or a missing shared
+# library are not evidence about the branch; they mean the check could not run, and a silent exit
+# there is indistinguishable from a healthy quiet hook - the defect class this whole harness exists
+# to police. Both say so on stderr. Likewise, once the branch is PROVEN behind, a failure to emit
+# the verdict must not degrade into an allow: it exits 2, which blocks with the reason on stderr.
+#
+# CHEAP BAIL FIRST. This is registered on `Bash`, so it runs on every tool call the agent makes;
+# review measured the first version at several times the cost of its siblings because it paid a
+# python3 and a git process before its pre-filter. The pre-filter may only SKIP work, never decide -
+# every payload either arm can act on contains one of its substrings, and a false positive falls
+# through to exactly the logic below. NOTE: it gates EVERY arm, so registering this script on a
+# third event means adding that event's marker to the case, and nothing checks that for you.
 set -uo pipefail
 
 payload="$(cat 2>/dev/null || true)"
 [ -n "$payload" ] || exit 0
 
+case "$payload" in
+    *merge*|*rebase*|*SessionStart*) ;;
+    *) exit 0 ;;
+esac
+
+# RUN IT, do not merely FIND it. `command -v python3` is an existence test, so an interpreter that
+# is on PATH and exits non-zero on every invocation passes it - and this guard then goes silently
+# dead, which is the failure it is here to announce. The self-test's shim is exactly that shape, and
+# it defeated the `command -v` form. Same reasoning as hook-common.sh's `stat` probe: ask whether the
+# tool WORKS, never whether it is present.
+python3 -c '' >/dev/null 2>&1 || {
+    echo "check-branch-behind-its-own-remote: python3 is missing or non-functional - this guard CANNOT RUN and is not passing." >&2
+    exit 0
+}
+
 hook_lib="${BASH_SOURCE[0]%/*}/lib/hook-common.sh"
-[ -r "$hook_lib" ] || exit 0
+[ -r "$hook_lib" ] || {
+    echo "check-branch-behind-its-own-remote: $hook_lib is unreadable - this guard CANNOT RUN and is not passing." >&2
+    exit 0
+}
 # shellcheck source=.claude/hooks/lib/hook-common.sh
 . "$hook_lib"
-
-event="$(printf '%s' "$payload" | python3 -c 'import json,sys
-try: print(json.load(sys.stdin).get("hook_event_name",""))
-except Exception: pass' 2>/dev/null || true)"
 
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] || exit 0
 cd "$root" 2>/dev/null || exit 0
 
 # GIT_TERMINAL_PROMPT=0 on every fetch below: a credential prompt inside a hook hangs the tool call
-# with nothing on screen to explain it, which is the one failure worse than not fetching.
+# with nothing on screen to explain it, which is the one failure worse than not fetching. A network
+# STALL has the same shape and needs its own bound - `timeout(1)` is GNU-only and absent here, so
+# the ceiling is set through git's own transport knobs, which cover both halves of a hang: a
+# connection that never establishes, and one that establishes and then delivers nothing.
 export GIT_TERMINAL_PROMPT=0
+export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh} -o ConnectTimeout=10 -o BatchMode=yes"
+bounded_fetch() { git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=20 fetch "$@" >/dev/null 2>&1 || true; }
 
 # ------------------------------------------------------------------------------------------------
 # SessionStart: fetch everything, once per throttle window
 # ------------------------------------------------------------------------------------------------
-FETCH_FLOOR_SECONDS="${BRANCH_FRESHNESS_FETCH_FLOOR:-300}"
-
-if [ "$event" = "SessionStart" ]; then
-    stamp="$(hook_stamp_path pc-fetch-all "$(git rev-parse --git-common-dir 2>/dev/null || echo repo)")"
-    now="$(date +%s)"
-    last="$(hook_file_mtime "$stamp")"
-    case "$last" in ''|*[!0-9]*) last=0 ;; esac
-    if [ $((now - last)) -ge "$FETCH_FLOOR_SECONDS" ]; then
+if [ "$(printf '%s' "$payload" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("hook_event_name",""))
+except Exception: pass' 2>/dev/null || true)" = "SessionStart" ]; then
+    # ABSOLUTE, ALWAYS. `--git-common-dir` answers a RELATIVE `.git` from a main checkout and an
+    # absolute path from a linked worktree, so keying on it raw put every clone on this machine
+    # onto one stamp - one clone's session start then suppressed another's fetch for the whole
+    # window, leaving it reading exactly the stale refs this hook exists to refresh. Measured twice,
+    # independently, in review. The `cd` above means a relative answer is relative to $root.
+    common="$(git rev-parse --git-common-dir 2>/dev/null || echo .git)"
+    case "$common" in /*) ;; *) common="$root/$common" ;; esac
+    stamp="$(hook_stamp_path pc-fetch-all "$common")"
+    if hook_throttle_expired "$stamp" "${BRANCH_FRESHNESS_FETCH_FLOOR:-300}"; then
         : > "$stamp" 2>/dev/null || true
         # --prune so a deleted remote branch stops answering queries as though it still existed.
         # Backgrounded is NOT an option: a later ref read in the same session would race it and get
         # the stale answer this exists to prevent.
-        git fetch --all --prune --quiet >/dev/null 2>&1 || true
+        bounded_fetch --all --prune --quiet
     fi
     exit 0
 fi
@@ -83,18 +140,7 @@ fi
 # PreToolUse: refuse a merge or rebase onto a branch that is behind its own published tip
 # ------------------------------------------------------------------------------------------------
 
-# Cheap bail before paying for python3 on EVERY Bash call.
-case "$payload" in
-    *merge*|*rebase*) ;;
-    *) exit 0 ;;
-esac
-
-hook_git_runs "$payload" merge || hook_git_runs "$payload" rebase || exit 0
-
-# The documented escape hatch, read from the PAYLOAD rather than this process's environment:
-# a hook does not inherit the variables an agent prefixes onto its own command, so testing
-# "$BRANCH_FRESHNESS_OVERRIDE" here would look right and never fire.
-case "$payload" in *BRANCH_FRESHNESS_OVERRIDE=1*) exit 0 ;; esac
+hook_git_runs_any "$payload" merge rebase || exit 0
 
 branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 [ -n "$branch" ] && [ "$branch" != "HEAD" ] || exit 0
@@ -104,7 +150,51 @@ branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 remote_ref="origin/$branch"
 git rev-parse --verify --quiet "$remote_ref" >/dev/null 2>&1 || exit 0
 
-git fetch --quiet origin "$branch" >/dev/null 2>&1 || true
+# THE ESCAPE HATCH IS A TOKEN, NOT A SUBSTRING, and this is the one place the distinction has teeth:
+# the deny message below TEACHES the agent the exact string, so an agent that reads it and then
+# writes `git commit -m "note BRANCH_FRESHNESS_OVERRIDE=1" && git merge ...`, or merely paraphrases
+# it into the payload's agent-written `description` field, silently bypassed the guard. Review
+# confirmed all three. Matched against the parsed command's tokens, and against a genuinely exported
+# variable too, the way check-shallow-history.sh honours both forms of its own override.
+[ "${BRANCH_FRESHNESS_OVERRIDE:-}" = "1" ] && exit 0
+printf '%s' "$payload" | python3 -c '
+import json, shlex, sys
+try:
+    cmd = json.load(sys.stdin).get("tool_input", {}).get("command", "")
+    toks = shlex.split(cmd)
+except Exception:
+    sys.exit(1)
+sys.exit(0 if any(t == "BRANCH_FRESHNESS_OVERRIDE=1" for t in toks) else 1)
+' 2>/dev/null && exit 0
+
+# EXEMPT THE REMEDY AND THE WAY OUT - see WHAT IT MUST NEVER DENY in the header. Every merge/rebase
+# invocation is inspected; the guard stands only if at least one of them is neither.
+exempt="$(hook_git_invocations "$payload" | REMOTE_REF="$remote_ref" BRANCH="$branch" python3 -c '
+import os, sys
+remote_ref = os.environ["REMOTE_REF"]
+branch = os.environ["BRANCH"]
+# The refs that NAME this branch published tip. Merging or rebasing onto any of them IS the
+# reconciliation the deny message asks for, so denying it would block the fix and nothing else.
+REMEDY = {remote_ref, "FETCH_HEAD", branch + "@{upstream}", "@{upstream}", "@{u}"}
+# The forms that finish or abandon an in-progress operation. Trapping an agent between a rebase it
+# cannot continue and one it cannot abort is worse than any staleness.
+CONTROL = {"--abort", "--continue", "--skip", "--quit", "--edit-todo", "--show-current-patch"}
+guarded = False
+for line in sys.stdin:
+    parts = line.rstrip("\n").split("\t")
+    sub, args = parts[0], parts[1:]
+    if sub not in ("merge", "rebase"):
+        continue
+    if CONTROL & set(args):
+        continue
+    if REMEDY & set(args):
+        continue
+    guarded = True
+print("guarded" if guarded else "exempt")
+' 2>/dev/null || true)"
+[ "$exempt" = "guarded" ] || exit 0
+
+bounded_fetch --quiet origin "$branch"
 
 behind="$(git rev-list --count "HEAD..$remote_ref" 2>/dev/null || true)"
 case "$behind" in ''|*[!0-9]*) exit 0 ;; esac
@@ -112,7 +202,9 @@ case "$behind" in ''|*[!0-9]*) exit 0 ;; esac
 
 subjects="$(git log --oneline --max-count=10 "HEAD..$remote_ref" 2>/dev/null || true)"
 
-printf '%s' "$payload" | BEHIND="$behind" BRANCH="$branch" SUBJECTS="$subjects" python3 -c '
+# The branch is now PROVEN behind, so a failure to emit must not become an allow: exit 2 blocks the
+# call with stderr as the reason, which is the honest fallback for a verdict already established.
+BEHIND="$behind" BRANCH="$branch" SUBJECTS="$subjects" python3 -c '
 import json, os
 behind = os.environ["BEHIND"]
 branch = os.environ["BRANCH"]
@@ -120,14 +212,20 @@ subjects = os.environ["SUBJECTS"]
 reason = (
     "origin/" + branch + " has " + behind + " commit(s) this checkout does not have, so this "
     "branch is BEHIND its own published tip:\n\n" + subjects + "\n\n"
-    "Merging or rebasing now builds on a stale ref. Whatever you produce cannot be pushed without "
-    "discarding those commits, and you will not find out until the push is rejected - which is "
-    "exactly how an hour of duplicated package-rename work was thrown away once already.\n\n"
-    "Run `git fetch --all --prune` first, then reconcile with the published tip before you build on "
-    "it. If the remote commits are genuinely to be abandoned, say so explicitly and re-run with "
+    "Merging or rebasing something ELSE into it now builds on a stale ref. Whatever you produce "
+    "cannot be pushed without discarding those commits, and you will not find out until the push is "
+    "rejected - which is exactly how an hour of duplicated package-rename work was thrown away "
+    "once already.\n\n"
+    "Run `git fetch --all --prune`, then reconcile with the published tip - merging or rebasing "
+    "onto origin/" + branch + " itself is NOT blocked, and is the way out. If those remote commits "
+    "are genuinely to be abandoned, say so explicitly and re-run prefixed with "
     "BRANCH_FRESHNESS_OVERRIDE=1."
 )
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse",
     "permissionDecision": "deny",
     "permissionDecisionReason": reason}}))
-' 2>/dev/null || true
+' || {
+    echo "check-branch-behind-its-own-remote: $branch is behind $remote_ref, but the verdict could not be emitted - blocking rather than allowing a merge already proven unsafe." >&2
+    exit 2
+}
+exit 0

--- a/.claude/hooks/check-branch-behind-its-own-remote.sh
+++ b/.claude/hooks/check-branch-behind-its-own-remote.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Two arms against ONE failure: working from a remote-tracking ref that is out of date.
+#
+#   SessionStart  - fetch every remote, pruned, so every ref this session reads is real
+#   PreToolUse    - DENY `git merge` / `git rebase` while this branch is BEHIND its own
+#                   `origin/<branch>`, naming the commits it has not got
+#
+# THE INCIDENT. On 2026-08-26 a session picked up astubbs/parallel-consumer#205, fetched
+# `origin/master`, and merged it in. It never fetched the BRANCH's own ref, which had been two weeks
+# stale since the package-rename sweep pushed five commits to it. So the session re-did the rename
+# from scratch - taking the tooling, clearing the legacy-token residue, moving 239 files - resolved
+# 43 merge conflicts on top of it, and only found out at `git push`, which rejected the
+# non-fast-forward. Everything after the first command was wasted, and the recovery was to throw the
+# local work away and start again from the published tip.
+#
+# WHY `origin/master` BEING FRESH IS NOT ENOUGH, and why this is a separate hook from
+# remind-master-drift-on-push.sh. That one fetches and reports what MASTER has gained; it is about
+# the base moving under you. This is the mirror image - YOUR OWN BRANCH moving under you, from
+# another session, another machine, or a sweep that touched every open branch at once. A repo where
+# several agents run at once has that happen routinely, and nothing was looking: the divergence is
+# invisible until a push is rejected, by which time the cost is already paid.
+#
+# WHY THIS ONE DENIES, when the other push hooks only report. `AGENTS.md` says a hook blocks a
+# VIOLATION and reports a SITUATION, and "should I merge master now" is a situation with no wrong
+# answer. Merging into a branch you know is behind its own published tip is not that: the result
+# cannot be pushed without discarding somebody else's commits, so there is no outcome the agent
+# wanted. Denying costs one fetch; allowing cost an hour, once, measurably.
+#
+# IT ONLY DENIES WHAT IT CAN PROVE. No branch, no upstream, no network, a detached HEAD, a fetch
+# that fails - every one of those exits silent. The deny fires on exactly one answer: the
+# remote-tracking ref contains commits HEAD does not. `git push` is deliberately NOT an arm, because
+# git already refuses that case itself and the refusal is legible.
+#
+# NOT `git fetch` ITSELF ON EVERY TOOL CALL. The SessionStart arm is throttled on a stamp file so
+# that a session which starts, stops and resumes does not turn into a fetch loop; the PreToolUse arm
+# fetches ONE ref, which is cheap enough to pay for every merge.
+set -uo pipefail
+
+payload="$(cat 2>/dev/null || true)"
+[ -n "$payload" ] || exit 0
+
+hook_lib="${BASH_SOURCE[0]%/*}/lib/hook-common.sh"
+[ -r "$hook_lib" ] || exit 0
+# shellcheck source=.claude/hooks/lib/hook-common.sh
+. "$hook_lib"
+
+event="$(printf '%s' "$payload" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("hook_event_name",""))
+except Exception: pass' 2>/dev/null || true)"
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$root" ] || exit 0
+cd "$root" 2>/dev/null || exit 0
+
+# GIT_TERMINAL_PROMPT=0 on every fetch below: a credential prompt inside a hook hangs the tool call
+# with nothing on screen to explain it, which is the one failure worse than not fetching.
+export GIT_TERMINAL_PROMPT=0
+
+# ------------------------------------------------------------------------------------------------
+# SessionStart: fetch everything, once per throttle window
+# ------------------------------------------------------------------------------------------------
+FETCH_FLOOR_SECONDS="${BRANCH_FRESHNESS_FETCH_FLOOR:-300}"
+
+if [ "$event" = "SessionStart" ]; then
+    stamp="$(hook_stamp_path pc-fetch-all "$(git rev-parse --git-common-dir 2>/dev/null || echo repo)")"
+    now="$(date +%s)"
+    last="$(hook_file_mtime "$stamp")"
+    case "$last" in ''|*[!0-9]*) last=0 ;; esac
+    if [ $((now - last)) -ge "$FETCH_FLOOR_SECONDS" ]; then
+        : > "$stamp" 2>/dev/null || true
+        # --prune so a deleted remote branch stops answering queries as though it still existed.
+        # Backgrounded is NOT an option: a later ref read in the same session would race it and get
+        # the stale answer this exists to prevent.
+        git fetch --all --prune --quiet >/dev/null 2>&1 || true
+    fi
+    exit 0
+fi
+
+# ------------------------------------------------------------------------------------------------
+# PreToolUse: refuse a merge or rebase onto a branch that is behind its own published tip
+# ------------------------------------------------------------------------------------------------
+
+# Cheap bail before paying for python3 on EVERY Bash call.
+case "$payload" in
+    *merge*|*rebase*) ;;
+    *) exit 0 ;;
+esac
+
+hook_git_runs "$payload" merge || hook_git_runs "$payload" rebase || exit 0
+
+# The documented escape hatch, read from the PAYLOAD rather than this process's environment:
+# a hook does not inherit the variables an agent prefixes onto its own command, so testing
+# "$BRANCH_FRESHNESS_OVERRIDE" here would look right and never fire.
+case "$payload" in *BRANCH_FRESHNESS_OVERRIDE=1*) exit 0 ;; esac
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+[ -n "$branch" ] && [ "$branch" != "HEAD" ] || exit 0
+
+# The branch's OWN counterpart, not whatever @{upstream} happens to point at - a branch tracking
+# origin/master would otherwise be compared against the base, which the other hook already covers.
+remote_ref="origin/$branch"
+git rev-parse --verify --quiet "$remote_ref" >/dev/null 2>&1 || exit 0
+
+git fetch --quiet origin "$branch" >/dev/null 2>&1 || true
+
+behind="$(git rev-list --count "HEAD..$remote_ref" 2>/dev/null || true)"
+case "$behind" in ''|*[!0-9]*) exit 0 ;; esac
+[ "$behind" -gt 0 ] || exit 0
+
+subjects="$(git log --oneline --max-count=10 "HEAD..$remote_ref" 2>/dev/null || true)"
+
+printf '%s' "$payload" | BEHIND="$behind" BRANCH="$branch" SUBJECTS="$subjects" python3 -c '
+import json, os
+behind = os.environ["BEHIND"]
+branch = os.environ["BRANCH"]
+subjects = os.environ["SUBJECTS"]
+reason = (
+    "origin/" + branch + " has " + behind + " commit(s) this checkout does not have, so this "
+    "branch is BEHIND its own published tip:\n\n" + subjects + "\n\n"
+    "Merging or rebasing now builds on a stale ref. Whatever you produce cannot be pushed without "
+    "discarding those commits, and you will not find out until the push is rejected - which is "
+    "exactly how an hour of duplicated package-rename work was thrown away once already.\n\n"
+    "Run `git fetch --all --prune` first, then reconcile with the published tip before you build on "
+    "it. If the remote commits are genuinely to be abandoned, say so explicitly and re-run with "
+    "BRANCH_FRESHNESS_OVERRIDE=1."
+)
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": reason}}))
+' 2>/dev/null || true

--- a/.claude/hooks/lib/hook-common.sh
+++ b/.claude/hooks/lib/hook-common.sh
@@ -79,8 +79,18 @@ for i, t in enumerate(toks):
             # cannot: the flag it needs was consumed by the loop above, and the ref it needs was
             # never emitted. Re-tokenising in the caller is what this file exists to prevent, so the
             # ONE tokeniser emits both and the two views below differ only in what they cut.
+            #
+            # STOP AT ANY OPERATOR TOKEN, not a hand-listed few. `punctuation_chars=True` makes shlex
+            # emit `> >> < << ( ) ; ;; | || & &&` as tokens of their own, and an earlier version
+            # named only the command SEPARATORS. That left redirections inside the argument list, so
+            # `git merge origin/master > out.log` walked args as ["origin/master", ">", "out.log"] -
+            # and a redirect target named like a control flag or a remedy ref could then spoof the
+            # exemption test in the consumer. Testing that every character is punctuation catches the
+            # whole family, including operators nobody has thought of, and cannot catch a real
+            # argument: refs, paths and flags all contain at least one non-operator character.
+            OPERATORS = set("();<>|&")
             k, args = j + 1, []
-            while k < len(toks) and toks[k] not in ("&&", "||", ";", "|", "&"):
+            while k < len(toks) and not (toks[k] and all(c in OPERATORS for c in toks[k])):
                 args.append(toks[k]); k += 1
             print("\t".join([rest[0]] + args))
 ' 2>/dev/null || true

--- a/.claude/hooks/lib/hook-common.sh
+++ b/.claude/hooks/lib/hook-common.sh
@@ -37,7 +37,7 @@
 # TOKENS, NOT SUBSTRINGS, which is the whole point: `git commit -m "ready to push"` contains the
 # word and must not fire. git is matched by BASENAME so /usr/bin/git counts, and an unbalanced quote
 # makes shlex raise, which fails open.
-hook_git_subcommands() { # <payload-json>
+hook_git_invocations() { # <payload-json>
     printf '%s' "$1" | python3 -c '
 import json, shlex, sys
 try:
@@ -74,8 +74,53 @@ for i, t in enumerate(toks):
                 j += 1; continue
             rest.append(t); break
         if rest:
-            print(rest[0])
+            # ALSO THE ARGUMENTS, stopping at the next shell operator. `hook_git_subcommands` throws
+            # them away, but a caller that must tell `git rebase origin/x` from `git rebase --abort`
+            # cannot: the flag it needs was consumed by the loop above, and the ref it needs was
+            # never emitted. Re-tokenising in the caller is what this file exists to prevent, so the
+            # ONE tokeniser emits both and the two views below differ only in what they cut.
+            k, args = j + 1, []
+            while k < len(toks) and toks[k] not in ("&&", "||", ";", "|", "&"):
+                args.append(toks[k]); k += 1
+            print("\t".join([rest[0]] + args))
 ' 2>/dev/null || true
+}
+
+# Prints only the subcommand of each git invocation - the original contract, kept because both push
+# hooks and their fixtures depend on it verbatim.
+hook_git_subcommands() { # <payload-json>
+    hook_git_invocations "$1" | cut -f1
+}
+
+# True when the payload runs ANY of the named git subcommands. One tokeniser spawn for the whole
+# question: `hook_git_runs a || hook_git_runs b` paid python3 twice to walk the same token list.
+hook_git_runs_any() { # <payload-json> <subcommand>...
+    local payload="$1" sub want found=1
+    shift
+    while IFS= read -r sub; do
+        for want in "$@"; do
+            if [ "$sub" = "$want" ]; then found=0; fi
+        done
+    done <<EOF
+$(hook_git_subcommands "$payload")
+EOF
+    return "$found"
+}
+
+# True when <stamp> is missing, unreadable, or older than <seconds>.
+#
+# THE THROTTLE TRIAD, NOT JUST THE `stat`. `hook_file_mtime` already removed one copy of the
+# platform probe; the three lines that CONSUME it - now, mtime, numeric-shape guard, subtract,
+# compare - were then copied into every hook that needed a floor, which is the same defect class one
+# level up. The shape guard is load-bearing: without it a non-numeric answer aborts the arithmetic
+# under `set -u`, and the hook dies rather than throttling.
+hook_throttle_expired() { # <stamp-path> <seconds>
+    local last now floor="$2"
+    case "$floor" in ''|*[!0-9]*) floor=0 ;; esac
+    last="$(hook_file_mtime "$1")"
+    case "$last" in ''|*[!0-9]*) last=0 ;; esac
+    now="$(date +%s)"
+    [ $(( now - last )) -ge "$floor" ]
 }
 
 # True when the payload runs `git <subcommand>` ANYWHERE in its command, including after another git
@@ -116,9 +161,12 @@ hook_file_mtime() { # <path>
     fi
 }
 
-# Path of a per-branch throttle stamp, given a prefix. Branch names contain `/`, which is the only
-# real content here: the substitution keeps a path from a name, and doing it in one place stops the
-# two hooks from disagreeing about how a branch is spelled on disk.
-hook_stamp_path() { # <prefix> <branch>
+# Path of a throttle stamp, given a prefix and a KEY. The key is usually a branch name but need not
+# be - one caller keys by git-common-dir - and either way it contains `/`, which is the only real
+# content here: the substitution keeps a path from a name, and doing it in one place stops the hooks
+# from disagreeing about how a key is spelled on disk. A caller passing a PATH must make it absolute
+# first: `git rev-parse --git-common-dir` answers `.git` from a main checkout and an absolute path
+# from a linked worktree, so keying on it raw collides every clone on the machine onto one stamp.
+hook_stamp_path() { # <prefix> <key>
     printf '%s/%s-%s' "${TMPDIR:-/tmp}" "$1" "$(printf '%s' "$2" | tr '/' '_')"
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-branch-behind-its-own-remote.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "if": "Bash(git commit *)",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-gate.sh\""
           }
@@ -102,6 +111,14 @@
       }
     ],
     "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-branch-behind-its-own-remote.sh\""
+          }
+        ]
+      },
       {
         "hooks": [
           {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,13 @@ settling it: **a fix that works is not evidence of the cause.**
 The same rule one step earlier: read the record before you build on it, not before you ship. It has
 **two triggers**, and the second one is the one that gets missed.
 
+**`git fetch --all --prune` before you read any ref, every session.** A remote-tracking ref is a
+cache, and a stale one answers confidently: `origin/<your-branch>` can be weeks behind while every
+`git log` and `rev-list` you run looks healthy, because another session, another machine or a
+sweep across every open branch pushed to it. Claude Code sessions get this done for them by
+`.claude/hooks/check-branch-behind-its-own-remote.sh`, which also refuses a merge or rebase onto a
+branch behind its own published tip; nothing fetches for anyone else, so it is on you.
+
 **Your base moved under you** - cutting a worktree from a master that advanced, merging master in
 mid-flight, rebasing, replaying, or picking a branch back up. Run
 `git log --oneline <old-base>..<new-base>` and read the **bodies** of anything touching your area.

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -2415,6 +2415,15 @@ bbr_expect ALLOW "git push alone is not an arm"         "$bbr_tmp/work" 'git pus
 bbr_expect DENY  "a merge chained with a push still denies" \
     "$bbr_tmp/work" 'git merge origin/master && git push origin feat/thing'
 
+# A REDIRECTION IS AN OPERATOR, NOT AN ARGUMENT. `punctuation_chars=True` emits `>` as its own
+# token, and the arg walk once stopped only at command separators - so a redirect target could sit
+# in the argument list and spoof an exemption. Both cases below name a redirect target that is
+# EXACTLY a control flag / a remedy ref, which is the only way the confusion is observable.
+bbr_expect DENY  "a redirect target cannot spoof a control flag" \
+    "$bbr_tmp/work" 'git merge origin/master > --abort'
+bbr_expect DENY  "a redirect target cannot spoof the remedy ref" \
+    "$bbr_tmp/work" 'git merge origin/master > origin/feat/thing'
+
 # THE OVERRIDE IS A TOKEN. The first version matched the raw payload, so any prose mentioning the
 # variable let a merge straight through - and the deny message teaches the agent that exact string.
 bbr_expect ALLOW "override token lets a deliberate merge through" \

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -71,8 +71,10 @@ verdict() { # <bash-command> -> ALLOW | DENY, from $HOOK_UNDER_TEST
     # would die and the failure would read as the hook's.
     local out tmp
     tmp=$(mktemp)
-    printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.stdin.read()}}))' > "$tmp"
-    out=$("$HOOK_UNDER_TEST" < "$tmp" 2>/dev/null)
+    printf '%s' "$1" | VERDICT_EVENT="${VERDICT_EVENT:-PreToolUse}" python3 -c 'import json,os,sys; print(json.dumps({"tool_name":"Bash","hook_event_name":os.environ["VERDICT_EVENT"],"tool_input":{"command":sys.stdin.read()}}))' > "$tmp"
+    # VERDICT_CWD lets a section drive its hook from inside a fixture repo. Default `.` keeps every
+    # existing caller running exactly where it did.
+    out=$(cd "${VERDICT_CWD:-.}" && "$HOOK_UNDER_TEST" < "$tmp" 2>/dev/null)
     rm -f "$tmp"
     case "$out" in
         *'"deny"'*) echo DENY ;;
@@ -2315,21 +2317,37 @@ rm -rf "$bctx_tmp" "$stub_pr" "$stub_nopr" "$stub_broken" "$stub_slow" "$BCTX_TM
 # ---------------------------------------------------------------------------------------------
 # check-branch-behind-its-own-remote.sh
 #
-# The deny arm needs real git state, not just a parsed command line, so each case builds a throwaway
-# origin plus a clone and drives the hook from inside it. The negative control matters more than
-# usual here: a hook that exits 0 on every payload passes an ALLOW-only suite perfectly, and that is
-# precisely the shape this hook would fail into (every guard in it exits silent when it cannot
-# answer).
+# The deny arm needs real git state, not just a parsed command line, so this builds a throwaway
+# origin plus a clone and drives the hook from inside it, via the shared verdict() harness with
+# VERDICT_CWD pointed at the fixture.
+#
+# THE NEGATIVE CONTROLS MATTER MORE THAN USUAL. A hook that exits 0 on every payload passes an
+# ALLOW-only suite perfectly, and that is exactly the shape this hook would fail into - every guard
+# in it exits silent when it cannot answer. So every ALLOW case below is paired with a DENY that
+# proves the same code path can still fire.
+#
+# The four cases marked "regression" each fail against the FIRST version of this hook, which review
+# caught: it denied its own remedy (including `git merge origin/master` on master, the commonest
+# command in the repo), it denied `--continue`/`--abort` and trapped a conflicted rebase, and its
+# override was a raw-payload substring that any prose mentioning the variable could satisfy.
+#
+# Reported through `assert`, not `expect`: `expect` counts into `fails`, which is folded into
+# `failures` far above this point, so a failure recorded here would be silently dropped.
 # ---------------------------------------------------------------------------------------------
 
 echo
 echo "--- check-branch-behind-its-own-remote.sh ---"
 
-bbr_hook="$HOOKS/check-branch-behind-its-own-remote.sh"
 bbr_tmp="$(mktemp -d)"
-
-# An origin with one commit on a feature branch, and a clone of it.
 bbr_git() { git -c user.email=selftest@example.invalid -c user.name=selftest "$@"; }
+
+# `outside a git repo` below is only a real case while $bbr_tmp is not itself inside one; a CI that
+# points TMPDIR into the workspace would silently turn it into something else.
+if git -C "$bbr_tmp" rev-parse --show-toplevel >/dev/null 2>&1; then
+    echo "FAIL: mktemp -d landed inside a git repo, so the outside-a-repo case tests nothing"
+    failures=$((failures + 1))
+fi
+
 (
     set -e
     bbr_git init -q --bare "$bbr_tmp/origin.git"
@@ -2338,22 +2356,28 @@ bbr_git() { git -c user.email=selftest@example.invalid -c user.name=selftest "$@
     echo one > f.txt && bbr_git add f.txt && bbr_git commit -qm "chore(fixture): first"
     bbr_git branch -M feat/thing
     bbr_git push -q origin feat/thing
+    # A second branch, so the master case below is not the same ref under another name.
+    bbr_git branch -q master && bbr_git push -q origin master
 ) >/dev/null 2>&1
 
 bbr_git clone -q "$bbr_tmp/origin.git" "$bbr_tmp/work" >/dev/null 2>&1
 (cd "$bbr_tmp/work" && bbr_git checkout -q feat/thing) >/dev/null 2>&1
 
-bbr_verdict() { # <cwd> <command> -> ALLOW | DENY
-    local out tmp
-    tmp=$(mktemp)
-    printf '%s' "$2" | python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","hook_event_name":"PreToolUse","tool_input":{"command":sys.stdin.read()}}))' > "$tmp"
-    out=$(cd "$1" && "$bbr_hook" < "$tmp" 2>/dev/null)
-    rm -f "$tmp"
-    case "$out" in *'"deny"'*) echo DENY ;; *) echo ALLOW ;; esac
+bbr_publish() { # <branch> - push a commit the clone has never seen
+    (
+        set -e
+        cd "$bbr_tmp/seed"
+        bbr_git checkout -q "$1"
+        echo "$1-$(wc -c < f.txt)" >> f.txt
+        bbr_git add f.txt
+        bbr_git commit -qm "chore(fixture): pushed to $1 by somebody else"
+        bbr_git push -q origin "$1"
+    ) >/dev/null 2>&1
 }
 
 bbr_expect() { # <expected> <name> <cwd> <command>
-    local got; got=$(bbr_verdict "$3" "$4")
+    local got
+    got=$(HOOK_UNDER_TEST="$HOOKS/check-branch-behind-its-own-remote.sh" VERDICT_CWD="$3" verdict "$4")
     assert "$2" "$1" "$got"
 }
 
@@ -2361,30 +2385,99 @@ bbr_expect() { # <expected> <name> <cwd> <command>
 bbr_expect ALLOW "up to date, merge allowed"        "$bbr_tmp/work" 'git merge origin/master'
 bbr_expect ALLOW "up to date, rebase allowed"       "$bbr_tmp/work" 'git rebase origin/master'
 
-# Now publish a commit the clone has never seen - the incident's exact shape.
-(
-    set -e
-    cd "$bbr_tmp/seed"
-    echo two >> f.txt && bbr_git add f.txt && bbr_git commit -qm "chore(fixture): pushed by somebody else"
-    bbr_git push -q origin feat/thing
-) >/dev/null 2>&1
+bbr_publish feat/thing
 
+# THE INCIDENT'S SHAPE: merging something ELSE into a branch behind its own tip.
 bbr_expect DENY  "behind its own remote blocks merge"   "$bbr_tmp/work" 'git merge origin/master'
 bbr_expect DENY  "...and blocks rebase"                 "$bbr_tmp/work" 'git rebase origin/master'
 bbr_expect DENY  "...through a compound command"        "$bbr_tmp/work" 'git fetch origin master && git merge origin/master'
 bbr_expect DENY  "...and with a -C repo flag"           "$bbr_tmp/work" 'git -C . merge origin/master'
 
-# THE FLAG WORD IS NOT A SUBCOMMAND. Both of these contain the word and must not fire, or the guard
-# becomes noise on every commit message that mentions a merge.
+# REGRESSION: the remedy the deny message prescribes must not itself be denied.
+bbr_expect ALLOW "merging its OWN published tip is the remedy, not a violation" \
+    "$bbr_tmp/work" 'git merge origin/feat/thing'
+bbr_expect ALLOW "...and rebasing onto it"              "$bbr_tmp/work" 'git rebase origin/feat/thing'
+bbr_expect ALLOW "...and @{upstream}"                   "$bbr_tmp/work" 'git merge @{upstream}'
+bbr_expect ALLOW "...and FETCH_HEAD"                    "$bbr_tmp/work" 'git merge FETCH_HEAD'
+
+# REGRESSION: finishing or abandoning an in-progress operation must never be blocked, or a
+# conflicted rebase becomes a trap with no exit.
+bbr_expect ALLOW "rebase --continue is never blocked"   "$bbr_tmp/work" 'git rebase --continue'
+bbr_expect ALLOW "rebase --abort is never blocked"      "$bbr_tmp/work" 'git rebase --abort'
+bbr_expect ALLOW "rebase --skip is never blocked"       "$bbr_tmp/work" 'git rebase --skip'
+bbr_expect ALLOW "merge --abort is never blocked"       "$bbr_tmp/work" 'git merge --abort'
+
+# THE FLAG WORD IS NOT A SUBCOMMAND, and `push` is deliberately not an arm.
 bbr_expect ALLOW "the word merge in a commit message"   "$bbr_tmp/work" 'git commit -m "explain the merge"'
-bbr_expect ALLOW "git push is not an arm"               "$bbr_tmp/work" 'git push origin feat/thing'
+bbr_expect ALLOW "git push alone is not an arm"         "$bbr_tmp/work" 'git push origin feat/thing'
+# ...but a merge CHAINED with a push still denies, so the case above is not passing on the
+# pre-filter alone.
+bbr_expect DENY  "a merge chained with a push still denies" \
+    "$bbr_tmp/work" 'git merge origin/master && git push origin feat/thing'
 
-# The documented escape hatch, and it must be read from the payload - a hook does not inherit an
-# env prefix the agent puts on its own command.
-bbr_expect ALLOW "override lets a deliberate merge through" "$bbr_tmp/work" 'BRANCH_FRESHNESS_OVERRIDE=1 git merge origin/master'
+# THE OVERRIDE IS A TOKEN. The first version matched the raw payload, so any prose mentioning the
+# variable let a merge straight through - and the deny message teaches the agent that exact string.
+bbr_expect ALLOW "override token lets a deliberate merge through" \
+    "$bbr_tmp/work" 'BRANCH_FRESHNESS_OVERRIDE=1 git merge origin/master'
+bbr_expect DENY  "REGRESSION: the override named in prose is NOT an override" \
+    "$bbr_tmp/work" 'git commit -m "note BRANCH_FRESHNESS_OVERRIDE=1" && git merge origin/master'
 
-# NOT A REPO AT ALL: fail open, silent.
+# REGRESSION: on master, origin/<branch> IS origin/master, so the commonest command in the repo was
+# denied every time master advanced.
+(cd "$bbr_tmp/work" && bbr_git checkout -q master && bbr_git branch -q --set-upstream-to=origin/master) >/dev/null 2>&1
+bbr_publish master
+bbr_expect ALLOW "on master, merging origin/master is the remedy" \
+    "$bbr_tmp/work" 'git merge origin/master'
+bbr_expect DENY  "...but a stale master merging something else still denies" \
+    "$bbr_tmp/work" 'git merge origin/feat/thing'
+(cd "$bbr_tmp/work" && bbr_git checkout -q feat/thing) >/dev/null 2>&1
+
+# FAIL-OPEN PATHS, each documented in the hook's header and none previously tested.
+(cd "$bbr_tmp/work" && bbr_git checkout -q --detach) >/dev/null 2>&1
+bbr_expect ALLOW "detached HEAD, silent"                "$bbr_tmp/work" 'git merge origin/master'
+(cd "$bbr_tmp/work" && bbr_git checkout -q feat/thing) >/dev/null 2>&1
+
+(cd "$bbr_tmp/work" && bbr_git checkout -q -b local-only) >/dev/null 2>&1
+bbr_expect ALLOW "a branch with no origin/<branch>, silent" "$bbr_tmp/work" 'git merge origin/master'
+(cd "$bbr_tmp/work" && bbr_git checkout -q feat/thing) >/dev/null 2>&1
+
 bbr_expect ALLOW "outside a git repo, silent"           "$bbr_tmp" 'git merge origin/master'
+
+# A BROKEN GUARD MUST SAY SO. Without python3 the hook can answer nothing; the failure it must NOT
+# have is the silent one, which is byte-identical to a healthy quiet hook.
+bbr_nopy="$bbr_tmp/nopy"
+mkdir -p "$bbr_nopy"
+printf '#!/bin/sh\nexit 127\n' > "$bbr_nopy/python3"
+chmod +x "$bbr_nopy/python3"
+bbr_payload="$bbr_tmp/payload.json"
+printf '%s' 'git merge origin/master' | python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","hook_event_name":"PreToolUse","tool_input":{"command":sys.stdin.read()}}))' > "$bbr_payload"
+bbr_stderr="$(cd "$bbr_tmp/work" && PATH="$bbr_nopy:$PATH" "$HOOKS/check-branch-behind-its-own-remote.sh" < "$bbr_payload" 2>&1 >/dev/null)"
+case "$bbr_stderr" in *"CANNOT RUN"*) got=loud ;; *) got=silent ;; esac
+assert "a broken python3 says the guard cannot run, rather than going quiet" loud "$got"
+
+# ---- the SessionStart arm, which produces no output ever and is therefore the half most able to
+# stop working invisibly. Driven by event, and asserted on the tracking ref actually moving.
+bbr_session() { # <fetch-floor-seconds>
+    printf '%s' 'startup' | python3 -c 'import json,sys; print(json.dumps({"hook_event_name":"SessionStart","source":sys.stdin.read()}))' > "$bbr_tmp/session.json"
+    (cd "$bbr_tmp/work" && BRANCH_FRESHNESS_FETCH_FLOOR="$1" "$HOOKS/check-branch-behind-its-own-remote.sh" < "$bbr_tmp/session.json" >/dev/null 2>&1)
+}
+bbr_behind() { (cd "$bbr_tmp/work" && git rev-list --count HEAD..origin/feat/thing 2>/dev/null || echo unknown); }
+
+bbr_publish feat/thing
+bbr_before="$(bbr_behind)"
+bbr_session 0
+bbr_after="$(bbr_behind)"
+[ "$bbr_after" -gt "$bbr_before" ] 2>/dev/null && got=fetched || got=did-not-fetch
+assert "SessionStart fetches, so the tracking ref actually moves" fetched "$got"
+
+# THROTTLED: with a floor far in the future the second session start must NOT fetch, or the
+# stamp is doing nothing and a resumed session becomes a fetch loop.
+bbr_publish feat/thing
+bbr_before="$(bbr_behind)"
+bbr_session 86400
+bbr_after="$(bbr_behind)"
+[ "$bbr_after" = "$bbr_before" ] && got=throttled || got=fetched-anyway
+assert "...and a second start inside the floor is throttled" throttled "$got"
 
 rm -rf "$bbr_tmp"
 

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -907,8 +907,13 @@ registrations = sum(len(g["hooks"]) for groups in cfg["hooks"].values() for g in
 # not failing. A number nobody verifies is a number that rots, so both are verified here rather than
 # trusted to the next editor, and both are needed because one script can be registered against
 # several events.
+# Runs to twenty because a table that stops at the current count turns the next hook into a
+# self-test failure whose message reads like the doc is wrong - which is how this list ended one
+# short of the number the doc had to state.
 WORDS = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7,
-         "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12}
+         "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13,
+         "fourteen": 14, "fifteen": 15, "sixteen": 16, "seventeen": 17, "eighteen": 18,
+         "nineteen": 19, "twenty": 20}
 doc = (root / "docs/agent-harness.md").read_text()
 m = re.search(r"`\.claude/settings\.json`\*\* - ([a-z]+) hook scripts across ([a-z]+) registrations", doc)
 if not m:
@@ -2305,6 +2310,83 @@ assert "...and the heading counts every commit, not just the listed ones" true_t
 
 bctx_clean_stamps
 rm -rf "$bctx_tmp" "$stub_pr" "$stub_nopr" "$stub_broken" "$stub_slow" "$BCTX_TMPDIR"
+
+
+# ---------------------------------------------------------------------------------------------
+# check-branch-behind-its-own-remote.sh
+#
+# The deny arm needs real git state, not just a parsed command line, so each case builds a throwaway
+# origin plus a clone and drives the hook from inside it. The negative control matters more than
+# usual here: a hook that exits 0 on every payload passes an ALLOW-only suite perfectly, and that is
+# precisely the shape this hook would fail into (every guard in it exits silent when it cannot
+# answer).
+# ---------------------------------------------------------------------------------------------
+
+echo
+echo "--- check-branch-behind-its-own-remote.sh ---"
+
+bbr_hook="$HOOKS/check-branch-behind-its-own-remote.sh"
+bbr_tmp="$(mktemp -d)"
+
+# An origin with one commit on a feature branch, and a clone of it.
+bbr_git() { git -c user.email=selftest@example.invalid -c user.name=selftest "$@"; }
+(
+    set -e
+    bbr_git init -q --bare "$bbr_tmp/origin.git"
+    bbr_git clone -q "$bbr_tmp/origin.git" "$bbr_tmp/seed"
+    cd "$bbr_tmp/seed"
+    echo one > f.txt && bbr_git add f.txt && bbr_git commit -qm "chore(fixture): first"
+    bbr_git branch -M feat/thing
+    bbr_git push -q origin feat/thing
+) >/dev/null 2>&1
+
+bbr_git clone -q "$bbr_tmp/origin.git" "$bbr_tmp/work" >/dev/null 2>&1
+(cd "$bbr_tmp/work" && bbr_git checkout -q feat/thing) >/dev/null 2>&1
+
+bbr_verdict() { # <cwd> <command> -> ALLOW | DENY
+    local out tmp
+    tmp=$(mktemp)
+    printf '%s' "$2" | python3 -c 'import json,sys; print(json.dumps({"tool_name":"Bash","hook_event_name":"PreToolUse","tool_input":{"command":sys.stdin.read()}}))' > "$tmp"
+    out=$(cd "$1" && "$bbr_hook" < "$tmp" 2>/dev/null)
+    rm -f "$tmp"
+    case "$out" in *'"deny"'*) echo DENY ;; *) echo ALLOW ;; esac
+}
+
+bbr_expect() { # <expected> <name> <cwd> <command>
+    local got; got=$(bbr_verdict "$3" "$4")
+    assert "$2" "$1" "$got"
+}
+
+# UP TO DATE: nothing to say, whatever the command.
+bbr_expect ALLOW "up to date, merge allowed"        "$bbr_tmp/work" 'git merge origin/master'
+bbr_expect ALLOW "up to date, rebase allowed"       "$bbr_tmp/work" 'git rebase origin/master'
+
+# Now publish a commit the clone has never seen - the incident's exact shape.
+(
+    set -e
+    cd "$bbr_tmp/seed"
+    echo two >> f.txt && bbr_git add f.txt && bbr_git commit -qm "chore(fixture): pushed by somebody else"
+    bbr_git push -q origin feat/thing
+) >/dev/null 2>&1
+
+bbr_expect DENY  "behind its own remote blocks merge"   "$bbr_tmp/work" 'git merge origin/master'
+bbr_expect DENY  "...and blocks rebase"                 "$bbr_tmp/work" 'git rebase origin/master'
+bbr_expect DENY  "...through a compound command"        "$bbr_tmp/work" 'git fetch origin master && git merge origin/master'
+bbr_expect DENY  "...and with a -C repo flag"           "$bbr_tmp/work" 'git -C . merge origin/master'
+
+# THE FLAG WORD IS NOT A SUBCOMMAND. Both of these contain the word and must not fire, or the guard
+# becomes noise on every commit message that mentions a merge.
+bbr_expect ALLOW "the word merge in a commit message"   "$bbr_tmp/work" 'git commit -m "explain the merge"'
+bbr_expect ALLOW "git push is not an arm"               "$bbr_tmp/work" 'git push origin feat/thing'
+
+# The documented escape hatch, and it must be read from the payload - a hook does not inherit an
+# env prefix the agent puts on its own command.
+bbr_expect ALLOW "override lets a deliberate merge through" "$bbr_tmp/work" 'BRANCH_FRESHNESS_OVERRIDE=1 git merge origin/master'
+
+# NOT A REPO AT ALL: fail open, silent.
+bbr_expect ALLOW "outside a git repo, silent"           "$bbr_tmp" 'git merge origin/master'
+
+rm -rf "$bbr_tmp"
 
 if [ "$failures" -eq 0 ]; then
     echo "All .claude/hooks self-tests passed"

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -304,8 +304,17 @@ grants stay in `settings.local.json`, still ignored.
   At session start it runs `git fetch --all --prune`, throttled on a stamp file, so every ref the
   session goes on to read is real; on a `git merge` or `git rebase` it **refuses** while
   `origin/<branch>` holds commits the checkout does not, and names them.
-  `BRANCH_FRESHNESS_OVERRIDE=1` is the documented override, read from the payload because a hook
-  does not inherit an env prefix the agent puts on its own command.
+  `BRANCH_FRESHNESS_OVERRIDE=1` is the documented override, honoured both as a genuinely exported
+  variable and as a **token** of the parsed command - never as a raw-payload substring, which review
+  showed any prose mentioning the variable could satisfy, including the agent-written `description`
+  field, on a guard whose own deny message teaches that exact string.
+  `BRANCH_FRESHNESS_FETCH_FLOOR` (default 300s) is the SessionStart fetch throttle, and exists so
+  the self-test can drive both sides of it.
+  **It exempts two things on purpose, and a guard that blocks its own remedy is why**: merging or
+  rebasing onto `origin/<this-branch>` (or `@{upstream}`/`FETCH_HEAD`) is the reconciliation it asks
+  for, and `--abort`/`--continue`/`--skip`/`--quit` are the way out of a conflicted tree. The first
+  version denied both - which on `master` meant denying `git merge origin/master` every time master
+  advanced.
   It denies where the other push hooks only report, and the line is the one this document already
   draws: a situation with no wrong answer gets `additionalContext`, and merging onto a ref you know
   is behind its published tip is not that - the result cannot be pushed without discarding somebody

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -213,7 +213,7 @@ merged as a no-op - `git ls-files | grep -c CLAUDE.md` returned **0**. The three
 negated individually rather than with a blanket `!CLAUDE.md`; the reasoning is in `.gitignore`
 itself, next to the rule.
 
-**`.claude/settings.json`** - eleven hook scripts across twelve registrations, and the file is
+**`.claude/settings.json`** - twelve hook scripts across fourteen registrations, and the file is
 **tracked**. The entries below are the ones whose design decisions are worth recording here;
 `remind-inflight-on-push.sh` and `check-history-rewrite.sh` carry theirs in their own headers.
 The count is stated because it drifted: this said "five" while the file registered seven, which is
@@ -298,6 +298,22 @@ grants stay in `settings.local.json`, still ignored.
   moves reports again immediately; the one clock is a floor on how often it fetches, so a push loop
   cannot become a fetch loop. It **fetches** before reading, because a stale `origin/master`
   under-reports, which is the exact failure it exists to prevent.
+- `SessionStart` **and** `PreToolUse` on `Bash` - runs
+  `.claude/hooks/check-branch-behind-its-own-remote.sh`, the mirror image of the drift hook above:
+  that one watches the base moving under you, this one watches **your own branch** moving under you.
+  At session start it runs `git fetch --all --prune`, throttled on a stamp file, so every ref the
+  session goes on to read is real; on a `git merge` or `git rebase` it **refuses** while
+  `origin/<branch>` holds commits the checkout does not, and names them.
+  `BRANCH_FRESHNESS_OVERRIDE=1` is the documented override, read from the payload because a hook
+  does not inherit an env prefix the agent puts on its own command.
+  It denies where the other push hooks only report, and the line is the one this document already
+  draws: a situation with no wrong answer gets `additionalContext`, and merging onto a ref you know
+  is behind its published tip is not that - the result cannot be pushed without discarding somebody
+  else's commits, so no outcome was wanted. `git push` is deliberately not an arm, because git
+  refuses that case itself and legibly. Measured cost of not having it, on 2026-08-26: a session
+  fetched `origin/master`, never fetched astubbs#205's own two-week-stale ref, re-did a package
+  rename of 239 files, resolved 43 conflicts on top, and learned at the rejected push that all of it
+  was already published. Its own header owns the incident.
 - The push detection and the portable `stat` both live in `.claude/hooks/lib/hook-common.sh`, shared
   by the two push hooks. Each had been got wrong once in a way that made a hook *silently stop
   working* - `git -C <path> push` unmatched, `stat -c` unavailable on BSD - and a second copy hides


### PR DESCRIPTION
## Description

A remote-tracking ref is a cache, and a stale one does not error — it answers. `origin/master` being fresh says nothing about `origin/<your-branch>`, which in a repo where several agents run at once moves without you: another session, another machine, or a sweep that touches every open branch in one pass.

**Measured, on 2026-08-26.** A session picked up astubbs/parallel-consumer#205, fetched `origin/master`, and merged it. It never fetched the branch's own ref, two weeks stale since the package-rename sweep had pushed to it — so it re-did the rename from scratch, resolved the resulting merge conflicts on top of the duplicate, and found out at `git push`, which rejected the non-fast-forward. The recovery was to discard all of it and rebuild on the published tip. Every command in between reported success.

### What lands

`.claude/hooks/check-branch-behind-its-own-remote.sh`, two arms against that one failure:

- **`SessionStart`** — `git fetch --all --prune`, throttled on a stamp file, so every ref the session goes on to read is real.
- **`PreToolUse` on `git merge` / `git rebase`** — **refuses** while `origin/<branch>` holds commits the checkout does not, and names them.

It is the mirror image of `remind-master-drift-on-push.sh`: that one watches the base moving under you, this one watches your own branch moving under you.

Three helpers move into `lib/hook-common.sh` rather than being copied: the tokeniser now emits each git invocation's **arguments** as well as its subcommand (the exemptions below need the flags and refs it was discarding); `hook_git_runs_any` answers "merge or rebase" in one interpreter spawn; and `hook_throttle_expired` owns the now/mtime/shape-guard/compare triad this was becoming the third copy of.

### Why it denies, and what it must never deny

`docs/agent-harness.md` already draws the line: a situation with no wrong answer gets `additionalContext`, a violation gets a `deny`. Merging onto a ref known to be behind its published tip is not a judgement call — the result cannot be pushed without discarding someone else's commits.

But a guard that blocks its own remedy gets switched off, so two things are exempt:

- **The reconciliation itself** — `origin/<this-branch>`, `@{upstream}`, `FETCH_HEAD`. Without this, obeying the deny message required invoking the override, whose documented meaning is the opposite; and on `master` it denied `git merge origin/master` every time master advanced.
- **The way out of a conflicted tree** — `--abort`, `--continue`, `--skip`, `--quit`.

`BRANCH_FRESHNESS_OVERRIDE=1` is the escape hatch, honoured as an exported variable and as a **token** of the parsed command — never as a raw-payload substring, which any prose naming the variable could satisfy, on a guard whose own message teaches that string. `git push` is deliberately not an arm: git refuses that case itself, legibly, and that refusal is what ended the incident.

Four known imprecisions are listed in the header rather than left to be rediscovered, including that `-s ours` satisfies the remedy exemption while discarding the content it was meant to admit.

### How it was checked

Three local reviewers (reuse, quality, efficiency) and one on the PR. Between them they found that the guard denied its own remedy, trapped a conflicted rebase, took a substring for its override, went silently dead on a broken interpreter, shared one throttle stamp across every clone on the machine, cost several times its siblings on the hot Bash path, and let a redirect target spoof an exemption. All fixed here.

The self-test drives both arms, including the `SessionStart` half that produces no output and is therefore the part most able to stop working invisibly — it asserts the tracking ref actually moves, and that a second start inside the throttle does not fetch. Every ALLOW case is paired with a DENY proving the same path can still fire, because an allow-only suite is passed perfectly by a hook that does nothing. The regression cases were verified as true negative controls: reverting the fix alone, fixtures in place, turns them red.

One fix caught another: the interpreter guard was first written as `command -v python3`, and the new self-test case defeated it immediately — that is an existence test, and an interpreter present but exiting non-zero passes it. It now runs `python3 -c ''`.

`AGENTS.md` gains the rule in one line plus its enforcer's name, because Codex and anything else reading it get no hooks at all.

### Left for a separate decision

`command -v <tool>` as an existence-rather-than-works check is not unique to this hook. The same form is in `inject-branch-context.sh`, `pre-commit-gate.sh`, `check-history-rewrite.sh`, `check-merge-outstanding-work.sh`, `check-shallow-history.sh`, `remind-inflight-on-push.sh` and `bin/check-pr-analysis-surfaces.sh` — and the identical class is already written up for `node` in `bin/test-check-file-refs.sh` and `bin/test-check-issue-refs.sh`. The two DENY guards are where a silently-dead guard actually costs something. Out of scope here on purpose.

## Checklist

- [x] Docs updated — `docs/agent-harness.md` gains the hook's entry, its overrides and its registration counts; `AGENTS.md` gains the one-line rule
- [x] N/A — user-facing feature documentation: this is agent tooling, invisible to library users
- [x] Tests added/updated — both arms driven in `bin/test-check-agent-hooks.sh`, negative controls included
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` locally (three reviewers; their findings are the second commit) and asked for `@claude review this` on the PR rather than a local `ce-code-review`
