### PR TITLE
ci(citations): read citations inside .java files, not only prose formats

### DIFF
--- a/.github/scripts/file-ref-gate.js
+++ b/.github/scripts/file-ref-gate.js
@@ -94,12 +94,19 @@ const LINE_OPT_OUT = /file-refs:\s*N\/?A\b\s*-\s*[A-Za-z]/i;
 //
 // LOWERCASE, and that is not cosmetic: a java file is named for its class and classes are
 // capitalised, so `.../internal/A.java` is a plausible real path while `docs/a.md` is not a
-// plausible real document. Anchored at the FILENAME rather than at any segment, so a short
-// DIRECTORY segment - `src/a/b/Thing.java` - is untouched.
-const PLACEHOLDER = new RegExp(
-  String.raw`(?:^|[/\-_.])(?:foo|bar|baz|qux|quux)(?:[/\-_.]|$)` +
-  String.raw`|/[a-z0-9]\.[a-z0-9]+$`,
-);
+// plausible real document. A single DIGIT stem is in for the same reason from the other side - no
+// java class may start with one, so `docs/1.md` is illustrative too. Anchored at the FILENAME
+// rather than at any segment, so a short DIRECTORY segment - `src/a/b/Thing.java` - is untouched.
+//
+// TWO REGEXES RATHER THAN ONE ALTERNATION, because their FLAGS differ and JavaScript has no inline
+// flag syntax to vary case-sensitivity within a pattern. Written as one `new RegExp(a + b)` the
+// word list silently lost the `/i` it had carried since it was a literal, so `Foo.md` in a worked
+// example started being read as a real citation - a regression a concatenated regex makes invisible
+// and no test caught, because no case exercised an uppercase placeholder word. There are now two.
+const PLACEHOLDER_WORD = /(?:^|[/\-_.])(?:foo|bar|baz|qux|quux)(?:[/\-_.]|$)/i;
+const PLACEHOLDER_SHORT_NAME = /\/[a-z0-9]\.[a-z0-9]+$/;
+
+const isPlaceholder = (token) => PLACEHOLDER_WORD.test(token) || PLACEHOLDER_SHORT_NAME.test(token);
 
 // Tokens that are patterns rather than paths: globs, `<placeholders>`, shell/CI interpolation, and
 // the elided `.../` form docs use to shorten a long package path.
@@ -161,6 +168,11 @@ const TAIL_OF_SOMETHING_ELSE = /[/~}$\\]/;
 const REVISION = String.raw`(?:[0-9a-f]{7,40}|HEAD|master|origin/[\w.-]+)(?:[~^]\d*)*`;
 
 const GIT_REVISION = new RegExp(`${REVISION}:$`);
+// Hoisted alongside GIT_REVISION rather than built inside historyPointersIn's per-line loop. It was
+// recompiled once per line, which cost nothing while only prose was scanned and is a per-line
+// allocation across the whole java tree now that .java is a citing file. `matchAll` does not mutate
+// a shared regex's lastIndex, so reuse is safe - the same way TOKEN and MD_LINK_TARGET are reused.
+const HISTORY_POINTER = new RegExp(`${REVISION}:([A-Za-z0-9_.@/-]+)`, "g");
 
 // The PR-wide form. Deliberately looser than LINE_OPT_OUT - any non-blank reason will do - because
 // the `-->` hole that rule guards against needs an HTML comment to open it, and this one must START
