### PR TITLE
build(streams) astubbs#255: patch Kafka Streams at build time, with Kafka's own suite as the oracle

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,6 +55,64 @@ jobs:
             setup-java-Linux-x64-maven-
       - name: Download all dependencies
         run: ./mvnw --batch-mode -Pci dependency:go-offline -DincludeScope=test -U
+      # The plugin-resolves-for-itself class, reached from a new direction: here the plugin doing its
+      # own resolving is maven-dependency-plugin. `parallel-consumer-streams` unpacks Kafka's
+      # `sources` and `test-sources` CLASSIFIER jars through two `dependency:unpack` executions that
+      # name them as <artifactItems>, and go-offline resolves the DECLARED dependency graph - an
+      # artifactItem is not in it, and neither jar is declared anywhere else. So both stay cold, and
+      # every lane that builds this module fetches them from Central inside generate-sources, on the
+      # CDN route lottery in
+      # docs/solutions/build-errors/maven-central-timeout-azure-west-regions-2026-04-21.md: an
+      # exactly-240s read timeout, and re-running does not reliably help because the runner is often
+      # reassigned to the same region. Seen on astubbs/parallel-consumer#394 and
+      # astubbs/parallel-consumer#395 - Unit AND Integration both red at
+      # `unpack (unpack-kafka-streams-sources)` with ZERO tests run, so the lane called "Unit Tests"
+      # names a subsystem that never got as far as compiling.
+      #
+      # Warmed by COORDINATE rather than by building the module. Building it warms the jars too, and
+      # is what the Connect spike branch does (`-pl parallel-consumer-connect -am -DskipTests
+      # package`) - but it costs a full build of core inside this job, and that branch records why it
+      # cannot be shortened to a cheap phase-only walk: the module's test-scope resolution wants
+      # core's tests-classifier jar, which does not exist until core reaches `package`. Two jars are
+      # the whole gap here and `kafka.version` is a real root-pom property, so naming them is both
+      # cheaper and no more prone to rot.
+      #
+      # Verified locally against an empty local repository: the two `get`s fetch exactly the two jars
+      # the assertions name, after which `-pl parallel-consumer-streams -am generate-test-sources`
+      # runs OFFLINE from a cleaned target and both unpack executions succeed - so what this warms is
+      # sufficient for the artifactItems resolve, not merely adjacent to it.
+      #
+      # `kafka.version` is the default every live lane builds at. The one job that overrides it,
+      # `test-kafka-compat`, is `if: false`; re-enabling it puts its Kafka version back outside this
+      # warm. (astubbs#255)
+      - name: Warm the Kafka sources jars the streams module unpacks
+        run: |
+          set -euo pipefail
+          evaluate() {
+            ./mvnw -q --batch-mode -N \
+              -Dexpression="$1" -DforceStdout \
+              org.apache.maven.plugins:maven-help-plugin:3.5.2:evaluate 2>/dev/null | tail -1
+          }
+          # A renamed property makes help:evaluate print "null object or invalid expression", which
+          # dependency:get would happily turn into a warm of the wrong coordinate - and warming
+          # nothing is indistinguishable from a cache hit until it fails a job downstream. Require a
+          # version-shaped answer rather than merely a non-empty one.
+          require_version() {
+            case "$2" in
+              [0-9]*) : ;;
+              *) echo "::error::$1 did not resolve to a version from the root pom (got '$2') - the Kafka sources cache warm would be a silent no-op"; exit 1 ;;
+            esac
+          }
+          kafka_version=$(evaluate kafka.version)
+          require_version kafka.version "$kafka_version"
+          for classifier in sources test-sources; do
+            ./mvnw --batch-mode -ntp \
+              org.apache.maven.plugins:maven-dependency-plugin:3.11.0:get \
+              -Dartifact="org.apache.kafka:kafka-streams:${kafka_version}:jar:${classifier}"
+            # Assert the jar is on disk: the exit code says the goal ran, only the file says the
+            # cache this job exists to populate actually got populated.
+            test -s ~/.m2/repository/org/apache/kafka/kafka-streams/"${kafka_version}"/kafka-streams-"${kafka_version}"-"${classifier}".jar
+          done
       - name: Save Maven cache (rotating key)
         if: success()
         uses: actions/cache/save@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,7 @@ bin/performance-test.sh      # performance tests (substantial hardware)
 | `parallel-consumer-vertx` | Vert.x integration for async HTTP |
 | `parallel-consumer-reactor` | Project Reactor integration |
 | `parallel-consumer-mutiny` | SmallRye Mutiny integration (Quarkus) |
+| `parallel-consumer-streams` | Kafka Streams (alpha, **unpublished**) - build-time patching of Kafka's internals; its own README owns the mechanism |
 | `parallel-consumer-examples` | Example implementations for each module |
 
 ## Key Architecture Decisions

--- a/NOTICE
+++ b/NOTICE
@@ -8,3 +8,21 @@ Apache License, Version 2.0.
 
 This fork is maintained independently at:
   https://github.com/astubbs/parallel-consumer
+
+The parallel-consumer-streams artifact contains MODIFIED versions of these classes
+from Apache Kafka:
+
+  org.apache.kafka.streams.processor.internals.AbstractProcessorContext
+  org.apache.kafka.streams.processor.internals.ProcessorContextImpl
+  org.apache.kafka.streams.processor.internals.RecordCollectorImpl
+
+Apache Kafka
+Copyright 2024 The Apache Software Foundation
+Licensed under the Apache License, Version 2.0.
+https://kafka.apache.org
+
+These files have been CHANGED by Antony Stubbs and contributors, to make Kafka Streams'
+processor context and record collector safe to drive from more than one thread. The
+changes are expressed as, and limited to, the patch tracked at
+parallel-consumer-streams/src/main/patch/pc-streams.patch; no Apache Kafka source is
+redistributed in this repository. See parallel-consumer-streams/README.md.

--- a/bin/check-copyright-headers.sh
+++ b/bin/check-copyright-headers.sh
@@ -137,6 +137,7 @@ EXEMPT_PATHS="
 *.json|JSON has no comment syntax - see docs/copyright.md for the in-band conventions that fit
 *.sln|Visual Studio solution format carries no comment syntax
 *.bin|binary test fixture