@@ -225,7 +237,7 @@ function citationsIn(line) {
   const out = new Set();
   for (const m of clean.matchAll(TOKEN)) {
     const token = m[0];
-    if (NOT_A_PATH.test(token) || PLACEHOLDER.test(token)) continue;
+    if (NOT_A_PATH.test(token) || isPlaceholder(token)) continue;
     if (m.index > 0 && TAIL_OF_SOMETHING_ELSE.test(clean[m.index - 1])) continue;
     if (GIT_REVISION.test(clean.slice(0, m.index))) continue;
     out.add(token);
@@ -237,7 +249,7 @@ function citationsIn(line) {
     const raw = m[1];
     if (NOT_A_LINK_PATH.test(raw)) continue;
     const target = stripFragment(raw);
-    if (!target || NOT_A_PATH.test(target) || PLACEHOLDER.test(target)) continue;
+    if (!target || NOT_A_PATH.test(target) || isPlaceholder(target)) continue;
     if (TAIL_OF_SOMETHING_ELSE.test(target[0])) continue;
     if (!HAS_EXTENSION.test(target)) continue;
     out.add(target);
@@ -313,7 +325,7 @@ function resolves(citation, citingFile, tree) {
 function historyPointersIn(lines) {
   const out = new Set();
   for (const line of lines || []) {
-    for (const m of line.matchAll(new RegExp(`${REVISION}:([A-Za-z0-9_.@/-]+)`, "g"))) {
+    for (const m of line.matchAll(HISTORY_POINTER)) {
       out.add(normalise(m[1]));
     }
   }

--- a/.github/scripts/file-ref-gate.js
+++ b/.github/scripts/file-ref-gate.js
@@ -85,7 +85,21 @@ const LINE_OPT_OUT = /file-refs:\s*N\/?A\b\s*-\s*[A-Za-z]/i;
 // Matched at segment and stem boundaries so `bin/foo.sh`, `bin/check-foo.sh` and `docs/bar.md` are
 // all covered, while `parallel-consumer-examples/` - a real directory containing "example" - is
 // not. Deliberately a short, closed list: anything longer starts swallowing real filenames.
-const PLACEHOLDER = /(?:^|[/\-_.])(?:foo|bar|baz|qux|quux)(?:[/\-_.]|$)/i;
+//
+// A ONE-CHARACTER LOWERCASE FILENAME is the same thing without the word: `docs/x.md`, `docs/a.md`,
+// `docs/b.md` are how this repo writes "some document" when the identity of the document is not the
+// point - this module's own header does it twice ("a pointer for docs/a.md says nothing about
+// docs/b.md"), and the quarantine script tests embed `tracking = "docs/x.md"` inside java string
+// literals describing a synthetic repo. No tracked file has a single-character stem.
+//
+// LOWERCASE, and that is not cosmetic: a java file is named for its class and classes are
+// capitalised, so `.../internal/A.java` is a plausible real path while `docs/a.md` is not a
+// plausible real document. Anchored at the FILENAME rather than at any segment, so a short
+// DIRECTORY segment - `src/a/b/Thing.java` - is untouched.
+const PLACEHOLDER = new RegExp(
+  String.raw`(?:^|[/\-_.])(?:foo|bar|baz|qux|quux)(?:[/\-_.]|$)` +
+  String.raw`|/[a-z0-9]\.[a-z0-9]+$`,
+);
 
 // Tokens that are patterns rather than paths: globs, `<placeholders>`, shell/CI interpolation, and
 // the elided `.../` form docs use to shorten a long package path.
@@ -161,13 +175,28 @@ function isExempt(path) {
   return EXEMPT_PATHS.some((re) => re.test(path));
 }
 
-// Only text files carry citations, and only their added lines are this PR's responsibility. A .java
-// file's imports are the compiler's problem, not this gate's.
+// WHICH FILES CARRY CITATIONS. Prose does, whatever it is written in - and this list has now been
+// wrong twice in the same direction, so the rule is stated rather than the list.
+//
 // `.html` IS A CITING FILE. It was excluded, so a path inside one was never checked - and a rename
 // left `docs/ideation/2026-08-17-distributed-throttling-ideation.html` pointing at a note that no
 // longer existed, silently, because the gate could not see the file at all (astubbs#323 review).
 // The ideation documents cite notes and scripts the same way prose does; the format is not the point.
-const CITING_FILE = /\.(md|adoc|txt|html)$/i;
+//
+// `.java` IS A CITING FILE, for the same reason and against the same argument. The excuse for
+// leaving it out was that "a .java file's imports are the compiler's problem, not this gate's" -
+// and that does not survive contact with TOKEN. A Java import is a dotted package name,
+// `bz.stub.parallelconsumer.state.ShardKey`, with no `/` in it at all, so the two-segment rule
+// cannot fire on one; the exclusion bought nothing and cost the javadoc. Javadoc and comments cite
+// `docs/...` paths as prose exactly the way markdown does - astubbs/parallel-consumer#342 carries a
+// javadoc citing `docs/inflight/perf-throughput-regression-since-0-3.md`, a file that exists only
+// on another branch - and code cites them too, in `@Quarantined(tracking = "docs/...")` and in
+// `REPO_ROOT.resolve("bin/...")`. Nothing checked any of it.
+//
+// `.sh` is the remaining known gap, recorded in docs/inflight/ci-copyright-gate-review-leftovers.md
+// and deliberately not closed here: it wants its own pass over the shell corpus, not a third
+// one-off extension.
+const CITING_FILE = /\.(md|adoc|txt|html|java)$/i;
 
 function normalise(path) {
   const parts = [];

--- a/.github/scripts/file-ref-gate.test.js
+++ b/.github/scripts/file-ref-gate.test.js
@@ -162,6 +162,11 @@ check("a bare filename is not a path", () => {
 check("globs, placeholders and elisions are patterns, not paths", () => {
   assert.deepStrictEqual(citationsIn("the bin/check-*.sh scripts"), []);
   assert.deepStrictEqual(citationsIn("name it bin/check-foo.sh and it is granted"), []);
+  // CASE-INSENSITIVE, and asserted because it stopped being so once. The word list was a `/i`
+  // literal until it was concatenated into a `new RegExp(a + b)` that took no flags, and nothing
+  // went red: no case here used a capitalised placeholder, so `Foo.md` quietly became a citation.
+  assert.deepStrictEqual(citationsIn("name it bin/check-FOO.sh and it is granted"), []);
+  assert.deepStrictEqual(citationsIn("see docs/Bar.md for the shape"), []);
   assert.deepStrictEqual(citationsIn("run bin/<name>.sh"), []);
   assert.deepStrictEqual(citationsIn("parallel-consumer-core/.../chaostests/ChaosConductor.java"), []);
 });

--- a/.github/scripts/file-ref-gate.test.js
+++ b/.github/scripts/file-ref-gate.test.js
@@ -182,6 +182,21 @@ check("a link writes its target twice and is one finding, not two", () => {
   assert.strictEqual(hits.length, 1);
 });
 
+// A ONE-CHARACTER LOWERCASE FILENAME is an illustrative name without the word - `docs/x.md`,
+// `docs/a.md`. This module's own header writes two of them, and the quarantine script tests embed
+// `tracking = "docs/x.md"` inside string literals describing a synthetic repo. Lowercase because a
+// java file is named for its class: `.../internal/A.java` is a plausible real path, `docs/a.md` is
+// not a plausible real document.
+check("a one-character lowercase filename is a placeholder, not a citation", () => {
+  assert.deepStrictEqual(citationsIn('tracking = "docs/x.md"'), []);
+  assert.deepStrictEqual(citationsIn("a pointer for docs/a.md says nothing about docs/b.md"), []);
+  assert.deepStrictEqual(citationsIn("parallel-consumer-core/src/main/java/bz/stub/A.java"),
+    ["parallel-consumer-core/src/main/java/bz/stub/A.java"],
+    "a capitalised one-character java class is a real path, not a placeholder");
+  assert.deepStrictEqual(citationsIn("docs/inflight/ab.md"), ["docs/inflight/ab.md"],
+    "two characters is a name, not a placeholder");
+});
+
 check("a real directory containing 'example' is not treated as a placeholder", () => {
   // The placeholder list must not swallow parallel-consumer-examples/.
   assert.deepStrictEqual(
@@ -194,9 +209,10 @@ check("a URL is somebody else's file, and cannot leak a token from its path", ()
 });
 
 check("only citing file types are scanned", () => {
-  // A .java import is the compiler's business; a .yml path fragment is usually a key, not a file.
-  assert.deepStrictEqual(danglingRefs(file("src/A.java", "import bz.stub.nope/Gone.java;"), TREE),
-                         []);
+  // A .yml path fragment is usually a key, not a file, and nothing in a .png is prose. `.java` used
+  // to be on this list and no longer is - see the java section at the foot of this file.
+  assert.deepStrictEqual(danglingRefs(file("src/a.yml", "runs: bin/nope.sh"), TREE), []);
+  assert.deepStrictEqual(danglingRefs(file("docs/img.png", "bin/nope.sh"), TREE), []);
 });
 
 check("an exempt document is skipped entirely", () => {
@@ -447,13 +463,94 @@ check("html is scanned as a citing file", () => {
   assert.ok(CITING_FILE.test("docs/ideation/a.html"), "an .html document must be scanned");
   assert.ok(CITING_FILE.test("x.md") && CITING_FILE.test("x.adoc") && CITING_FILE.test("x.txt"),
     "the formats that already worked must keep working");
-  assert.ok(!CITING_FILE.test("x.java") && !CITING_FILE.test("x.png"),
-    "code and binaries are still not citing documents");
+  assert.ok(!CITING_FILE.test("x.png") && !CITING_FILE.test("x.yml"),
+    "binaries and config are still not citing documents");
 
   const docs = file("docs/ideation/d.html", "<code>docs/inflight/gone.md</code>");
   const found = danglingRefs(docs, treeOf("docs/inflight/here.md"));
   assert.ok(found.length === 1, "a dangling path inside html must be reported");
   assert.ok(found[0].ref === "docs/inflight/gone.md");
+});
+
+// ---------------------------------------------------------------- java is a citing file
+//
+// SAME FAILURE AS .html, SAME FIX. Javadoc and comments cite `docs/...` paths as prose exactly the
+// way markdown does, and the gate could not see the file at all - astubbs/parallel-consumer#342
+// carries a javadoc citing `docs/inflight/perf-throughput-regression-since-0-3.md`, a note that
+// exists only on another branch, and nothing said so.
+//
+// The argument for the exclusion was that "a .java file's imports are the compiler's problem". It
+// was never true of TOKEN: an import is a DOTTED package name with no `/` in it, so the
+// two-segment rule cannot fire on one. The first two cases below pin that, because it is the whole
+// reason this is safe to turn on.
+
+check("a java import is not a citation - the claim the old exclusion rested on", () => {
+  assert.deepStrictEqual(citationsIn("import bz.stub.parallelconsumer.state.ShardKey;"), []);
+  assert.deepStrictEqual(citationsIn("import static org.assertj.core.api.Assertions.assertThat;"), []);
+  assert.deepStrictEqual(citationsIn("package bz.stub.parallelconsumer.internal;"), []);
+  assert.deepStrictEqual(citationsIn("import java.util.concurrent.ConcurrentHashMap;"), []);
+});
+
+check("a whole java file of imports produces no findings", () => {
+  const docs = file("parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/A.java",
+    "package bz.stub.parallelconsumer;",
+    "",
+    "import bz.stub.parallelconsumer.internal.ConsumerManager;",
+    "import org.apache.kafka.clients.consumer.ConsumerRecord;",
+    "",
+    "class A {}");
+  assert.deepStrictEqual(danglingRefs(docs, TREE), []);
+});
+
+check("java IS a citing file", () => {
+  assert.ok(CITING_FILE.test("parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/A.java"),
+    "a .java file must be scanned");
+});
+
+check("a javadoc citation that resolves is not flagged", () => {
+  const docs = file("parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/A.java",
+    " * The reasoning lives in docs/ci.md, and bin/build.sh runs it.");
+  assert.deepStrictEqual(danglingRefs(docs, TREE), []);
+});
+
+// THE RED CONTROL. A gate that passes everything is indistinguishable from a gate that is not
+// looking, so the dangling case is asserted as directly as the clean one - this is the exact shape
+// of the astubbs/parallel-consumer#342 javadoc, a path that exists only on another branch.
+check("a dangling javadoc citation IS flagged", () => {
+  const docs = file("parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/A.java",
+    " * Measurements: docs/inflight/perf-throughput-regression-since-0-3.md");
+  const hits = danglingRefs(docs, TREE);
+  assert.deepStrictEqual(hits.map((h) => h.ref),
+    ["docs/inflight/perf-throughput-regression-since-0-3.md"]);
+  assert.strictEqual(hits[0].file,
+    "parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/A.java:1");
+});
+
+// Code cites repo paths too, and those are worth checking for the same reason prose is: a renamed
+// script leaves `@Quarantined(tracking = "docs/...")` and `REPO_ROOT.resolve("bin/...")` pointing at
+// nothing, and both are silent until something runs.
+check("a repo path in java CODE is checked, not just in comments", () => {
+  const good = file("parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/T.java",
+    '    @Quarantined(reason = "diagnosed", tracking = "docs/ci.md")');
+  assert.deepStrictEqual(danglingRefs(good, TREE), []);
+
+  const bad = file("parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/T.java",
+    '    String lane = read(REPO_ROOT.resolve("bin/gone.sh"));');
+  assert.deepStrictEqual(danglingRefs(bad, TREE).map((h) => h.ref), ["bin/gone.sh"]);
+});
+
+// The paragraph marker has to work in java or the escape does not exist where the new findings are.
+// `//` is the natural place for it, and the paragraph is the contiguous block of code around it -
+// which in java is a statement block, not a prose paragraph. Read UPWARD from the marker, as in
+// markdown, so it excuses the fixture line above it and nothing after the blank line.
+check("the line opt-out works in a java file", () => {
+  const docs = file("parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/T.java",
+    '    Files.write(fixture.resolve("module/src/test-integration/java/SomeIT.java"),',
+    "    // file-refs: N/A - a path inside the temporary fixture repo, not a path in this one",
+    "",
+    '    String lane = read(REPO_ROOT.resolve("bin/gone.sh"));');
+  assert.deepStrictEqual(danglingRefs(docs, TREE).map((h) => h.ref), ["bin/gone.sh"],
+    "the marker covers its own block and nothing past the blank line");
 });
 
 console.log("\n" + run + " assertions passed");

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -1307,6 +1307,65 @@ the only thing separating the truncated download from the complete one was `unzi
 [`docs/ci.md`](../ci.md) needs its own completeness check: test the archive before believing a grep
 that came back quiet.
 
+## 2026-08-26, third capture: the discriminator now fires on TWO PRs' chaos jobs minutes apart
+
+**The two sections above each closed on "not a rate", and each argued the box was not a suspect
+because sibling chaos jobs in the window were green. That argument does not hold this time: two
+different PRs' chaos jobs went red on the same BLOCKED-on-monitor discriminator within two minutes
+of each other, on different scenario arms and different seeds.**
+
+**The clean capture** is `Chaos Pain Suite`,
+`ChaosRevokeUnderWorkIT.revokeUnderWorkStaysProtocolHonest` - the **eager** assignor, plain
+revoke-under-work - on the same correctness SLO,
+<!-- post-merge: checked-begin -->
+[run 32975256292](https://github.com/astubbs/parallel-consumer/actions/runs/32975256292), from
+astubbs/parallel-consumer#374 at head `cdfb05456`:
+<!-- post-merge: checked-end -->
+
+```
+instance 72: RuntimeException: Error from poll control thread: Timeout waiting for commit response
+PT10S ... POLL THREAD AT TIMEOUT: BLOCKED ... Lock:
+java.util.concurrent.atomic.AtomicBoolean@47a58040, held by: pc-control-PC-72.
+Top frames: [...commitOffsetsThatAreReady(AbstractParallelEoSStreamProcessor.java:1585),
+             ...onPartitionsRevoked(AbstractParallelEoSStreamProcessor.java:548), ...]
+```
+
+Frame for frame it is the first two captures - same `:1585` (the `synchronized (commitCommand)`
+acquisition itself), same `:548`, same `AtomicBoolean`, holder again the control thread of the same
+instance. The reasoning that identified the AB-BA pair there applies unchanged and is not repeated.
+<!-- post-merge: checked-begin -->
+**The branch was not a suspect**: astubbs#374 changed the file-ref gate script, its test and two
+markdown files, plus one comment line in a test class - no main Java, no pom, no workflow, so it
+could not reach the chaos engine. Every other scenario in that same JVM passed.
+<!-- post-merge: checked-end -->
+
+**Seed `1355976854716465757`**:
+
+    ./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true \
+      -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=1355976854716465757
+
+**The corroborating capture, and why it is weaker.** `ChaosRevokeUnderWorkDrainIT` on
+[run 32975169315](https://github.com/astubbs/parallel-consumer/actions/runs/32975169315)
+(astubbs/parallel-consumer#267, `fix/concurrent-listener-registration`, seed
+<!-- post-merge: checked-begin -->
+`3135248854766953145`, instance 56, monitor held by `pc-control-PC-56`) is the same monitor reached
+through the same two methods - but its frames read `:1621` and `:555`, because that branch edits
+`AbstractParallelEoSStreamProcessor` and shifts the line numbers. So it corroborates the pair, and it
+is **not** a second not-PR-introduced control arm. Take the astubbs#374 capture as the clean one.
+<!-- post-merge: checked-end -->
+
+**What the pairing removes is the last ambient explanation.** `Chaos Pain Suite` moved off the shared
+`highcpu` box to `ubuntu-latest` earlier the same day - grep `maven.yml` for `the per-PR ambient
+tripwire` - so each chaos job now gets its own VM and co-residency between these two runs is
+structurally impossible. Two isolated VMs, two seeds, two scenario arms, the same monitor and the
+same holder, inside two minutes. Contention on one loaded machine cannot be what produced both.
+
+**Still not a rate, and still no replay.** Neither seed here has been replayed either, and there is
+no denominator - other chaos jobs in the same window were green. What this adds is that the cycle is
+not rare enough to need a hunt to see, and that the verification the first 2026-08-26 section asks
+for (replay a captured seed with astubbs#29's `tryLock()` applied, and read whether the poll thread
+is still found `BLOCKED` on the same monitor) now has three seeds to choose from.
+
 ## Delete when
 
 The `CLASS2_STALL` entries above are superseded by this section and kept only as the record of how a

--- a/docs/inflight/ci-copyright-gate-review-leftovers.md
+++ b/docs/inflight/ci-copyright-gate-review-leftovers.md
@@ -60,9 +60,11 @@ astubbs#338 fixed one instance. Two more stand:
   .claude/hooks/" - but resolves it with `git ls-files 'bin/*.sh'`, and a git pathspec `*` crosses
   `/`, so it *does* scan `bin/lib/`. Two gates whose headers claim identical scope scan different
   sets, and nothing says so. Whatever closes the gap should make them share one resolution.
-- **`.github/scripts/file-ref-gate.js` reads citations from `.md`/`.adoc`/`.txt`/`.html` only**,
-  which is why a dangling path inside a `.sh` was invisible. It already grew once, for `.html`, so
-  this is the second recurrence and nothing records the class.
+- **`.github/scripts/file-ref-gate.js` still does not read `.sh`**, which is why a dangling path
+  inside a script is invisible. `CITING_FILE` has now grown twice - for `.html`, then for `.java`
+  (astubbs/parallel-consumer#342 found the second) - so shell is the third recurrence of one shape,
+  and the only extension left where prose cites repo paths. Closing it wants a pass over the shell
+  corpus: every `bin/*.sh` header cites paths, and the exclusion has never been measured.
 
-Three instances is enough to be predictive - this wants a `docs/solutions/` entry, not a third
+Four instances is enough to be predictive - this wants a `docs/solutions/` entry, not a fourth
 one-off fix.

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CheckQuarantineOwnersScriptTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CheckQuarantineOwnersScriptTest.java
@@ -61,8 +61,6 @@ class CheckQuarantineOwnersScriptTest extends AbstractQuarantineScriptTest {
                 ("class SomeQuarantinedIT {\n" +
                         "    @Quarantined(reason = \"d\", tracking = \"t\", fixedBy = \"PR #999999\")\n" +
                         "    void someMethod() {}\n}\n").getBytes(StandardCharsets.UTF_8));
-        // file-refs: N/A - a path inside the temporary fixture repo this test builds, not a path in
-        // this one; `module/` is the stand-in module name the fixture uses throughout.
         writeRegistry("- [ ] `SomeQuarantinedIT.someMethod` - diagnosed. **Owner: PR #999999**\n");
     }
 

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CheckQuarantineOwnersScriptTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CheckQuarantineOwnersScriptTest.java
@@ -61,6 +61,8 @@ class CheckQuarantineOwnersScriptTest extends AbstractQuarantineScriptTest {
                 ("class SomeQuarantinedIT {\n" +
                         "    @Quarantined(reason = \"d\", tracking = \"t\", fixedBy = \"PR #999999\")\n" +
                         "    void someMethod() {}\n}\n").getBytes(StandardCharsets.UTF_8));
+        // file-refs: N/A - a path inside the temporary fixture repo this test builds, not a path in
+        // this one; `module/` is the stand-in module name the fixture uses throughout.
         writeRegistry("- [ ] `SomeQuarantinedIT.someMethod` - diagnosed. **Owner: PR #999999**\n");
     }
 
@@ -162,6 +164,8 @@ class CheckQuarantineOwnersScriptTest extends AbstractQuarantineScriptTest {
                 ("class SomeQuarantinedIT {\n" +
                         "    @Quarantined(reason = \"d\", tracking = \"t\", fixedBy = \"astubbs#999999\")\n" +
                         "    void someMethod() {}\n}\n").getBytes(StandardCharsets.UTF_8));
+        // file-refs: N/A - a path inside the temporary fixture repo this test builds, not a path in
+        // this one; `module/` is the stand-in module name the fixture uses throughout.
         writeRegistry("- [ ] `SomeQuarantinedIT.someMethod` - diagnosed. **Owner: PR astubbs#999998**\n");
         Result r = run("GIT_STUB_BASE_ANNOTATED", "0");
         assertThat(r.exitCode).isEqualTo(0);


### PR DESCRIPTION
## Description

`.github/scripts/file-ref-gate.js` could not see a `.java` file at all - `CITING_FILE` listed
`.md`/`.adoc`/`.txt`/`.html`. Javadoc and comments cite `docs/...` paths as prose exactly the way
markdown does, and nothing checked any of them. astubbs/parallel-consumer#342 flagged the gap and
carries the live example: a javadoc citing `docs/inflight/perf-throughput-regression-since-0-3.md`,
a note that exists only on another branch.

**`.html` is the precedent - same failure, same fix.** It was excluded too, a rename stranded a path
inside one, and the gate was blind because of the extension rather than the content
(astubbs/parallel-consumer#323 review).

### The argument for the exclusion does not survive reading the code

The comment said "a `.java` file's imports are the compiler's problem, not this gate's". `TOKEN`
requires at least two `/`-separated segments ending in a real extension; a Java import is a **dotted
package name** - `bz.stub.parallelconsumer.state.ShardKey` - with no `/` in it, so it can never
match. Verified before relying on it, and now pinned by two tests (single imports, and a whole file
of them), because it is the entire reason this is safe to turn on.

### What the whole-tree run surfaced

Three findings across 283 `.java` files. **All three are false positives - no genuinely broken
citation exists in a `.java` file today**, so the change is pure upside plus the narrowing below.

| Finding | Disposition |
|---|---|
| `docs/x.md` x2 in `QuarantineRegistryScriptTest`, inside embedded fixture source | **Tightened the matcher, not an exemption.** A one-character *lowercase* filename is an illustrative name - this module's own header writes "a pointer for `docs/a.md` says nothing about `docs/b.md`". Lowercase is load-bearing: a java file is named for its class, so `.../internal/A.java` is a plausible real path while `docs/a.md` is not a plausible real document. Anchored at the filename, so a short *directory* segment is untouched. No tracked file in the tree has a single-character stem. |
| `module/src/test-integration/java/SomeQuarantinedIT.java` in `CheckQuarantineOwnersScriptTest` | **The gate's own documented paragraph marker**, with a reason. It is a path inside the temporary fixture repo the test builds. Nothing textually separates it from the *real* repo paths in the same file (`bin/check-quarantine-owners.sh`, `bin/check-quarantine-registry.sh`), so an `EXEMPT_PATHS` entry would have thrown those away - which is exactly how a gate rots. |

`EXEMPT_PATHS` is unchanged.

### Code paths are checked too, deliberately

`@Quarantined(tracking = "docs/...")` and `REPO_ROOT.resolve("bin/...")` are repo citations that go
silently stale on a rename, and they are the majority of what a `.java` file cites. Restricting the
scan to comment lines would have been simpler and would have thrown all of that away.

### Red control

A gate that passes everything is indistinguishable from one that is not looking, so the *no* was
constructed rather than assumed: a `.java` file citing
`docs/inflight/perf-throughput-regression-since-0-3.md` was added to the tree and
`bin/check-file-refs.sh` exited 1, naming the file, the line and the path; removing it returned the
run to clean. The unit suite asserts the same shape directly.
<!-- file-refs: N/A - the red control's path is deliberately one that exists only on another branch -->

### Not closed here

`.sh` is the one remaining extension where prose cites repo paths.
`docs/inflight/ci-copyright-gate-review-leftovers.md` now records shell as the open half of the
class rather than claiming java is still excluded. It wants a pass over the shell corpus, not a
third one-off extension.

### Verification

- `node .github/scripts/file-ref-gate.test.js` - 56 assertions pass (was 45)
- `bin/test-check-file-refs.sh` - all cases pass
- `bin/check-file-refs.sh` - clean
- `bin/check-all.sh` - 15 ran, 15 passed, 0 failed

## Checklist

- [x] Docs updated - `docs/inflight/ci-copyright-gate-review-leftovers.md`; the rule itself lives in the module's own header, which is updated
- [x] N/A - no user-facing behaviour changes; this is a CI gate
- [x] Tests added/updated - `.github/scripts/file-ref-gate.test.js` gains a java section: imports do not trip it, a resolving javadoc citation passes, a dangling one fails, code paths are checked, the line opt-out works in `.java`, and the one-character-filename narrowing is pinned in both directions
- [x] Title & body reflect the final content of this PR
- [x] N/A - asked for `@codex review` and `@claude review this` on the PR instead