+*.patch|a diff of third-party source, regenerated wholesale by its own tool - the NOTICE names what it modifies
 */py.typed|PEP 561 marker, required by the spec to be empty
 */META-INF/services/*|JDK ServiceLoader registry - the file's entire content is the provider list
 *.md|prose - never distributed detached from LICENSE, so a per-file notice has no recipient

--- a/bin/check-test-log-config.sh
+++ b/bin/check-test-log-config.sh
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2026 Antony Stubbs and contributors
 #
-# Guards the test logging harness in the four LIBRARY modules' logback-test.xml.
+# Guards the test logging harness in the LIBRARY modules' logback-test.xml.
 #
 # Why a gate rather than a note: every failure in this class is silent. A committed `debug` default
 # does not go red - it floods the CI log and slows the run, and the volume alone can break tests.
@@ -40,6 +40,7 @@ MODULES=(
     parallel-consumer-vertx
     parallel-consumer-reactor
     parallel-consumer-mutiny
+    parallel-consumer-streams
 )
 
 # Allow the self-test to point the gate at a fixture tree.

--- a/bin/test-check-test-log-config.sh
+++ b/bin/test-check-test-log-config.sh
@@ -10,7 +10,22 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 GATE="$PWD/bin/check-test-log-config.sh"
 
-MODULES=(parallel-consumer-core parallel-consumer-vertx parallel-consumer-reactor parallel-consumer-mutiny)
+# READ THE MODULE LIST OUT OF THE GATE, DO NOT RESTATE IT. A second copy here does not merely go
+# stale, it INVERTS the self-test: the fixture tree is built from this list, so a module the gate
+# checks but the fixture omits makes the *conforming* case fail, and every "expected pass" case
+# reports a gate bug that does not exist. That is what a fifth library module did on first arrival.
+# The anchored parse is why the gate's array stays one name per line.
+# A read loop rather than mapfile: macOS ships bash 3.2, where mapfile does not exist and the
+# failure is `command not found` on a line nobody looks at twice.
+MODULES=()
+while IFS= read -r module; do
+    MODULES+=("$module")
+done < <(sed -n '/^MODULES=(/,/^)/p' bin/check-test-log-config.sh | sed -n 's/^[[:space:]]\{1,\}\(parallel-consumer-[a-z-]*\)$/\1/p')
+
+if (( ${#MODULES[@]} == 0 )); then
+    echo "test-check-test-log-config: could not read MODULES out of bin/check-test-log-config.sh" >&2
+    exit 1
+fi
 
 pass=0
 fail=0

--- a/docs/data/staging/module-maturity-rows.yaml
+++ b/docs/data/staging/module-maturity-rows.yaml
@@ -1,15 +1,21 @@
 # Copyright (C) 2026 Antony Stubbs and contributors
 
-# STAGED. These rows describe modules that are not in the reactor yet, so they are held here rather
-# than asserting in module-maturity.yaml something the tree contradicts.
+# STAGED. These rows describe modules whose artifact nobody can depend on yet, so they are held here
+# rather than asserting in module-maturity.yaml something the tree contradicts.
 #
-# Whichever PR lands each module moves its row into module-maturity.yaml in the same change, and
-# re-checks the wording against what actually shipped:
+# Whichever PR makes each artifact PUBLISHABLE moves its row into module-maturity.yaml in the same
+# change, and re-checks the wording against what actually shipped:
 #
 #   parallel-consumer-streams    astubbs#271  (issue astubbs#255)
 #   parallel-consumer-connect    astubbs#269  (issue astubbs#240)
 #
-# Both are open and neither touches docs/data, so both have been told on the PR that merging must
+# The trigger is publication, not the reactor, and the streams row is why the distinction is written
+# down: parallel-consumer-streams IS a module in pom.xml today, carrying only the Kafka Streams
+# fork/build machinery with publication deliberately off - so every claim in its row below
+# ("opt_in: artifact dependency", "evaluate the Kafka Streams integration") is still false. Moving a
+# row on reactor membership alone would publish exactly the contradiction this file exists to avoid.
+#
+# Both PRs are open and neither touches docs/data, so both have been told on the PR that merging must
 # move the row. A third module is coming with no row here yet: astubbs#268 adds
 # parallel-consumer-dashboard, and needs one written when its shape settles.
 #

--- a/docs/inflight/branch-ks-streams-workstream.md
+++ b/docs/inflight/branch-ks-streams-workstream.md
@@ -1,12 +1,16 @@
-# Kafka Streams on PC (astubbs#255): the workstream exists, and master cannot see it
+# Kafka Streams on PC (astubbs#255): master sees the machinery, not the workstream
 
 <!-- inflight-type: feature -->
 <!-- inflight-impact: coordination -->
 
 
-A signpost, not a handover. None of this work is on `master` - not the
-`parallel-consumer-streams` module, not its plan documents, not its own in-flight notes - so an
-agent listing this directory sees only the sideways references other notes make to it and no way in.
+A signpost, not a handover. **What is on `master` is the fork/build machinery only** - the
+`parallel-consumer-streams` module shell, its patch/regenerate discipline and the upstream-suite
+oracle, landed as the base of a reconstructed stack. It patches Kafka's processor context and record
+collector for thread safety and stops there: no PC execution seam, no dispatcher, no records through
+PC, and the module is **not published**. Everything else - the seam, the semantics, the measurements,
+the plan documents and the workstream's own in-flight notes - is still off `master`, so an agent
+listing this directory sees only sideways references to it and no way in.
 
 **What it is.** Give a Kafka Streams topology PC's per-key concurrency by replacing Streams' record
 selection with PC's `WorkManager` and running the processor chain on PC's worker pool, applied as a
@@ -18,6 +22,15 @@ carries the assessment and the tiered cost.
 the tip.** The live work sits on a dozen sibling branches (`git branch -a | grep -E 'ks-|streams-'`)
 merged forward from that base and deliberately **never rebased**, because they build on each other.
 Reading the PR head as the state of the work is the mistake this note exists to prevent.
+
+**How it reaches master.** Not by merging that forest. The decomposition plan
+(`docs/plans/2026-08-31-001-process-god-branch-decomposition-plan.md`, Wagon B) reconstructs it as a
+fresh stack cut from `master`, taking content from the forest by copy: the forest stays as the
+evidence record, and the PRs document what the design *is* rather than how it was discovered. The
+machinery described above is the first rung; the seam is the second. The forest branches are not
+retired by any of this and are still where the unlanded work lives.
+<!-- file-refs: N/A - the decomposition plan arrives on master with its own PR, not with the first rung -->
+
 
 **Before touching any of them, read the branch's own handover:**
 `git show abcc811e6:docs/inflight/branch-ks-streams-handover.md` - branch topology, the build traps
@@ -40,4 +53,6 @@ options recorded in the plan on the branch.
 
 ## Delete when
 
-astubbs#271 merges - which brings its own handover onto master, and that supersedes this file.
+The reconstructed stack has landed far enough that `master` carries the seam and the handover it
+points at - at which point that handover supersedes this file. Landing the machinery alone does not
+qualify: the forest, and the reason this signpost exists, both outlive it.

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -1800,6 +1800,28 @@ which is why the capture is worth attributing to the merge rather than to the br
 
 <!-- post-merge: checked-end -->
 
+## 2026-08-31, CHAOS lane: the BLOCKED-on-monitor discriminator again, on the COOPERATIVE DRAIN arm
+
+Recorded for the seed, since the log expires and no replay has been run.
+
+`ChaosRevokeUnderWorkCooperativeDrainIT.revokeUnderDrainingStopsWithCooperativeAssignorStaysProtocolHonest`,
+seed **`1159274055608047297`**. Replay:
+
+```
+./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=1159274055608047297
+```
+
+Same discriminator as the captures above, not a new one: instance 12 ended with
+`Timeout waiting for commit response PT10S`, and the probe classified the poll thread as **BLOCKED -
+waiting to acquire a monitor**, on an `AtomicBoolean` held by `pc-control-PC-12`, whose top frame is
+`commitOffsetsThatAreReady` reached from `onPartitionsRevoked`. The instrumentation states the
+disjunction it was written to settle: contention or a lock-ordering defect, **not** a slow broker.
+
+**Not the observing PR's defect.** astubbs/parallel-consumer#379 adds an unpublished Kafka Streams
+build-machinery module and touches no core Java, no locking, no rebalance path and no in-flight
+accounting - its diff outside `parallel-consumer-streams/` is the root pom's module line, `NOTICE`,
+three `bin/` gates and docs. Same crossing as the entries above: what it brought in is master.
+
 ## Delete when
 
 The `CLASS2_STALL` entries above are superseded by this section and kept only as the record of how a

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -1818,6 +1818,18 @@ waiting to acquire a monitor**, on an `AtomicBoolean` held by `pc-control-PC-12`
 disjunction it was written to settle: contention or a lock-ordering defect, **not** a slow broker.
 
 <!-- post-merge: checked-begin -->
+**It did not reproduce on the next run of the same tree, which is an intermittency datum rather
+than a clearance.** The two `Chaos Pain Suite` runs on astubbs/parallel-consumer#379 are separated
+only by two documentation commits - no Java, no pom, no workflow - so the tree the second run
+scheduled is the first run's tree for every purpose this failure could care about. One red, one
+green: **1 of 2**, with different seeds each time, since the lane seeds per run. That is the same
+shape as the pair of runs one commit apart already cited above, and it says the same thing - the
+trigger is the schedule, not the tree - on a pair whose two halves are closer together than any
+previous one. It is not evidence the capture was noise, and a green run has never been treated as
+one here.
+<!-- post-merge: checked-end -->
+
+<!-- post-merge: checked-begin -->
 **Not the observing PR's defect.** It was seen on astubbs/parallel-consumer#379, which adds an
 unpublished Kafka Streams build-machinery module and touches no core Java, no locking, no rebalance
 path and no in-flight accounting - its diff outside `parallel-consumer-streams/` is the root pom's

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -1817,10 +1817,13 @@ waiting to acquire a monitor**, on an `AtomicBoolean` held by `pc-control-PC-12`
 `commitOffsetsThatAreReady` reached from `onPartitionsRevoked`. The instrumentation states the
 disjunction it was written to settle: contention or a lock-ordering defect, **not** a slow broker.
 
-**Not the observing PR's defect.** astubbs/parallel-consumer#379 adds an unpublished Kafka Streams
-build-machinery module and touches no core Java, no locking, no rebalance path and no in-flight
-accounting - its diff outside `parallel-consumer-streams/` is the root pom's module line, `NOTICE`,
-three `bin/` gates and docs. Same crossing as the entries above: what it brought in is master.
+<!-- post-merge: checked-begin -->
+**Not the observing PR's defect.** It was seen on astubbs/parallel-consumer#379, which adds an
+unpublished Kafka Streams build-machinery module and touches no core Java, no locking, no rebalance
+path and no in-flight accounting - its diff outside `parallel-consumer-streams/` is the root pom's
+module line, `NOTICE`, three `bin/` gates and docs. Same crossing as the entries above: what it
+brought in is master.
+<!-- post-merge: checked-end -->
 
 ## Delete when
 

--- a/docs/inflight/ci-streams-classifier-artifacts-escape-the-cache-warming-job.md
+++ b/docs/inflight/ci-streams-classifier-artifacts-escape-the-cache-warming-job.md
@@ -1,0 +1,44 @@
+# The streams module's `sources` jars are warmed HERE, and nowhere else yet
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+`parallel-consumer-streams` (astubbs#255) fetches Kafka's `sources` and `test-sources` classifier
+jars through `dependency:unpack` `<artifactItems>`, which `dependency:go-offline` does not resolve -
+so they were fetched live from Maven Central inside `generate-sources` on every lane, in exactly the
+phase where the region-dependent read timeout in
+[`docs/solutions/build-errors/maven-central-timeout-azure-west-regions-2026-04-21.md`](../solutions/build-errors/maven-central-timeout-azure-west-regions-2026-04-21.md)
+bites. It presented as Unit **and** Integration red at `unpack (unpack-kafka-streams-sources)` with
+zero tests run, so the lane called "Unit Tests" named a subsystem that never reached compilation.
+
+<!-- post-merge: checked-begin -->
+**Fixed by astubbs/parallel-consumer#379**, which added the `Warm the Kafka sources jars the streams
+module unpacks` step to `prepare-deps` in `.github/workflows/maven.yml` - so wherever that step is
+present, this is closed. **That step's own comment is the durable owner** of why go-offline
+misses an artifactItem, why the warm names coordinates rather than building the module, and what the
+two guards are for; this note does not restate it.
+<!-- post-merge: checked-end -->
+
+## What is still open
+
+<!-- post-merge: checked-begin -->
+**Every branch carrying `parallel-consumer-streams` without that step still has the unwarmed
+workflow**, and stays exposed until it merges astubbs/parallel-consumer#379 forward. The candidates
+are
+`for r in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin); do git cat-file -e "$r:parallel-consumer-streams/pom.xml" 2>/dev/null && echo "$r"; done`,
+minus those that already contain the step - `git grep -l 'Warm the Kafka sources jars' <ref> --
+.github/workflows/maven.yml`.
+
+**`feats/ks-streams-task-lifecycle` carries its own copy of this file**, written before the fix and
+describing the defect as unfixed. It already contains `feats/ks-streams-fork-machinery`'s pre-fix
+commits, so merging astubbs/parallel-consumer#379 forward collides add/add on this path: **take the
+version that names the step**, not the one that calls the fix a candidate.
+<!-- post-merge: checked-end -->
+
+**`test-kafka-compat` is the one job whose Kafka version falls outside the warm.** It is `if: false`
+today; re-enabling it re-opens this for that lane only.
+
+## Delete when
+
+No open branch builds the streams module without that step - at which point nothing here is both
+true and unowned by the workflow comment.

--- a/docs/inflight/release-experimental-module-records.md
+++ b/docs/inflight/release-experimental-module-records.md
@@ -8,14 +8,24 @@
 then removed from the corpus. They are held here until their modules exist.
 <!-- file-refs: N/A - the sentence is about records that were written and then not kept -->
 
-**Why.** Neither `parallel-consumer-streams-spike` nor `parallel-consumer-connect` is a module in
-`pom.xml` or a directory in the tree. Both records carried `status: planned` with
-`target_release: 0.6.0.0`, which is honest, but they also carried a Maven coordinate that reads as
-copy-pasteable for an artifact that will not resolve. The corpus's own standard, set by the maturity
-work, is not to assert what the tree contradicts.
+**Why.** Both records carried `status: planned` with `target_release: 0.6.0.0`, which is honest, but
+they also carried a Maven coordinate that reads as copy-pasteable for an artifact that will not
+resolve. The corpus's own standard, set by the maturity work, is not to assert what the tree
+contradicts.
 
-**When they return.** Whichever PR lands each module restores its record in the same change, with
-`status: published`, a real `since`, and setup that resolves. Do not rewrite the drafts - but do not
+**`parallel-consumer-streams` is now a module in `pom.xml` and a directory in the tree, and that
+changes nothing here.** What landed is the fork/build machinery: no Parallel Consumer execution seam,
+and **publication deliberately off** (`maven.deploy.skip`, `gpg.skip`, `skipPublishing` in its own
+pom). So the coordinate still does not resolve for anyone, and a record whose whole problem was
+uncopy-pasteable setup is no closer to being restorable. The trigger is unchanged: the PR that makes
+the artifact real. `parallel-consumer-connect` is not in the tree at all.
+
+**When they return.** Whichever PR makes each artifact *publishable* restores its record in the same
+change, with `status: published`, a real `since`, and setup that resolves. "Lands the module" was the
+wording until the streams module shell landed unpublished, and it does not survive that: a directory
+in the reactor is not an artifact anyone can depend on. The same distinction governs the staged
+maturity row in `docs/data/staging/module-maturity-rows.yaml`, whose `opt_in: artifact dependency`
+is the claim that has to become true. Do not rewrite the drafts - but do not
 look for them in master's history either: the astubbs#273 squash-merge made them unreachable from
 here. Where each draft actually is:
 
@@ -30,4 +40,4 @@ and [`branch-connect-on-pc-workstream.md`](branch-connect-on-pc-workstream.md).
 
 ## Delete when
 
-Both modules are in the reactor and both records are back in `docs/features/`.
+Both modules publish an artifact and both records are back in `docs/features/`.

--- a/docs/solutions/architecture-patterns/patch-a-dependency-at-build-time-without-vendoring-it.md
+++ b/docs/solutions/architecture-patterns/patch-a-dependency-at-build-time-without-vendoring-it.md
@@ -1,0 +1,259 @@
+---
+title: Patch a dependency's internals at build time instead of vendoring or forking it
+date: 2026-08-31
+category: architecture-patterns
+module: build
+problem_type: architecture_pattern
+component: tooling
+severity: high
+applies_when:
+  - You need to change behaviour inside a third-party library that has no extension point where you need one
+  - The code you need to reach is package-private, final, or otherwise not designed to be subclassed or intercepted
+  - Reflection or a bytecode agent can observe the internals but cannot change the control flow you care about
+  - You want the size of your change to be a reviewable, re-derivable number rather than a whole vendored tree
+  - You are about to copy third-party source into the repository and are looking for a cheaper option
+tags:
+  - build-time-patching
+  - classpath-shadowing
+  - vendoring
+  - maven
+  - control-arm
+  - apache-license
+  - kafka-streams
+---
+
+# Patch a dependency's internals at build time instead of vendoring or forking it
+
+## Context
+
+`parallel-consumer-streams` needs to change how Kafka Streams hands records to a processor chain, and
+everything load-bearing lives in `org.apache.kafka.streams.processor.internals` - package-private,
+explicitly not an API, and offering no seam to inject through. Reflection can read those fields but
+cannot restructure the dispatch loop, and a `KafkaClientSupplier` swap sits below the point where
+Streams serialises, so it gains nothing.
+
+Three routes were open, and two were rejected:
+
+- **Vendor the classes into the repository.** Rejected by the repo owner. Beyond taste, it drags in a
+  copyright-gate provenance class and a `NOTICE` change to make committed ASF source legal and
+  CI-clean, and a vendored copy drifts *silently* into a runtime `NoSuchMethodError` when the upstream
+  version moves.
+- **Fork and publish the library.** It works locally and is unresolvable on a CI runner, so the branch
+  could never go green. It also means owning a full release, test and signing cycle for someone else's
+  project on every upstream release.
+- **Unpack the published sources, apply a tracked patch at build time, and compile the result into
+  your own module.** This is what shipped.
+
+The third option is the reusable technique. What follows is the mechanism, and then the practices
+without which the mechanism is *silently* wrong.
+
+## Guidance
+
+### The mechanism
+
+Four build steps, all using plugins the build already had. Every one of them is in
+`parallel-consumer-streams/pom.xml`, which carries the reasoning at each step.
+
+1. **Unpack the named classes from the published sources jar, twice.**
+   `maven-dependency-plugin:unpack` at `generate-sources` (execution `unpack-kafka-streams-sources`),
+   with `<classifier>sources</classifier>` and `<includes>` limited to a named list. One copy is
+   *pristine* - the regeneration baseline - and one is the working copy that gets patched.
+2. **Apply the tracked patch, failing the build on any rejected hunk.** `exec-maven-plugin` running
+   `parallel-consumer-streams/bin/apply-patch.sh`, which dry-runs before applying, because a
+   half-applied patch produces a tree that compiles but is not the thing anyone reviewed.
+3. **Add the generated directory as a compile source root.** `build-helper-maven-plugin:add-source`
+   (execution `add-patched-kafka-sources`), so the patched sources compile into the module's own
+   `target/classes`.
+4. **Let classpath order do the rest.** `target/classes` precedes the dependency jar, so the patched
+   classes win while every sibling still loads from the jar. Same package name and same classloader
+   means package-private access into the jar's internals works without a fork.
+
+Only the `.patch` is tracked. No third-party source enters the repository, and the patch's line count
+is the honest answer to "how much had to change" - `bin/regen-patch.sh` prints it.
+
+### Wiring details that cost real time to find
+
+- **Bind the patch step to the phase *after* the unpack, not the same phase.** Within one phase Maven
+  orders executions by plugin declaration order in the *effective* pom. Here the root pom declares
+  `exec-maven-plugin` before `maven-dependency-plugin`, so a same-phase binding would run the patch
+  before the sources exist. Hence `unpack` at `generate-sources` and `apply-patch` at
+  `process-sources`.
+- **Choose the output directory deliberately.** `target/generated-sources` looked natural and was
+  wrong: the root pom adds that whole directory as an *integration-test* source root for every module,
+  which compiles the patched classes a second time into `target/test-classes` - and that precedes
+  `target/classes` on the surefire classpath. Two copies, and the winner is an accident. The module
+  uses `target/kafka-patched`, set by the `kafka.patched.dir` property.
+- **Name the class set; do not discover it.** The `patched.classes` property lists the files
+  explicitly, with a comment for each one the compiler would never have demanded - here
+  `RecordCollectorImpl`, which is constructed outside the class being changed yet has non-concurrent
+  maps written from other threads. A named set also gives you a stop-threshold: if the list has to grow
+  past roughly a dozen, the sprawl *is* the answer, and you are building a fork by instalments.
+- **Promote the dependency's runtime-scope dependencies to compile scope.** `jackson-databind` is
+  `runtime` in the `kafka-streams` pom, so the jar resolves it but the generated sources will not
+  *compile* without it. Declare it module-local and explicitly versioned, never in root
+  `dependencyManagement`, or you break unrelated modules - here pinning it globally breaks WireMock in
+  `parallel-consumer-vertx`.
+- **Expect the enforcer to notice what you just did to the dependency graph.** Promoting
+  `jackson-databind` to a *newer* version than the library resolves puts `jackson-annotations` on two
+  different versions, and `RequireUpperBoundDeps` fails the build - correctly. Declaring the second
+  artifact at the same version is the fix; it is not optional just because no code imports it.
+- **The library's test fixtures may need the same treatment.** Kafka's `InternalMockProcessorContext`
+  reads and writes the very fields the patch thread-confines, so it gets its own unpack, its own patch
+  and `add-test-source`. Without it, the upstream suite in practice 3 below cannot construct its
+  subject at all.
+
+### The practices that make it safe
+
+**1. Prove the shadowing before believing any downstream result.** This is the single most likely false
+positive available. If the jar's copy wins, every behavioural test still passes - it is simply testing
+the unmodified library against itself, beautifully.
+`parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java`
+asserts it directly rather than inferring it from behaviour: each generated class loads from a code
+source containing `/classes/` and not `.jar`; a deliberately un-generated sibling still loads from the
+jar, which is what makes this shadowing rather than a fork; and every generated class shares both a
+package name and a *classloader* with the jar-resident ones, because different classloaders split the
+package and break package-private access even when the names match.
+
+Pick that un-generated sibling for sharpness, not convenience: the best one is the class you are most
+likely to add to the set next, because then the assertion has to change, visibly, on the day the set
+does.
+
+**2. Start with an empty patch as the control arm.** Byte-for-byte the released sources, compiled
+through the same pipeline, must behave identically. Without that baseline, a later failure cannot be
+attributed between the technique and the change, and the whole verdict is worthless. `apply-patch.sh`
+treats an empty patch as an explicit, successful no-op - checking emptiness itself rather than trusting
+`patch`, whose behaviour on empty input differs between BSD `patch` on macOS and GNU `patch` on CI.
+Keep the control runnable after the patch is non-empty: `diff -ru` between the pristine and patched
+trees is the whole check.
+
+**3. Run the library's own test suite against your patched classes, with your change switched off.**
+That is the behaviour-preservation claim, and nothing else you can write is as strong. Kafka publishes
+its compiled tests to Central, so the module takes them as a `test`-classifier dependency and points
+surefire at them with `<dependenciesToScan>` on a *separate* execution (`kafka-upstream-tests`), so the
+module's own tests are unaffected. Details that matter:
+
+- include only the tests of classes you actually patch, plus their principal driver - scanning the
+  whole jar runs thousands of unrelated tests and drowns the signal;
+- set your feature flag off *explicitly* on that execution rather than inheriting whatever the default
+  happens to be, and write that pin even before the flag has a reader, because the claim is about the
+  patch and must never become a claim about a default;
+- override inherited tag filters, which would otherwise silently drop every one of them;
+- disable JUnit parallelism, because a suite written for a serial runner fails on shared fixtures and
+  tells you nothing about your patch. Parallelism can arrive by accident - a `junit-platform.properties`
+  inside a test-jar you depend on is enough;
+- give the execution its own `reportsDirectory`. The count is a citable claim, and reading it out of
+  the report files is what makes it re-derivable rather than remembered.
+
+The count is only meaningful with zero exclusions and zero relaxed assertions: the moment you exclude a
+test, the claim is void.
+
+**4. Design around the regeneration foot-gun, and make it detectable.** The unpack step runs with
+`overWriteReleases=true`, so *any* build invocation between editing the generated sources and
+re-deriving the patch silently restores the tree and discards the edits. It says nothing when it does
+this. `bin/regen-patch.sh` counts the hunks in the tracked patch *before* overwriting it and warns when
+the count drops, pointing at `git checkout` as the recovery path.
+
+The hunk count is a proxy, not the invariant, and it is wrong in both directions - adding lines can
+*merge* hunks and lower it legitimately. The real invariant is content: every line the old patch added
+must still be added, and the removed lines must be identical. Comparing those two sets between old and
+new patch is a few lines of script and gives an answer rather than a hint. It is also what makes it
+safe to *reduce* a patch deliberately: drop a file from `patched.classes`, delete it from both
+generated trees, regenerate, and then prove the surviving files' change sets are untouched.
+
+**5. Always `clean` before an experiment, and verify the instrumentation reached the run.**
+`maven-dependency-plugin:unpack` preserves the archive's file timestamps, so a re-unpacked source file
+goes *backwards in time* relative to the already-compiled class, and `maven-compiler-plugin` decides
+nothing needs recompiling. A control-arm run without `clean` therefore tests the previous build's
+classes while the developer believes the source is pristine, and will happily confirm a regression that
+does not exist. Confirm with `javap -p -classpath target/classes ...` before believing any result.
+
+**6. Handle the licence at distribution time, not at commit time.** Not committing the source removes
+the commit-time obligation, but publishing an artifact containing *compiled, modified* Apache 2.0
+classes triggers section 4(b): the distribution must carry prominent notices stating that you changed
+the files. This repo names the modified classes in `NOTICE`, attributes the ASF, states plainly that
+they were changed, and points at the patch as the complete expression of the change.
+
+**7. Name the split-package hazard as the limitation it is, and let it decide publication.** The
+artifact would contain classes in the third party's package namespace. Any consumer holding both it and
+the original gets behaviour decided by classpath order, which build tools do not guarantee; class
+loading is per class, so the result is always a mixture of two versions; and JPMS forbids split
+packages outright. The technique is sound inside your own module's build and is **not** a distribution
+mechanism. In this repo that is why `parallel-consumer-streams` sets `maven.deploy.skip`, `gpg.skip`
+and the publishing plugin's `skipPublishing` - merging a leaf module is cheap to reverse, publishing an
+artifact is not.
+
+## Why This Matters
+
+**The failure mode is silence, not error.** Every other approach here fails loudly. A missing reflective
+field throws. A fork that does not build does not build. Classpath shadowing that loses the race
+produces a green suite that measures the unmodified library, and there is nothing in the output to tell
+you. Practices 1, 2 and 5 exist solely because the technique gives you no natural signal when it is not
+working.
+
+**The patch is the measurement.** "How little did we have to change" becomes `wc -l` on a tracked file,
+reviewable in a normal diff, and re-derivable against a new upstream version. A vendored tree cannot
+answer that question at all: the change and the copy are the same artifact, and the reviewer has no way
+to see one without the other.
+
+**Drift fails at build time rather than at runtime.** When the upstream version moves,
+`apply-patch.sh` dry-runs, fails, and tells you the patch needs re-deriving. The equivalent vendored
+copy compiles fine and throws `NoSuchMethodError` in production. The maintenance obligation is
+identical in size and vastly better in timing.
+
+**It keeps the licensing surface small.** No third-party source in the repository means no
+copyright-gate machinery, no provenance headers, no review burden on files nobody here wrote. The only
+remaining obligation attaches to the published artifact, and one `NOTICE` paragraph discharges it.
+
+## When to Apply
+
+- **Apply when** the change is bounded to a handful of classes you can name up front, the library
+  publishes a sources jar for the exact version you depend on, and the artifact's consumers are you -
+  your own tests, your own module - rather than arbitrary downstream applications.
+- **Apply when** you need package-private or otherwise unreachable access and want the size of the
+  intrusion to stay visible and reviewable over time.
+- **Do not apply when** the patched class set keeps growing. Past roughly a dozen classes you are
+  maintaining a fork with extra steps, and the sprawl is itself the result worth reporting.
+- **Do not apply when** third parties must get the patched behaviour on their own classpath. Classpath
+  order is not a distribution contract. Publish a fork under a different coordinate, or upstream the
+  change.
+- **Do not apply when** the target is a moving trunk rather than a pinned release. These classes have
+  already diverged materially on Kafka 4.x, so a green result on 3.9 does not transfer unexamined.
+
+## Examples
+
+**The developer loop, and the order that matters:**
+
+```bash
+# 1. unpack pristine + patched trees, and apply the tracked patch.
+#    process-sources, NOT generate-sources - the latter only unpacks, so regenerating from that
+#    tree deletes every hunk. The leading `.` is required: the leaf module alone fails at enforcer.
+./mvnw -pl .,parallel-consumer-streams process-sources
+
+# 2. edit parallel-consumer-streams/target/kafka-patched/... like normal Java
+#    RUN NO MAVEN between here and step 3 - unpack silently reverts your edits
+
+# 3. re-derive the tracked patch from your edits (warns if the hunk count DROPPED)
+parallel-consumer-streams/bin/regen-patch.sh
+
+# 4. commit the patch. The generated trees are gitignored and never committed.
+```
+
+**The empty-patch control arm, encoded in the tooling rather than left to discipline:**
+
+```bash
+if ! grep -qE '^(---|\+\+\+|@@|diff )' "$patch_file"; then
+    echo "apply-patch: $patch_file contains no hunks - control arm, generated sources left as released"
+    exit 0
+fi
+```
+
+An empty patch is a *successful* build that produces byte-for-byte the released classes, so the harness
+can be falsified independently of anything you intend to change.
+
+## Related
+
+- `parallel-consumer-streams/README.md` - the user-facing statement of the same mechanism, its version
+  pinning obligation, and the classpath hazard that keeps the module unpublished
+- astubbs/parallel-consumer#255 - the tracking issue for Kafka Streams on Parallel Consumer
+- astubbs/parallel-consumer#271 - the feasibility study the machinery was built inside, where the
+  execution seam that motivates it still lives

--- a/parallel-consumer-streams/.gitignore
+++ b/parallel-consumer-streams/.gitignore
@@ -1,0 +1,4 @@
+# Generated at build time from the kafka-streams sources jar - never tracked.
+# The invariant, checkable at any time: `git ls-files | grep 'org/apache/kafka/.*\.java'` must return
+# nothing. No Apache Kafka source is committed to this repository; only src/main/patch/*.patch is.
+target/

--- a/parallel-consumer-streams/README.md
+++ b/parallel-consumer-streams/README.md
@@ -1,0 +1,191 @@
+# `parallel-consumer-streams` - patching Kafka Streams without vendoring or forking it
+
+> ## ALPHA. EXPERIMENTAL. NOT PUBLISHED.
+> This module is in the reactor so the machinery below can be built and reviewed. It is **not**
+> published to Maven Central, deliberately - see
+> [The classpath hazard this module does not solve](#the-classpath-hazard-this-module-does-not-solve).
+> Tracking issue: [astubbs#255](https://github.com/astubbs/parallel-consumer/issues/255).
+
+**What is here today is the build machinery and its oracle, and nothing else.** Apache Kafka Streams'
+`processor.internals` package is package-private, explicitly not an API, and has no seam at the point
+Parallel Consumer needs one. This module establishes a repeatable way to change those internals - one
+that keeps no Apache source in this repository, states the size of the change as a reviewable number,
+and fails at build time rather than at runtime when the change stops applying.
+
+**What is not here: the Parallel Consumer execution seam.** No record goes through Parallel Consumer
+in this module today. `StreamTask` is not patched, there is no dispatcher, and there is no switch. That
+work arrives in the PR stacked on this one, and it is what
+[astubbs#271](https://github.com/astubbs/parallel-consumer/pull/271) was cut from.
+
+---
+
+## The mechanism
+
+Four steps, all with plugins this build already had. The module's [`pom.xml`](pom.xml) carries the
+reasoning for each in place; this is the shape.
+
+1. **Unpack** the named classes from the published `kafka-streams` **sources** jar, twice - a
+   *pristine* copy that is the regeneration baseline, and a working copy. `maven-dependency-plugin`,
+   at `generate-sources`.
+2. **Apply** the tracked patch to the working copy, dry-running first so a rejected hunk fails the
+   build rather than leaving a half-applied tree that compiles.
+   [`bin/apply-patch.sh`](bin/apply-patch.sh), at `process-sources`.
+3. **Compile** the working copy into this module's own `target/classes`, by adding it as a source
+   root. `build-helper-maven-plugin`.
+4. **Let classpath order do the rest.** `target/classes` precedes the `kafka-streams` jar, so the
+   patched classes win while every one of their thousand siblings still loads from the jar. Same
+   package name and same classloader, so package-private access still works - without a fork.
+
+**No Apache Kafka source is committed to this repository.** Only
+[`src/main/patch/pc-streams.patch`](src/main/patch/pc-streams.patch) is tracked; the generated trees
+are gitignored. Kafka's own test *fixture* `InternalMockProcessorContext` gets the same treatment
+through a second, smaller patch, for the reason given below.
+
+### What the patch changes, and why exactly these classes
+
+| Class | Change | Why it is in the set |
+|---|---|---|
+| `AbstractProcessorContext` | the current record context and current processor node move from two `protected` fields to thread-confined ones | stock Streams holds one of these per task and gets away with it because exactly one thread is ever inside the task |
+| `ProcessorContextImpl` | reads and writes them through the accessors instead of the inherited fields | it is a subclass doing `getfield`/`putfield` on those fields, so leaving it alone defeats the confinement *with no compile error to say so* |
+| `RecordCollectorImpl` | two `HashMap`s become `ConcurrentHashMap`s | written from the producer's I/O thread for every in-flight send; the compiler would never have demanded this class, so it is named rather than discovered |
+
+That is the whole patch. The set is **named in the pom, not discovered**
+(`patched.classes`), and the stop-threshold is stated there: if it has to grow much past a dozen, the
+sprawl is itself the answer to "how little had to change", and this is a fork by instalments.
+
+Kafka's `InternalMockProcessorContext` needs the second patch because it *also* reads those fields
+directly. Un-patched, every `RecordCollectorTest` case dies at construction with a
+`NoSuchFieldError` - so without the fixture patch the oracle below cannot run at all.
+
+---
+
+## Why we believe the machinery works
+
+The technique's failure mode is **silence**, not error. If the jar's copy of a class wins the
+classpath race, every test still passes - it is simply testing unmodified Kafka Streams against
+itself, beautifully. So each claim here has a control.
+
+### The generated classes really do win
+
+[`ShadowedClassLoadingTest`](src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java)
+asserts it directly rather than inferring it from behaviour: each generated class loads from a code
+source under `/classes/` and not a `.jar`; `StreamTask` and `StreamThread`, which are deliberately
+*not* generated, still load from the jar - which is what makes this shadowing rather than a fork; and
+every generated class shares both a package name and a **classloader** with them, because different
+classloaders split the package and break package-private access while the names still match.
+
+`StreamTask` is the sharp one. It is the immediate neighbour of all three patched classes and the
+class the seam will patch next, so "it still comes from the jar" is the tightest available statement
+that the generated set is exactly what the pom declares.
+
+### An empty patch is a no-op, and that is checked by the tooling
+
+`apply-patch.sh` treats a patch with no hunks as an explicit, successful no-op - checking emptiness
+itself rather than trusting `patch`, whose behaviour on empty input differs between BSD `patch` on
+macOS and GNU `patch` on CI. Run the build that way and the generated tree is byte-for-byte the
+released sources. Without that baseline, a later behavioural difference could not be attributed
+between the technique and the change.
+
+### Apache Kafka's own test suite, run against the patched classes
+
+Kafka publishes its **compiled** tests to Maven Central. This module takes them as a `test`-classifier
+dependency and points a dedicated surefire execution at them, so Kafka's own
+`StreamTaskTest`, `RecordCollectorTest` and `ProcessorContextImplTest` exercise **our**
+`AbstractProcessorContext`, **our** `ProcessorContextImpl` and **our** `RecordCollectorImpl`. Nothing
+is excluded, rewritten, recompiled or relaxed. It runs in the module's normal `test` phase, on every
+build, with no profile and no flag.
+
+That is the behaviour-preservation claim, and it is the strongest one available: **anything the patch
+broke that Kafka tested, fails here.**
+
+> **Re-derive the counts; never copy them.** They move with the patch, with `kafka.version`, and they
+> will move again when the seam arrives. Run the module's whole `test` phase and read the per-class
+> numbers out of `target/surefire-reports-kafka-upstream/`.
+>
+> **Do not scope the run with `-Dtest=`.** It silently overrides that execution's `<includes>`, so
+> Kafka's suite does not run at all - and the build still goes green, with the number you were
+> checking never computed. It has cost several people a whole run.
+
+---
+
+## The classpath hazard this module does not solve
+
+**This module is not published, and that is the reason.**
+
+It compiles a handful of classes into Apache Kafka's *own* package namespace and depends on
+`kafka-streams` for the rest. Inside this module's build that is controlled and asserted. As a
+published dependency it is not defensible, in three distinct ways:
+
+1. **Classpath order is a convention, not a guarantee.** Maven, Gradle, IDEs, shaded uber-jars and
+   Spring Boot's loader may order entries differently. When ours lose, you silently get stock Kafka
+   Streams with no error - the worst shape a failure can take.
+2. **Class loading is per class, so the result is always a mixture.** That works only while both
+   halves are the same version, and nothing checks that they are. A routine `kafka-streams` bump
+   would run our patched internals against their newer ones.
+3. **It is illegal on the module path.** JPMS forbids split packages outright.
+
+Merging an isolated leaf module is cheap to reverse; publishing an artifact is not - **merge freely,
+publish deliberately**. The pom carries the deploy, signing and publishing skips, and says so at the
+point of the skip.
+
+`NOTICE` already carries the Apache 2.0 section 4(b) statement naming the modified classes, so the
+obligation is discharged for whatever is eventually distributed rather than deferred to the day it is.
+
+---
+
+## Working on the patch
+
+**Never hand-edit `pc-streams.patch`.** Its `@@` headers encode line counts; edit the generated Java
+and re-derive.
+
+```bash
+# 1. unpack the pristine tree AND produce the patched one. process-sources, NOT generate-sources -
+#    generate-sources only unpacks, and regenerating from that tree deletes every hunk.
+./mvnw -pl .,parallel-consumer-streams process-sources
+
+# 2. edit parallel-consumer-streams/target/kafka-patched/... like normal Java.
+#    RUN NO MAVEN between here and step 3 - unpack silently reverts your edits and says nothing.
+
+# 3. re-derive the tracked patch
+parallel-consumer-streams/bin/regen-patch.sh
+
+# 4. commit the patch. The generated trees are gitignored and never committed.
+```
+
+The `.` in `-pl .,parallel-consumer-streams` is required: selecting the leaf module alone fails at
+`enforcer:enforce`, because the parent is not in the reactor.
+
+[`bin/regen-patch.sh`](bin/regen-patch.sh) warns when the hunk count drops, which is the tripwire for
+edits lost to a stray maven run. Its header owns the rest, including why the hunk count is a proxy
+rather than an invariant, and how to reconcile two branches that both regenerate the patch (merge the
+generated Java, never the patch).
+
+The fixture patch is re-derived the same way, with all three arguments:
+
+```bash
+parallel-consumer-streams/bin/regen-patch.sh kafka-test-pristine kafka-test-patched src/main/patch/pc-streams-testfixtures.patch
+```
+
+### On a Kafka version bump
+
+The patch is derived against exactly the sources of the reactor's `${kafka.version}`, and
+`org.apache.kafka.streams.processor.internals` is package-private, unsupported, and free to change
+shape in any patch release. When it stops applying, the build fails **loudly** at `apply-patch.sh`,
+which is a real improvement on a vendored copy: that would compile fine and throw `NoSuchMethodError`
+in production. It remains a recurring maintenance obligation, with the upstream suite above as the
+regression run behind each one.
+
+On Kafka trunk and 4.x these classes have already diverged materially - `ProcessorContextImpl` is
+`final` there, and the record context is mutated in place. A green result on 3.9 does **not** transfer
+unexamined.
+
+---
+
+## Further reading
+
+- [Patch a dependency's internals at build time instead of vendoring or forking it](../docs/solutions/architecture-patterns/patch-a-dependency-at-build-time-without-vendoring-it.md) -
+  the technique in general, its practices, and when not to apply it
+- [astubbs#255](https://github.com/astubbs/parallel-consumer/issues/255) - the tracking issue for
+  Kafka Streams on Parallel Consumer
+- [astubbs#271](https://github.com/astubbs/parallel-consumer/pull/271) - the feasibility study this
+  machinery was cut from, where the execution seam and its measurements still live

--- a/parallel-consumer-streams/bin/apply-patch.sh
+++ b/parallel-consumer-streams/bin/apply-patch.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Applies the tracked patch to the Kafka sources unpacked into the module's generated tree.
+#
+# Called from the pom at process-sources - NOT generate-sources, which is where the unpack runs. The
+# split is deliberate: binding both to one phase would order them by plugin declaration order in the
+# effective pom, and the root pom declares exec before dependency, so the patch would run before the
+# sources it patches exist. Two properties matter:
+#   $1  the directory holding the freshly unpacked (pristine) Kafka sources
+#   $2  the patch file to apply
+#
+# An EMPTY patch file is an explicit, successful no-op - that is the harness's control arm, where the generated
+# classes must be byte-for-byte the released sources so any behaviour difference is the harness's fault
+# and nothing else's. We check emptiness ourselves rather than relying on `patch`, whose behaviour on
+# empty input differs between the BSD patch on macOS and GNU patch on CI.
+#
+# We dry-run before applying because a half-applied patch is the worst failure available here: it
+# produces a tree that compiles but is not the thing anyone reviewed.
+
+set -euo pipefail
+
+target_dir="${1:?usage: apply-patch.sh <target-dir> <patch-file>}"
+patch_file="${2:?usage: apply-patch.sh <target-dir> <patch-file>}"
+
+if [[ ! -d "$target_dir" ]]; then
+    echo "apply-patch: target directory does not exist: $target_dir" >&2
+    exit 1
+fi
+
+if [[ ! -f "$patch_file" ]]; then
+    echo "apply-patch: no patch file at $patch_file - nothing to apply"
+    exit 0
+fi
+
+# Strip comments and blank lines to decide emptiness, so a patch file that only carries an explanatory
+# header still counts as "no change".
+if ! grep -qE '^(---|\+\+\+|@@|diff )' "$patch_file"; then
+    echo "apply-patch: $patch_file contains no hunks - control arm, generated sources left as released"
+    exit 0
+fi
+
+cd "$target_dir"
+
+if ! patch -p1 --dry-run --forward <"$patch_file" >/dev/null 2>&1; then
+    echo "apply-patch: FAILED - $patch_file does not apply cleanly to the unpacked sources." >&2
+    echo "apply-patch: this usually means kafka.version moved and the patch needs re-deriving." >&2
+    echo "apply-patch: re-run with the diagnostics below, then use bin/regen-patch.sh." >&2
+    patch -p1 --dry-run --forward <"$patch_file" >&2 || true
+    exit 1
+fi
+
+patch -p1 --forward <"$patch_file"
+echo "apply-patch: applied $(grep -c '^@@' "$patch_file") hunk(s) from $patch_file"

--- a/parallel-consumer-streams/bin/regen-patch.sh
+++ b/parallel-consumer-streams/bin/regen-patch.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Re-derives src/main/patch/pc-streams.patch from your edits to the generated sources.
+#
+# The workflow this exists to make bearable:
+#
+#   1. ./mvnw -pl .,parallel-consumer-streams process-sources
+#        -> unpacks pristine Kafka sources into target/kafka-pristine   (generate-sources)
+#        -> unpacks + patches a working copy into target/kafka-patched  (process-sources)
+#   2. edit the files under target/kafka-patched/ like normal Java
+#
+#   PHASE MATTERS, AND THIS COMMENT USED TO GET IT WRONG. It said `generate-sources`, which only
+#   UNPACKS - the patch is applied at process-sources, deliberately, so it is ordered after the unpack
+#   by lifecycle phase rather than by plugin declaration order (see the pom's note). Stop at
+#   generate-sources and target/kafka-patched is pristine: your edits then land on unpatched sources,
+#   and regenerating from that tree DELETES every existing hunk. Two agents followed this comment and
+#   hit exactly that. The hunk-count tripwire below is what catches it.
+#
+#   The `.` in `-pl .,parallel-consumer-streams` is also required: selecting the leaf module alone
+#   fails at enforcer:enforce (ReactorModuleConvergence) because the parent is not in the reactor.
+#   3. bin/regen-patch.sh
+#        -> diffs pristine against your edits and rewrites the tracked patch
+#   4. commit the patch. The generated trees are gitignored and never committed.
+#
+# Editing generated files feels wrong, and it is the honest cost of not committing Apache Kafka source
+# into this repository - see README.md, "The mechanism". This script is what keeps that cost small.
+#
+# PARALLEL BRANCHES ARE FINE. RECONCILE AT THE SOURCE, NOT AT THE PATCH.
+# Two branches regenerating this file will conflict, and the conflicts look terrible: they land on `@@`
+# hunk headers, which are arithmetic rather than text. Do NOT conclude from that appearance that the
+# work must be serialised. Measured on astubbs#255, two feature branches run concurrently plus
+# reconciliation beat running them in sequence, and the reconciliation was mechanical.
+#
+# The trick is to never merge the patch. Merge the GENERATED JAVA and re-derive:
+#
+#   1. resolve the ordinary source files (pom `patched.classes` to the UNION first, so the unpack
+#      covers every file either side patches)
+#   2. `./mvnw -pl .,parallel-consumer-streams process-sources` for a pristine tree and a patched one
+#   3. reconstruct each side's tree by applying its patch to a fresh copy of pristine, then
+#      `git merge-file --diff3` the Java. Files only one side touches are taken wholesale.
+#   4. copy the merged tree over target/kafka-patched and run this script - NO maven in between
+#   5. check the hunk count is the per-file union of the inputs, not less
+#
+# Where the patch showed 8 conflict blocks of offset arithmetic, the same change merged as Java had
+# ZERO conflicts - the two edits were simply in different methods. The conflict was an artifact of the
+# representation, and merging the representation git is good at makes it vanish.
+#
+# And a conflict here is worth having. When the two astubbs#255 branches met, the merge exposed a test
+# asserting that `StreamThread` loads from the kafka-streams jar - true until the other branch started
+# patching `StreamThread`. Serialising would have hidden that: the second branch would have been
+# written against the new reality and nobody would have learned the assertion was fragile.
+#
+# THE HUNK COUNT IS A PROXY, NOT THE INVARIANT - A DROP IS NOT PROOF OF LOSS.
+# The comparison printed at the end of this script is a cheap tripwire, and it has a known false
+# positive: adding lines can MERGE hunks. Insert a few lines into each of three edits that sit close
+# together and they fall inside diff's 3-line context window and become one hunk, so the count falls
+# while nothing whatsoever was lost. Seen for real on astubbs#255 - adding javadoc to three compact
+# `windowedBy` blocks took KGroupedStream from 4 hunks to 2, and the count went 112 -> 110.
+#
+# So when the count drops, INVESTIGATE, do not assume either way. The actual invariant is about
+# content, not structure: every line the old patch ADDED must still be added by the new one, and the
+# removed lines must be identical. Compare those two sets (the `^+` and `^-` bodies, ignoring the
+# `+++`/`---` headers) between the old and new patch and you have an answer rather than a hint.
+# A rise is equally weak evidence in the other direction.
+#
+# !! FOOT-GUN, READ THIS !!
+# The unpack step runs with overWriteReleases=true, so ANY maven invocation between step 2 and step 3
+# silently restores target/kafka-patched to (released sources + the *tracked* patch) and discards
+# whatever you had just edited. It says nothing when it does this. It cost a full editing pass to learn.
+# Rule of thumb: after you start editing, run regen-patch.sh BEFORE you run maven again. The hunk-count
+# comparison at the end of this script is the tripwire - if it says the count went DOWN, you lost work.
+#
+# The patch is the deliverable: its line count is the answer to "how little had to change".
+#
+# There is a second tree, generated at generate-test-sources in every build: Kafka's own test fixtures,
+# which need the same accessor conversion for the same reason. Re-derive that one with:
+#
+#   bin/regen-patch.sh kafka-test-pristine kafka-test-patched src/main/patch/pc-streams-testfixtures.patch
+#
+# The three arguments are all-or-nothing; with none, the main tree above is assumed.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+module_dir="$(dirname "$here")"
+
+pristine_name="${1:-kafka-pristine}"
+patched_name="${2:-kafka-patched}"
+patch_rel="${3:-src/main/patch/pc-streams.patch}"
+
+pristine="$module_dir/target/$pristine_name"
+patched="$module_dir/target/$patched_name"
+patch_file="$module_dir/$patch_rel"
+
+for d in "$pristine" "$patched"; do
+    if [[ ! -d "$d" ]]; then
+        echo "regen-patch: missing $d" >&2
+        # Both the phase and the `.` matter - see the header. generate-sources only UNPACKS, so
+        # regenerating from that tree deletes every hunk, and the leaf module alone fails enforcer.
+        echo "regen-patch: run './mvnw -pl .,parallel-consumer-streams process-sources' first" >&2
+        exit 1
+    fi
+done
+
+# diff exits 1 when files differ, which is the normal case here - so don't let set -e kill us.
+set +e
+(cd "$module_dir/target" && diff -ruN "$pristine_name" "$patched_name") >"$patch_file.tmp"
+diff_status=$?
+set -e
+
+if [[ $diff_status -gt 1 ]]; then
+    echo "regen-patch: diff failed with status $diff_status" >&2
+    rm -f "$patch_file.tmp"
+    exit 1
+fi
+
+# Count what is already tracked BEFORE overwriting, so the foot-gun above is detectable rather than
+# silent: if a stray maven run reverted the working tree, the regenerated patch is smaller than the one
+# on disk and we are about to commit a loss.
+hunks_before=$(grep -c '^@@' "$patch_file" 2>/dev/null || true)
+
+# diff -ruN prefixes paths with the two directory names; strip them so the patch applies with -p1 from
+# inside the generated directory, which is what apply-patch.sh does.
+sed -e "s|^--- $pristine_name/|--- a/|" \
+    -e "s|^+++ $patched_name/|+++ b/|" \
+    "$patch_file.tmp" >"$patch_file"
+rm -f "$patch_file.tmp"
+
+hunks=$(grep -c '^@@' "$patch_file" || true)
+
+if [[ "${hunks_before:-0}" -gt "$hunks" ]]; then
+    echo "regen-patch: WARNING - hunk count went DOWN, $hunks_before -> $hunks." >&2
+    echo "regen-patch: you have probably lost edits. The usual cause is a maven run between editing" >&2
+    echo "regen-patch: target/kafka-patched/ and running this script - unpack overwrites without asking." >&2
+    echo "regen-patch: the previous patch is recoverable with 'git checkout -- $patch_file'." >&2
+fi
+files=$(grep -c '^--- ' "$patch_file" || true)
+lines=$(wc -l <"$patch_file" | tr -d ' ')
+
+if [[ "$hunks" -eq 0 ]]; then
+    echo "regen-patch: no differences - patch is empty (control arm)"
+else
+    echo "regen-patch: wrote $patch_file"
+    echo "regen-patch: $files file(s), $hunks hunk(s), $lines lines"
+    echo "regen-patch: that line count is the change-set size - quote it wherever the size is claimed"
+fi

--- a/parallel-consumer-streams/pom.xml
+++ b/parallel-consumer-streams/pom.xml
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2026 Antony Stubbs and contributors
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>bz.stub.parallelconsumer</groupId>
+        <artifactId>parallel-consumer-parent</artifactId>
+        <version>0.6.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>parallel-consumer-streams</artifactId>
+    <name>Kafka Parallel Consumer - Kafka Streams (ALPHA - EXPERIMENTAL, NOT PUBLISHED)</name>
+    <description>
+        ALPHA / EXPERIMENTAL - NOT PRODUCTION READY, AND NOT PUBLISHED.
+
+        Build machinery for patching Apache Kafka Streams internals without vendoring or forking them:
+        the named classes are unpacked from the published kafka-streams sources jar, a tracked patch is
+        applied, and the result is compiled into this module's own target/classes, which precedes the
+        kafka-streams jar on the classpath. Apache Kafka's own compiled test suite is then run against
+        the patched classes as the behaviour-preservation oracle.
+
+        NO PARALLEL CONSUMER EXECUTION SEAM LIVES HERE YET. The patch carried by this module is limited
+        to the concurrency-safety groundwork inside Kafka's processor context and record collector -
+        changes that Kafka's own suite proves behaviour-preserving. StreamTask's dispatch seam, and the
+        PC dispatcher it calls into, arrive in the PR stacked on this one (issue astubbs#255).
+
+        NO APACHE KAFKA SOURCE IS COMMITTED TO THIS REPOSITORY. The patched Kafka classes are generated
+        at build time; only src/main/patch/*.patch is tracked. README.md owns the mechanism and the
+        developer loop, and docs/solutions/architecture-patterns/patch-a-dependency-at-build-time-without-vendoring-it.md
+        owns the technique in general.
+    </description>
+
+    <properties>
+        <!-- PUBLICATION IS OFF FOR THIS MODULE, DELIBERATELY - "merge freely, publish deliberately".
+             Merging an isolated leaf module is cheap to reverse; publishing an artifact that carries
+             compiled, modified Apache Kafka classes in Apache's own package namespace is not. The
+             split-package hazard that makes publication a decision rather than a formality is stated in
+             README.md, "The classpath hazard this module does not solve".
+
+             maven.install.skip is deliberately NOT set: a local `./mvnw install` still puts the jar in
+             the local repository, which is how anyone experiments with it. It is the remote publication
+             that is off. Ordering matters as well as the flags - see the <module> comment in the root
+             pom for the central-publishing-maven-plugin bug this module must not be positioned into. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <gpg.skip>true</gpg.skip>
+
+        <!-- Where the unpacked-then-patched Kafka sources land. Generated, gitignored, never tracked.
+
+             Deliberately NOT under target/generated-sources: the root pom adds that whole directory as an
+             *integration-test* source root for every module (see its build-helper add-integration-test-source
+             execution). Generating there compiles these classes a second time into target/test-classes,
+             which then precedes target/classes on the surefire classpath - two copies of the same patched
+             Kafka classes, and the one that wins is an accident of classpath order rather than a decision. -->
+        <kafka.patched.dir>${project.build.directory}/kafka-patched</kafka.patched.dir>
+        <kafka.pristine.dir>${project.build.directory}/kafka-pristine</kafka.pristine.dir>
+
+        <!-- The classes this module patches. Named deliberately, not discovered.
+
+             AbstractProcessorContext holds the current record and the current processor node in two
+             `protected` fields that stock Streams gets away with because exactly one thread is ever inside
+             a task. Thread-confining them is the groundwork every concurrent execution seam needs, and it
+             cannot be done in isolation: ProcessorContextImpl reads and writes those inherited fields
+             directly, so it has to move to the accessors in the same change or the confinement is bypassed
+             by getfield/putfield without a single compile error to say so.
+
+             RecordCollectorImpl is here for a different reason and is the one the compiler would never have
+             demanded: it is constructed outside StreamTask, and its non-concurrent maps are written from
+             the producer's I/O thread for every in-flight send.
+
+             If this list has to grow much past a dozen, that sprawl is itself the answer to "how little had
+             to change" - see the "Do not apply when" section of the technique write-up. -->
+        <patched.classes>org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java,org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java,org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java</patched.classes>
+
+        <!-- Module-local and explicitly versioned on purpose: pinning jackson-databind in root
+             dependencyManagement forces WireMock (parallel-consumer-vertx) onto an incompatible Jackson and
+             breaks VertxTest.
+
+             Deliberately AHEAD of the 2.16.2 that kafka-streams 3.9.2 resolves, rather than matching it.
+             2.16.2 carries two high-severity PolymorphicTypeValidator bypasses (GHSA-j3rv-43j4-c7qm,
+             GHSA-rmj7-2vxq-3g9f), both first patched at 2.18.8, and this declaration is compile scope, so
+             the version chosen here is the one that would reach anyone depending on this module. Neither
+             advisory is reachable from the generated sources - Kafka's use here is metadata
+             serialisation, not polymorphic deserialisation of untrusted input - but carrying a flagged
+             version to save a patch bump is not a trade worth making. Held on the 2.18 line to stay close
+             to what the jar was built against. -->
+        <kafka.streams.jackson.version>2.18.9</kafka.streams.jackson.version>
+
+        <!-- Only used by Kafka's own test suite (see the build section). Matched to what Kafka 3.9 builds
+             its own tests against, so their assertions mean what their authors meant. -->
+        <hamcrest.version>2.2</hamcrest.version>
+        <reload4j.version>1.2.25</reload4j.version>
+
+        <!-- Kafka's own test FIXTURES need the same treatment as its main classes, for the same reason.
+             InternalMockProcessorContext extends AbstractProcessorContext and, as shipped, reads and
+             writes the `recordContext` / `currentNode` fields directly. Thread-confining those fields
+             turns every one of those getfield/putfield instructions into a NoSuchFieldError at
+             construction time, so every RecordCollectorTest case dies before reaching a single assertion.
+             Regenerating the fixture from the published test-sources jar and converting it to the
+             accessors - exactly what the main patch does to ProcessorContextImpl - is what lets those
+             tests run at all. Still no Apache source in the repository: generated, gitignored, only the
+             patch is tracked. -->
+        <kafka.test.patched.dir>${project.build.directory}/kafka-test-patched</kafka.test.patched.dir>
+        <kafka.test.pristine.dir>${project.build.directory}/kafka-test-pristine</kafka.test.pristine.dir>
+        <patched.test.classes>org/apache/kafka/test/InternalMockProcessorContext.java</patched.test.classes>
+    </properties>
+
+    <dependencies>
+        <!-- No parallel-consumer-core dependency at compile scope, deliberately: nothing in this module's
+             main output is Parallel Consumer code. It arrives with the execution seam that needs it. The
+             test-scoped core test-jar below is only for the shared ArchUnit convention rules. -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+
+        <!-- jackson-databind is runtime-scope in the kafka-streams POM, so the generated sources will
+             not compile without it promoted to compile scope here. (slf4j-api has the same problem but
+             needs no declaration - the root pom's <dependencies> already gives it to every module.) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${kafka.streams.jackson.version}</version>
+        </dependency>
+        <!-- Not optional despite nothing here importing it directly. kafka-streams pulls
+             jackson-annotations 2.16.2 transitively while the databind above pulls 2.18.9, and the root
+             pom's enforcer RequireUpperBoundDeps rule fails the build on that pairing - correctly, since
+             the resolved 2.16.2 would be older than what databind was built against. Declaring it here at
+             the same version is the fix that keeps both halves of Jackson on one line. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${kafka.streams.jackson.version}</version>
+        </dependency>
+
+        <!-- Tests -->
+
+        <!-- The shared TestConventionRules that TestConventionsArchTest points ArchUnit at. -->
+        <dependency>
+            <groupId>bz.stub.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-core</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <!-- Core's MAIN classes, test scope only, because the test-jar above needs them at runtime and a
+             test-scoped dependency's own dependencies do not come with it. The core tests jar registers
+             MyRunListener as a JUnit TestExecutionListener through ServiceLoader, and that listener reaches
+             into core's StringUtils - so without this every single test EVENT logs a
+             NoClassDefFoundError warning and a full stack trace. Nothing fails, which is the point: the
+             build stays green and the log becomes unreadable. -->
+        <dependency>
+            <groupId>bz.stub.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Apache Kafka's OWN test suite, and the fixtures it is built on. These are what make the
+             upstream execution below possible; see the comment on that surefire execution. -->
+
+        <!-- Kafka's compiled tests, plus the org.apache.kafka.test.* fixtures they are built on
+             (InternalMockProcessorContext, MockSourceNode, MockClientSupplier, ...). Preferred over
+             recompiling test-sources: no Apache source enters the build, and no Java 8 problem. -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <!-- org.apache.kafka.test.TestUtils, org.apache.kafka.common.utils.MockTime and
+             LogCaptureAppender live here, not in the streams test jar. -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <!-- LogCaptureAppender is a log4j 1.x Appender; RecordCollectorTest imports
+             org.apache.log4j.Level directly. reload4j is the maintained drop-in for that API. -->
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Having the log4j 1.x API on the classpath is not enough: LogCaptureAppender only sees a
+             message if SLF4J actually routes to log4j. Under logback it captures nothing and
+             RecordCollectorTest's one log-assertion test fails on an empty list. This binding is
+             swapped in for the Kafka execution only - see classpathDependencyExcludes below. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- 1. Unpack the target classes from the published sources jar, twice: a pristine copy
+                    (used by bin/regen-patch.sh to re-derive the patch) and the working copy that gets
+                    patched. Always overwrite, so every build starts from released source and the patch
+                    applies to a clean tree rather than to itself.
+
+                    The second execution does the same for Kafka's own test FIXTURE - see the
+                    kafka.test.patched.dir property for why the fixture needs patching too. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-kafka-streams-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.kafka</groupId>
+                                    <artifactId>kafka-streams</artifactId>
+                                    <version>${kafka.version}</version>
+                                    <classifier>sources</classifier>
+                                    <type>jar</type>
+                                    <includes>${patched.classes}</includes>
+                                    <outputDirectory>${kafka.patched.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.kafka</groupId>
+                                    <artifactId>kafka-streams</artifactId>
+                                    <version>${kafka.version}</version>
+                                    <classifier>sources</classifier>
+                                    <type>jar</type>
+                                    <includes>${patched.classes}</includes>
+                                    <outputDirectory>${kafka.pristine.dir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-kafka-streams-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.kafka</groupId>
+                                    <artifactId>kafka-streams</artifactId>
+                                    <version>${kafka.version}</version>
+                                    <classifier>test-sources</classifier>
+                                    <type>jar</type>
+                                    <includes>${patched.test.classes}</includes>
+                                    <outputDirectory>${kafka.test.patched.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.kafka</groupId>
+                                    <artifactId>kafka-streams</artifactId>
+                                    <version>${kafka.version}</version>
+                                    <classifier>test-sources</classifier>
+                                    <type>jar</type>
+                                    <includes>${patched.test.classes}</includes>
+                                    <outputDirectory>${kafka.test.pristine.dir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- 2. Apply the tracked patches. The script dry-runs first and fails the build on any
+                    rejected hunk - a half-applied patch is the worst failure available here. An empty
+                    patch is an explicit no-op, which is the control arm that falsifies the harness
+                    independently of anything the patch intends to change.
+
+                    Bound to process-sources / process-test-sources, NOT the matching generate-* phase, so
+                    each is ordered AFTER the unpack above by lifecycle phase. Within a single phase Maven
+                    orders executions by plugin declaration order in the EFFECTIVE pom - and the root pom
+                    declares exec-maven-plugin before maven-dependency-plugin, so a same-phase binding runs
+                    the patch before the sources it patches exist. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>apply-kafka-patch</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${project.basedir}/bin/apply-patch.sh</executable>
+                            <arguments>
+                                <argument>${kafka.patched.dir}</argument>
+                                <argument>${project.basedir}/src/main/patch/pc-streams.patch</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>apply-kafka-test-patch</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${project.basedir}/bin/apply-patch.sh</executable>
+                            <arguments>
+                                <argument>${kafka.test.patched.dir}</argument>
+                                <argument>${project.basedir}/src/main/patch/pc-streams-testfixtures.patch</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- 3. Compile the patched sources into target/classes, which precedes the kafka-streams
+                    jar on the classpath - so these win and their siblings still load from the jar.
+                    The patched fixture goes in as a TEST source root, so it lands in target/test-classes,
+                    which precedes the kafka-streams TEST jar for exactly the same reason. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-patched-kafka-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${kafka.patched.dir}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-patched-kafka-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${kafka.test.patched.dir}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- 4. THE ORACLE. Apache Kafka's OWN test suite, run against our patched classes, in the
+                    module's NORMAL test run - no profile, no flag, every build.
+
+                    This is the strongest behaviour-preservation gate available: Kafka publishes its
+                    compiled tests to Central, our patched classes precede the kafka-streams jar on the
+                    classpath (proven directly by ShadowedClassLoadingTest), so Kafka's own
+                    ProcessorContextImplTest and RecordCollectorTest exercise OUR AbstractProcessorContext,
+                    OUR ProcessorContextImpl and OUR RecordCollectorImpl - not the released ones. Anything
+                    the patch broke that Kafka tested fails here.
+
+                    StreamTaskTest is included although StreamTask itself is NOT in patched.classes: it is
+                    the richest exercise of the patched context and collector there is, driving both
+                    through a real task rather than a fixture. It is also where the seam lands next, so
+                    keeping it in the include list now means the seam's arrival changes a number rather
+                    than introducing a suite.
+
+                    THE COUNTS ARE A CITABLE CLAIM AND MUST BE RE-DERIVED, NEVER COPIED. They move with
+                    the patch, with the Kafka version and with the seam. Read them out of
+                    target/surefire-reports-kafka-upstream/ after running the module's whole `test` phase.
+                    Do NOT scope the run with -Dtest=: it silently overrides the <includes> below, this
+                    suite does not run at all, and the build still goes green having computed nothing.
+
+                    Surefire only scans target/test-classes by default, so <dependenciesToScan> is what
+                    makes it look inside the kafka-streams test jar at all. It sits on this extra
+                    execution and NOT on the plugin, so the default-test execution (our own tests) is
+                    unaffected. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- Exactly one SLF4J binding per fork. Our own tests keep logback (and
+                     logback-test.xml); Kafka's fork gets reload4j so LogCaptureAppender works.
+                     Both bindings are on the module's test classpath - surefire is what keeps
+                     them apart, per execution. -->
+                <configuration>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.slf4j:slf4j-reload4j</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>kafka-upstream-tests</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <dependenciesToScan>
+                                <dependency>org.apache.kafka:kafka-streams</dependency>
+                            </dependenciesToScan>
+                            <!-- Only the tests of the classes we patch, plus the task that drives them.
+                                 Scanning the whole jar would run ~2500 tests of code this module never
+                                 touches, and drown the signal. -->
+                            <includes>
+                                <include>org/apache/kafka/streams/processor/internals/StreamTaskTest.java</include>
+                                <include>org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java</include>
+                                <include>org/apache/kafka/streams/processor/internals/RecordCollectorTest.java</include>
+                            </includes>
+                            <reportsDirectory>${project.build.directory}/surefire-reports-kafka-upstream</reportsDirectory>
+                            <!-- The oracle's independence from the seam, pinned here rather than
+                                 inherited. Nothing in this module reads this property yet - the PC
+                                 dispatch seam and its switch arrive in the PR stacked on this one, and a
+                                 switch with nothing to switch would be dead code. What must never happen
+                                 is for this execution to acquire its seam state from whatever default the
+                                 seam later picks: the behaviour-preservation claim only means anything
+                                 with the seam OFF, and it is a claim about the patch, not about a
+                                 default. So the pin is written now, ahead of its reader. -->
+                            <systemPropertyVariables>
+                                <pc.streams.dispatch.enabled>false</pc.streams.dispatch.enabled>
+                            </systemPropertyVariables>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>ch.qos.logback:logback-classic</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <!-- Kafka's tests are written for a serial JUnit runner: StreamTaskTest
+                                 pins a fixed state-directory name and MockProducer/MockConsumer are
+                                 shared per instance, so running them concurrently fails most of them
+                                 on state-dir locks alone and says nothing about our patch.
+                                 Concurrency arrives on this module by accident anyway - the
+                                 parallel-consumer-core tests jar ships a junit-platform.properties
+                                 with parallel.enabled=true, and it lands on our test classpath.
+                                 Surefire's configurationParameters outrank that file. -->
+                            <properties>
+                                <configurationParameters>
+                                    junit.jupiter.execution.parallel.enabled = false
+                                </configurationParameters>
+                            </properties>
+                            <!-- Kafka's tests are not written for our tag scheme; the inherited
+                                 group filters would silently drop all of them. -->
+                            <groups combine.self="override"/>
+                            <excludedGroups combine.self="override"/>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- The generated Apache Kafka classes are not ours to hold to this project's static-analysis
+                 rules. `target/classes` here holds nothing else, so this exclusion is the whole module -
+                 and it says something true rather than hiding something of ours: the root pom's
+                 jdk-unsafe signatures fire on locale-dependent String.format calls that are in Kafka's
+                 RELEASED source, at sites the patch does not touch. Fixing them would mean patching
+                 Apache code for a rule Apache never adopted, growing the change-set that this module's
+                 whole design exists to keep small and re-derivable.
+
+                 Anything of ours that lands in this module later - the execution seam and its
+                 dispatcher - will sit under bz.stub and will NOT be excluded by this pattern, so it
+                 gets the same analysis as every other module. The same scoping decision, for the same
+                 reason, is already made for ArchUnit in TestConventionsArchTest. -->
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>org/apache/kafka/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Publication off, the plugin's own switch. The properties above stop deploy and signing;
+                 this stops the Central bundle from carrying the module. See the properties block for why
+                 publication is a deliberate decision rather than a default. -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/parallel-consumer-streams/src/main/patch/pc-streams-testfixtures.patch
+++ b/parallel-consumer-streams/src/main/patch/pc-streams-testfixtures.patch
@@ -1,0 +1,167 @@
+diff -ruN kafka-test-pristine/org/apache/kafka/test/InternalMockProcessorContext.java kafka-test-patched/org/apache/kafka/test/InternalMockProcessorContext.java
+--- a/org/apache/kafka/test/InternalMockProcessorContext.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/test/InternalMockProcessorContext.java	2026-08-08 03:17:20.356524003 +1200
+@@ -239,13 +239,18 @@
+                 appConfigs(),
+                 IQ_CONSISTENCY_OFFSET_VECTOR_ENABLED,
+                 false);
+-        this.recordContext = new ProcessorRecordContext(
++        // PC dispatch (astubbs#255): converted to the AbstractProcessorContext accessors. This fixture is a
++        // subclass, so as shipped it reads/writes the inherited `recordContext` / `currentNode` fields
++        // directly. Those fields are now thread-confined and private, and a compiled-against-the-field
++        // call site is a NoSuchFieldError at runtime - which is what took out all 59 RecordCollectorTest
++        // cases before this. Same conversion the tracked patch applies to ProcessorContextImpl.
++        setRecordContext(new ProcessorRecordContext(
+                 0,
+                 0,
+                 0,
+                 "topic",
+                 new RecordHeaders()
+-        );
++        ));
+     }
+ 
+     @Override
+@@ -330,17 +335,23 @@
+     @SuppressWarnings("unchecked")
+     @Override
+     public <K extends KOut, V extends VOut> void forward(final Record<K, V> record, final String childName) {
+-        if (recordContext != null && record.timestamp() != recordContext.timestamp()) {
++        // PC dispatch (astubbs#255): converted to the AbstractProcessorContext accessors. This fixture is a
++        // subclass, so as shipped it reads/writes the inherited `recordContext` / `currentNode` fields
++        // directly. Those fields are now thread-confined and private, and a compiled-against-the-field
++        // call site is a NoSuchFieldError at runtime - which is what took out all 59 RecordCollectorTest
++        // cases before this. Same conversion the tracked patch applies to ProcessorContextImpl.
++        final ProcessorRecordContext currentContext = recordContext();
++        if (currentContext != null && record.timestamp() != currentContext.timestamp()) {
+             setTime(record.timestamp());
+         }
+-        final ProcessorNode<?, ?, ?, ?> thisNode = currentNode;
++        final ProcessorNode<?, ?, ?, ?> thisNode = currentNode();
+         try {
+             for (final ProcessorNode<?, ?, ?, ?> childNode : thisNode.children()) {
+-                currentNode = childNode;
++                setCurrentNode(childNode);
+                 ((ProcessorNode<K, V, ?, ?>) childNode).process(record);
+             }
+         } finally {
+-            currentNode = thisNode;
++            setCurrentNode(thisNode);
+         }
+     }
+ 
+@@ -356,11 +367,16 @@
+         if (toInternal.hasTimestamp()) {
+             setTime(toInternal.timestamp());
+         }
+-        final ProcessorNode<?, ?, ?, ?> thisNode = currentNode;
++        // PC dispatch (astubbs#255): converted to the AbstractProcessorContext accessors. This fixture is a
++        // subclass, so as shipped it reads/writes the inherited `recordContext` / `currentNode` fields
++        // directly. Those fields are now thread-confined and private, and a compiled-against-the-field
++        // call site is a NoSuchFieldError at runtime - which is what took out all 59 RecordCollectorTest
++        // cases before this. Same conversion the tracked patch applies to ProcessorContextImpl.
++        final ProcessorNode<?, ?, ?, ?> thisNode = currentNode();
+         try {
+             for (final ProcessorNode<?, ?, ?, ?> childNode : thisNode.children()) {
+                 if (toInternal.child() == null || toInternal.child().equals(childNode.name())) {
+-                    currentNode = childNode;
++                    setCurrentNode(childNode);
+                     final Record<Object, Object> record = new Record<>(key, value, toInternal.timestamp(), headers());
+                     ((ProcessorNode<Object, Object, ?, ?>) childNode).process(record);
+                     toInternal.update(to); // need to reset because MockProcessorContext is shared over multiple
+@@ -368,31 +384,38 @@
+                 }
+             }
+         } finally {
+-            currentNode = thisNode;
++            setCurrentNode(thisNode);
+         }
+     }
+ 
+     // allow only setting time but not other fields in for record context,
+     // and also not throwing exceptions if record context is not available.
+     public void setTime(final long timestamp) {
+-        if (recordContext != null) {
+-            recordContext = new ProcessorRecordContext(
++        // PC dispatch (astubbs#255): converted to the AbstractProcessorContext accessors. This fixture is a
++        // subclass, so as shipped it reads/writes the inherited `recordContext` / `currentNode` fields
++        // directly. Those fields are now thread-confined and private, and a compiled-against-the-field
++        // call site is a NoSuchFieldError at runtime - which is what took out all 59 RecordCollectorTest
++        // cases before this. Same conversion the tracked patch applies to ProcessorContextImpl.
++        final ProcessorRecordContext currentContext = recordContext();
++        if (currentContext != null) {
++            setRecordContext(new ProcessorRecordContext(
+                 timestamp,
+-                recordContext.offset(),
+-                recordContext.partition(),
+-                recordContext.topic(),
+-                recordContext.headers()
+-            );
++                currentContext.offset(),
++                currentContext.partition(),
++                currentContext.topic(),
++                currentContext.headers()
++            ));
+         }
+         this.timestamp = timestamp;
+     }
+ 
+     @Override
+     public long timestamp() {
+-        if (recordContext == null) {
++        final ProcessorRecordContext currentContext = recordContext();
++        if (currentContext == null) {
+             return timestamp;
+         }
+-        return recordContext.timestamp();
++        return currentContext.timestamp();
+     }
+ 
+     @Override
+@@ -407,34 +430,38 @@
+ 
+     @Override
+     public String topic() {
+-        if (recordContext == null) {
++        final ProcessorRecordContext currentContext = recordContext();
++        if (currentContext == null) {
+             return null;
+         }
+-        return recordContext.topic();
++        return currentContext.topic();
+     }
+ 
+     @Override
+     public int partition() {
+-        if (recordContext == null) {
++        final ProcessorRecordContext currentContext = recordContext();
++        if (currentContext == null) {
+             return -1;
+         }
+-        return recordContext.partition();
++        return currentContext.partition();
+     }
+ 
+     @Override
+     public long offset() {
+-        if (recordContext == null) {
++        final ProcessorRecordContext currentContext = recordContext();
++        if (currentContext == null) {
+             return -1L;
+         }
+-        return recordContext.offset();
++        return currentContext.offset();
+     }
+ 
+     @Override
+     public Headers headers() {
+-        if (recordContext == null) {
++        final ProcessorRecordContext currentContext = recordContext();
++        if (currentContext == null) {
+             return new RecordHeaders();
+         }
+-        return recordContext.headers();
++        return currentContext.headers();
+     }
+ 
+     @Override

--- a/parallel-consumer-streams/src/main/patch/pc-streams.patch
+++ b/parallel-consumer-streams/src/main/patch/pc-streams.patch
@@ -1,0 +1,209 @@
+diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java kafka-patched/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+--- a/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java	2026-08-31 13:51:00.760206957 +1200
+@@ -44,8 +44,13 @@
+     private final Serde<?> keySerde;
+     private final Serde<?> valueSerde;
+     private boolean initialized;
+-    protected ProcessorRecordContext recordContext;
+-    protected ProcessorNode<?, ?, ?, ?> currentNode;
++    // PC dispatch (astubbs#255): thread-confined. Stock Streams gets away with one instance per task because
++    // exactly one StreamThread ever touches it; under PC, N worker threads are inside process() on the same
++    // task at once and would otherwise scribble over each other's current record and current node.
++    // These were `protected` fields read directly by subclasses - ProcessorContextImpl had to be converted to
++    // the accessors below in the same change, or the confinement is silently bypassed by getfield/putfield.
++    private final ThreadLocal<ProcessorRecordContext> recordContext = new ThreadLocal<>();
++    private final ThreadLocal<ProcessorNode<?, ?, ?, ?>> currentNode = new ThreadLocal<>();
+     private long cachedSystemTimeMs;
+     protected ThreadCache cache;
+     private ProcessorMetadata processorMetadata;
+@@ -131,66 +136,66 @@
+ 
+     @Override
+     public String topic() {
+-        if (recordContext == null) {
++        if (recordContext.get() == null) {
+             // This is only exposed via the deprecated ProcessorContext,
+             // in which case, we're preserving the pre-existing behavior
+             // of returning dummy values when the record context is undefined.
+             // For topic, the dummy value is `null`.
+             return null;
+         } else {
+-            return recordContext.topic();
++            return recordContext.get().topic();
+         }
+     }
+ 
+     @Override
+     public int partition() {
+-        if (recordContext == null) {
++        if (recordContext.get() == null) {
+             // This is only exposed via the deprecated ProcessorContext,
+             // in which case, we're preserving the pre-existing behavior
+             // of returning dummy values when the record context is undefined.
+             // For partition, the dummy value is `-1`.
+             return -1;
+         } else {
+-            return recordContext.partition();
++            return recordContext.get().partition();
+         }
+     }
+ 
+     @Override
+     public long offset() {
+-        if (recordContext == null) {
++        if (recordContext.get() == null) {
+             // This is only exposed via the deprecated ProcessorContext,
+             // in which case, we're preserving the pre-existing behavior
+             // of returning dummy values when the record context is undefined.
+             // For offset, the dummy value is `-1L`.
+             return -1L;
+         } else {
+-            return recordContext.offset();
++            return recordContext.get().offset();
+         }
+     }
+ 
+     @Override
+     public Headers headers() {
+-        if (recordContext == null) {
++        if (recordContext.get() == null) {
+             // This is only exposed via the deprecated ProcessorContext,
+             // in which case, we're preserving the pre-existing behavior
+             // of returning dummy values when the record context is undefined.
+             // For headers, the dummy value is an empty headers collection.
+             return new RecordHeaders();
+         } else {
+-            return recordContext.headers();
++            return recordContext.get().headers();
+         }
+     }
+ 
+     @Override
+     public long timestamp() {
+-        if (recordContext == null) {
++        if (recordContext.get() == null) {
+             // This is only exposed via the deprecated ProcessorContext,
+             // in which case, we're preserving the pre-existing behavior
+             // of returning dummy values when the record context is undefined.
+             // For timestamp, the dummy value is `0L`.
+             return 0L;
+         } else {
+-            return recordContext.timestamp();
++            return recordContext.get().timestamp();
+         }
+     }
+ 
+@@ -209,27 +214,27 @@
+ 
+     @Override
+     public void setRecordContext(final ProcessorRecordContext recordContext) {
+-        this.recordContext = recordContext;
++        this.recordContext.set(recordContext);
+     }
+ 
+     @Override
+     public ProcessorRecordContext recordContext() {
+-        return recordContext;
++        return recordContext.get();
+     }
+ 
+     @Override
+     public Optional<RecordMetadata> recordMetadata() {
+-        return Optional.ofNullable(recordContext);
++        return Optional.ofNullable(recordContext.get());
+     }
+ 
+     @Override
+     public void setCurrentNode(final ProcessorNode<?, ?, ?, ?> currentNode) {
+-        this.currentNode = currentNode;
++        this.currentNode.set(currentNode);
+     }
+ 
+     @Override
+     public ProcessorNode<?, ?, ?, ?> currentNode() {
+-        return currentNode;
++        return currentNode.get();
+     }
+ 
+     @Override
+diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java kafka-patched/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+--- a/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java	2026-08-31 13:51:00.760915375 +1200
+@@ -243,7 +243,11 @@
+                     "multiple times.");
+         }
+ 
+-        final ProcessorRecordContext previousContext = recordContext;
++        // PC dispatch (astubbs#255): read through the accessor, not the inherited `recordContext` field. This
++        // getfield/putfield pair IS the save/restore stack that makes nested forward() work, so if it keeps
++        // touching the field directly then thread-confining that field in AbstractProcessorContext changes
++        // nothing here and the confinement is defeated without a single compile error to say so.
++        final ProcessorRecordContext previousContext = recordContext();
+ 
+         try {
+             // we don't want to set the recordContext if it's null, since that means that
+@@ -255,13 +259,14 @@
+             // too much about heterogeneous applications, in which the upstream processor is
+             // implementing the new API and the downstream one is implementing the old API.
+             // So, this seems like a fine compromise for now.
+-            if (recordContext != null && (record.timestamp() != timestamp() || record.headers() != headers())) {
+-                recordContext = new ProcessorRecordContext(
++            // previousContext is the current record context - nothing has changed it since it was read above.
++            if (previousContext != null && (record.timestamp() != timestamp() || record.headers() != headers())) {
++                setRecordContext(new ProcessorRecordContext(
+                     record.timestamp(),
+-                    recordContext.offset(),
+-                    recordContext.partition(),
+-                    recordContext.topic(),
+-                    record.headers());
++                    previousContext.offset(),
++                    previousContext.partition(),
++                    previousContext.topic(),
++                    record.headers()));
+             }
+ 
+             if (childName == null) {
+@@ -279,7 +284,7 @@
+             }
+ 
+         } finally {
+-            recordContext = previousContext;
++            setRecordContext(previousContext);
+             setCurrentNode(previousNode);
+         }
+     }
+diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java kafka-patched/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+--- a/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java	2026-08-31 13:51:00.761925919 +1200
+@@ -64,6 +64,7 @@
+ import java.util.Objects;
+ import java.util.Optional;
+ import java.util.Set;
++import java.util.concurrent.ConcurrentHashMap;
+ import java.util.concurrent.atomic.AtomicReference;
+ 
+ import static org.apache.kafka.streams.processor.internals.ClientUtils.producerRecordSizeInBytes;
+@@ -80,7 +81,10 @@
+ 
+     private final StreamsMetricsImpl streamsMetrics;
+     private final Sensor droppedRecordsSensor;
+-    private final Map<String, Sensor> producedSensorByTopic = new HashMap<>();
++    // PC dispatch (astubbs#255): the send callback runs on the producer's I/O thread and computeIfAbsent's here
++    // are triggered by whichever worker thread hit a dynamically routed topic first - a plain HashMap can
++    // corrupt its table under that. Concurrent map also makes computeIfAbsent create the sensor exactly once.
++    private final Map<String, Sensor> producedSensorByTopic = new ConcurrentHashMap<>();
+ 
+     private final AtomicReference<KafkaException> sendException;
+ 
+@@ -116,7 +120,9 @@
+                 ));
+         }
+ 
+-        this.offsets = new HashMap<>();
++        // PC dispatch (astubbs#255): written from the producer callback for every in-flight send at once, and
++        // snapshotted by the committing thread in offsets().
++        this.offsets = new ConcurrentHashMap<>();
+     }
+ 
+     @Override

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java
@@ -1,0 +1,116 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.streams.processor.internals.AbstractProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
+import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
+import org.apache.kafka.streams.processor.internals.StreamTask;
+import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves the classpath-shadowing premise this whole module rests on: the classes we generate and compile win
+ * over the ones in the {@code kafka-streams} jar, while their un-generated siblings still come from the jar.
+ * <p>
+ * This exists because the technique is <em>silent</em> when it fails. If the jar's copy were to win, every
+ * behavioural test downstream would still pass - it would simply be testing stock Kafka Streams and proving
+ * nothing at all. That is the single most likely way this module produces a false positive, so it is asserted
+ * directly rather than inferred from behaviour.
+ */
+@Slf4j
+class ShadowedClassLoadingTest {
+
+    /**
+     * The classes listed in {@code patched.classes} in this module's pom. Keep in sync: a class that is
+     * generated but missing here is unguarded, and one listed here but not generated fails loudly below.
+     */
+    private static final Class<?>[] GENERATED = {
+            AbstractProcessorContext.class,
+            ProcessorContextImpl.class,
+            RecordCollectorImpl.class,
+    };
+
+    /**
+     * Classes we deliberately do <em>not</em> generate. They must still load from the jar - that is what makes
+     * this "shadowing" rather than "a fork": the two sets have to coexist in one runtime package.
+     * <p>
+     * {@link StreamTask} is the interesting one, and it is here rather than above on purpose. It is the class
+     * the execution seam will patch next, and it is the immediate neighbour of all three generated classes -
+     * it constructs the context and drives the collector. Asserting that it still comes from the jar is
+     * therefore the sharpest available check that the generated set is exactly what the pom declares, and it
+     * is what will have to change, visibly, when the seam arrives.
+     */
+    private static final Class<?>[] JAR_RESIDENT = {
+            StreamTask.class,
+            StreamThread.class,
+    };
+
+    @Test
+    void generatedClassesWinOverTheJar() {
+        for (Class<?> generated : GENERATED) {
+            URL location = codeSourceOf(generated);
+            log.info("{} loaded from {}", generated.getSimpleName(), location);
+
+            assertThat(location.toString())
+                    .as("%s must load from this module's compiled output, not the kafka-streams jar. "
+                                    + "If this is a jar URL, classpath ordering has put the jar first and this module "
+                                    + "is measuring stock Kafka Streams - every result downstream of it, including the "
+                                    + "upstream-suite oracle, would be a false positive.",
+                            generated.getName())
+                    .doesNotContain(".jar")
+                    .contains("/classes/");
+        }
+    }
+
+    @Test
+    void unGeneratedSiblingsStillComeFromTheJar() {
+        for (Class<?> resident : JAR_RESIDENT) {
+            URL location = codeSourceOf(resident);
+            log.info("{} loaded from {}", resident.getSimpleName(), location);
+
+            assertThat(location.toString())
+                    .as("%s is not in patched.classes, so it must still come from the jar. If it does not, "
+                                    + "something is generating more than the declared set.",
+                            resident.getName())
+                    .contains("kafka-streams")
+                    .endsWith(".jar");
+        }
+    }
+
+    /**
+     * Package-private access into Kafka internals only works if the generated classes and the jar's classes land
+     * in the same runtime package - same package name <em>and</em> same classloader. Different classloaders would
+     * split the package and break that access even though the names match.
+     */
+    @Test
+    void generatedAndJarClassesShareOneRuntimePackage() {
+        for (Class<?> generated : GENERATED) {
+            for (Class<?> resident : JAR_RESIDENT) {
+                assertThat(generated.getPackage().getName())
+                        .as("%s must sit in the same package as the jar-resident classes it reaches into", generated.getName())
+                        .isEqualTo(resident.getPackage().getName());
+
+                assertThat(generated.getClassLoader())
+                        .as("%s must share a classloader with %s, or they are in different runtime packages and "
+                                        + "package-private access fails despite the matching package name",
+                                generated.getName(), resident.getName())
+                        .isSameAs(resident.getClassLoader());
+            }
+        }
+    }
+
+    private static URL codeSourceOf(Class<?> type) {
+        var protectionDomain = type.getProtectionDomain();
+        assertThat(protectionDomain).as("no protection domain for %s", type.getName()).isNotNull();
+        var codeSource = protectionDomain.getCodeSource();
+        assertThat(codeSource).as("no code source for %s - cannot tell where it was loaded from", type.getName()).isNotNull();
+        return codeSource.getLocation();
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/TestConventionsArchTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/TestConventionsArchTest.java
@@ -1,0 +1,24 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import bz.stub.parallelconsumer.TestConventionRules;
+
+/**
+ * Applies the shared {@link TestConventionRules} to this module's test classes - the rule logic lives once in
+ * {@link TestConventionRules} (core test-jar); this only points ArchUnit at this module's packages.
+ * <p>
+ * Deliberately scoped to this module's own package, not the generated {@code org.apache.kafka} tree - those
+ * are released Kafka sources plus our patch, and are not ours to hold to this project's test conventions.
+ */
+@AnalyzeClasses(packages = "bz.stub.parallelconsumer.streams", importOptions = ImportOption.OnlyIncludeTests.class)
+class TestConventionsArchTest {
+
+    @ArchTest
+    static final ArchTests conventions = ArchTests.in(TestConventionRules.class);
+}

--- a/parallel-consumer-streams/src/test/resources/logback-test.xml
+++ b/parallel-consumer-streams/src/test/resources/logback-test.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright (C) 2026 Antony Stubbs and contributors
+
+-->
+<configuration packagingData="true" scan="true" scanPeriod="5 seconds">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{mm:ss.SSS} %highlight(%-5level) %yellow([%thread]) %cyan(\(%file:%line\)#%M) %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${pc.log.level:-warn}">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <!-- primary -->
+    <!-- Raised from the command line, not by editing: -Dpc.log.level=debug|trace. See docs/testing.md. -->
+    <logger name="bz.stub.parallelconsumer" level="${pc.log.level:-warn}"/>
+
+    <!-- This module's own tests never see this file when Kafka's suite runs: that execution swaps logback
+         out for reload4j, because Kafka's LogCaptureAppender is a log4j 1.x appender and captures nothing
+         under logback. See the kafka-upstream-tests surefire execution in this module's pom. -->
+
+    <!-- related -->
+    <logger name="org.apache.kafka.clients" level="warn"/>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
         <module>parallel-consumer-vertx</module>
         <module>parallel-consumer-reactor</module>
         <module>parallel-consumer-mutiny</module>
+        <!-- Alpha/experimental (astubbs#255), and NOT published - its own pom carries the deploy and
+             signing skips plus skipPublishing, and says why. Ordered before parallel-consumer-examples,
+             which is the other module that skips publishing: the examples pom records a
+             central-publishing-maven-plugin bug where a skipPublishing module LAST in reactor order
+             suppressed the whole bundle, so neither of them may be the final entry above. -->
+        <module>parallel-consumer-streams</module>
         <module>parallel-consumer-examples</module>
     </modules>
 


### PR DESCRIPTION
Serves astubbs/parallel-consumer#255.

## Description

**The claim this PR makes, and nothing more: there is a reproducible mechanism for patching Apache
Kafka Streams, and the unmodified path still behaves like upstream.**

Kafka Streams' `processor.internals` is package-private, explicitly not an API, and offers no seam
where Parallel Consumer needs one. This adds `parallel-consumer-streams` as an unpublished alpha
leaf module carrying the build machinery for changing those internals without vendoring or forking
them, plus the oracle that proves the change is behaviour-preserving.

**There is no Parallel Consumer execution seam here.** `StreamTask` is not patched, there is no
dispatcher, no switch, and no record goes through PC. That is the next rung of this stack.

### How it works

1. **Unpack** the named classes from the published `kafka-streams` **sources** jar at
   `generate-sources` - twice, a pristine baseline and a working copy.
2. **Apply** the tracked patch at `process-sources`, dry-running first so a rejected hunk fails the
   build rather than leaving a half-applied tree that compiles.
3. **Compile** the working copy into this module's own `target/classes`.
4. **Classpath order does the rest** - ours precede the jar, so they win while their thousand
   siblings still load from it. Same package, same classloader, so package-private access works.

**No Apache Kafka source is committed.** Only the patch is tracked, and its line count is the
reviewable answer to "how little had to change".

### What is in the patch, and why it stops there

The judgement call was the smallest patch that honestly exercises the machinery. A marker-sized
patch would have made the oracle vacuous and left the fixture patch pointless; the full patch from
astubbs/parallel-consumer#271 would have dragged the execution seam in. The seam turned out to be
**cleanly separable**: only the `StreamTask` hunks reference Parallel Consumer classes. So this
carries the other three files, whose changes are the concurrency-safety groundwork and are pure
Kafka edits:

| Class | Change | Why it is in the set |
|---|---|---|
| `AbstractProcessorContext` | current record context and current node move to thread-confined slots | stock Streams holds one per task and gets away with it because exactly one thread is ever inside |
| `ProcessorContextImpl` | reads/writes them through the accessors | it is a subclass doing `getfield`/`putfield` on those fields, so leaving it alone defeats the confinement **with no compile error to say so** |
| `RecordCollectorImpl` | two `HashMap`s become `ConcurrentHashMap`s | written from the producer's I/O thread for every in-flight send; the compiler would never have demanded this class |

Kafka's own `InternalMockProcessorContext` needs the same accessor conversion through a second
patch, or `RecordCollectorTest` cannot construct its subject at all - so both patch streams are
genuinely exercised.

**The patch was not carved by hand.** It was produced by the prescribed procedure: apply the source
patch through `process-sources`, delete `StreamTask` from both generated trees, run
`bin/regen-patch.sh` with no maven run in between. `regen-patch.sh`'s hunk-count tripwire fired as
designed, and the real invariant was then checked by content: the added and removed lines of all
three surviving files are **byte-identical** to their originals.

### The oracle, and how its counts were read

Kafka publishes its compiled tests to Central. A dedicated surefire execution points at
`StreamTaskTest`, `RecordCollectorTest` and `ProcessorContextImplTest`, which therefore exercise
**our** patched classes, with nothing excluded, relaxed or recompiled. It runs in the normal `test`
phase on every build.

Locally, the whole module `test` phase was run and the counts read out of the report XML in
`parallel-consumer-streams/target/surefire-reports-kafka-upstream/` - **not** from the console
summary, and not with `-Dtest=`, which silently overrides that execution's `<includes>` so the suite
does not run at all while the build still goes green. All three classes are green with zero failures
and **zero skipped**; the per-class numbers are deliberately not written here, because they move
with the patch, with `kafka.version`, and again when the seam arrives - re-derive them.

Three other checks, each with its control:

- **The shadowing is asserted directly, not inferred.** `ShadowedClassLoadingTest` checks each
  generated class loads from `/classes/` and not a `.jar`; that `StreamTask` and `StreamThread`
  still come from the jar; and that both sets share a package name *and* a classloader.
  `StreamTask` is the sharp choice - it is the class the seam patches next, so the assertion has to
  change visibly on the day the generated set does.
- **The empty-patch control arm was re-run.** With no hunks, the generated tree is byte-for-byte the
  released sources.
- **The full reactor builds clean** with the new module in it, and the jar contains exactly the three
  patched classes.

### Publication is off, deliberately

`maven.deploy.skip`, `gpg.skip` and the publishing plugin's `skipPublishing`. Merging an isolated
leaf module is cheap to reverse; publishing an artifact carrying classes in Apache's own package
namespace is not - classpath order is a convention rather than a guarantee, class loading is per
class so the result is always a mixture of two versions, and JPMS forbids split packages outright.
`maven.install.skip` is **not** set, so a local install still works. `NOTICE` carries the Apache 2.0
section 4(b) statement naming the three modified classes.

### Two things cutting fresh from master surfaced

Neither exists on the origin branch, whose base predates both gates:

- The enforcer's `RequireUpperBoundDeps` fails on `jackson-annotations` once `jackson-databind` is
  promoted ahead of what `kafka-streams` resolves. Declared at the matching version.
- `forbiddenapis` fires on locale-dependent `String.format` calls in Kafka's **released** source, at
  sites the patch does not touch. The generated tree is excluded rather than patched - fixing them
  would mean patching Apache code for a rule Apache never adopted, growing the change-set this
  design exists to keep small. Anything of ours landing later sits under `bz.stub` and is not
  covered by that exclusion. Same scoping decision ArchUnit already makes here.

A third was found on the way in: the origin branch's `logback-test.xml` for this module would fail
`bin/check-test-log-config.sh` (root pinned to `info`, a stray `io.vertx` debug logger). The module's
config is written to the gate instead, and the module is registered with the gate - which exposed
that the gate's self-test held a second copy of the module list and **inverted** when the two
disagreed, reporting four failures for a gate that was working. The self-test now reads the list out
of the gate.

### Where this came from, and what it de-risks

Copied out of **astubbs/parallel-consumer#271**, the Kafka Streams feasibility study, which keeps the
execution seam, the measurements and the semantic work. This is the first rung of the reconstructed
Wagon B stack: the branch forest stays as the evidence record, and each rung is cut fresh from
`master` rather than merged, so the PRs document what the design *is* rather than how it was
discovered.

It also de-risks **astubbs/parallel-consumer#269** (Kafka Connect on PC), which uses the same
shadowing technique against a different Apache module and piggybacks this machinery and its
write-up.

### What is deliberately not in this PR

- **The roadmap stage is unchanged.** `docs/data/roadmap.yaml`'s `streams-parallelism-preview` stays
  at `limited-poc` with `pull_request: astubbs/parallel-consumer#271`. The stages block orders the
  ladder by *the most advanced artifact that exists*, and that is still the spike; this PR carries no
  per-key parallelism, so nothing here advances the track. Its `done_when` - an opt-in alpha module
  with setup a reader can follow - is not met while publication is off.
- **The staged maturity row and the held feature record do not move.** Both said "whichever PR lands
  each module", which read literally makes this the trigger; moving them would assert
  `opt_in: artifact dependency` for an artifact that publishes nothing. Both now say *publishable*
  rather than *landed*, and the reasoning is written at the point where somebody would otherwise
  move them.

### One inherited sighting recorded, not fixed

The first CI run's Chaos lane went red on
`ChaosRevokeUnderWorkCooperativeDrainIT`, seed `1159274055608047297` - the standing revoke-path
commit deadlock, with the same discriminator its ledger was written to distinguish (poll thread
BLOCKED acquiring a monitor held by `pc-control` inside `commitOffsetsThatAreReady`, reached from
`onPartitionsRevoked`). That is core's, tracked in `docs/inflight/bug-857-family.md` and owned by
astubbs/parallel-consumer#29; this diff touches no core Java, no locking and no rebalance path.

**It did not reproduce on the second run, and that is recorded as intermittency rather than as a
clearance.** The two Chaos runs here are separated only by documentation commits, so this is a
same-tree pass/fail pair - **1 of 2**, the closest-together one that ledger has. Both the seed and
the pair are written down there, because the log expires and the seed is the asset; nobody has
replayed it.

The Unit and Integration lanes failed on that same first run for an unrelated reason: a Maven
Central read timeout resolving `org.apache.kafka:kafka-streams:jar:sources:3.9.2`. Both are green
on the re-run, so it was transient - but it is a real new dependency of CI, since the machinery
needs a **sources** jar and nothing here fetched one before. Worth knowing if it recurs.

## Checklist

- [x] Docs updated - the module README (the mechanism, the oracle and the classpath hazard that keeps
      it unpublished), the technique write-up in `docs/solutions/architecture-patterns/`, `NOTICE`,
      `AGENTS.md`'s module table, and the three records this module's arrival made inaccurate
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - there is no
      user-facing feature here and no artifact to depend on. The held record and its trigger are
      corrected in docs/inflight/release-experimental-module-records.md instead`
- [x] Tests added/updated - `ShadowedClassLoadingTest` (the premise everything rests on),
      `TestConventionsArchTest`, Kafka's own suite as the behaviour-preservation oracle, and the
      log-config gate's self-test taught to read the module list from the gate
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - `N/A - spending the review on the PR instead;
      the diff is a module extraction whose correctness claim is the upstream suite, which runs in CI`
