### PR TITLE
fix(ci): guards that name the wrong branch, gate the wrong tree, or refuse in silence

### DIFF
--- a/.claude/hooks/check-history-rewrite.sh
+++ b/.claude/hooks/check-history-rewrite.sh
@@ -66,12 +66,21 @@ esac
 # is how two copies of a scan start disagreeing. An empty line is a real answer - "the command did
 # not say" - and the working-directory arm below is what turns each one into a message.
 scan="$(printf '%s' "$payload" | python3 -c '
-import json, shlex, sys
+import json, os, shlex, sys
 try:
     data = json.load(sys.stdin)
     cmd = data.get("tool_input", {}).get("command", "")
     payload_cwd = data.get("cwd") or ""
-    toks = shlex.split(cmd)
+    # OPERATOR-AWARE, INCLUDING NEWLINE, the same lexer pre-commit-gate.sh uses. Plain shlex.split
+    # left operators fused to their neighbours (`feature&&git` read as a branch name) and treated a
+    # line break as whitespace, so `git push -f<newline>git log -1` swallowed the next command as
+    # push arguments and named `log` as the branch - a confident wrong answer, found by two
+    # reviewers at once on astubbs/parallel-consumer#382. A QUOTED newline is untouched: posix
+    # shlex keeps quoted text one token, so a multiline commit message still lexes as one argument.
+    lex = shlex.shlex(cmd, posix=True, punctuation_chars="();<>|&;\n")
+    lex.whitespace = " \t\r"
+    lex.whitespace_split = True
+    toks = list(lex)
 except Exception:
     sys.exit(0)
 
@@ -79,7 +88,7 @@ FORCE = {"--force", "-f", "--force-with-lease", "--force-if-includes"}
 # Push options that consume a SEPARATE value token. Dropping only the flag would leave its value
 # where the repository or the refspec should be.
 PUSH_VALUE_FLAGS = {"-o", "--push-option", "--receive-pack", "--exec", "--repo"}
-OPERATORS = set("();<>|&")
+OPERATORS = set("();<>|&\n")  # must name the same characters as the lexer punctuation above
 
 
 def push_head_ref(rest, sub):
@@ -125,24 +134,84 @@ def push_head_ref(rest, sub):
         name = name[len("refs/heads/"):]
     if not name or name == "HEAD" or name.startswith("refs/"):
         return ""
+    # A `$` or backtick is unexpanded SOURCE TEXT, not the branch git will see - answering with the
+    # literal is the confident-wrong-answer class this hook exists to kill. Fall back to the
+    # labelled inferred tier instead. Mirrored in hook_push_head_ref (hook-common.sh).
+    if "$" in name or "`" in name:
+        return ""
     return name
 
 
 # A LEADING `cd <path> &&` IS THE COMMAND SAYING WHERE IT RUNS, and it outranks the payload cwd for
-# exactly that reason. Only a LEADING one: a `cd` later in a compound command may be undoing an
-# earlier one, and guessing which is worse than not guessing. The trailing strip handles the
-# unspaced `cd path&& git ...` that plain shlex fuses into one token.
+# exactly that reason. Only a LEADING one, AND ONLY WHEN IT IS THE ONLY ONE: this used to trust the
+# first `cd` unconditionally, but `cd A && x && cd B && git commit --amend` runs the amend in B, and
+# presenting A as "the directory the command changes into" is a measured-sounding wrong answer -
+# the exact class this hook exists to kill (reliability review, astubbs/parallel-consumer#382,
+# reproduced with the real tokeniser). With more than one command-position `cd` the honest answer
+# is "ambiguous", so this falls through to the payload cwd, whose label already says it is a guess.
+# The unspaced `cd path&&git ...` form is handled by the operator-aware lexer above.
 cd_prefix = ""
-if len(toks) > 1 and toks[0] == "cd" and not toks[1].startswith("-"):
-    cd_prefix = toks[1].rstrip(";&|")
+cd_count = 0
+at_cmd = True
+for t in toks:
+    if t and all(c in OPERATORS for c in t):
+        at_cmd = True
+        continue
+    if at_cmd and t == "cd":
+        cd_count += 1
+    at_cmd = False
+if cd_count == 1 and len(toks) > 1 and toks[0] == "cd" and not toks[1].startswith("-"):
+    cd_prefix = toks[1]
+
+
+def resolve_against(path, base):
+    """A RELATIVE command-named path is relative to where the COMMAND runs - the payload cwd -
+    never to this hook process, whose directory describes the session. `parallel-consumer-core`
+    exists in every worktree of this repository, so testing a relative path from the wrong
+    directory SUCCEEDS on the wrong tree rather than failing. Unresolvable (no base to anchor it)
+    returns "", which drops to the next, labelled tier rather than guessing
+    (astubbs/parallel-consumer#382, found cross-model)."""
+    if not path:
+        return ""
+    if os.path.isabs(path):
+        return path
+    if base:
+        return os.path.join(base, path)
+    return ""
+
+
+cd_prefix = resolve_against(cd_prefix, payload_cwd)
 
 verdict = ""
 ref = ""
+git_c = ""
 for i, t in enumerate(toks):
     if t.rsplit("/", 1)[-1] != "git":
         continue
     rest = toks[i+1:]
-    sub = next((x for x in rest if not x.startswith("-")), None)
+    # GLOBAL FLAGS THAT TAKE A VALUE, skipped WITH their value - `git -C /path push --force` put
+    # "/path" where the subcommand should be, so the guard matched nothing and a force-push
+    # sailed through in silence (correctness review, astubbs/parallel-consumer#382; the same
+    # defect hook_git_invocations records for the reminders). `-C` is also RECORDED: it is the
+    # command relocating itself, the strongest working-directory statement available. The walk
+    # stops at an operator so the next command cannot donate a subcommand.
+    GIT_VALUE_FLAGS = ("-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path")
+    sub = None
+    j = 0
+    while j < len(rest):
+        x = rest[j]
+        if x and all(c in OPERATORS for c in x):
+            break
+        if x in GIT_VALUE_FLAGS:
+            if x == "-C" and j + 1 < len(rest):
+                git_c = rest[j + 1]
+            j += 2
+            continue
+        if x.startswith("-"):
+            j += 1
+            continue
+        sub = x
+        break
     flags = set(rest)
     # An env-prefixed override reaches here as a token, not as process env.
     if any(x == "REWRITE_HISTORY_CONFIRMED=1" for x in toks):
@@ -181,14 +250,18 @@ for i, t in enumerate(toks):
         verdict, ref = "remote branch deletion", push_head_ref(rest, sub); break
 
 if verdict:
+    # `git -C <rel>` is relative to where git runs - after any leading `cd` - so it anchors to the
+    # resolved cd_prefix first and the payload cwd second.
+    git_c = resolve_against(git_c, cd_prefix or payload_cwd)
     print(verdict)
     print(ref)
     print(cd_prefix)
     print(payload_cwd)
+    print(git_c)
 ' 2>/dev/null || true)"
 # A HERESTRING, NOT A HEREDOC: an unquoted heredoc would expand `$` and `\` inside a path, and a
 # quoted one would not expand `$scan` at all. `IFS=` keeps a path's own leading spaces.
-{ IFS= read -r verdict; IFS= read -r pushed_ref; IFS= read -r cd_prefix; IFS= read -r payload_cwd; } <<<"$scan"
+{ IFS= read -r verdict; IFS= read -r pushed_ref; IFS= read -r cd_prefix; IFS= read -r payload_cwd; IFS= read -r git_c_dir; } <<<"$scan"
 [ -n "$verdict" ] || exit 0
 
 # WHERE THE COMMAND RUNS IS NOT WHERE THIS HOOK RUNS - see the header. Strongest source first, and
@@ -196,7 +269,10 @@ if verdict:
 # whose provenance is hidden.
 workdir=""
 workdir_desc=""
-if [ -n "$cd_prefix" ] && [ -d "$cd_prefix" ]; then
+if [ -n "$git_c_dir" ] && [ -d "$git_c_dir" ]; then
+    workdir="$git_c_dir"
+    workdir_desc="the directory the command names with -C"
+elif [ -n "$cd_prefix" ] && [ -d "$cd_prefix" ]; then
     workdir="$cd_prefix"
     workdir_desc="the directory the command changes into"
 elif [ -n "$payload_cwd" ] && [ -d "$payload_cwd" ]; then

--- a/.claude/hooks/check-history-rewrite.sh
+++ b/.claude/hooks/check-history-rewrite.sh
@@ -20,6 +20,25 @@
 # review running right now. With nothing found it still stops, but says so honestly - and says WHICH
 # nothing it found, because "this branch has no PR" and "the lookup never answered" are different
 # facts that one message used to report identically.
+#
+# WHICH BRANCH, AND HOW IT WAS DECIDED. This hook does not run in the directory its guarded command
+# runs in, and this repository keeps many worktrees checked out at once - so the original
+# `git rev-parse --abbrev-ref HEAD` answered about whichever branch the SESSION sat on. Twice on
+# 2026-08-31 that named a completely unrelated branch: a force-push of `feats/proxy-verdict-free-return`
+# (open PR astubbs/parallel-consumer#295, with review history - the case this hook exists for) and a
+# `git commit --amend` in the `feats/ks-streams-fork-machinery` worktree were BOTH reported against
+# `docs/god-branch-decomposition-plan`, the plan worktree the session happened to occupy. The most
+# confident sentence this hook can print - "the lookup ran and came back empty" - was describing the
+# wrong target, which is the same silent-wrong-answer class as the wrong-REPOSITORY fix in
+# astubbs/parallel-consumer#364, one field over.
+#
+# So the branch is taken from the strongest source available, and the message says which one:
+#   1. the push refspec, when the command names one - the only authoritative answer, and free,
+#      because the token scan below has already split the command;
+#   2. otherwise the HEAD of a directory, chosen from a `cd <path> &&` prefix, then the tool call's
+#      own `cwd` from the payload, then this hook process's directory as a last resort.
+# Anything but (1) is a GUESS about where the command runs, and the refusal says so in as many
+# words rather than presenting it as a measured fact.
 set -uo pipefail
 
 payload="$(cat 2>/dev/null || true)"
@@ -40,16 +59,85 @@ esac
 # TOKENS, NOT SUBSTRINGS - the rule the sibling hooks state. `git commit -m "rebase notes"` and
 # `gh pr comment --body "we should force-push"` must not fire. An unbalanced quote makes shlex raise,
 # and that fails open.
-verdict="$(printf '%s' "$payload" | python3 -c '
+#
+# FOUR LINES OUT, NOT ONE, and they are all read from the SAME token walk: the verdict, the branch
+# the push refspec names, a leading `cd <path>` the command changes into, and the payload's own
+# `cwd`. Deriving the last three anywhere else would mean tokenising the command a second time, which
+# is how two copies of a scan start disagreeing. An empty line is a real answer - "the command did
+# not say" - and the working-directory arm below is what turns each one into a message.
+scan="$(printf '%s' "$payload" | python3 -c '
 import json, shlex, sys
 try:
     data = json.load(sys.stdin)
     cmd = data.get("tool_input", {}).get("command", "")
+    payload_cwd = data.get("cwd") or ""
     toks = shlex.split(cmd)
 except Exception:
     sys.exit(0)
 
 FORCE = {"--force", "-f", "--force-with-lease", "--force-if-includes"}
+# Push options that consume a SEPARATE value token. Dropping only the flag would leave its value
+# where the repository or the refspec should be.
+PUSH_VALUE_FLAGS = {"-o", "--push-option", "--receive-pack", "--exec", "--repo"}
+OPERATORS = set("();<>|&")
+
+
+def push_head_ref(rest, sub):
+    """The REMOTE-side branch name this push publishes, or "" when the command names none.
+
+    THE PR HEAD IS THE DESTINATION, NOT THE SOURCE: `git push origin src:dst` publishes `dst`, so
+    `dst` is what a pull request has as its head branch. `+src` is the force spelling of `src`.
+    A push with no refspec, `HEAD`, a bare `refs/`-something and `tag <name>` all name nothing this
+    can read as a branch, and each returns "" so the caller falls back and SAYS it fell back.
+
+    The same rule is spelled out a second time, in bash, as `hook_push_head_ref` in
+    .claude/hooks/lib/hook-common.sh. This hook REFUSES tool calls, so it may not depend on a
+    library it might fail to source (astubbs/parallel-consumer#341); the duplication is tracked with
+    the rest of it in docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md.
+    """
+    try:
+        args = rest[rest.index(sub) + 1:]
+    except ValueError:
+        return ""
+    positional = []
+    j = 0
+    while j < len(args):
+        t = args[j]
+        # A shell operator ends this command; everything after it belongs to the next one.
+        if t and all(c in OPERATORS for c in t):
+            break
+        if t in PUSH_VALUE_FLAGS:
+            j += 2
+            continue
+        if t.startswith("-"):
+            j += 1
+            continue
+        positional.append(t)
+        j += 1
+    # positional[0] is the repository, positional[1] the first refspec. A multi-refspec push is
+    # answered with its first, which is incomplete rather than wrong - that branch really is one of
+    # the branches being rewritten.
+    if len(positional) < 2 or positional[1] == "tag":
+        return ""
+    src, sep, dst = positional[1].partition(":")
+    name = (dst if sep else src).lstrip("+")
+    if name.startswith("refs/heads/"):
+        name = name[len("refs/heads/"):]
+    if not name or name == "HEAD" or name.startswith("refs/"):
+        return ""
+    return name
+
+
+# A LEADING `cd <path> &&` IS THE COMMAND SAYING WHERE IT RUNS, and it outranks the payload cwd for
+# exactly that reason. Only a LEADING one: a `cd` later in a compound command may be undoing an
+# earlier one, and guessing which is worse than not guessing. The trailing strip handles the
+# unspaced `cd path&& git ...` that plain shlex fuses into one token.
+cd_prefix = ""
+if len(toks) > 1 and toks[0] == "cd" and not toks[1].startswith("-"):
+    cd_prefix = toks[1].rstrip(";&|")
+
+verdict = ""
+ref = ""
 for i, t in enumerate(toks):
     if t.rsplit("/", 1)[-1] != "git":
         continue
@@ -60,13 +148,13 @@ for i, t in enumerate(toks):
     if any(x == "REWRITE_HISTORY_CONFIRMED=1" for x in toks):
         sys.exit(0)
     if sub == "push" and (flags & FORCE or any(x.startswith("--force-with-lease=") for x in rest)):
-        print("force-push"); break
+        verdict, ref = "force-push", push_head_ref(rest, sub); break
     if sub == "rebase" and "--abort" not in flags and "--continue" not in flags and "--skip" not in flags:
-        print("rebase"); break
+        verdict = "rebase"; break
     if sub == "commit" and "--amend" in flags:
-        print("amend"); break
+        verdict = "amend"; break
     if sub in ("filter-branch", "filter-repo"):
-        print(sub); break
+        verdict = sub; break
     # EVERY OTHER WAY TO MOVE A REF AND LOSE COMMITS. Found by probing the first version, which
     # caught only the obvious four - a guard that reaches just the shapes you thought of is a
     # documented bypass.
@@ -77,27 +165,67 @@ for i, t in enumerate(toks):
         if tgt and not tgt.startswith("origin/") and not tgt.startswith("upstream/"):
             import re as _re
             if _re.search(r"[~^]", tgt) or _re.fullmatch(r"[0-9a-f]{7,40}", tgt):
-                print("reset-backwards"); break
+                verdict = "reset-backwards"; break
     if sub == "branch" and "-f" in flags or (sub == "branch" and "--force" in flags):
-        print("branch -f"); break
+        verdict = "branch -f"; break
     if sub in ("checkout", "switch"):
         moved = "-B" in flags or "-C" in flags
         # `-B name` alone just points at HEAD; `-B name <start>` moves the ref somewhere else.
         if moved:
             after = rest[rest.index("-B") + 1:] if "-B" in rest else rest[rest.index("-C") + 1:]
             if len([x for x in after if not x.startswith("-")]) >= 2:
-                print("branch reset via " + sub); break
+                verdict = "branch reset via " + sub; break
     if sub == "update-ref" and any(x.startswith("refs/heads/") for x in rest):
-        print("update-ref"); break
+        verdict = "update-ref"; break
     if sub == "push" and ("--delete" in flags or "-d" in flags or any(x.startswith(":") and len(x) > 1 for x in rest)):
-        print("remote branch deletion"); break
+        verdict, ref = "remote branch deletion", push_head_ref(rest, sub); break
+
+if verdict:
+    print(verdict)
+    print(ref)
+    print(cd_prefix)
+    print(payload_cwd)
 ' 2>/dev/null || true)"
+# A HERESTRING, NOT A HEREDOC: an unquoted heredoc would expand `$` and `\` inside a path, and a
+# quoted one would not expand `$scan` at all. `IFS=` keeps a path's own leading spaces.
+{ IFS= read -r verdict; IFS= read -r pushed_ref; IFS= read -r cd_prefix; IFS= read -r payload_cwd; } <<<"$scan"
 [ -n "$verdict" ] || exit 0
+
+# WHERE THE COMMAND RUNS IS NOT WHERE THIS HOOK RUNS - see the header. Strongest source first, and
+# whichever one answers is carried into the refusal, because the operator cannot check an answer
+# whose provenance is hidden.
+workdir=""
+workdir_desc=""
+if [ -n "$cd_prefix" ] && [ -d "$cd_prefix" ]; then
+    workdir="$cd_prefix"
+    workdir_desc="the directory the command changes into"
+elif [ -n "$payload_cwd" ] && [ -d "$payload_cwd" ]; then
+    workdir="$payload_cwd"
+    workdir_desc="this tool call's own working directory"
+else
+    workdir="$PWD"
+    workdir_desc="this hook process's directory, because the tool call did not say where it runs"
+fi
+if ! cd "$workdir" 2>/dev/null; then
+    workdir_desc="this hook process's directory, because \`$workdir\` could not be entered"
+    workdir="$PWD"
+fi
 
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] || exit 0
 cd "$root" 2>/dev/null || exit 0
-branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+
+# THE PROVENANCE SENTENCE IS NOT DECORATION. Everything below - the PR number, the thread count, the
+# runs in progress - is about `$branch`, and when the command did not name a branch that is a GUESS
+# about which worktree this call belongs to. Saying so is what turns a wrong answer into a checkable
+# one; the two incidents in the header are both cases where it read as measured fact.
+provenance=""
+if [ -n "$pushed_ref" ]; then
+    branch="$pushed_ref"
+else
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    provenance="THE COMMAND DOES NOT NAME A BRANCH, so this hook used \`${branch:-<none>}\` - the current HEAD of ${root}, reached from ${workdir_desc} (\`${workdir}\`). This repository normally has several worktrees checked out at once, so that may not be where your command runs: check it is the branch you are rewriting before reading anything below as being about it. "
+fi
 
 # WHAT WOULD ACTUALLY BE LOST. Best-effort: a missing PR, a missing gh or a dead network all fall
 # through to the refusal rather than letting the rewrite past - the point is the pause, the detail is
@@ -222,7 +350,10 @@ try:
         threads, threads_problem = threads_call.result()
         runs, runs_problem = runs_call.result()
 
-    parts = ["This branch is %s#%s." % (slug, number)]
+    # NAME THE BRANCH, not just the PR. Everything that follows is a measurement of one branch, and
+    # a reader who cannot see which one cannot tell a correct answer from the wrong-worktree answer
+    # this hook used to give (see WHICH BRANCH at the top of this file).
+    parts = ["`%s` is %s#%s." % (BRANCH, slug, number)]
     found = False
     unmeasured = []
     if threads_problem:
@@ -259,6 +390,7 @@ PY
 )"
 fi
 [ -n "$detail" ] || detail="The pull-request lookup produced no answer at all, so nothing could be measured - which is not the same as nothing being at risk."
+detail="${provenance}${detail}"
 
 export VERDICT="$verdict"
 export DETAIL="$detail"

--- a/.claude/hooks/check-history-rewrite.sh
+++ b/.claude/hooks/check-history-rewrite.sh
@@ -87,7 +87,7 @@ except Exception:
 FORCE = {"--force", "-f", "--force-with-lease", "--force-if-includes"}
 # Push options that consume a SEPARATE value token. Dropping only the flag would leave its value
 # where the repository or the refspec should be.
-PUSH_VALUE_FLAGS = {"-o", "--push-option", "--receive-pack", "--exec", "--repo"}
+PUSH_VALUE_FLAGS = {"-o", "--push-option", "--receive-pack", "--exec", "--repo", "--recurse-submodules"}
 OPERATORS = set("();<>|&\n")  # must name the same characters as the lexer punctuation above
 
 
@@ -160,8 +160,15 @@ for t in toks:
     if at_cmd and t == "cd":
         cd_count += 1
     at_cmd = False
-if cd_count == 1 and len(toks) > 1 and toks[0] == "cd" and not toks[1].startswith("-"):
-    cd_prefix = toks[1]
+# ...AND ONLY WHEN THE JOIN PRESERVES THE CWD. `cd /x & git commit` backgrounds the cd into a
+# subshell and `cd /x | cmd` pipes it into one - the commit stays in the payload cwd either way,
+# so trusting the prefix would gate an unrelated tree (Codex review, astubbs/parallel-consumer#382).
+# Only `&&`, `;` and a newline hand the changed directory to the next command in the same shell;
+# operator runs may carry trailing newlines/semicolons, so strip those before comparing.
+if cd_count == 1 and len(toks) > 2 and toks[0] == "cd" and not toks[1].startswith("-"):
+    joiner = toks[2].strip("\n;")
+    if joiner in ("", "&&"):
+        cd_prefix = toks[1]
 
 
 def resolve_against(path, base):
@@ -197,6 +204,12 @@ for i, t in enumerate(toks):
     # stops at an operator so the next command cannot donate a subcommand.
     GIT_VALUE_FLAGS = ("-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path")
     sub = None
+    # RESET PER INVOCATION: a -C recorded while scanning an earlier command in a compound payload
+    # must not survive into the invocation that carries the verdict - `git -C /a status && git
+    # commit --amend` runs the amend in the payload cwd, not /a (Codex review,
+    # astubbs/parallel-consumer#382). And REPEATED -C values COMPOSE, each relative one applied
+    # from the previous, so only the chain - never just the last token - names the directory.
+    git_c = ""
     j = 0
     while j < len(rest):
         x = rest[j]
@@ -204,7 +217,11 @@ for i, t in enumerate(toks):
             break
         if x in GIT_VALUE_FLAGS:
             if x == "-C" and j + 1 < len(rest):
-                git_c = rest[j + 1]
+                nxt = rest[j + 1]
+                if os.path.isabs(nxt) or not git_c:
+                    git_c = nxt
+                else:
+                    git_c = os.path.join(git_c, nxt)
             j += 2
             continue
         if x.startswith("-"):

--- a/.claude/hooks/lib/hook-common.sh
+++ b/.claude/hooks/lib/hook-common.sh
@@ -49,7 +49,16 @@ try:
     # real push. `git push; echo done` was worse and commoner: the token is `push;`, so even the
     # SPACED form missed. punctuation_chars makes the operators their own tokens, which is exactly
     # what the git-token scan below assumes it is walking.
-    lex = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    # NEWLINE IS AN OPERATOR, NOT WHITESPACE. shlex treats \n as plain whitespace by default, so
+    # `git push -f<newline>git log -1` fused across the line break and the push swallowed the next
+    # command as its arguments - hook_push_head_ref then answered `log` as the pushed branch, a
+    # confident wrong answer with no caveat (found by cross-model review on
+    # astubbs/parallel-consumer#382). Removing \n from whitespace and adding it to the punctuation
+    # set makes each line break an operator token, which the args-stop below already knows to stop
+    # at. A QUOTED newline is untouched: posix shlex keeps quoted text as one token, so a multiline
+    # commit message still lexes as one argument.
+    lex = shlex.shlex(cmd, posix=True, punctuation_chars="();<>|&;\n")
+    lex.whitespace = " \t\r"
     lex.whitespace_split = True
     toks = list(lex)
 except Exception:
@@ -80,15 +89,17 @@ for i, t in enumerate(toks):
             # never emitted. Re-tokenising in the caller is what this file exists to prevent, so the
             # ONE tokeniser emits both and the two views below differ only in what they cut.
             #
-            # STOP AT ANY OPERATOR TOKEN, not a hand-listed few. `punctuation_chars=True` makes shlex
-            # emit `> >> < << ( ) ; ;; | || & &&` as tokens of their own, and an earlier version
-            # named only the command SEPARATORS. That left redirections inside the argument list, so
-            # `git merge origin/master > out.log` walked args as ["origin/master", ">", "out.log"] -
-            # and a redirect target named like a control flag or a remedy ref could then spoof the
-            # exemption test in the consumer. Testing that every character is punctuation catches the
-            # whole family, including operators nobody has thought of, and cannot catch a real
-            # argument: refs, paths and flags all contain at least one non-operator character.
-            OPERATORS = set("();<>|&")
+            # STOP AT ANY OPERATOR TOKEN, not a hand-listed few. The punctuation set makes shlex
+            # emit `> >> < << ( ) ; ;; | || & &&` - and, per the lexer note above, `\n` - as tokens
+            # of their own, and an earlier version named only the command SEPARATORS. That left
+            # redirections inside the argument list, so `git merge origin/master > out.log` walked
+            # args as ["origin/master", ">", "out.log"] - and a redirect target named like a control
+            # flag or a remedy ref could then spoof the exemption test in the consumer. Testing that
+            # every character is punctuation catches the whole family, including merged runs like
+            # `&&\n`, and cannot catch a real argument: refs, paths and flags all contain at least
+            # one non-operator character. This set and the lexer punctuation string above must name
+            # the same characters.
+            OPERATORS = set("();<>|&;\n")
             k, args = j + 1, []
             while k < len(toks) and not (toks[k] and all(c in OPERATORS for c in toks[k])):
                 args.append(toks[k]); k += 1
@@ -153,8 +164,11 @@ hook_push_head_ref() { # <invocations - the output of hook_git_invocations>
             case "$t" in
                 # Push options that consume a SEPARATE value token. Dropping only the flag would
                 # leave its value where the repository or the refspec should be - the same class of
-                # bug this file records above for `git -C /path push`.
-                -o|--push-option|--receive-pack|--exec|--repo) skip=1; continue ;;
+                # bug this file records above for `git -C /path push`. Attached forms (`--repo=x`)
+                # are already skipped by the `-?*` arm; the cost is only ever a SAFE miss - with
+                # `--repo=origin feats/x` the refspec lands in the repository slot, no second
+                # positional appears, and the caller falls back WITH its inferred-answer label.
+                -o|--push-option|--receive-pack|--exec|--repo|--recurse-submodules) skip=1; continue ;;
                 -?*) continue ;;
             esac
             count=$((count + 1))
@@ -171,7 +185,13 @@ EOF
         esac
         dst="${dst#+}"
         dst="${dst#refs/heads/}"
-        case "$dst" in ''|HEAD|refs/*) continue ;; esac
+        # A `$` or backtick means the shell would EXPAND this before git saw it - the token here is
+        # the unexpanded source text, so `git push origin "$TARGET_BRANCH"` would otherwise be
+        # answered with the literal string `$TARGET_BRANCH`, queried against gh as though it were a
+        # branch. A ref can technically contain `$`, but a wrong literal presented as authoritative
+        # is the exact defect class this helper exists to fix; falling back to the labelled
+        # inferred-answer tier is the honest reading (cross-model review, astubbs/parallel-consumer#382).
+        case "$dst" in ''|HEAD|refs/*|*\$*|*\`*) continue ;; esac
         printf '%s\n' "$dst"
         return 0
     done <<EOF

--- a/.claude/hooks/lib/hook-common.sh
+++ b/.claude/hooks/lib/hook-common.sh
@@ -132,7 +132,12 @@ hook_git_subcommands() { # <payload-json>
 # refuses tool calls and therefore may not depend on a library it might fail to source
 # (astubbs/parallel-consumer#341). That duplication is deliberate and is tracked with the rest of it
 # in docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md; change one and change the other.
-hook_push_head_ref() { # <payload-json>
+#
+# TAKES THE TOKENISER'S OUTPUT, NOT THE PAYLOAD. The caller has already spawned
+# `hook_git_invocations` to ask whether the payload is a push at all; reading that list rather than
+# re-deriving it keeps the whole hook to ONE python3 spawn - the same economy `hook_git_runs_any`
+# exists for, one function down.
+hook_push_head_ref() { # <invocations - the output of hook_git_invocations>
     local line args t spec dst count skip
     while IFS= read -r line; do
         case "$line" in push|push$'\t'*) ;; *) continue ;; esac
@@ -170,7 +175,7 @@ EOF
         printf '%s\n' "$dst"
         return 0
     done <<EOF
-$(hook_git_invocations "$1")
+$1
 EOF
     return 0
 }

--- a/.claude/hooks/lib/hook-common.sh
+++ b/.claude/hooks/lib/hook-common.sh
@@ -102,6 +102,79 @@ hook_git_subcommands() { # <payload-json>
     hook_git_invocations "$1" | cut -f1
 }
 
+# Prints the REMOTE-side branch name that the payload's `git push` names, or nothing when it names
+# none. Nothing is a real answer here: it means the caller must fall back to a working directory,
+# and must SAY that it did.
+#
+# WHY THE COMMAND AND NOT `HEAD`. A hook process does not run in the directory its guarded command
+# runs in, and this repository keeps many worktrees checked out at once - so
+# `git rev-parse --abbrev-ref HEAD` answers about whichever branch the SESSION happens to sit on,
+# confidently and wrongly. On 2026-08-31 that made check-history-rewrite.sh report
+# "no open pull request has `docs/god-branch-decomposition-plan` as its head branch" while refusing a
+# force-push of `feats/proxy-verdict-free-return`, which had an open PR with review history - the
+# exact thing that hook exists to name. When the command spells the refspec out, that is the only
+# authoritative answer available, and it is free.
+#
+# THE PR HEAD IS THE DESTINATION, NOT THE SOURCE: `git push origin src:dst` publishes `dst`, so
+# `dst` is what a pull request has as its head branch. `+src` is the force spelling of `src`, and
+# `refs/heads/x` is the long spelling of `x`.
+#
+# FOUR SHAPES DELIBERATELY RETURN NOTHING, because each names something this cannot read as a branch:
+# a push with no refspec (`git push -f`), `HEAD` (which means the command's own directory, the thing
+# a hook cannot see), a bare `refs/`-something (a tag or a note), and `tag <name>`.
+#
+# A MULTI-REFSPEC PUSH IS ANSWERED WITH ITS FIRST REFSPEC, which is incomplete rather than wrong -
+# that branch really is one of the branches being pushed, so a refusal naming it is about work the
+# command actually touches. Falling back to the working directory instead would trade an incomplete
+# answer for an unrelated one.
+#
+# THE SAME RULE IS SPELLED OUT A SECOND TIME, in python, inside check-history-rewrite.sh - which
+# refuses tool calls and therefore may not depend on a library it might fail to source
+# (astubbs/parallel-consumer#341). That duplication is deliberate and is tracked with the rest of it
+# in docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md; change one and change the other.
+hook_push_head_ref() { # <payload-json>
+    local line args t spec dst count skip
+    while IFS= read -r line; do
+        case "$line" in push|push$'\t'*) ;; *) continue ;; esac
+        # `hook_git_invocations` already stopped this invocation's arguments at the next shell
+        # operator, so everything here belongs to this push and nothing to the command after it.
+        args="${line#push}"
+        count=0
+        spec=""
+        skip=0
+        while IFS= read -r t; do
+            [ -n "$t" ] || continue
+            if [ "$skip" = 1 ]; then skip=0; continue; fi
+            case "$t" in
+                # Push options that consume a SEPARATE value token. Dropping only the flag would
+                # leave its value where the repository or the refspec should be - the same class of
+                # bug this file records above for `git -C /path push`.
+                -o|--push-option|--receive-pack|--exec|--repo) skip=1; continue ;;
+                -?*) continue ;;
+            esac
+            count=$((count + 1))
+            # positional 1 is the repository, positional 2 is the first refspec.
+            if [ "$count" = 2 ]; then spec="$t"; break; fi
+        done <<EOF
+$(printf '%s' "$args" | tr '\t' '\n')
+EOF
+        [ -n "$spec" ] || continue
+        [ "$spec" = "tag" ] && continue
+        case "$spec" in
+            *:*) dst="${spec#*:}" ;;
+            *)   dst="$spec" ;;
+        esac
+        dst="${dst#+}"
+        dst="${dst#refs/heads/}"
+        case "$dst" in ''|HEAD|refs/*) continue ;; esac
+        printf '%s\n' "$dst"
+        return 0
+    done <<EOF
+$(hook_git_invocations "$1")
+EOF
+    return 0
+}
+
 # True when the payload runs ANY of the named git subcommands. One tokeniser spawn for the whole
 # question: `hook_git_runs a || hook_git_runs b` paid python3 twice to walk the same token list.
 hook_git_runs_any() { # <payload-json> <subcommand>...

--- a/.claude/hooks/lib/hook-common.sh
+++ b/.claude/hooks/lib/hook-common.sh
@@ -148,7 +148,15 @@ hook_git_subcommands() { # <payload-json>
 # `hook_git_invocations` to ask whether the payload is a push at all; reading that list rather than
 # re-deriving it keeps the whole hook to ONE python3 spawn - the same economy `hook_git_runs_any`
 # exists for, one function down.
-hook_push_head_ref() { # <invocations - the output of hook_git_invocations>
+#
+# THE OPTIONAL SECOND ARGUMENT PICKS A SIDE. `git push origin src:dst` publishes the LOCAL branch
+# `src` under the REMOTE name `dst`: `dst` is what a pull request has as its head branch (the
+# default answer, and the label a reminder should print), but `src` is the content actually being
+# pushed - so a hook that MEASURES the branch (the drift reminder) must ask for `src`, or it
+# measures a same-named local branch that is not what git is publishing (Codex review,
+# astubbs/parallel-consumer#382). With no colon the two sides are the same name.
+hook_push_head_ref() { # <invocations - the output of hook_git_invocations> [dst|src]
+    local side="${2:-dst}"
     local line args t spec dst count skip
     while IFS= read -r line; do
         case "$line" in push|push$'\t'*) ;; *) continue ;; esac
@@ -180,7 +188,7 @@ EOF
         [ -n "$spec" ] || continue
         [ "$spec" = "tag" ] && continue
         case "$spec" in
-            *:*) dst="${spec#*:}" ;;
+            *:*) if [ "$side" = src ]; then dst="${spec%%:*}"; else dst="${spec#*:}"; fi ;;
             *)   dst="$spec" ;;
         esac
         dst="${dst#+}"
@@ -198,6 +206,20 @@ EOF
 $1
 EOF
     return 0
+}
+
+# The tool call's own working directory from the payload, or nothing. A hook process does not run
+# where its guarded command runs - a subagent, or a `git -C /other/clone push`, acts on a repository
+# the hook's own directory says nothing about - so a push hook that derives its repository from
+# `$PWD` pairs the command's branch with the SESSION's repo (Codex review,
+# astubbs/parallel-consumer#382). Fail-open like everything here: no python3, no cwd field, or
+# unparseable JSON all print nothing and the caller stays with its own directory.
+hook_payload_cwd() { # <payload-json>
+    printf '%s' "$1" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("cwd") or "")
+except Exception:
+    pass' 2>/dev/null || true
 }
 
 # True when the payload runs ANY of the named git subcommands. One tokeniser spawn for the whole

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -23,16 +23,39 @@
 # on stderr produces "hook error: No stderr output", which tells the agent it was blocked and
 # nothing about why; that was the observed behaviour of the inline form.
 #
-# WHICH REPOSITORY IT GATES - THE SESSION'S, NOT THE COMMAND'S. Both the gate path below and the
-# gate's own `git rev-parse --show-toplevel` resolve from this hook process, so what gets checked is
-# the checkout the SESSION is rooted in. Raised in review as a worktree hazard: a session in the
-# primary checkout running `cd .claude/worktrees/task && git commit` would be gated against the
-# wrong tree. It cannot reach here - `if: Bash(git commit *)` matches the command as WRITTEN, so
-# that command does not fire this hook at all (docs/agent-harness.md, "Known gaps"). Every command
-# that does fire it is a bare `git commit ...` in the session's own cwd, where session repo and
-# commit repo are the same one. The residual case - a `cd`'d or `git -C` commit into another
-# worktree - is covered by `.githooks/pre-commit`, which git runs inside the target repository. That
-# is why the git hook is the primary mechanism and this is belt-and-braces.
+# WHICH REPOSITORY IT GATES - THE COMMAND'S, WHICH IS NOT ALWAYS THE SESSION'S. This used to resolve
+# the gate from `$CLAUDE_PROJECT_DIR`, and to run it with this hook process's own working directory,
+# so what got checked was the tree the SESSION is rooted in.
+#
+# The hazard was raised in review and dismissed with the wrong argument: that `if: Bash(git commit *)`
+# matches the command as WRITTEN, so a `cd other-worktree && git commit` never reaches here, leaving
+# only bare commits "in the session's own cwd, where session repo and commit repo are the same one".
+# The premise is false for a SUBAGENT, which has its own working directory while `$CLAUDE_PROJECT_DIR`
+# still names the session's most recent worktree - and a subagent's `git commit ...` is bare, so it
+# matches the registration and arrives here.
+#
+# Observed 2026-08-31: a subagent committing in `.claude/worktrees/proxy-server-shell` was gated
+# against `.claude/worktrees/bench-harness`. `check-file-refs.sh` failed on citations to `bench/`
+# files that do not exist on the agent's branch, while the agent's own tree ran the same gate at
+# exit 0, and five commits had to go through with `--no-verify`. The dangerous half is the mirror
+# image and leaves no trace at all: a RED tree passes because the session's tree is green, so a
+# violation lands with the gate reporting success - the silent-wrong-answer shape that
+# astubbs/parallel-consumer#382 fixed in the two hooks either side of this one.
+#
+# So the working tree is now derived from the COMMAND, strongest source first, and the block message
+# says which directory answered:
+#
+#   1. `git -C <path> commit` - the commit naming its own repository, and unambiguous only when
+#      every commit in the payload names the same one;
+#   2. a leading `cd <path> &&` - belt-and-braces, since the registration above does not currently
+#      match that shape;
+#   3. the payload's own `cwd`, which is what a subagent's directory arrives in;
+#   4. `$CLAUDE_PROJECT_DIR`, then this process's directory - the labelled last resorts.
+#
+# The gate script and its working directory both come from that answer, so a gate added on one
+# branch and absent on another behaves correctly in each. `.githooks/pre-commit` remains the primary
+# mechanism: git runs it inside the target repository by construction, which is the property this
+# hook now has to derive.
 #
 # FAIL OPEN ON OUR OWN BUG. If the payload does not parse, or the gate script is missing, this exits
 # 0. The git hook and CI both still gate the same commit.
@@ -51,16 +74,15 @@ payload_file=$(mktemp)
 trap 'rm -f "$payload_file"' EXIT
 cat > "$payload_file"
 
-project_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-gate="$project_dir/.githooks/pre-commit"
-[ -x "$gate" ] || exit 0
-
-# NO PYTHON, NO GATE. The bypass below cannot be detected without parsing the payload, and the
-# repo's documented build requirements are JDK 17, Docker and the Maven wrapper - python is not
-# among them. Falling through on a missing interpreter meant `git commit --no-verify` ran the gates
-# and was blocked at exit 2 with no way to argue: the escape hatch the header calls load-bearing,
-# absent on exactly the machine that has no other way out. Fail open, like every other limit here;
-# `.githooks/pre-commit` and CI still gate the same commit.
+# NO PYTHON, NO GATE. Neither the bypass below nor the working tree above can be read without
+# parsing the payload, and the repo's documented build requirements are JDK 17, Docker and the Maven
+# wrapper - python is not among them. Falling through on a missing interpreter meant
+# `git commit --no-verify` ran the gates and was blocked at exit 2 with no way to argue: the escape
+# hatch the header calls load-bearing, absent on exactly the machine that has no other way out. Fail
+# open, like every other limit here; `.githooks/pre-commit` and CI still gate the same commit.
+#
+# THIS TEST MOVED ABOVE THE GATE-EXISTS TEST when the working tree stopped being read from the
+# environment: which gate script to look for is now an answer python has to produce.
 command -v python3 >/dev/null 2>&1 || exit 0
 
 # Does THIS COMMIT carry a real `--no-verify` argument? Three things are load-bearing:
@@ -77,7 +99,13 @@ command -v python3 >/dev/null 2>&1 || exit 0
 # token in a command line that merely CONTAINS a commit (`echo -n`, an unquoted `$(...)`), and a
 # bypass triggered by accident is a gate that silently stopped running. The long form is what the
 # hook headers and docs tell people to type, and it is unambiguous.
-if python3 - "$payload_file" <<'PYGATE'
+#
+# ONE SCAN, TWO ANSWERS: the exit code is the bypass decision, and stdout is the directory the
+# commit runs in (empty when the command does not say). Reading the directory in a second python
+# call would mean tokenising the same command twice, which is how two copies of a scan start
+# disagreeing - the argument .claude/hooks/check-history-rewrite.sh makes for the same pairing.
+scan_rc=0
+commit_dir="$(python3 - "$payload_file" <<'PYGATE'
 import json, re, shlex, sys
 
 OPERATORS = {"&&", "||", ";", ";;", "|", "&", "(", ")"}
@@ -107,18 +135,27 @@ GIT_VALUE_FLAGS = {"-C", "-c", "--git-dir", "--work-tree"}
 
 try:
     with open(sys.argv[1], encoding="utf-8") as fh:
-        cmd = json.load(fh).get("tool_input", {}).get("command", "")
+        payload = json.load(fh)
+    cmd = payload.get("tool_input", {}).get("command", "")
+    # A SUBAGENT'S OWN DIRECTORY ARRIVES HERE and nowhere else. `$CLAUDE_PROJECT_DIR` names the
+    # session's project root, which for a subagent working in another worktree is a different tree
+    # entirely - see WHICH REPOSITORY IT GATES at the top of this file.
+    payload_cwd = payload.get("cwd") or ""
 except Exception:
     sys.exit(0)                      # unparseable payload: treat as bypass, never block on our bug
 
 
 def commit_bypass_counts(line):
-    """(commits, bypassing) for `git commit` in COMMAND POSITION on this line.
+    """(commits, bypassing, dirs) for `git commit` in COMMAND POSITION on this line.
 
     Counted rather than short-circuited because ONE command line can hold SEVERAL commits, and a
     later one asking for a bypass must not exempt an earlier one that did not:
     `git commit -m first; git commit --no-verify -m second` used to exit 0 for both, so in a clone
     with no core.hooksPath the first commit landed with no gate run at all.
+
+    `dirs` holds one entry per commit: the value of its `git -C <path>`, or "" when it has none and
+    so runs where the tool call runs. Collected HERE rather than by a second walk because this loop
+    already skips the git global flags that take a value, which is the whole difficulty.
     """
     # `\n` joins the default punctuation set and leaves `whitespace`, so a newline becomes a
     # TOKEN the loop can reset command position on - see SEPARATOR_CHARS above. Quoted newlines
@@ -128,6 +165,7 @@ def commit_bypass_counts(line):
     lexer.whitespace_split = True
     tokens = list(lexer)
     commits = bypassing = 0
+    dirs = []
     i, at_command = 0, True
     while i < len(tokens):
         token = tokens[i]
@@ -148,13 +186,20 @@ def commit_bypass_counts(line):
             continue
         if at_command and (token == "git" or token.endswith("/git")):
             j = i + 1
+            repo_dir = ""
             while j < len(tokens) and tokens[j] in GIT_VALUE_FLAGS:
+                # `-C <path>` is the only one of these that relocates the command. Recorded on the
+                # way past rather than re-derived, and the LAST one wins because git applies them
+                # cumulatively in order.
+                if tokens[j] == "-C" and j + 1 < len(tokens):
+                    repo_dir = tokens[j + 1]
                 j += 2               # git global flags that consume a value
             if j < len(tokens) and tokens[j] == "commit":
                 end = j
                 while end < len(tokens) and not is_separator(tokens[end]):
                     end += 1
                 commits += 1
+                dirs.append(repo_dir)
                 if "--no-verify" in tokens[j:end]:
                     bypassing += 1
                 i = end
@@ -162,15 +207,35 @@ def commit_bypass_counts(line):
                 continue
         at_command = False
         i += 1
-    return commits, bypassing
+    return commits, bypassing, dirs
 
 
+def leading_cd(line):
+    """The path of a LEADING `cd <path> &&`, or "".
+
+    ONLY A LEADING ONE. A `cd` further along may be undoing an earlier one, and guessing which is
+    worse than not guessing. Belt-and-braces either way: the registration matches the command as
+    written, so `cd X && git commit` does not currently fire this hook at all.
+    """
+    try:
+        lexer = shlex.shlex(line, posix=True, punctuation_chars="();<>|&;\n")
+        lexer.whitespace = " \t\r"
+        lexer.whitespace_split = True
+        toks = list(lexer)
+    except ValueError:
+        return ""
+    if len(toks) > 1 and toks[0] == "cd" and not toks[1].startswith("-"):
+        return toks[1]
+    return ""
+
+
+dirs = []
 try:
     # The WHOLE command is lexed at once. Splitting into lines first breaks a quoted multiline
     # message down the middle, so the first line raises ValueError and the fallback below finds
     # `--no-verify` in the MESSAGE TEXT - which meant `git commit -m "...\n--no-verify\n..."`
     # skipped the gate entirely. shlex handles the newlines; the line split never needed to.
-    commits, bypassing = commit_bypass_counts(cmd)
+    commits, bypassing, dirs = commit_bypass_counts(cmd)
     # NO COMMIT AT ALL: skip. The registration's `if: Bash(git commit *)` is supposed to scope
     # this hook, but the script must not lean on it - observed live (astubbs#324 babysit): with
     # the gate red, a plain `ls` and a read-only `cat` of the gate itself were blocked with the
@@ -182,16 +247,67 @@ except ValueError:
     # Genuinely unbalanced quoting. Fail OPEN so a hook bug cannot jam the tool call shut, but do
     # not try to read the flag out of text we could not lex.
     bypass = True
+
+if not bypass:
+    # WHICH TREE, printed only on the path that is about to gate something. `git -C` is used only
+    # when it is UNAMBIGUOUS - every commit in the payload naming the same directory. A payload that
+    # commits in two repositories has no single answer, and this hook can gate one tree; the mixed
+    # case therefore falls through to the tool call's own directory, which gates the commits that
+    # run there and leaves the relocated ones to `.githooks/pre-commit`, which git runs inside the
+    # target repository. Incomplete, and never wrong about the tree it did read.
+    named = set(dirs)
+    target = ""
+    if len(named) == 1 and dirs and dirs[0]:
+        target = dirs[0]
+    if not target:
+        target = leading_cd(cmd)
+    if not target:
+        target = payload_cwd
+    print(target)
+
 sys.exit(0 if bypass else 1)
 PYGATE
-then
+)" || scan_rc=$?
+if [ "$scan_rc" -eq 0 ]; then
     exit 0
 fi
 
-if ! output=$("$gate" 2>&1); then
+# THE LAST RESORTS ARE LABELLED, and they are the pre-fix behaviour: `$CLAUDE_PROJECT_DIR` is the
+# session's project root, which is the right answer only when the session and the command share a
+# working tree. Reached when the payload carries no `cwd` and the command relocates nothing.
+work_dir=""
+work_dir_desc=""
+if [ -n "$commit_dir" ] && [ -d "$commit_dir" ]; then
+    work_dir="$commit_dir"
+    work_dir_desc="the directory the commit runs in"
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "${CLAUDE_PROJECT_DIR:-}" ]; then
+    work_dir="$CLAUDE_PROJECT_DIR"
+    work_dir_desc="\$CLAUDE_PROJECT_DIR - the SESSION's project root, because the tool call did not say where it runs"
+else
+    work_dir="$PWD"
+    work_dir_desc="this hook process's own directory, because nothing else said where the commit runs"
+fi
+
+# THE REPOSITORY ROOT, falling back to the directory itself. The gate lives at the root of a
+# checkout, so a commit made from a subdirectory must climb; a directory that is not a git
+# repository at all still gets asked directly, which is what keeps a plain fixture directory working.
+if gate_dir="$(cd "$work_dir" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)" && [ -n "$gate_dir" ]; then
+    :
+else
+    gate_dir="$work_dir"
+fi
+
+gate="$gate_dir/.githooks/pre-commit"
+[ -x "$gate" ] || exit 0
+
+# RUN IT WHERE THE COMMIT RUNS. `.githooks/pre-commit` starts with its own
+# `git rev-parse --show-toplevel`, so inheriting this hook process's directory was the second half
+# of the same defect: even the right gate script read the wrong tree.
+if ! output=$(cd "$gate_dir" && "$gate" 2>&1); then
     printf '%s\n' "$output" >&2
-    printf '\nBlocked by the repo pre-commit gate (.githooks/pre-commit). Fix the gate(s) above, or\n' >&2
-    printf 'commit with --no-verify if you have a reason - the bypass is deliberate, not an oversight.\n' >&2
+    printf '\nBlocked by the repo pre-commit gate (%s), run against %s\n' "$gate" "$gate_dir" >&2
+    printf '(%s). Fix the gate(s) above, or commit with --no-verify if you\n' "$work_dir_desc" >&2
+    printf 'have a reason - the bypass is deliberate, not an oversight.\n' >&2
     exit 2
 fi
 

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -106,7 +106,7 @@ command -v python3 >/dev/null 2>&1 || exit 0
 # disagreeing - the argument .claude/hooks/check-history-rewrite.sh makes for the same pairing.
 scan_rc=0
 commit_dir="$(python3 - "$payload_file" <<'PYGATE'
-import json, re, shlex, sys
+import json, os, re, shlex, sys
 
 OPERATORS = {"&&", "||", ";", ";;", "|", "&", "(", ")"}
 # An unquoted NEWLINE separates statements exactly like `;`, but shlex's default whitespace
@@ -213,9 +213,15 @@ def commit_bypass_counts(line):
 def leading_cd(line):
     """The path of a LEADING `cd <path> &&`, or "".
 
-    ONLY A LEADING ONE. A `cd` further along may be undoing an earlier one, and guessing which is
-    worse than not guessing. Belt-and-braces either way: the registration matches the command as
-    written, so `cd X && git commit` does not currently fire this hook at all.
+    ONLY A LEADING ONE, AND ONLY WHEN IT IS THE ONLY ONE. This used to trust the first `cd`
+    unconditionally, but `cd A && x && cd B && git commit` runs the commit in B, and gating A
+    against that commit is a confident wrong answer - the class this whole hook exists to kill
+    (reliability review, astubbs/parallel-consumer#382). More than one command-position `cd` is
+    honestly ambiguous, so this returns "" and the caller falls through to the payload cwd.
+    Belt-and-braces either way: the registration matches the command as written, so
+    `cd X && git commit` does not currently fire this hook at all.
+    NO APOSTROPHES IN THIS HEREDOC: the body sits inside a $( ) substitution, and an unbalanced
+    quote stops bash finding the closing paren - proven the first time this docstring was written.
     """
     try:
         lexer = shlex.shlex(line, posix=True, punctuation_chars="();<>|&;\n")
@@ -224,8 +230,33 @@ def leading_cd(line):
         toks = list(lexer)
     except ValueError:
         return ""
-    if len(toks) > 1 and toks[0] == "cd" and not toks[1].startswith("-"):
+    cd_count = 0
+    at_cmd = True
+    for t in toks:
+        if is_separator(t):
+            at_cmd = True
+            continue
+        if at_cmd and t == "cd":
+            cd_count += 1
+        at_cmd = False
+    if cd_count == 1 and len(toks) > 1 and toks[0] == "cd" and not toks[1].startswith("-"):
         return toks[1]
+    return ""
+
+
+def resolve_against(path, base):
+    """A RELATIVE command-named path is relative to where the COMMAND runs - the payload cwd -
+    never to this hook process, whose directory describes the session. Same-named subdirectories
+    exist in every worktree of this repository, so resolving from the wrong directory SUCCEEDS on
+    the wrong tree rather than failing. Unresolvable returns "", dropping to the next, labelled
+    tier (astubbs/parallel-consumer#382, found cross-model; the history guard carries the same
+    helper - change one, change the other)."""
+    if not path:
+        return ""
+    if os.path.isabs(path):
+        return path
+    if base:
+        return os.path.join(base, path)
     return ""
 
 
@@ -256,11 +287,13 @@ if not bypass:
     # run there and leaves the relocated ones to `.githooks/pre-commit`, which git runs inside the
     # target repository. Incomplete, and never wrong about the tree it did read.
     named = set(dirs)
+    cd_dir = resolve_against(leading_cd(cmd), payload_cwd)
     target = ""
     if len(named) == 1 and dirs and dirs[0]:
-        target = dirs[0]
+        # `git -C <rel>` is relative to where git runs - after any leading `cd`.
+        target = resolve_against(dirs[0], cd_dir or payload_cwd)
     if not target:
-        target = leading_cd(cmd)
+        target = cd_dir
     if not target:
         target = payload_cwd
     print(target)

--- a/.claude/hooks/pre-commit-gate.sh
+++ b/.claude/hooks/pre-commit-gate.sh
@@ -189,10 +189,17 @@ def commit_bypass_counts(line):
             repo_dir = ""
             while j < len(tokens) and tokens[j] in GIT_VALUE_FLAGS:
                 # `-C <path>` is the only one of these that relocates the command. Recorded on the
-                # way past rather than re-derived, and the LAST one wins because git applies them
-                # cumulatively in order.
+                # way past rather than re-derived - and repeated -C values COMPOSE, each relative
+                # path applied from the directory the previous one established, so `git -C sub -C ..
+                # commit` runs in the ORIGINAL repository. Keeping only the last token resolved
+                # `..` against the payload cwd instead, and a parent with no gate then passed the
+                # commit unchecked (Codex review, astubbs/parallel-consumer#382).
                 if tokens[j] == "-C" and j + 1 < len(tokens):
-                    repo_dir = tokens[j + 1]
+                    nxt = tokens[j + 1]
+                    if os.path.isabs(nxt) or not repo_dir:
+                        repo_dir = nxt
+                    else:
+                        repo_dir = os.path.join(repo_dir, nxt)
                 j += 2               # git global flags that consume a value
             if j < len(tokens) and tokens[j] == "commit":
                 end = j
@@ -239,8 +246,15 @@ def leading_cd(line):
         if at_cmd and t == "cd":
             cd_count += 1
         at_cmd = False
-    if cd_count == 1 and len(toks) > 1 and toks[0] == "cd" and not toks[1].startswith("-"):
-        return toks[1]
+    # ...AND ONLY WHEN THE JOIN PRESERVES THE CWD. `cd /x & git commit` backgrounds the cd into a
+    # subshell and `cd /x | cmd` pipes it into one - the commit stays in the payload cwd either
+    # way, so trusting the prefix would run an unrelated green gate over a red tree (Codex review,
+    # astubbs/parallel-consumer#382). Only `&&`, `;` and a newline hand the changed directory to
+    # the next command in the same shell; operator runs can carry trailing newlines/semicolons.
+    if cd_count == 1 and len(toks) > 2 and toks[0] == "cd" and not toks[1].startswith("-"):
+        joiner = toks[2].strip("\n;")
+        if joiner in ("", "&&"):
+            return toks[1]
     return ""
 
 

--- a/.claude/hooks/remind-inflight-on-push.sh
+++ b/.claude/hooks/remind-inflight-on-push.sh
@@ -57,6 +57,16 @@ hook_lib="${BASH_SOURCE[0]%/*}/lib/hook-common.sh"
 invocations="$(hook_git_invocations "$payload")"
 case $'\n'"$invocations"$'\n' in *$'\n'push$'\n'*|*$'\n'push$'\t'*) ;; *) exit 0 ;; esac
 
+# THE REPOSITORY COMES FROM THE COMMAND'S OWN DIRECTORY, not this hook process's. A subagent (or a
+# push run with an explicit path) acts on a repository the hook's own cwd says nothing about, and
+# pairing the command's branch with the SESSION's repo quoted another tree's inflight note (Codex
+# review, astubbs/parallel-consumer#382). The payload cwd is the strongest source this fail-open
+# reminder can afford; a `git -C <path> push` to a THIRD repository remains the documented edge in
+# docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md.
+cmd_cwd="$(hook_payload_cwd "$payload")"
+if [ -n "$cmd_cwd" ] && [ -d "$cmd_cwd" ]; then
+    cd "$cmd_cwd" 2>/dev/null || true
+fi
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] || exit 0
 cd "$root" 2>/dev/null || exit 0

--- a/.claude/hooks/remind-inflight-on-push.sh
+++ b/.claude/hooks/remind-inflight-on-push.sh
@@ -45,7 +45,12 @@ hook_lib="${BASH_SOURCE[0]%/*}/lib/hook-common.sh"
 # shellcheck source=.claude/hooks/lib/hook-common.sh
 . "$hook_lib"
 
-hook_git_runs "$payload" push || exit 0
+# ONE tokeniser spawn answers both of this hook's questions - "is this a push?" here, and "which
+# branch does it name?" below. `hook_git_runs "$payload" push` would pay python3 a second time to
+# walk the same token list, the economy hook-common.sh's `hook_git_runs_any` records. A push
+# invocation is a line reading `push` or `push<TAB>args...`.
+invocations="$(hook_git_invocations "$payload")"
+case "$invocations" in push|push$'\t'*|*$'\n'push|*$'\n'push$'\t'*) ;; *) exit 0 ;; esac
 
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] || exit 0
@@ -59,7 +64,7 @@ cd "$root" 2>/dev/null || exit 0
 # guard, twice, on two different branches - .claude/hooks/check-history-rewrite.sh records both under
 # "WHICH BRANCH". `hook_push_head_ref` owns the refspec rules.
 inferred_branch=0
-branch="$(hook_push_head_ref "$payload")"
+branch="$(hook_push_head_ref "$invocations")"
 if [ -z "$branch" ]; then
     inferred_branch=1
     branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"

--- a/.claude/hooks/remind-inflight-on-push.sh
+++ b/.claude/hooks/remind-inflight-on-push.sh
@@ -48,9 +48,14 @@ hook_lib="${BASH_SOURCE[0]%/*}/lib/hook-common.sh"
 # ONE tokeniser spawn answers both of this hook's questions - "is this a push?" here, and "which
 # branch does it name?" below. `hook_git_runs "$payload" push` would pay python3 a second time to
 # walk the same token list, the economy hook-common.sh's `hook_git_runs_any` records. A push
-# invocation is a line reading `push` or `push<TAB>args...`.
+# invocation is a line reading `push` or `push<TAB>args...` - matched with the haystack WRAPPED in
+# newlines so every line has a boundary on both sides. The first version matched a bare `push` only
+# at the string's start or end, so `git push && git status` (invocation list `push`,`status`) never
+# fired the reminder at all - the exact silently-stops-working class hook-common.sh exists to stop,
+# reintroduced by the refactor meant to save a process spawn (caught by three reviewers at once on
+# astubbs/parallel-consumer#382).
 invocations="$(hook_git_invocations "$payload")"
-case "$invocations" in push|push$'\t'*|*$'\n'push|*$'\n'push$'\t'*) ;; *) exit 0 ;; esac
+case $'\n'"$invocations"$'\n' in *$'\n'push$'\n'*|*$'\n'push$'\t'*) ;; *) exit 0 ;; esac
 
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] || exit 0

--- a/.claude/hooks/remind-inflight-on-push.sh
+++ b/.claude/hooks/remind-inflight-on-push.sh
@@ -51,7 +51,19 @@ root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] || exit 0
 cd "$root" 2>/dev/null || exit 0
 
-branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+# WHICH BRANCH IS BEING PUSHED - the command's refspec first, this directory's HEAD only as a
+# fallback. A hook does not run in the directory its guarded command runs in, and this repository
+# keeps many worktrees checked out at once, so HEAD alone answers about whichever branch the SESSION
+# sits on: `git push origin other-branch` from here would look up THIS branch's PR and quote
+# `docs/inflight/pr-<n>-*.md` for work the push does not touch. Observed on 2026-08-31 in the sibling
+# guard, twice, on two different branches - .claude/hooks/check-history-rewrite.sh records both under
+# "WHICH BRANCH". `hook_push_head_ref` owns the refspec rules.
+inferred_branch=0
+branch="$(hook_push_head_ref "$payload")"
+if [ -z "$branch" ]; then
+    inferred_branch=1
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+fi
 [ -n "$branch" ] && [ "$branch" != "HEAD" ] || exit 0
 
 # THROTTLE. Same branch, same hour, one reminder.
@@ -179,10 +191,19 @@ outstanding="$(awk '/^## Already fixed/ {exit} {print}' "$note" 2>/dev/null)"
 export NOTE_BODY="$outstanding"
 export NOTE_PATH="$note"
 export PR_NUM="$pr_num"
+# SAY WHEN THE BRANCH WAS A GUESS. A bare `git push` names no refspec, so the branch came from this
+# directory's HEAD - and "You are pushing to astubbs/parallel-consumer#N" is then a claim the hook
+# cannot support. The reminder is still worth making; presenting it as a fact is not.
+if [ "$inferred_branch" = 1 ]; then
+    export BRANCH_CAVEAT="The command names no branch, so this was looked up for \`$branch\`, the current HEAD of $root. If you are pushing something else, ignore all of this and read that branch's own note. "
+else
+    export BRANCH_CAVEAT=""
+fi
 python3 -c '
 import json, os
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse",
     "additionalContext": (
+        os.environ["BRANCH_CAVEAT"] +
         "READINESS IS THE OPERATOR\u2019S CALL, NOT YOURS. Do not tell them this PR is ready, "
         "mergeable or good to go. `MERGEABLE/CLEAN` from gh is a GIT fact - it means no conflicts - "
         "and saying it in prose reaches them earlier than any guard can fire, because a hook can "

--- a/.claude/hooks/remind-master-drift-on-push.sh
+++ b/.claude/hooks/remind-master-drift-on-push.sh
@@ -60,11 +60,24 @@ hook_lib="${BASH_SOURCE[0]%/*}/lib/hook-common.sh"
 invocations="$(hook_git_invocations "$payload")"
 case $'\n'"$invocations"$'\n' in *$'\n'push$'\n'*|*$'\n'push$'\t'*) ;; *) exit 0 ;; esac
 
+# THE REPOSITORY COMES FROM THE COMMAND'S OWN DIRECTORY, not this hook process's - same reasoning
+# and same edge as remind-inflight-on-push.sh, which owns the comment.
+cmd_cwd="$(hook_payload_cwd "$payload")"
+if [ -n "$cmd_cwd" ] && [ -d "$cmd_cwd" ]; then
+    cd "$cmd_cwd" 2>/dev/null || true
+fi
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] || exit 0
 cd "$root" 2>/dev/null || exit 0
 
+# TWO SIDES OF ONE REFSPEC: `git push origin src:dst` publishes the LOCAL branch `src` under the
+# REMOTE name `dst`. The dst is the right LABEL (it is what a PR has as its head branch, and what
+# the stamp is keyed by); the src is the CONTENT being pushed, so it is what the drift measurement
+# must read - measuring a same-named local `dst` reported another branch's drift, or went silent
+# when no such local branch existed (Codex review, astubbs/parallel-consumer#382). With no colon
+# the sides agree; an empty src (bare push, HEAD:x, an unexpanded $var) falls back to HEAD below.
 branch="$(hook_push_head_ref "$invocations")"
+push_src="$(hook_push_head_ref "$invocations" src)"
 head_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 [ -n "$branch" ] || branch="$head_branch"
 [ -n "$branch" ] && [ "$branch" != "HEAD" ] || exit 0
@@ -79,8 +92,8 @@ head_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 # measure stays silent rather than guessing.
 measure_ref="HEAD"
 worktree_diff=1
-if [ "$branch" != "$head_branch" ]; then
-    measure_ref="$(git rev-parse --verify --quiet "refs/heads/$branch" 2>/dev/null || true)"
+if [ -n "$push_src" ] && [ "$push_src" != "$head_branch" ]; then
+    measure_ref="$(git rev-parse --verify --quiet "refs/heads/$push_src" 2>/dev/null || true)"
     [ -n "$measure_ref" ] || exit 0
     worktree_diff=0
 fi

--- a/.claude/hooks/remind-master-drift-on-push.sh
+++ b/.claude/hooks/remind-master-drift-on-push.sh
@@ -52,14 +52,38 @@ hook_lib="${BASH_SOURCE[0]%/*}/lib/hook-common.sh"
 # shellcheck source=.claude/hooks/lib/hook-common.sh
 . "$hook_lib"
 
-hook_git_runs "$payload" push || exit 0
+# ONE tokeniser spawn answers both questions - "is this a push?" and "which branch does it name?" -
+# the same shape as remind-inflight-on-push.sh, wrapped-haystack match included. The refspec
+# outranks HEAD for the reason hook-common.sh's `hook_push_head_ref` states: this hook does not run
+# in the directory its guarded command runs in, so `git push origin other-branch` from here used to
+# measure THIS worktree's drift and report it against a push that never touched this branch.
+invocations="$(hook_git_invocations "$payload")"
+case $'\n'"$invocations"$'\n' in *$'\n'push$'\n'*|*$'\n'push$'\t'*) ;; *) exit 0 ;; esac
 
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] || exit 0
 cd "$root" 2>/dev/null || exit 0
 
-branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+branch="$(hook_push_head_ref "$invocations")"
+head_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+[ -n "$branch" ] || branch="$head_branch"
 [ -n "$branch" ] && [ "$branch" != "HEAD" ] || exit 0
+
+# THE MEASUREMENT MUST DESCRIBE THE SAME BRANCH AS THE NAME. Everything below measured `HEAD..` -
+# fine while the branch WAS HEAD, but pairing a refspec-named branch with the session tree's
+# measurement would report branch B's name over branch A's drift, the exact wrong-pairing defect
+# astubbs/parallel-consumer#382 exists to kill. So: pushing the checked-out branch measures HEAD
+# (working tree included, as before); pushing another branch measures that branch's own local ref,
+# with a plain committed diff because the working tree here belongs to a different branch; a branch
+# with no local ref in this repository cannot be measured at all, and a reminder that cannot
+# measure stays silent rather than guessing.
+measure_ref="HEAD"
+worktree_diff=1
+if [ "$branch" != "$head_branch" ]; then
+    measure_ref="$(git rev-parse --verify --quiet "refs/heads/$branch" 2>/dev/null || true)"
+    [ -n "$measure_ref" ] || exit 0
+    worktree_diff=0
+fi
 
 base_ref="${MASTER_DRIFT_REF:-origin/master}"
 # Pushing master itself has nothing to inherit. Compared against the ref BOTH ways, so a local
@@ -89,25 +113,29 @@ prev=""
 [ -f "$stamp" ] && prev="$(head -n1 "$stamp" 2>/dev/null || true)"
 printf '%s\n' "$base_sha" > "$stamp" 2>/dev/null || true
 
-behind="$(git rev-list --count "HEAD..$base_sha" 2>/dev/null || echo 0)"
+behind="$(git rev-list --count "$measure_ref..$base_sha" 2>/dev/null || echo 0)"
 case "$behind" in ''|*[!0-9]*) behind=0 ;; esac
 [ "$behind" -gt 0 ] || exit 0
 [ "$prev" != "$base_sha" ] || exit 0
 
-merge_base="$(git merge-base HEAD "$base_sha" 2>/dev/null || true)"
+merge_base="$(git merge-base "$measure_ref" "$base_sha" 2>/dev/null || true)"
 [ -n "$merge_base" ] || exit 0
 
 # CAPPED, AND THE CAP IS STATED. A silent truncation reads as a complete list, which is the failure
 # this repo has already published a wrong count from.
 commit_cap="${MASTER_DRIFT_COMMIT_CAP:-25}"
-commits="$(git log --format='  %h  %s' -n "$commit_cap" "HEAD..$base_sha" 2>/dev/null || true)"
+commits="$(git log --format='  %h  %s' -n "$commit_cap" "$measure_ref..$base_sha" 2>/dev/null || true)"
 commits_omitted=$(( behind > commit_cap ? behind - commit_cap : 0 ))
 
 # OVERLAP is the question the report exists to answer: has master touched anything this branch
 # touches? `git diff <merge-base>` with no second commit reads the WORKING TREE, so uncommitted work
 # counts as this branch's - a file you are editing right now is exactly the one you want to know
 # about.
-mine="$(git diff --name-only "$merge_base" 2>/dev/null | sort -u)"
+if [ "$worktree_diff" = 1 ]; then
+    mine="$(git diff --name-only "$merge_base" 2>/dev/null | sort -u)"
+else
+    mine="$(git diff --name-only "$merge_base" "$measure_ref" 2>/dev/null | sort -u)"
+fi
 theirs="$(git diff --name-only "$merge_base" "$base_sha" 2>/dev/null | sort -u)"
 overlap="$(comm -12 <(printf '%s\n' "$mine") <(printf '%s\n' "$theirs") 2>/dev/null | sed '/^$/d')"
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -4,8 +4,9 @@ Shared domain vocabulary for this project — entities, named processes, and sta
 project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and
 ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
 
-Seeded from the transactional-commit learning of 2026-08-07, so it covers the concurrency and
-transactional-commit area. Other areas of the project are not yet described here.
+Seeded from the transactional-commit learning of 2026-08-07 (the concurrency and
+transactional-commit area) and extended from the guard-lexing learning of 2026-09-01 (the agent
+harness area). Other areas of the project are not yet described here.
 
 ## Relationships
 
@@ -223,6 +224,38 @@ A ratchet is therefore a way to adopt a strict check against code that cannot pa
 today's findings as known, and every new one is blocked from that moment. It is not a suppression
 list - a suppression says "never report this", where a ratchet says "this one is already on the
 books, and here is the list you are expected to shorten".
+
+## Agent harness
+
+### Guard
+A check that runs automatically against an agent's action and can refuse it. Guards are split by
+failure direction, and the split decides their construction: a **refusing guard** must fail closed
+(a guard that cannot run must still block, because its whole value is stopping the action), so it
+inlines its logic rather than depending on anything it might fail to load; an **advisory reminder**
+must fail open (a reminder that breaks must stay silent rather than jam the action it decorates),
+so it may share helpers freely. The two look alike from outside - both observe the same actions -
+which is why the distinction is recorded per guard rather than inferred from where one is installed.
+
+### Advisory reminder
+A guard that only informs: it surfaces context alongside an action - open work, drift, a caveat -
+and never blocks. Its failure budget is the mirror of a refusing guard's: silence is acceptable,
+blocking is not, and a reminder that fires too often trains its reader to skip it, which is the
+same end state as one that never fires.
+
+### Labelled fallback
+The rule that an automated answer must name its own provenance, and that an answer derived from a
+weaker source must say so. A guard that cannot read the authoritative fact (the thing the action
+itself states) degrades tier by tier to weaker sources, and the message carries which tier
+answered - so a wrong answer is checkable instead of confidently misleading. The discipline exists
+because the failure mode it prevents is silent: a guess presented as a measurement reads exactly
+like a measurement.
+
+### Gate
+A repository check that a build or merge must pass, run both locally and in CI from one shared set
+so the two cannot drift. Gates differ from guards in what they inspect: a gate examines the state
+of the tree or the pull request, while a guard examines an action about to happen. A gate that
+cannot run must say so loudly - a skipped gate counted as a pass is the silent failure this
+vocabulary keeps naming from different sides.
 
 ## Flagged ambiguities
 

--- a/bin/check-quarantine-registry.sh
+++ b/bin/check-quarantine-registry.sh
@@ -41,9 +41,10 @@ for e in $(registry_entries); do
     cls=${e%%.*}
     method=""
     case "$e" in *.*) method=${e#*.} ;; esac
-    f=$(quarantined_files | while read -r qf; do
-            [ "$(basename "$qf" .java)" = "$cls" ] && { echo "$qf"; break; }
-        done)
+    # NOT an inline `quarantined_files | while ... break` - that shape aborted this script under
+    # `set -e` in exactly the no-match case the branch below reports, so the gate refused with no
+    # message at all. quarantine-common.sh's header owns the mechanism and the control arm.
+    f=$(quarantined_file_for_class "$cls")
     if [ -z "$f" ]; then
         echo "DRIFT: $REGISTRY lists $e but no @Quarantined annotation found in a class named $cls - stale entry; delete it (rule 3: annotation and entry go together)."
         drift=1

--- a/bin/lib/quarantine-common.sh
+++ b/bin/lib/quarantine-common.sh
@@ -45,6 +45,37 @@ quarantined_audit() {
         --exclude-dir=.git -A 4 "$QUARANTINE_ANNOTATION_ERE" . 2>/dev/null
 }
 
+# The annotated file whose basename is <Class>, or nothing when no annotated class has that name.
+#
+# IT IS A FUNCTION BECAUSE THE INLINE VERSION SILENTLY KILLED ITS CALLER. Every copy was
+# `f=$(quarantined_files | while read -r qf; do [ ... ] && { echo "$qf"; break; }; done)`, and under
+# `set -euo pipefail` that has two independent faults:
+#
+#   - THE NO-MATCH CASE ABORTS THE SCRIPT. A `while` carries out the status of the last command its
+#     body ran, so a final `[ ... ]` that found no match makes the loop exit 1, `pipefail` promotes
+#     it to the pipeline, the assignment takes it, and `set -e` kills the script THERE - before the
+#     caller's own message about the missing class can print. In bin/check-quarantine-registry.sh
+#     that destroyed the `DRIFT:` line for a registry entry whose class has no annotation, which is
+#     precisely the drift the gate exists to name: exit 1 was right, the explanation was gone.
+#     Control arm, same fixture, one term changed: `set -euo pipefail` printed nothing and exited 1;
+#     `set -uo pipefail` printed the full DRIFT line and exited 1.
+#   - THE `break` IS AN EARLY-EXITING PIPE READER, the EPIPE-into-`pipefail` hazard
+#     bin/check-shell-sigpipe.sh polices for `grep -q`. It needs more than one pipe buffer of
+#     pending input to bite, so it hides until the annotated-file list grows.
+#
+# So: no pipeline (a herestring), and an `if` rather than a `&&` list, because an `if` whose
+# condition is false is defined to exit 0 while a `&&` list is defined to carry the failure out.
+quarantined_file_for_class() { # <ClassName>
+    local qf
+    while IFS= read -r qf; do
+        if [ -n "$qf" ] && [ "$(basename "$qf" .java)" = "$1" ]; then
+            printf '%s\n' "$qf"
+            return 0
+        fi
+    done <<<"$(quarantined_files)"
+    return 0
+}
+
 # Registry entries, one per line: `Class.method` (or `Class` for class-level quarantines).
 registry_entries() {
     grep -E '^- \[ \] `' "$REGISTRY" 2>/dev/null | sed -E 's/^- \[ \] `([^`]+)`.*/\1/' || true

--- a/bin/quarantine-lane-report.sh
+++ b/bin/quarantine-lane-report.sh
@@ -81,17 +81,19 @@ outcome_of() {
 # is_flapping <Class>: 1 if the class's annotation carries flapping = true (single-annotation files only)
 is_flapping() {
     local f
-    f=$(quarantined_files | while read -r qf; do
-            [ "$(basename "$qf" .java)" = "$1" ] && { echo "$qf"; break; }
-        done)
+    # Same class of defect as bin/check-quarantine-registry.sh carried: the inline
+    # `quarantined_files | while ... break` this replaces exits 1 when NO file matches, and under
+    # this script's `set -e` that killed the report at the assignment. quarantine-common.sh's
+    # `quarantined_file_for_class` header owns the mechanism.
+    f=$(quarantined_file_for_class "$1")
     [ -n "$f" ] && grep -q 'flapping = true' "$f" && echo 1 || echo 0
 }
 
 annotation_location() { # <Class> -> path:line of the @Quarantined( line
     local f
-    f=$(quarantined_files | while read -r qf; do
-            [ "$(basename "$qf" .java)" = "$1" ] && { echo "$qf"; break; }
-        done)
+    f=$(quarantined_file_for_class "$1")
+    # Reachable only now: with the inline lookup, `set -e` killed the script one line above and this
+    # documented fallback never ran.
     [ -n "$f" ] || { echo "unknown"; return; }
     local line
     line=$(grep -nE "$QUARANTINE_ANNOTATION_ERE" "$f" | head -1 | cut -d: -f1)

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -1572,6 +1572,41 @@ out="$(push_fire 'npm push')"
 [ -z "$out" ] && got=silent || got=fired
 assert "a non-git binary does not fire" silent "$got"
 
+# WHICH BRANCH IT IS REMINDING ABOUT. Same defect as the history-rewrite guard's, in the hook whose
+# entire output is a claim about a named PR: `git push origin other-branch` from this directory used
+# to look up THIS branch's PR and quote its inflight note, opening with "You are pushing to
+# astubbs/parallel-consumer#N" - a flat statement about a branch the command does not touch. The stub
+# above answers 90003 whatever it is asked, so the observable is the argv, as it is for the sibling.
+push_log_stub="$(mktemp -d)"
+cat > "$push_log_stub/gh" <<GH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$push_log_stub/argv.log"
+echo 90003
+GH
+chmod +x "$push_log_stub/gh"
+push_fire_logged() { # <command> -> stdout of the hook
+    rm -f "$PUSH_TMPDIR"/pc-push-reminder-* 2>/dev/null
+    : > "$push_log_stub/argv.log"
+    printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$1" \
+        | PATH="$push_log_stub:$PATH" TMPDIR="$PUSH_TMPDIR" bash "$PUSH_HOOK" 2>/dev/null
+}
+push_head() { awk '{for (i = 1; i < NF; i++) if ($i == "--head") { print $(i+1); exit }}' "$push_log_stub/argv.log"; }
+
+push_fire_logged 'git push origin feats/somewhere-else' >/dev/null
+assert "the reminder looks up the branch the push names" feats/somewhere-else "$(push_head)"
+[ "$(push_head)" = "selftest/push-fixture" ] && got=the_pre_fix_answer || got=not_the_cwd_branch
+assert "and not the branch this directory is on" not_the_cwd_branch "$got"
+
+# A bare push has no refspec, so the directory is all there is - and the reminder must say the branch
+# was inferred rather than asserting it.
+out="$(push_fire_logged 'git push')"
+assert "a bare push falls back to this directory's branch" selftest/push-fixture "$(push_head)"
+case "$out" in *"names no branch"*) got=says_it_inferred ;; *) got=presented_as_fact ;; esac
+assert "and the reminder says the branch was inferred" says_it_inferred "$got"
+case "$out" in *'"deny"'*) got=blocked ;; *) got=advisory ;; esac
+assert "the caveat did not turn the reminder into a deny" advisory "$got"
+rm -rf "$push_log_stub"
+
 # THROTTLED, or a push loop repeats the whole note and teaches the reader to skip it.
 printf '{"tool_name":"Bash","tool_input":{"command":"git push"}}' | PATH="$push_stub:$PATH" TMPDIR="$PUSH_TMPDIR" bash "$PUSH_HOOK" >/dev/null 2>&1
 out="$(printf '{"tool_name":"Bash","tool_input":{"command":"git push"}}' | PATH="$push_stub:$PATH" TMPDIR="$PUSH_TMPDIR" bash "$PUSH_HOOK" 2>/dev/null)"
@@ -1831,6 +1866,99 @@ assert "a PR with nothing outstanding still states the risk" states_the_risk "$g
 hist_out="$(hist 'git push --force origin main')"
 case "$hist_out" in *"LAST step before a merge"*) got=explains ;; *) got=bare_refusal ;; esac
 assert "the refusal says when a rewrite IS allowed" explains "$got"
+
+# --- WHICH BRANCH THE REFUSAL IS ABOUT -------------------------------------------------------
+#
+# A hook does NOT run in the directory its guarded command runs in, and this repository keeps many
+# worktrees checked out at once - so `git rev-parse --abbrev-ref HEAD` in the hook process answers
+# about whichever branch the SESSION sits on. Twice on 2026-08-31 that made this hook's most
+# confident sentence describe an unrelated branch: a force-push of `feats/proxy-verdict-free-return`
+# (open PR astubbs/parallel-consumer#295, with review history) and a `git commit --amend` inside the
+# `feats/ks-streams-fork-machinery` worktree were both reported against
+# `docs/god-branch-decomposition-plan`, the plan worktree that session occupied.
+#
+# THE OBSERVABLE IS THE ARGV gh WAS HANDED, not the message - a lookup for the wrong branch succeeds
+# and reads exactly like a correct one, which is what let this run for as long as it did. Same
+# technique as case 3 of the lookup section below, for the same reason.
+#
+# EACH CASE ASSERTS BOTH HALVES: the branch asked about is the one the command names, AND it is not
+# the branch the working directory is on. The second half is the negative control - it is precisely
+# the pre-fix answer, so a fixture that stopped reaching the defect (both names collapsing to one)
+# fails rather than passing vacuously.
+hb_prev_cwd="$PWD"
+hb_cwd_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+hb_stub="$(mktemp -d)"
+cat > "$hb_stub/gh" <<GH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$hb_stub/argv.log"
+case "\$*" in
+    *"pr list"*)   echo 90007 ;;
+    *"/comments"*) echo 0 ;;
+    *"run list"*)  echo 0 ;;
+esac
+GH
+chmod +x "$hb_stub/gh"
+
+# A SECOND WORKTREE, standing in for the one the session is not sitting in. Hosted `origin` because
+# both the slug derivation and the refusal depend on it - see the push fixture's own note.
+hb_other="$(mktemp -d)"
+(
+  cd "$hb_other" || exit 1
+  git init -q .
+  git checkout -q -b selftest/other-worktree 2>/dev/null || git branch -q -m selftest/other-worktree
+  git remote add origin https://github.com/astubbs/parallel-consumer.git
+  : > .keep
+  git add .keep
+  git -c user.email=selftest@example.invalid -c user.name=selftest commit -qm "fixture"
+)
+
+hb_fire() { # <command> [payload-cwd] -> stdout of the hook
+    : > "$hb_stub/argv.log"
+    printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "${2:-$PWD}" "$1" \
+        | PATH="$hb_stub:$PATH" bash "$HIST_HOOK" 2>/dev/null
+}
+# No pipeline: `grep -o ... | head -1` is the early-exiting-reader shape bin/AGENTS.md warns about,
+# and this suite runs under pipefail.
+hb_head() { awk '{for (i = 1; i < NF; i++) if ($i == "--head") { print $(i+1); exit }}' "$hb_stub/argv.log"; }
+
+hb_out="$(hb_fire 'git push --force origin feats/elsewhere')"
+assert "a force-push names the branch its refspec names" feats/elsewhere "$(hb_head)"
+[ "$(hb_head)" = "$hb_cwd_branch" ] && got=the_pre_fix_answer || got=not_the_cwd_branch
+assert "and not the branch this directory happens to be on" not_the_cwd_branch "$got"
+[ -n "$hb_out" ] && got=DENY || got=ALLOW
+assert "naming the branch from the command still REFUSES" DENY "$got"
+
+# THE PR HEAD IS THE DESTINATION of a `src:dst` refspec, not the source - `dst` is what a pull
+# request has as its head branch.
+hb_fire 'git push --force origin HEAD:feats/destination' >/dev/null
+assert "a src:dst refspec is read at its destination" feats/destination "$(hb_head)"
+hb_fire 'git push origin --delete doomed-branch' >/dev/null
+assert "a remote branch deletion names the branch being deleted" doomed-branch "$(hb_head)"
+
+# NO REFSPEC IS A REAL ANSWER: the working directory is all there is, and the refusal has to say so
+# rather than presenting a guess as a measurement.
+hb_out="$(hb_fire 'git push -f')"
+assert "a push with no refspec falls back to this directory" "$hb_cwd_branch" "$(hb_head)"
+case "$hb_out" in *"DOES NOT NAME A BRANCH"*) got=says_it_guessed ;; *) got=presented_as_fact ;; esac
+assert "and the refusal says the branch was not named by the command" says_it_guessed "$got"
+
+# THE AMEND CASE, which is the second half of the 2026-08-31 incident: a non-push rewrite has no
+# refspec to read, so the only improvement available is to look in the right DIRECTORY and to say
+# which one. A leading `cd <path> &&` is the command saying where it runs, and outranks everything.
+hb_fire "cd $hb_other && git commit --amend --no-edit" >/dev/null
+assert "an amend behind a cd prefix is looked up in THAT worktree" selftest/other-worktree "$(hb_head)"
+[ "$(hb_head)" = "$hb_cwd_branch" ] && got=the_pre_fix_answer || got=not_the_cwd_branch
+assert "and not in the directory the hook itself runs in" not_the_cwd_branch "$got"
+
+# ...and with no `cd`, the tool call's own `cwd` from the payload, which is the field the pre-fix
+# hook ignored entirely in favour of its own process directory.
+hb_out="$(hb_fire 'git commit --amend --no-edit' "$hb_other")"
+assert "an amend is looked up in the tool call's own directory" selftest/other-worktree "$(hb_head)"
+case "$hb_out" in *"$hb_other"*) got=names_the_directory ;; *) got=unattributed ;; esac
+assert "the refusal names the directory it derived the branch from" names_the_directory "$got"
+
+rm -rf "$hb_stub" "$hb_other"
+cd "$hb_prev_cwd" || exit 1
 echo
 echo "--- the PR lookup, in the three hooks that make one ---"
 

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -46,6 +46,13 @@ assert() { # <description> <expected> <actual>
     fi
 }
 
+# The `--head` value a stubbed `gh` was asked about, read from that stub's argv log. Awk rather
+# than `grep -o ... | head -1`, which is the early-exiting-reader pipeline shape bin/AGENTS.md
+# warns about - and this suite runs under pipefail.
+stub_head_arg() { # <argv-log>
+    awk '{for (i = 1; i < NF; i++) if ($i == "--head") { print $(i+1); exit }}' "$1"
+}
+
 # ---------------------------------------------------------------------------------------------
 # check-squash-subject.sh
 #
@@ -1679,7 +1686,7 @@ push_fire_logged() { # <command> -> stdout of the hook
     printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$1" \
         | PATH="$push_log_stub:$PATH" TMPDIR="$PUSH_TMPDIR" bash "$PUSH_HOOK" 2>/dev/null
 }
-push_head() { awk '{for (i = 1; i < NF; i++) if ($i == "--head") { print $(i+1); exit }}' "$push_log_stub/argv.log"; }
+push_head() { stub_head_arg "$push_log_stub/argv.log"; }
 
 push_fire_logged 'git push origin feats/somewhere-else' >/dev/null
 assert "the reminder looks up the branch the push names" feats/somewhere-else "$(push_head)"
@@ -2006,9 +2013,7 @@ hb_fire() { # <command> [payload-cwd] -> stdout of the hook
     printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "${2:-$PWD}" "$1" \
         | PATH="$hb_stub:$PATH" bash "$HIST_HOOK" 2>/dev/null
 }
-# No pipeline: `grep -o ... | head -1` is the early-exiting-reader shape bin/AGENTS.md warns about,
-# and this suite runs under pipefail.
-hb_head() { awk '{for (i = 1; i < NF; i++) if ($i == "--head") { print $(i+1); exit }}' "$hb_stub/argv.log"; }
+hb_head() { stub_head_arg "$hb_stub/argv.log"; }
 
 hb_out="$(hb_fire 'git push --force origin feats/elsewhere')"
 assert "a force-push names the branch its refspec names" feats/elsewhere "$(hb_head)"

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -2057,10 +2057,15 @@ hb_other="$(mktemp -d)"
   git -c user.email=selftest@example.invalid -c user.name=selftest commit -qm "fixture"
 )
 
-hb_fire() { # <command> [payload-cwd] -> stdout of the hook
+hb_fire() { # <command> [payload-cwd | "-" to omit the cwd field] -> stdout of the hook
     : > "$hb_stub/argv.log"
-    printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "${2:-$PWD}" "$1" \
-        | PATH="$hb_stub:$PATH" bash "$HIST_HOOK" 2>/dev/null
+    if [ "${2:-}" = "-" ]; then
+        printf '{"tool_name":"Bash","tool_input":{"command":"%s"}}' "$1" \
+            | PATH="$hb_stub:$PATH" bash "$HIST_HOOK" 2>/dev/null
+    else
+        printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "${2:-$PWD}" "$1" \
+            | PATH="$hb_stub:$PATH" bash "$HIST_HOOK" 2>/dev/null
+    fi
 }
 hb_head() { stub_head_arg "$hb_stub/argv.log"; }
 
@@ -2099,6 +2104,62 @@ hb_out="$(hb_fire 'git commit --amend --no-edit' "$hb_other")"
 assert "an amend is looked up in the tool call's own directory" selftest/other-worktree "$(hb_head)"
 case "$hb_out" in *"$hb_other"*) got=names_the_directory ;; *) got=unattributed ;; esac
 assert "the refusal names the directory it derived the branch from" names_the_directory "$got"
+
+# THE REVIEW ROUND ON astubbs/parallel-consumer#382, pinned. Each of these was a way for this
+# refusing guard to answer about the wrong thing - or not answer at all - found by fresh reviewers
+# and an independent cross-model pass after the first fix landed.
+
+# `git -C <path>` used to put the path where the subcommand should be, so the guard matched NOTHING
+# and a force-push sailed through in silence - a total bypass of the thing this hook refuses.
+hb_out="$(hb_fire "git -C $hb_other push --force origin feats/elsewhere")"
+[ -n "$hb_out" ] && got=DENY || got=ALLOW
+assert "git -C <path> push --force is not a silent bypass" DENY "$got"
+assert "and its refspec still names the branch" feats/elsewhere "$(hb_head)"
+hb_out="$(hb_fire "git -C $hb_other commit --amend --no-edit")"
+assert "git -C relocates the amend lookup to THAT worktree" selftest/other-worktree "$(hb_head)"
+
+# A NEWLINE is a command boundary, not whitespace: `git push -f<newline>git log -1` used to swallow
+# the next command as push arguments and name `log` as the branch - a confident wrong answer where
+# the honest one is the labelled fallback.
+hb_out="$(hb_fire 'git push -f\ngit log -1')"
+assert "a newline-separated payload does not donate a fake branch" "$hb_cwd_branch" "$(hb_head)"
+case "$hb_out" in *"DOES NOT NAME A BRANCH"*) got=says_it_guessed ;; *) got=presented_as_fact ;; esac
+assert "and that fallback says the branch was not named" says_it_guessed "$got"
+hb_fire 'git push --force origin feats/real\ngit log' >/dev/null
+assert "a real refspec before a newline still wins" feats/real "$(hb_head)"
+
+# UNSPACED OPERATORS stay operators: `feature&&git` is not a branch name.
+hb_fire 'git push --force origin feats/spliced&&git status' >/dev/null
+assert "an unspaced && does not fuse into the branch name" feats/spliced "$(hb_head)"
+
+# TWO command-position `cd`s are AMBIGUOUS - the amend may run in either - so the guard must fall
+# back to the payload cwd, whose label already says it is a guess, rather than presenting the
+# FIRST cd as the directory the command changes into.
+hb_dead="$(mktemp -d)"
+hb_fire "cd $hb_dead && echo x && cd $hb_other && git commit --amend --no-edit" "$hb_other" >/dev/null
+assert "two cds fall back to the payload cwd, not the first cd" selftest/other-worktree "$(hb_head)"
+rm -rf "$hb_dead"
+
+# A RELATIVE `cd` is relative to where the COMMAND runs. The hook process sits elsewhere, so
+# resolving it from the hook's own directory would test the wrong tree - and succeed, because
+# same-named subdirectories exist in every worktree of this repository.
+( cd "$hb_other" && mkdir -p relsub && cd relsub && : > .keep )
+hb_fire 'cd relsub && git commit --amend --no-edit' "$hb_other" >/dev/null
+assert "a relative cd resolves against the payload cwd" selftest/other-worktree "$(hb_head)"
+
+# THE LAST-RESORT TIER: no refspec, no cd, no payload cwd leaves only the hook process's own
+# directory, and the refusal must SAY that is what it used - the least trustworthy answer in the
+# derivation order, which is exactly why its label has to survive.
+hb_out="$(hb_fire 'git commit --amend --no-edit' -)"
+case "$hb_out" in *"this hook process's directory"*) got=labelled_last_resort ;; *) got=unlabelled ;; esac
+assert "with no cwd at all, the hook-directory fallback is labelled" labelled_last_resort "$got"
+
+# AN UNEXPANDED $VAR is source text, not a branch - fall back with the label, never assert the
+# literal.
+hb_out="$(hb_fire 'git push --force origin $TARGET_BRANCH')"
+assert "an unexpanded \$VAR refspec falls back to this directory" "$hb_cwd_branch" "$(hb_head)"
+case "$hb_out" in *"DOES NOT NAME A BRANCH"*) got=says_it_guessed ;; *) got=presented_as_fact ;; esac
+assert "and the \$VAR fallback is labelled as a guess" says_it_guessed "$got"
 
 rm -rf "$hb_stub" "$hb_other"
 cd "$hb_prev_cwd" || exit 1

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -1641,6 +1641,17 @@ for form in 'git add -A&&git commit -m x&&git push' 'git push;echo done' 'git pu
     assert "reminds with unspaced/semicolon operators: $form" reminded "$got"
 done
 
+# A COMMAND AFTER THE PUSH. `git push && git status` tokenises to the invocation lines
+# `push`,`status`, and the first single-tokeniser-spawn refactor matched a bare `push` line only at
+# the start or end of the whole list - so the commonest compound push of all went silent. Found
+# three times over by review on astubbs/parallel-consumer#382; these pin the per-line match, and
+# the `\n` form pins the lexer treating a line break as a command boundary.
+for form in 'git push && git status' 'git commit -m x && git push && git tag y' 'git push\ngit status'; do
+    out="$(push_fire "$form")"
+    case "$out" in *PUSH_OPEN_ITEM*) got=reminded ;; *) got=silent ;; esac
+    assert "reminds on a push FOLLOWED by another command: $form" reminded "$got"
+done
+
 # ...and the matching negative control the review asked for: a CHAIN of git calls with no push in it
 # must stay silent. The positive chained cases above cannot show that on their own.
 for form in 'git add -A && git commit -m x' 'git fetch origin&&git status'; do
@@ -1701,6 +1712,23 @@ case "$out" in *"names no branch"*) got=says_it_inferred ;; *) got=presented_as_
 assert "and the reminder says the branch was inferred" says_it_inferred "$got"
 case "$out" in *'"deny"'*) got=blocked ;; *) got=advisory ;; esac
 assert "the caveat did not turn the reminder into a deny" advisory "$got"
+
+# VALUE-TAKING PUSH OPTIONS. Dropping only the flag leaves its value where the repository should
+# be, shifting every positional: `-o ci.skip` would read `ci.skip` as the repo and `origin` as the
+# refspec. `--recurse-submodules` was the one missing from the skip list (cross-model review,
+# astubbs/parallel-consumer#382).
+push_fire_logged 'git push -o ci.skip origin feats/somewhere-else' >/dev/null
+assert "a value-taking push option does not shift the refspec" feats/somewhere-else "$(push_head)"
+push_fire_logged 'git push --recurse-submodules on-demand origin feats/somewhere-else' >/dev/null
+assert "--recurse-submodules value is not read as the repository" feats/somewhere-else "$(push_head)"
+
+# AN UNEXPANDED SHELL VARIABLE is source text, not a branch: the shell would expand it before git
+# ever saw it, so asserting anything about the literal is a confident wrong answer. Fall back to
+# the directory and say the branch was inferred.
+out="$(push_fire_logged 'git push origin $SOMEBRANCH')"
+assert "an unexpanded \$VAR refspec falls back to the directory branch" selftest/push-fixture "$(push_head)"
+case "$out" in *"names no branch"*) got=says_it_inferred ;; *) got=presented_as_fact ;; esac
+assert "and the \$VAR fallback says the branch was inferred" says_it_inferred "$got"
 rm -rf "$push_log_stub"
 
 # THROTTLED, or a push loop repeats the whole note and teaches the reader to skip it.
@@ -1812,6 +1840,27 @@ assert "the same base tip is not reported twice" throttled "$got"
 drift_moved="$(drift_ctx "$(drift_fire)")"
 case "$drift_moved" in *MASTER-SUBJECT-TWO*) got=reported_again ;; *) got="stayed quiet" ;; esac
 assert "a base ref that moved is reported again at once" reported_again "$got"
+
+# THE PUSH REFSPEC NAMES THE BRANCH, and the measurement must describe the SAME branch as the name
+# (astubbs/parallel-consumer#382). Two halves: pushing the base branch itself by refspec must be
+# silent even from a drifted worktree - the pre-fix hook read HEAD and would have reported this
+# worktree's drift against a push that never touched it - and pushing a named side branch must be
+# measured by that branch's own ref, so the session worktree's overlap cannot leak into its report.
+( cd "$drift_repo" && git branch -q sidework "$(git merge-base basefix feature)" )
+drift_refspec_tmp="$(mktemp -d)"
+out="$(printf '{"tool_name":"Bash","tool_input":{"command":"git push origin basefix"}}' |
+    env TMPDIR="$drift_refspec_tmp" MASTER_DRIFT_REF=basefix MASTER_DRIFT_FETCH_FLOOR_SECONDS=0 bash "$DRIFT_HOOK" 2>/dev/null)"
+[ -z "$out" ] && got=silent || got="reported the session's drift"
+assert "pushing the base branch BY REFSPEC is silent even from a drifted worktree" silent "$got"
+drift_side_tmp="$(mktemp -d)"
+out="$(printf '{"tool_name":"Bash","tool_input":{"command":"git push origin sidework"}}' |
+    env TMPDIR="$drift_side_tmp" MASTER_DRIFT_REF=basefix MASTER_DRIFT_FETCH_FLOOR_SECONDS=0 bash "$DRIFT_HOOK" 2>/dev/null)"
+drift_side_report="$(drift_ctx "$out")"
+case "$drift_side_report" in *MASTER-SUBJECT-ONE*) got=measured_sidework ;; *) got="no report" ;; esac
+assert "a refspec-named branch is measured by its own local ref" measured_sidework "$got"
+case "$drift_side_report" in *"BOTH sides"*) got="leaked the worktree's overlap" ;; *) got=no_false_overlap ;; esac
+assert "and the session worktree's overlap is not attributed to it" no_false_overlap "$got"
+rm -rf "$drift_refspec_tmp" "$drift_side_tmp"
 
 # UNCOMMITTED WORK COUNTS AS THIS BRANCH'S, which the hook states as a deliberate choice: a file you
 # are editing right now is the one you most want to hear about. `untouched.txt` is in neither side's

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -391,6 +391,95 @@ git status')"
 assert "a commit inside a function-keyword body is still gated" 2 \
     "$(gate_rc "$red" 'function deploy { git commit -m x; }; deploy')"
 
+# --- WHICH WORKING TREE IT GATES -----------------------------------------------------------------
+#
+# The gate script and its working directory both came from `$CLAUDE_PROJECT_DIR`, which names the
+# SESSION's project root. A SUBAGENT has its own working directory while that variable still points
+# at the session's most recent worktree - and a subagent's `git commit ...` is bare, so it matches
+# the registration and arrives here. Observed 2026-08-31: a subagent committing in
+# `.claude/worktrees/proxy-server-shell` was gated against `.claude/worktrees/bench-harness`, failing
+# check-file-refs.sh on citations to files that do not exist on its branch while its own tree ran the
+# same gate at exit 0, and five commits went through with --no-verify.
+#
+# THE WORSE HALF LEAVES NO TRACE, and gets its own case below: the misresolution can fail OPEN, a red
+# tree passing because the session's tree is green. Nobody investigates a commit that was allowed.
+#
+# REAL GIT REPOS, unlike `make_project` above, because the resolution now climbs to the repository
+# root - and the assertions are on the gate's own LABEL rather than on paths, since `mktemp -d` under
+# `/var` and `git rev-parse --show-toplevel` under `/private/var` name the same directory differently
+# on macOS.
+make_worktree() { # <label> <gate-exit-code> -> a git repo whose stub gate announces itself
+    local dir="$TMP/wt-$1-$RANDOM$RANDOM"
+    mkdir -p "$dir/.githooks" "$dir/nested/deeper"
+    ( cd "$dir" && git init -q . )
+    printf '#!/bin/sh\necho "GATE OF %s SPOKE in $(basename "$PWD")"\nexit %s\n' "$1" "$2" > "$dir/.githooks/pre-commit"
+    chmod +x "$dir/.githooks/pre-commit"
+    echo "$dir"
+}
+wt_fire() { # <CLAUDE_PROJECT_DIR> <payload-cwd|-> <command> -> "<exit>|<stderr>"
+    local payload out rc=0
+    payload=$(python3 -c '
+import json, sys
+d = {"tool_name": "Bash", "tool_input": {"command": sys.argv[1]}}
+if sys.argv[2] != "-":
+    d["cwd"] = sys.argv[2]
+print(json.dumps(d))' "$3" "$2")
+    out=$(printf '%s' "$payload" | CLAUDE_PROJECT_DIR="$1" "$HOOKS/pre-commit-gate.sh" 2>&1 >/dev/null) || rc=$?
+    printf '%s|%s' "$rc" "$(printf '%s' "$out" | tr '\n' ' ')"
+}
+
+session_green=$(make_worktree session-green 0)
+commit_red=$(make_worktree commit-red 1)
+session_red=$(make_worktree session-red 1)
+commit_green=$(make_worktree commit-green 0)
+
+# 1. THE INCIDENT. The commit runs in a worktree whose gate is red; the session's is green.
+wt_out=$(wt_fire "$session_green" "$commit_red" 'git commit -m "in the other worktree"')
+assert "a commit is gated by the tree it runs in, not the session's" 2 "${wt_out%%|*}"
+case "$wt_out" in
+    *"GATE OF commit-red"*) got=ran_the_commits_gate ;;
+    *"GATE OF session-green"*) got=ran_the_sessions_gate ;;
+    *) got="neither: ${wt_out#*|}" ;;
+esac
+assert "...and it is the commit's OWN gate script that ran" ran_the_commits_gate "$got"
+case "${wt_out#*|}" in *"in wt-commit-red"*) got=ran_there ;; *) got="wrong cwd: ${wt_out#*|}" ;; esac
+assert "...run WITH that tree as its working directory" ran_there "$got"
+
+# 2. THE SILENT HALF, which is the one nobody would have found: a red tree allowed because the
+# SESSION's tree is green. Exit 0 here is the fix; the pre-fix hook blocked on the session's gate.
+wt_out=$(wt_fire "$session_red" "$commit_green" 'git commit -m "clean tree"')
+assert "a clean tree is not blocked by the session's red one" 0 "${wt_out%%|*}"
+case "${wt_out#*|}" in *"GATE OF session-red"*) got=ran_the_sessions_gate ;; *) got=left_it_alone ;; esac
+assert "...and the session's gate was not consulted at all" left_it_alone "$got"
+
+# 3. `git -C <path> commit` names its own repository, and is the strongest signal there is.
+wt_out=$(wt_fire "$session_green" - "git -C $commit_red commit -m x")
+assert "git -C names the tree to gate" 2 "${wt_out%%|*}"
+case "$wt_out" in *"GATE OF commit-red"*) got=followed_dash_c ;; *) got="ignored it: ${wt_out#*|}" ;; esac
+assert "...even with no cwd in the payload" followed_dash_c "$got"
+
+# 4. A COMMIT FROM A SUBDIRECTORY has to climb: the gate lives at the checkout root, and stopping at
+# the literal directory would find no gate and fail open - a silent skip, not a visible error.
+wt_out=$(wt_fire "$session_green" "$commit_red/nested/deeper" 'git commit -m "from a subdir"')
+assert "a commit from a subdirectory climbs to the repository root" 2 "${wt_out%%|*}"
+
+# 5. THE FALLBACK IS A DECISION, not an accident: with nothing in the payload saying where the
+# command runs, `$CLAUDE_PROJECT_DIR` is still the best available answer and is still used. All the
+# cases above this section rely on it, so this pins it explicitly alongside its replacements.
+wt_out=$(wt_fire "$commit_red" - 'git commit -m "no cwd in the payload"')
+assert "with nothing else to go on it falls back to the project dir" 2 "${wt_out%%|*}"
+case "$wt_out" in *"GATE OF commit-red"*) got=used_the_fallback ;; *) got="${wt_out#*|}" ;; esac
+assert "...and says so rather than skipping" used_the_fallback "$got"
+case "$wt_out" in *"did not say where it runs"*) got=labelled ;; *) got=unlabelled ;; esac
+assert "...labelled as the session's root in the refusal" labelled "$got"
+
+# 6. A BYPASS IS STILL A BYPASS wherever the commit runs - the escape hatch must not have been
+# narrowed to the session's tree by any of the above.
+wt_out=$(wt_fire "$session_green" "$commit_red" 'git commit --no-verify -m "I have a reason"')
+assert "--no-verify bypasses the OTHER tree's red gate too" 0 "${wt_out%%|*}"
+
+rm -rf "$session_green" "$commit_red" "$session_red" "$commit_green"
+
 # ---------------------------------------------------------------------------------------------
 # inject-merge-checklist.sh
 # ---------------------------------------------------------------------------------------------

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -494,6 +494,23 @@ assert "...and runs the resolved tree's own gate" resolved_relative "$got"
 wt_out=$(wt_fire "$session_green" "$commit_green" 'git -C redsub commit -m x')
 assert "a relative git -C resolves against the payload cwd" 2 "${wt_out%%|*}"
 
+# 3e. REPEATED -C values COMPOSE: `git -C sub -C .. commit` runs in the ORIGINAL repository, so the
+# red gate must fire. Keeping only the last token resolved `..` against the payload cwd - the
+# parent, which has no gate - and the commit passed unchecked (Codex review on
+# astubbs/parallel-consumer#382).
+mkdir -p "$commit_red/sub"
+wt_out=$(wt_fire "$session_green" "$commit_red" 'git -C sub -C .. commit -m x')
+assert "repeated -C paths compose instead of last-wins" 2 "${wt_out%%|*}"
+case "$wt_out" in *"GATE OF commit-red"*) got=composed_the_chain ;; *) got="escaped to the parent: ${wt_out#*|}" ;; esac
+assert "...and the composed chain lands back in the red tree" composed_the_chain "$got"
+
+# 3f. `cd /x & git commit` backgrounds the cd - the commit stays in the payload cwd, so trusting
+# the prefix would run the green tree's gate over the red tree the commit actually lands in.
+wt_out=$(wt_fire "$session_green" "$commit_red" "cd $commit_green & git commit -m x")
+assert "a backgrounded cd does not relocate the gate" 2 "${wt_out%%|*}"
+case "$wt_out" in *"GATE OF commit-red"*) got=gated_the_real_tree ;; *) got="trusted the subshell cd: ${wt_out#*|}" ;; esac
+assert "...and the red tree's own gate is the one that ran" gated_the_real_tree "$got"
+
 # 4. A COMMIT FROM A SUBDIRECTORY has to climb: the gate lives at the checkout root, and stopping at
 # the literal directory would find no gate and fail open - a silent skip, not a visible error.
 wt_out=$(wt_fire "$session_green" "$commit_red/nested/deeper" 'git commit -m "from a subdir"')
@@ -1889,7 +1906,27 @@ case "$drift_side_report" in *MASTER-SUBJECT-ONE*) got=measured_sidework ;; *) g
 assert "a refspec-named branch is measured by its own local ref" measured_sidework "$got"
 case "$drift_side_report" in *"BOTH sides"*) got="leaked the worktree's overlap" ;; *) got=no_false_overlap ;; esac
 assert "and the session worktree's overlap is not attributed to it" no_false_overlap "$got"
-rm -rf "$drift_refspec_tmp" "$drift_side_tmp"
+
+# `git push origin src:dst` PUBLISHES src - dst is only the remote label. Measuring dst read a
+# same-named local branch that was not being pushed, or went silent when none existed (Codex
+# review, astubbs/parallel-consumer#382). sidework:renamed must measure sidework's own drift.
+drift_srcdst_tmp="$(mktemp -d)"
+out="$(printf '{"tool_name":"Bash","tool_input":{"command":"git push origin sidework:renamed"}}' |
+    env TMPDIR="$drift_srcdst_tmp" MASTER_DRIFT_REF=basefix MASTER_DRIFT_FETCH_FLOOR_SECONDS=0 bash "$DRIFT_HOOK" 2>/dev/null)"
+drift_srcdst_report="$(drift_ctx "$out")"
+case "$drift_srcdst_report" in *MASTER-SUBJECT-ONE*) got=measured_the_src ;; *) got="no report" ;; esac
+assert "a src:dst push is measured on its SOURCE branch" measured_the_src "$got"
+
+# THE REPOSITORY COMES FROM THE PAYLOAD CWD: a hook process running somewhere else entirely (a
+# subagent) must still measure the repository the command runs in. Pre-fix, rev-parse in the
+# hook's own directory found no repo and the reminder silently vanished.
+drift_cwd_tmp="$(mktemp -d)"
+out="$( (cd "$drift_cwd_tmp" && printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"git push"}}' "$drift_repo" |
+    env TMPDIR="$drift_cwd_tmp" MASTER_DRIFT_REF=basefix MASTER_DRIFT_FETCH_FLOOR_SECONDS=0 bash "$DRIFT_HOOK" 2>/dev/null) )"
+drift_cwd_report="$(drift_ctx "$out")"
+case "$drift_cwd_report" in *MASTER-SUBJECT-*) got=found_the_repo ;; *) got="stayed silent" ;; esac
+assert "the drift repo is derived from the payload cwd, not the hook's" found_the_repo "$got"
+rm -rf "$drift_refspec_tmp" "$drift_side_tmp" "$drift_srcdst_tmp" "$drift_cwd_tmp"
 
 # UNCOMMITTED WORK COUNTS AS THIS BRANCH'S, which the hook states as a deliberate choice: a file you
 # are editing right now is the one you most want to hear about. `untouched.txt` is in neither side's
@@ -2182,6 +2219,29 @@ assert "a relative cd resolves against the payload cwd" selftest/other-worktree 
 hb_out="$(hb_fire 'git commit --amend --no-edit' -)"
 case "$hb_out" in *"this hook process's directory"*) got=labelled_last_resort ;; *) got=unlabelled ;; esac
 assert "with no cwd at all, the hook-directory fallback is labelled" labelled_last_resort "$got"
+
+# THE CODEX ROUND (astubbs/parallel-consumer#382), pinned - four more ways to steer the guard.
+
+# A -C recorded while scanning an EARLIER invocation must not survive into the one that carries
+# the verdict: `git -C <dir> status && git commit --amend` runs the amend in the payload cwd.
+# Pre-fix this either answered about <dir> or, when <dir> was not a repository, went completely
+# SILENT - a bypass of the refusal itself.
+hb_bleed="$(mktemp -d)"
+hb_out="$(hb_fire "git -C $hb_bleed status && git commit --amend --no-edit" "$hb_other")"
+[ -n "$hb_out" ] && got=DENY || got=ALLOW
+assert "a -C on an EARLIER command does not bleed into the amend" DENY "$got"
+assert "...and the amend is answered from the payload cwd" selftest/other-worktree "$(hb_head)"
+rm -rf "$hb_bleed"
+
+# --recurse-submodules takes a separate value; the python copy of the parser must skip it too
+# (change one, change the other - and the first round changed only the bash one).
+hb_fire 'git push --force --recurse-submodules on-demand origin feats/subm' >/dev/null
+assert "the python parser skips --recurse-submodules and its value" feats/subm "$(hb_head)"
+
+# `cd /x & git commit` BACKGROUNDS the cd into a subshell - the amend stays where the payload says,
+# so the prefix must not be trusted across a cwd-losing operator.
+hb_fire "cd $hb_other & git commit --amend --no-edit" >/dev/null
+assert "a backgrounded cd does not relocate the amend" "$hb_cwd_branch" "$(hb_head)"
 
 # AN UNEXPANDED $VAR is source text, not a branch - fall back with the label, never assert the
 # literal.

--- a/bin/test-check-agent-hooks.sh
+++ b/bin/test-check-agent-hooks.sh
@@ -465,6 +465,35 @@ assert "git -C names the tree to gate" 2 "${wt_out%%|*}"
 case "$wt_out" in *"GATE OF commit-red"*) got=followed_dash_c ;; *) got="ignored it: ${wt_out#*|}" ;; esac
 assert "...even with no cwd in the payload" followed_dash_c "$got"
 
+# 3b. THE LEADING-CD TIER, previously untested end to end (review round on
+# astubbs/parallel-consumer#382): a leading `cd <path> &&` is the command saying where it runs, and
+# outranks the payload cwd.
+wt_out=$(wt_fire "$session_green" "$commit_green" "cd $commit_red && git commit -m x")
+assert "a leading cd names the tree to gate" 2 "${wt_out%%|*}"
+case "$wt_out" in *"GATE OF commit-red"*) got=followed_the_cd ;; *) got="ignored it: ${wt_out#*|}" ;; esac
+assert "...over the payload cwd" followed_the_cd "$got"
+
+# 3c. TWO command-position cds are AMBIGUOUS - the commit may run in either - so the gate must fall
+# back to the payload cwd rather than trusting the FIRST cd. Pre-fix, this gated wt-commit-green
+# (the first cd) and let the red tree pass.
+wt_out=$(wt_fire "$session_green" "$commit_red" "cd $commit_green && echo x && cd $commit_red && git commit -m x")
+assert "two cds fall back to the payload cwd" 2 "${wt_out%%|*}"
+case "$wt_out" in *"GATE OF commit-red"*) got=gated_the_payload_cwd ;; *) got="gated the first cd: ${wt_out#*|}" ;; esac
+assert "...which is the red tree the commit actually runs in" gated_the_payload_cwd "$got"
+
+# 3d. A RELATIVE cd or -C is relative to the PAYLOAD cwd, never to the hook process - same-named
+# subdirectories exist in every worktree, so the wrong resolution succeeds on the wrong tree.
+mkdir -p "$commit_green/redsub/.githooks"
+( cd "$commit_green/redsub" && git init -q . )
+printf '#!/bin/sh\necho "GATE OF redsub SPOKE"\nexit 1\n' > "$commit_green/redsub/.githooks/pre-commit"
+chmod +x "$commit_green/redsub/.githooks/pre-commit"
+wt_out=$(wt_fire "$session_green" "$commit_green" 'cd redsub && git commit -m x')
+assert "a relative cd resolves against the payload cwd" 2 "${wt_out%%|*}"
+case "$wt_out" in *"GATE OF redsub"*) got=resolved_relative ;; *) got="missed it: ${wt_out#*|}" ;; esac
+assert "...and runs the resolved tree's own gate" resolved_relative "$got"
+wt_out=$(wt_fire "$session_green" "$commit_green" 'git -C redsub commit -m x')
+assert "a relative git -C resolves against the payload cwd" 2 "${wt_out%%|*}"
+
 # 4. A COMMIT FROM A SUBDIRECTORY has to climb: the gate lives at the checkout root, and stopping at
 # the literal directory would find no gate and fail open - a silent skip, not a visible error.
 wt_out=$(wt_fire "$session_green" "$commit_red/nested/deeper" 'git commit -m "from a subdir"')

--- a/bin/test-check-quarantine-registry.sh
+++ b/bin/test-check-quarantine-registry.sh
@@ -4,7 +4,10 @@
 #
 
 # Self-test for bin/lib/quarantine-common.sh - the scan that check-quarantine-registry.sh,
-# check-quarantine-owners.sh and quarantined-test.sh all read their file list from.
+# check-quarantine-owners.sh and quarantined-test.sh all read their file list from - AND, in the
+# section at the foot of this file, for what bin/check-quarantine-registry.sh actually SAYS when it
+# finds drift. Both halves belong here: the gate's reporting failed inside the shared lookup, not in
+# its own message code, so splitting them would have put the fixture and the mechanism in two files.
 #
 # WHY THIS EXISTS. The exclusion of `.claude` from the scan is a behaviour change with a specific
 # cause: `.claude/worktrees/<name>` holds a full checkout of some OTHER branch, so without it the
@@ -139,6 +142,96 @@ assert "the PREVIOUS implementation does leak the .git copy" YES \
     "$(contains "$old" ".git/some-tooling-copy/Stashed.java")"
 assert "the PREVIOUS implementation already excluded target" NO \
     "$(contains "$old" "target/generated-sources/Generated.java")"
+
+echo
+echo "--- check-quarantine-registry.sh: drift is EXPLAINED, not merely refused ---"
+
+# THE GATE REFUSED SILENTLY IN EXACTLY THE CASE IT EXISTS TO CATCH. Its registry -> code loop ended
+# in `f=$(quarantined_files | while read -r qf; do [ ... ] && { echo "$qf"; break; }; done)`. When no
+# annotated class matches the entry, the final `[ ... ]` fails, the `while` carries that status out,
+# `pipefail` promotes it to the pipeline, the assignment takes it, and `set -e` kills the script
+# BEFORE the `DRIFT:` line can print. Exit 1 was right; the explanation was destroyed, so the gate
+# said nothing at all about the one thing it had found.
+#
+# CONTROL ARM, one term changed and everything else identical: `set -euo pipefail` printed nothing
+# and exited 1, `set -uo pipefail` printed the full DRIFT line and exited 1 - which is what named
+# `set -e` plus the loop status as the mechanism rather than the reporting code.
+#
+# THE NEGATIVE CONTROL BELOW IS THE SHIPPED PRE-FIX LOOP, patched back into a copy of the gate, so
+# the fixture is PROVEN to reach the defect rather than assumed to - the same discipline as
+# `previous_implementation()` above. If the anchor line it patches ever stops existing, the control
+# fails loudly instead of passing vacuously.
+
+gate_fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture" "$gate_fixture"' EXIT
+mkdir -p "$gate_fixture/docs" "$gate_fixture/bin/lib"
+annotated "$gate_fixture/parallel-consumer-core/src/test/java/Present.java"
+cp "$repo_root/bin/lib/quarantine-common.sh" "$gate_fixture/bin/lib/quarantine-common.sh"
+cat > "$gate_fixture/docs/quarantined-tests.md" <<'MD'
+# Quarantined tests - fixture
+
+- [ ] `Present.aTest` - an entry whose class really is annotated
+- [ ] `Vanished.someTest` - an entry naming a class with no @Quarantined anywhere in the tree
+MD
+
+run_gate() { # <gate-path> -> prints "<exit>|<output>"
+    local out rc=0
+    out="$(QUARANTINE_CHECK_ROOT="$gate_fixture" bash "$1" 2>&1)" || rc=$?
+    printf '%s|%s' "$rc" "$out"
+}
+
+gate_result="$(run_gate "$repo_root/bin/check-quarantine-registry.sh")"
+gate_rc="${gate_result%%|*}"
+gate_out="${gate_result#*|}"
+
+case "$gate_out" in
+    *"DRIFT:"*Vanished.someTest*) got=named_the_stale_entry ;;
+    '')                           got=said_nothing_at_all ;;
+    *)                            got="$gate_out" ;;
+esac
+assert "a stale registry entry is NAMED, not just refused" named_the_stale_entry "$got"
+assert "and the gate still fails" 1 "$gate_rc"
+
+# The other half of the same run: a genuinely annotated entry must not be reported as drift, or the
+# case above would pass on a gate that simply shouts about everything.
+case "$gate_out" in *Present*) got=false_positive ;; *) got=quiet_about_the_good_one ;; esac
+assert "the entry whose class IS annotated is not reported" quiet_about_the_good_one "$got"
+
+# --- negative control: the fixture must reach the defect ---
+previous_gate="$gate_fixture/bin/previous-check-quarantine-registry.sh"
+python3 - "$repo_root/bin/check-quarantine-registry.sh" "$previous_gate" <<'PY'
+import sys
+
+ANCHOR = '    f=$(quarantined_file_for_class "$cls")\n'
+SHIPPED_BEFORE_THE_FIX = (
+    '    f=$(quarantined_files | while read -r qf; do\n'
+    '            [ "$(basename "$qf" .java)" = "$cls" ] && { echo "$qf"; break; }\n'
+    '        done)\n'
+)
+src = open(sys.argv[1]).read()
+if ANCHOR not in src:
+    sys.stderr.write("anchor line not found - the negative control no longer patches anything\n")
+    sys.exit(1)
+open(sys.argv[2], "w").write(src.replace(ANCHOR, SHIPPED_BEFORE_THE_FIX))
+PY
+prev_result="$(run_gate "$previous_gate")"
+prev_rc="${prev_result%%|*}"
+prev_out="${prev_result#*|}"
+[ -z "$prev_out" ] && got=silent || got="$prev_out"
+assert "the PREVIOUS implementation refuses with NO explanation" silent "$got"
+assert "...while still exiting 1, which is why nobody noticed" 1 "$prev_rc"
+
+echo
+echo "--- quarantined_file_for_class(): the lookup both gates share ---"
+
+cd "$gate_fixture"
+assert "finds the file of an annotated class" \
+    "./parallel-consumer-core/src/test/java/Present.java" "$(quarantined_file_for_class Present)"
+# The whole defect in one line: a miss must be an empty answer, never a failing status. Called
+# inside a `$(...)` under this file's own `set -e`, a non-zero return here would kill the suite.
+assert "a class with no annotation answers empty" "" "$(quarantined_file_for_class Vanished)"
+quarantined_file_for_class Vanished >/dev/null
+assert '...and returns 0, so set -e does not kill the caller' 0 "$?"
 
 echo
 if [ "$failures" -gt 0 ]; then

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -346,10 +346,12 @@ grants stay in `settings.local.json`, still ignored.
   fetched `origin/master`, never fetched astubbs#205's own two-week-stale ref, re-did a package
   rename of 239 files, resolved 43 conflicts on top, and learned at the rejected push that all of it
   was already published. Its own header owns the incident.
-- The push detection and the portable `stat` both live in `.claude/hooks/lib/hook-common.sh`, shared
-  by the two push hooks. Each had been got wrong once in a way that made a hook *silently stop
-  working* - `git -C <path> push` unmatched, `stat -c` unavailable on BSD - and a second copy hides
-  the next such bug until somebody re-runs the same experiment on the same platform.
+- The push detection, the portable `stat` and the **pushed-branch derivation** all live in
+  `.claude/hooks/lib/hook-common.sh`, shared by the two push hooks. Each had been got wrong once in a
+  way that made a hook *silently stop working, or answer about the wrong thing* - `git -C <path> push`
+  unmatched, `stat -c` unavailable on BSD, and `git rev-parse --abbrev-ref HEAD` naming whichever
+  worktree the SESSION sat in rather than the branch the command names. A second copy hides the next
+  such bug until somebody re-runs the same experiment on the same platform.
 - `PreToolUse` on `Bash`, **with no `if`** - runs `.claude/hooks/check-history-rewrite.sh`, one of
   the two guards here that **refuse**: it stops a force-push, rebase, amend or any other ref-moving
   command while a review is in flight, because a rewrite orphans inline review threads and destroys

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -183,7 +183,7 @@ So the two hooks are registered differently, on purpose:
 |---|---|---|
 | `check-squash-subject.sh` | **none** - runs on every Bash call | It can only ever allow, or deny a real `gh pr merge`. A `grep` for `merge` in the payload rejects the overwhelming majority before python starts, so the cost is a shell test. |
 | `check-merge-outstanding-work.sh` (astubbs#324) | **none** - runs on every Bash call | Same reasoning as the squash guard, and the same shapes must reach it: `echo ready && gh pr merge ...` is exactly the case a prefix `if` would miss. A cheap `*merge*` pre-filter skips the interpreter on everything else; the decision itself is tokenised with `shlex`, so `gh pr comment --body "run gh pr merge later"` is not a merge. It watches this session's background TASKS only - it deliberately does not scan the process table for builds. |
-| `pre-commit-gate.sh` | `Bash(git commit *)` | It runs the gates and can `exit 2`. Firing it on every Bash call is the outage described above - and it must stay prefix-matched anyway, because it gates *the session's* repository, which is only the right one when the command has no `cd` in front of it. **It self-filters as well**, exiting 0 when the payload holds no commit, because the `if` is a belt the script must not hang its trousers on - see below. |
+| `pre-commit-gate.sh` | `Bash(git commit *)` | It runs the gates and can `exit 2`, so firing it on every Bash call is the outage described above. It no longer gates *the session's* repository: it derives the commit's own working tree from the payload, so a subagent committing in another worktree is gated against that worktree - see its bullet below. **It self-filters as well**, exiting 0 when the payload holds no commit, because the `if` is a belt the script must not hang its trousers on - see below. |
 
 The `git commit` case that `if` therefore misses (`cd sub && git commit`) is covered by
 `.githooks/pre-commit`, which git runs inside the target repository. That is the layering working
@@ -245,6 +245,12 @@ grants stay in `settings.local.json`, still ignored.
   It also **decides for itself** whether the payload contains a commit, rather than trusting the
   `if` to have filtered for it - and finding a commit means finding it wherever the shell would run
   one, `then`, `do`, `{` and `!` included, or the self-filter turns a scope fix into an exemption.
+  **And it decides for itself which working tree to gate**, from the command's `git -C`, a leading
+  `cd`, then the payload's `cwd`, with `$CLAUDE_PROJECT_DIR` as a labelled last resort - because that
+  variable names the SESSION's root, and a subagent working in another worktree issues a bare
+  `git commit` from a different tree entirely. Its own header owns the incident, both directions of
+  it: a red gate that was not the agent's, and the mirror image where a red tree passes because the
+  session's is green.
 - `PreToolUse` on `Bash`, **with no `if`** - it runs on every Bash call and filters itself - runs
   `.claude/hooks/check-squash-subject.sh`, which refuses a `--subject` that would drop or misstate
   the PR number. It carried `if: Bash(gh pr merge *)` until review pointed out that a prefix match

--- a/docs/inflight/ci-branch-behind-guard-answers-for-the-sessions-branch.md
+++ b/docs/inflight/ci-branch-behind-guard-answers-for-the-sessions-branch.md
@@ -11,6 +11,7 @@ branch the command never touches, and - the half nobody investigates - a silent 
 onto a branch that genuinely is behind its own remote, because the session's branch happened to be
 current.
 
+<!-- post-merge: checked-begin -->
 This is the same defect class astubbs/parallel-consumer#382 fixed in the two refusing guards and
 the two push reminders (mechanism:
 [`a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md`](../solutions/workflow-issues/a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md)).
@@ -23,6 +24,7 @@ test surface, not a rider.
 The fix inherits ready-made parts: the derivation order and its self-test idioms (the `-` cwd
 sentinel, the two-worktree fixture, the negative control asserting the pre-fix answer cannot
 reappear) are all in `bin/test-check-agent-hooks.sh` after astubbs#382. Because this hook refuses,
+<!-- post-merge: checked-end -->
 it inlines rather than sourcing `hook-common.sh` -
 [`ci-pr-lookup-is-copied-into-three-hooks.md`](ci-pr-lookup-is-copied-into-three-hooks.md) owns
 that dividing line and counts the copies.

--- a/docs/inflight/ci-branch-behind-guard-answers-for-the-sessions-branch.md
+++ b/docs/inflight/ci-branch-behind-guard-answers-for-the-sessions-branch.md
@@ -3,7 +3,7 @@
 <!-- inflight-type: bug -->
 <!-- inflight-impact: misdirection -->
 
-`.claude/hooks/check-branch-behind-its-own-remote.sh` still reads
+`.claude/hooks/check-branch-behind-its-own-remote.sh` reads
 `git rev-parse --abbrev-ref HEAD` from the hook process's own directory - the SESSION's branch,
 never the branch of the tree the guarded `git merge`/`git rebase` runs in. It is a **deny** hook,
 so both failure directions are live: a refusal citing a fabricated stale-branch reason about a
@@ -12,19 +12,21 @@ onto a branch that genuinely is behind its own remote, because the session's bra
 current.
 
 <!-- post-merge: checked-begin -->
-This is the same defect class astubbs/parallel-consumer#382 fixed in the two refusing guards and
-the two push reminders (mechanism:
+This is the one recorded surviving instance of the defect class astubbs/parallel-consumer#382
+fixed in the four hooks it touched - the two refusing guards and the two push reminders
+(mechanism:
 [`a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md`](../solutions/workflow-issues/a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md)).
-It was found by that PR's review round as a surviving instance and deliberately left out of the PR:
-merge/rebase has no refspec naming a branch, so the fix is the *directory* derivation
-(`git -C` -> leading `cd` -> payload `cwd` -> labelled last resort) feeding the `rev-parse`, plus
-the guard's SessionStart fetch arm deciding which repository to fetch in - a change with its own
-test surface, not a rider.
+It stayed out of that change on purpose: a merge/rebase has no refspec naming a branch, so the fix
+here is the *directory* derivation (`git -C` -> leading `cd` -> payload `cwd` -> labelled last
+resort) feeding the `rev-parse`, plus the guard's SessionStart fetch arm deciding which repository
+to fetch in - a change with its own test surface, not a rider on another one.
 
-The fix inherits ready-made parts: the derivation order and its self-test idioms (the `-` cwd
-sentinel, the two-worktree fixture, the negative control asserting the pre-fix answer cannot
-reappear) are all in `bin/test-check-agent-hooks.sh` after astubbs#382. Because this hook refuses,
+Whoever picks this up inherits ready-made parts from `bin/test-check-agent-hooks.sh`: the
+derivation order and its self-test idioms - the `-` cwd sentinel that omits the payload cwd, the
+two-worktree fixture, the negative control asserting the pre-fix answer cannot reappear - plus the
+cwd-preserving-joiner and composed-`-C` rules the guards apply, which this fix must apply too.
 <!-- post-merge: checked-end -->
-it inlines rather than sourcing `hook-common.sh` -
+
+Because this hook refuses, it inlines rather than sourcing `hook-common.sh` -
 [`ci-pr-lookup-is-copied-into-three-hooks.md`](ci-pr-lookup-is-copied-into-three-hooks.md) owns
 that dividing line and counts the copies.

--- a/docs/inflight/ci-branch-behind-guard-answers-for-the-sessions-branch.md
+++ b/docs/inflight/ci-branch-behind-guard-answers-for-the-sessions-branch.md
@@ -1,0 +1,28 @@
+# The branch-behind guard derives its branch from the session, not the merge it refuses
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+`.claude/hooks/check-branch-behind-its-own-remote.sh` still reads
+`git rev-parse --abbrev-ref HEAD` from the hook process's own directory - the SESSION's branch,
+never the branch of the tree the guarded `git merge`/`git rebase` runs in. It is a **deny** hook,
+so both failure directions are live: a refusal citing a fabricated stale-branch reason about a
+branch the command never touches, and - the half nobody investigates - a silent pass of a merge
+onto a branch that genuinely is behind its own remote, because the session's branch happened to be
+current.
+
+This is the same defect class astubbs/parallel-consumer#382 fixed in the two refusing guards and
+the two push reminders (mechanism:
+[`a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md`](../solutions/workflow-issues/a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md)).
+It was found by that PR's review round as a surviving instance and deliberately left out of the PR:
+merge/rebase has no refspec naming a branch, so the fix is the *directory* derivation
+(`git -C` -> leading `cd` -> payload `cwd` -> labelled last resort) feeding the `rev-parse`, plus
+the guard's SessionStart fetch arm deciding which repository to fetch in - a change with its own
+test surface, not a rider.
+
+The fix inherits ready-made parts: the derivation order and its self-test idioms (the `-` cwd
+sentinel, the two-worktree fixture, the negative control asserting the pre-fix answer cannot
+reappear) are all in `bin/test-check-agent-hooks.sh` after astubbs#382. Because this hook refuses,
+it inlines rather than sourcing `hook-common.sh` -
+[`ci-pr-lookup-is-copied-into-three-hooks.md`](ci-pr-lookup-is-copied-into-three-hooks.md) owns
+that dividing line and counts the copies.

--- a/docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md
+++ b/docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md
@@ -53,3 +53,25 @@ inherits more than the three hooks named above:
   so must read stderr, whereas `gh pr list --head` exits 0 with empty output for a real absence and
   non-zero only on failure. Its slug derivation also predates the `file://` fix. Read it for the
   shape of the problem, not for code to lift.
+
+**The INPUT to the lookup was wrong too, and that half is now fixed** (2026-08-31). Every copy fed
+it `git rev-parse --abbrev-ref HEAD` read in the hook process's own directory, which is the
+SESSION's - not the directory the guarded command runs in. With several worktrees checked out at
+once the lookup therefore asked about an unrelated branch and answered confidently. Seen twice in one
+session, both times reported against `docs/god-branch-decomposition-plan`, the plan worktree that
+session occupied: a force-push of `feats/proxy-verdict-free-return`
+(astubbs/parallel-consumer#295 - an open PR *with review history*, the exact case the guard exists to
+name) and a `git commit --amend` inside the `feats/ks-streams-fork-machinery` worktree.
+
+The fix takes the branch from the push refspec when the command names one, and otherwise from a
+leading `cd <path>`, the payload's `cwd`, or the hook's own directory in that order - with the
+refusal saying which it used. **The dedup decision above is untouched by it**, and it adds a fourth
+thing that now exists twice: the refspec rule, as `hook_push_head_ref` in
+`.claude/hooks/lib/hook-common.sh` (bash) and as `push_head_ref` inside
+`.claude/hooks/check-history-rewrite.sh` (python), duplicated for the same fail-open reason that
+keeps the lookup itself duplicated. Whoever folds these together folds that in too.
+
+`.claude/hooks/check-merge-outstanding-work.sh` was judged against the same defect and left alone: it
+reads the PR number out of `gh pr merge <n>` first, and its `HEAD` fallback is only reached for a
+bare `gh pr merge`, which resolves the current branch exactly as the fallback does. Correct, rather
+than merely untouched.

--- a/docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md
+++ b/docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md
@@ -54,43 +54,16 @@ inherits more than the three hooks named above:
   non-zero only on failure. Its slug derivation also predates the `file://` fix. Read it for the
   shape of the problem, not for code to lift.
 
-<!-- post-merge: checked-begin -->
-**The INPUT to the lookup was wrong too, and that half is now fixed**
-(astubbs/parallel-consumer#382, 2026-08-31). Every copy fed
-it `git rev-parse --abbrev-ref HEAD` read in the hook process's own directory, which is the
-SESSION's - not the directory the guarded command runs in. With several worktrees checked out at
-once the lookup therefore asked about an unrelated branch and answered confidently. Seen twice in one
-session, both times reported against `docs/god-branch-decomposition-plan`, the plan worktree that
-session occupied: a force-push of `feats/proxy-verdict-free-return`
-(astubbs/parallel-consumer#295 - an open PR *with review history*, the exact case the guard exists to
-name) and a `git commit --amend` inside the `feats/ks-streams-fork-machinery` worktree.
-
-The fix takes the branch from the push refspec when the command names one, and otherwise from a
-leading `cd <path>`, the payload's `cwd`, or the hook's own directory in that order - with the
-refusal saying which it used. **The dedup decision above is untouched by it**, and it adds a fourth
-thing that now exists twice: the refspec rule, as `hook_push_head_ref` in
-`.claude/hooks/lib/hook-common.sh` (bash) and as `push_head_ref` inside
-`.claude/hooks/check-history-rewrite.sh` (python), duplicated for the same fail-open reason that
-keeps the lookup itself duplicated. Whoever folds these together folds that in too.
-
-`.claude/hooks/check-merge-outstanding-work.sh` was judged against the same defect and left alone: it
-reads the PR number out of `gh pr merge <n>` first, and its `HEAD` fallback is only reached for a
-bare `gh pr merge`, which resolves the current branch exactly as the fallback does. Correct, rather
-than merely untouched.
-
-**A third sighting, in a hook with no PR lookup at all, and it widens the class.**
-`.claude/hooks/pre-commit-gate.sh` took its working tree from `$CLAUDE_PROJECT_DIR`, which names the
-SESSION's project root - so a *subagent*, which has its own working directory, was gated against the
-session's most recent worktree. On 2026-08-31 a subagent committing in
-`.claude/worktrees/proxy-server-shell` was gated against `.claude/worktrees/bench-harness`:
-`bin/check-file-refs.sh` failed on citations to `bench/` files absent from its branch while its own
-tree ran the same gate clean, and five commits went through with `--no-verify`. The mirror image
-leaves no trace at all - a red tree passes because the session's is green - and nobody investigates a
-commit that was allowed. Fixed the same way: `git -C`, then a leading `cd`, then the payload's `cwd`,
-with `$CLAUDE_PROJECT_DIR` kept as a labelled last resort.
-
-So the derivation rule now has **three** consumers rather than the two named above, and only two of
-them can share `hook-common.sh`. What generalises is not the code: it is that **a hook process's own
-directory and environment describe the session, never the command**, and every guard here that reads
-either has to be re-checked against that.
-<!-- post-merge: checked-end -->
+**The INPUT to the lookup was wrong too, and that half is now fixed - it adds a fourth duplicated
+thing this dedup task inherits.** Full incident and mechanism:
+[`a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md`](../solutions/workflow-issues/a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md).
+In short - every copy derived the branch from the hook process's own directory (the session's, not
+the guarded command's), fixed by deriving it from the push refspec, then a leading `cd`, then the
+payload's `cwd`, then the hook's own directory as a labelled last resort. That adds a **fourth**
+duplicated thing: the refspec rule now exists twice for the same fail-open reason the lookup itself
+is triplicated - `hook_push_head_ref` in `.claude/hooks/lib/hook-common.sh` (bash) and
+`push_head_ref` inside `.claude/hooks/check-history-rewrite.sh` (python). The derivation rule now has
+**three** consumers in total (the two above plus `.claude/hooks/pre-commit-gate.sh`'s own directory
+derivation), and only the advisory push hooks that already source `hook-common.sh` can share
+`hook_push_head_ref` - the two that refuse still have to inline, for the reason astubbs#341 gives
+above. Whoever folds the three lookups together folds this in too.

--- a/docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md
+++ b/docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md
@@ -54,7 +54,9 @@ inherits more than the three hooks named above:
   non-zero only on failure. Its slug derivation also predates the `file://` fix. Read it for the
   shape of the problem, not for code to lift.
 
-**The INPUT to the lookup was wrong too, and that half is now fixed** (2026-08-31). Every copy fed
+<!-- post-merge: checked-begin -->
+**The INPUT to the lookup was wrong too, and that half is now fixed**
+(astubbs/parallel-consumer#382, 2026-08-31). Every copy fed
 it `git rev-parse --abbrev-ref HEAD` read in the hook process's own directory, which is the
 SESSION's - not the directory the guarded command runs in. With several worktrees checked out at
 once the lookup therefore asked about an unrelated branch and answered confidently. Seen twice in one
@@ -75,3 +77,4 @@ keeps the lookup itself duplicated. Whoever folds these together folds that in t
 reads the PR number out of `gh pr merge <n>` first, and its `HEAD` fallback is only reached for a
 bare `gh pr merge`, which resolves the current branch exactly as the fallback does. Correct, rather
 than merely untouched.
+<!-- post-merge: checked-end -->

--- a/docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md
+++ b/docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md
@@ -77,4 +77,20 @@ keeps the lookup itself duplicated. Whoever folds these together folds that in t
 reads the PR number out of `gh pr merge <n>` first, and its `HEAD` fallback is only reached for a
 bare `gh pr merge`, which resolves the current branch exactly as the fallback does. Correct, rather
 than merely untouched.
+
+**A third sighting, in a hook with no PR lookup at all, and it widens the class.**
+`.claude/hooks/pre-commit-gate.sh` took its working tree from `$CLAUDE_PROJECT_DIR`, which names the
+SESSION's project root - so a *subagent*, which has its own working directory, was gated against the
+session's most recent worktree. On 2026-08-31 a subagent committing in
+`.claude/worktrees/proxy-server-shell` was gated against `.claude/worktrees/bench-harness`:
+`bin/check-file-refs.sh` failed on citations to `bench/` files absent from its branch while its own
+tree ran the same gate clean, and five commits went through with `--no-verify`. The mirror image
+leaves no trace at all - a red tree passes because the session's is green - and nobody investigates a
+commit that was allowed. Fixed the same way: `git -C`, then a leading `cd`, then the payload's `cwd`,
+with `$CLAUDE_PROJECT_DIR` kept as a labelled last resort.
+
+So the derivation rule now has **three** consumers rather than the two named above, and only two of
+them can share `hook-common.sh`. What generalises is not the code: it is that **a hook process's own
+directory and environment describe the session, never the command**, and every guard here that reads
+either has to be re-checked against that.
 <!-- post-merge: checked-end -->

--- a/docs/solutions/best-practices/a-guard-that-lexes-shell-commands-must-lex-like-the-shell.md
+++ b/docs/solutions/best-practices/a-guard-that-lexes-shell-commands-must-lex-like-the-shell.md
@@ -1,0 +1,186 @@
+---
+title: "A guard that lexes shell commands must lex like the shell: every divergence from real shell semantics is a silent steering vector"
+date: 2026-09-01
+category: best-practices
+module: tooling
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - "Writing or reviewing a Claude Code hook (or any guard) that parses a shell command string to decide whether to refuse, remind about, or steer it"
+  - "The guard tokenises with a simplified splitter instead of posix shlex, or does not treat newline as operator punctuation the way a shell does"
+  - "The guard reads a value-taking flag (-C, --branch, -m, -F) without consuming the value that follows it, letting it shift later positionals"
+  - "The guard trusts a leading `cd` across a subshell or pipe operator (&, |) rather than only cwd-preserving joiners (&&, ;)"
+  - "A review round on a guard-diagnostics PR keeps finding a new bypass or false-trigger of the same shape rather than a genuinely new class of bug"
+tags:
+  - shell-lexing
+  - guard-bypass
+  - posix-shlex
+  - value-flags
+  - cd-tracking
+  - silent-steering
+  - hook-security
+  - adversarial-fixtures
+---
+
+# A guard that lexes shell commands must lex like the shell
+
+> Every divergence between the guard's model of a command and the shell's actual semantics is a
+> silent steering vector: an attacker - or an innocent compound command - lands on the wrong side of
+> the divergence, and the guard confidently answers about a command nobody ran.
+
+## Context
+
+This repo's agent hooks read the Bash command an agent is about to run and answer questions about
+it: is this a history rewrite (`.claude/hooks/check-history-rewrite.sh`), which tree does this
+commit land in (`.claude/hooks/pre-commit-gate.sh`), which branch is being pushed
+(`.claude/hooks/remind-inflight-on-push.sh`, `.claude/hooks/remind-master-drift-on-push.sh`). Two of
+those refuse; two advise. One tokeniser configuration serves all four - owned by
+`hook_git_invocations` and `hook_push_head_ref` in `.claude/hooks/lib/hook-common.sh`, sourced by
+the two advisers, and deliberately MIRRORED rather than sourced by the two refusers, which may not
+depend on a library they might fail to load (the duplication is tracked, with its reasoning, in
+[ci-pr-lookup-is-copied-into-three-hooks.md](../../inflight/ci-pr-lookup-is-copied-into-three-hooks.md)).
+All four are pinned by fixtures in `bin/test-check-agent-hooks.sh`.
+
+The guards started life doing what every quick shell-inspecting script does: split the command on
+whitespace, look for `git`, look for the subcommand, read the arguments. That model is not the
+shell's model, and PR astubbs/parallel-consumer#382 is the record of how far apart they were. Three
+successive independent review rounds each found real bypasses the previous round had missed, and
+**every single one was a place where the guard's lexer and the shell disagreed about what a command
+means**:
+
+- Whole-string matching read `git push && git status` as not-a-push, because the trailing
+  `git status` broke the pattern.
+- Treating newline as whitespace fused separate commands: `git push -f` followed by a newline and
+  `git log -1` handed `log` to the branch extractor as the pushed branch (the `NEWLINE IS AN OPERATOR`
+  comment above the lexer in `hook-common.sh` owns the incident).
+- Unspaced operators fused into their neighbours, so `feature&&git` parsed as a branch name.
+- `git -C /path push --force` bypassed the history guard entirely - the `-C` value sat where the
+  subcommand was expected.
+- A second round (the Codex review on astubbs/parallel-consumer#382, each finding fixed and answered in its own resolved thread)
+  found the *state* divergences: a `-C` recorded while scanning an earlier invocation bled into the
+  later one carrying the verdict; repeated `-C` values compose in git (`git -C sub -C .. commit`
+  runs in the original repo) but the guard kept only the last; a leading `cd` was trusted across `&`
+  and `|`, which run the cd in a subshell the commit never inherits; and the python twin of the
+  refspec parser was missing `--recurse-submodules` one review round after the bash copy gained it - the exact
+  change-one-forget-the-other drift the code comments warn about, caught within one round of being
+  written.
+- The drift reminder measured the DESTINATION of a `src:dst` refspec, although git publishes the
+  SOURCE - the `TWO SIDES OF ONE REFSPEC` comment in `remind-master-drift-on-push.sh` now owns that
+  distinction.
+
+The inverse failure showed up live too, and it is the same defect mirrored: the history guard's
+lexer reads quoted heredoc *bodies* as command tokens, so a script that merely embeds text
+resembling a force-push as data can false-trigger the refusal. It fired on its own test fixtures
+while they were being written (recorded as the meta-finding in the Codex-round commit body on
+astubbs/parallel-consumer#382).
+Under-modelling the shell lets commands through; over-modelling data as commands blocks scripts
+that did nothing.
+
+## Guidance
+
+**1. Use a real lexer, configured to the shell's actual token classes - not a regex, not a
+whitespace split.** The shared tokeniser uses posix `shlex` with
+`punctuation_chars="();<>|&;\n"` and `whitespace = " \t\r"` (both in
+`hook_git_invocations` in `hook-common.sh`, mirrored in the python scanner inside
+`check-history-rewrite.sh`). The two deliberate choices there are the whole lesson in miniature:
+newline is an *operator* in shell grammar, not whitespace, and operators must become their own
+tokens so `feature&&git` splits rather than fusing.
+
+**2. Classify operators by character set, not by a hand-enumerated list of spellings.** shlex glues
+adjacent punctuation into runs, so `&&` followed by a newline arrives as one token. The
+`STOP AT ANY OPERATOR TOKEN` block in `hook-common.sh` classifies a token as an operator when every
+character is in `OPERATORS = set("();<>|&;\n")` - merged runs still classify, and the comment
+binds that set to the lexer's punctuation string so they cannot drift apart separately.
+
+**3. Consume value-carrying flags WITH their values, from a named list.** A flag whose value can
+look like a subcommand or a branch (`-C /path`, `--push-option x`) must swallow its value during
+the scan, or the value lands in a positional slot and steers the answer. The lists are
+`GIT_VALUE_FLAGS` and `PUSH_VALUE_FLAGS` in `check-history-rewrite.sh` and the matching skip list in
+`hook_push_head_ref`. An incomplete list is a bypass per missing flag - which is how
+`--recurse-submodules` became a finding.
+
+**4. Model the state the shell models, with the shell's scoping.** `-C` is per-invocation state:
+reset it at each new `git` token (the `git_c = ""` reset inside the invocation loop in
+`check-history-rewrite.sh`). Repeated `-C` values compose the way git composes them
+(`os.path.join`, absolute values restarting the chain). A leading `cd` changes the cwd of what
+follows only across cwd-preserving joiners - `&&`, `;`, newline - never across `&` or `|`, which
+run the cd in a subshell (the joiner check stripping `\n;` and accepting only `("", "&&")`, present
+in both `check-history-rewrite.sh` and `pre-commit-gate.sh`).
+
+**5. When the shell would do something your static scan cannot, degrade to a labelled guess - never
+a confident answer.** A refspec containing `$` or a backtick would be expanded before git saw it,
+so the token in the payload is not the branch; `hook_push_head_ref` drops it to the
+`inferred-answer tier`, whose label says it is a guess. Two `cd`s in one command is honestly
+ambiguous; `pre-commit-gate.sh` returns the empty answer and falls through to the payload cwd,
+whose label already admits it describes the session. This provenance discipline is what made the
+whole fix campaign safe: a divergence that still slips through degrades into a labelled guess
+instead of a confidently wrong verdict.
+
+**6. Pin every divergence with a fixture, and give the fixture a negative control that proves it
+reaches the defect.** `bin/test-check-agent-hooks.sh` pins each fix, and for the sharp ones patches
+the pre-fix code back in to show the fixture goes red against it - a fixture that passes against
+both versions tests nothing. Where a parser exists twice (bash and python twins), the drift between
+them is itself a fixture-worthy defect class.
+
+**7. Expect the inverse defect and budget for it.** Every step toward modelling the shell more
+faithfully raises the risk of reading *data* as commands - quoted heredoc bodies being the live
+example. A refusing guard that false-fires on innocent scripts trains its users to bypass it, which
+is the same end state as a guard that misses.
+
+## Why This Matters
+
+A guard that inspects commands is a parser with an adversary, and the adversary does not need to be
+malicious - ordinary compound commands (`git push && git status`, a `cd` prefix, a multi-line
+script) exercise the divergences for free. Each divergence fails *silently*: the guard still prints
+an answer, the answer is about a command nobody ran, and nothing downstream can tell. For the
+refusing guards that means a history rewrite sails through (`git -C /path push --force` did exactly
+that); for the advisory ones it means the reminder names the wrong branch and the reader learns to
+ignore reminders. The false-fire direction is as costly: a refusal triggered by fixture text as
+data blocks legitimate work and erodes trust in the gate.
+
+The fix campaign converged only because each round attacked the *model*, not the symptom: once
+"the lexer must agree with the shell" was the named defect class, each reviewer could probe a fresh
+semantic corner (operators, state scoping, subshells, expansion, refspec direction) instead of
+patching individual command strings. The third review round ran its own adversarial probes against
+head and found nothing left - which is what a class-level fix looks like, and what a
+string-level fix never achieves.
+
+## When to Apply
+
+- Writing or reviewing anything that inspects a shell command it did not construct: agent hooks,
+  CI gates, wrapper scripts, audit loggers, permission checkers.
+- Adding a flag, subcommand, or operator to an existing command scanner - check the value-flag
+  lists in *every* twin of the parser, not just the one you opened.
+- A guard produced a wrong-but-plausible answer about a command: before patching the string that
+  fooled it, ask which shell semantic its model lacks, and fix the model.
+- A guard false-fired on data (heredocs, quoted strings, fixture text): the same model-divergence
+  lens applies in reverse.
+- Pairing a command-derived fact with an environment-derived one (branch from the command,
+  repository from the process cwd): that is the WHERE half of this defect, owned by the sibling
+  write-up
+  [a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md](../workflow-issues/a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md) -
+  this doc is the WHAT-the-command-says half.
+
+## Examples
+
+**Newline fusion.** The command `git push -f` + newline + `git log -1` is two commands to the
+shell; a lexer treating `\n` as whitespace saw one token stream and handed `log` to the branch
+extractor as the pushed ref. The shell's grammar makes newline a command *separator* - an operator.
+Fix shape: remove `\n` from the lexer's whitespace, add it to `punctuation_chars`, and stop the
+argument scan at any all-operator token (`hook_git_invocations` in `hook-common.sh`).
+
+**The -C bypass.** `git -C /path push --force` is a force-push to git; a guard that looked for the
+subcommand at a fixed position found `/path` there and concluded not-a-push, waving the rewrite
+through. Git's semantics: `-C` takes a value, repeated `-C`s compose left to right, and the
+subcommand is the first non-flag token after all value-flags are consumed. Fix shape: a named
+value-flag list (`GIT_VALUE_FLAGS` in `check-history-rewrite.sh`) whose entries swallow their
+values, `-C` recorded and composed like git composes it, and the state reset at each new
+invocation.
+
+**The subshell cd.** `cd /x & git commit` looks like "commit in /x" to a scanner that trusts any
+leading cd - but `&` backgrounds the cd into a subshell, so the commit runs in the original cwd
+while the guard gated `/x` (a tree that may have no gate at all). Fix shape: trust a leading cd
+only when the joining operator preserves the cwd - `&&`, `;`, newline - and fall back to the
+labelled payload-cwd tier otherwise (the joiner check in `pre-commit-gate.sh` and
+`check-history-rewrite.sh`).

--- a/docs/solutions/workflow-issues/a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md
+++ b/docs/solutions/workflow-issues/a-hook-processes-own-directory-describes-the-session-not-the-command-2026-08-31.md
@@ -1,0 +1,158 @@
+---
+title: "A hook process's own directory describes the session, never the command it is guarding"
+date: 2026-08-31
+category: workflow-issues
+module: tooling
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+status: "Fixed in astubbs/parallel-consumer#382 for the two guards that refuse. check-merge-outstanding-work.sh was checked against the same defect and found correct, not merely untouched - see below."
+applies_when:
+  - Writing or reviewing a Claude Code hook that reads `$CLAUDE_PROJECT_DIR`, the hook process's own
+    `PWD`, or `git rev-parse --abbrev-ref HEAD` with no explicit directory
+  - Several worktrees of one repository are checked out at once
+  - A subagent (its own working directory, distinct from the session's) can trigger the hook
+  - A hook's refusal or gate result needs to name the tree or branch it actually measured
+symptoms:
+  - A guard names a branch nobody is touching, confidently and with no error
+  - A gate blocks (or passes) a commit by checking a different worktree than the one it runs in
+  - The failure is silent both ways - a wrong refusal looks like a real one, a wrong pass looks like
+    a clean result
+tags:
+  - agent-harness
+  - hooks
+  - worktree-isolation
+  - subagents
+  - silent-failure
+  - claude-code
+---
+
+# A hook process's own directory describes the session, never the command it is guarding
+
+## The mechanism
+
+A Claude Code hook is a separate process from the tool call it fires on. Anything the hook reads from
+its **own** environment or working directory - `$CLAUDE_PROJECT_DIR`, `git rev-parse --abbrev-ref
+HEAD` with no `-C`, the hook's own `PWD` - describes the **session's** state, not the command's. That
+is usually harmless, because in the common case the session and the command share one working tree.
+It stops being harmless the moment either of two things is true: several worktrees of this repository
+are checked out at once (routine here - see `AGENTS.md`, *Worktree ownership*), or the tool call comes
+from a **subagent**, which has its own working directory the session-level environment cannot see.
+
+Both conditions hold constantly in this repository, and the failure it produces is the worst kind: not
+an error, a **confident wrong answer**. A refusal that names the wrong branch reads exactly like a
+refusal that named the right one. A gate that passes because it measured the session's clean tree
+instead of the command's dirty one leaves no trace at all - nobody investigates a commit the gate
+allowed.
+
+## Three sightings, one session, 2026-08-31
+
+**1. The history-rewrite guard named the wrong branch.**
+`.claude/hooks/check-history-rewrite.sh` derived "the branch" from `git rev-parse --abbrev-ref HEAD`
+run in the hook process's own directory. With a dozen worktrees checked out, that answers about
+whichever branch the *session* sits on. Twice, both reported against `docs/god-branch-decomposition-plan`,
+the worktree that session occupied:
+
+- a force-push of `feats/proxy-verdict-free-return`, which had an open PR **with review history**
+  (astubbs/parallel-consumer#295) - exactly the case the guard exists to name - was refused with *"the
+  lookup ran and came back empty: no open pull request has `docs/god-branch-decomposition-plan` as its
+  head branch"*;
+- a `git commit --amend` inside the `feats/ks-streams-fork-machinery` worktree was reported against
+  that same unrelated branch.
+
+**2. The pre-commit gate gated the wrong working tree.**
+`.claude/hooks/pre-commit-gate.sh` resolved both the gate script and its working directory from
+`$CLAUDE_PROJECT_DIR`, which names the session's project root. A review comment once dismissed this as
+harmless, reasoning that `if: Bash(git commit *)` matches the command as written, so only a bare
+commit in the session's own cwd - where session repo and commit repo are the same one - reaches the
+hook. That premise is false for a **subagent**: it has its own working directory while
+`$CLAUDE_PROJECT_DIR` still names the session's most recent worktree, and a subagent's `git commit ...`
+is bare, so it matches the registration and arrives anyway.
+
+A subagent committing in `.claude/worktrees/proxy-server-shell` was gated against
+`.claude/worktrees/bench-harness`: `bin/check-file-refs.sh` failed on citations to `bench/` files
+absent from the agent's own branch, while that branch's own tree ran the same gate at exit 0. Five
+commits went through with `--no-verify` as the only way past a block that was never really about the
+tree being committed. **The dangerous half is the mirror image, and it leaves no trace**: a red tree
+passes because the session's tree is green, so a violation lands with the gate reporting success.
+
+**3. The quarantine registry gate refused silently** - a related but distinct defect (a swallowed
+`set -euo pipefail` exit, not a wrong-directory read); see astubbs/parallel-consumer#382 for the fix.
+Not part of this mechanism and not covered further here.
+
+## The fix's derivation order
+
+Both wrong-directory guards now derive the tree or branch from the **command**, strongest source
+first, and their refusal names which source answered:
+
+1. **Something the command itself names unambiguously.** For a push, the refspec's destination
+   (`git push origin src:dst` publishes `dst`, which is what a PR has as its head branch) - free,
+   because the command was already tokenised for other reasons. For a commit, `git -C <path>`, used
+   only when every commit in the payload names the same directory; a payload committing in two
+   repositories has no single answer and falls through rather than guessing.
+2. a leading `cd <path> &&`,
+3. the payload's own `cwd` - where a subagent's actual directory arrives,
+4. `$CLAUDE_PROJECT_DIR`, then the hook process's own directory - labelled **last resorts**, kept
+   because with nothing in the payload saying where the command runs, they remain the best answer
+   available.
+
+For `pre-commit-gate.sh`, the chosen directory then climbs to its repository root before the gate
+script and its working directory are both taken from there - running the right script with the wrong
+directory was the second half of the same defect, since `.githooks/pre-commit` itself opens with its
+own `git rev-parse --show-toplevel`.
+
+The full design reasoning for each guard - why `if: Bash(git commit *)` cannot be trusted to have
+filtered, why the directory is read in the same payload scan that decides a bypass rather than a
+second one, why the last resorts stay rather than being removed - lives in `docs/agent-harness.md`
+(the `pre-commit-gate.sh` and `check-history-rewrite.sh` entries) and in the two hooks' own headers;
+it is not repeated here.
+
+**Reproduced live, while the fixing commit for sighting 2 was itself being made**: the harness ran
+`pre-commit-gate.sh` out of a stray `bench-harness` worktree and blocked the commit on that tree's
+citations, while the worktree actually being committed to ran the same gate at exit 0. Same payload,
+same `$CLAUDE_PROJECT_DIR`, the only variable was which hook file answered:
+
+```
+pre-fix hook  -> exit 2, blocked on the other tree
+fixed hook    -> exit 0, gated the right tree, nothing to say
+```
+
+That commit was made with `--no-verify` as a result - the gate blocking it had measured a tree nobody
+was committing to.
+
+## A neighbour checked and found correct, not merely left alone
+
+`.claude/hooks/check-merge-outstanding-work.sh` has the same shape available to it - it too can read
+`git rev-parse --abbrev-ref HEAD` with no `-C` - and was checked against this defect rather than
+assumed safe by association. It reads the PR number out of `gh pr merge <n>` first; the `HEAD`
+fallback is reached only for a **bare** `gh pr merge`, and a bare `gh pr merge` resolves the current
+branch the same way the fallback does. There is no case where the two disagree, so it was left as is.
+Checking a neighbour explicitly, rather than sweeping it in on the strength of the pattern, is what
+turned "presumably fine" into a verdict.
+
+## The generalised lesson
+
+**A hook process's own directory and environment describe the session, never the command.** Every
+guard that reads either without deriving from the payload first has to be re-checked against that -
+not swept, checked: the neighbour above shows the difference between believing a pattern applies and
+confirming it does.
+
+## Related
+
+- `docs/agent-harness.md` - the registry entries for `pre-commit-gate.sh` and
+  `check-history-rewrite.sh` own the day-to-day design detail (the derivation order, the payload
+  self-filtering, the labelled last resorts); this document is the incident write-up, not a second
+  copy of that detail.
+- `docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md` - the still-open task this incident
+  intersects: the branch-to-PR lookup exists three times and should exist once. The fix here adds a
+  **fourth** duplicated thing for the same fail-open reason - the refspec-derivation rule, as
+  `hook_push_head_ref` in `.claude/hooks/lib/hook-common.sh` (bash) and `push_head_ref` inside
+  `.claude/hooks/check-history-rewrite.sh` (python) - which whoever folds the three lookups together
+  inherits too.
+- [`silent-cwd-reset-runs-git-in-the-wrong-checkout.md`](silent-cwd-reset-runs-git-in-the-wrong-checkout.md) -
+  the same family at the level of an interactive session rather than a hook process: trusting a
+  location instead of pinning it. Different actor, same fix shape - name the tree explicitly rather
+  than inheriting an ambient one.
+- [`compound-tooling-breaks-in-worktrees-and-forks-2026-08-07.md`](compound-tooling-breaks-in-worktrees-and-forks-2026-08-07.md) -
+  the read-only sibling class: tooling that infers repository identity from its surroundings instead
+  of being told, and also fails quietly.


### PR DESCRIPTION
Three guards told the operator something confident and wrong. All three were seen live this session;
none had a test that could have caught it. Two share a mechanism - **a hook process's own directory
and environment describe the SESSION, never the command it is guarding** - and the third is a gate
that destroyed its own explanation while refusing.

## 1. The history-rewrite guard looked up the wrong branch

`.claude/hooks/check-history-rewrite.sh` derived "the branch" from `git rev-parse --abbrev-ref HEAD`
in the **hook process's own directory**. This repository normally has a dozen worktrees checked out
at once, so that answers about whichever branch the *session* sits on. Twice on 2026-08-31 it named a
branch nobody was touching, both times `docs/god-branch-decomposition-plan`, the plan worktree that
session occupied:

- a force-push of `feats/proxy-verdict-free-return`, which had an open PR **with review history**
  (astubbs/parallel-consumer#295) - exactly what the guard exists to name - was refused with
  *"the lookup ran and came back empty: no open pull request has `docs/god-branch-decomposition-plan`
  as its head branch"*;
- a `git commit --amend` inside the `feats/ks-streams-fork-machinery` worktree was reported against
  the same unrelated branch.

The hook's most confident sentence - the one that exists to distinguish a *measured absence* from a
lookup that never answered - was describing the wrong target. Same silent-wrong-answer class as the
wrong-**repository** fix in astubbs/parallel-consumer#364, one field over.

**The fix.** The branch now comes from the strongest source available, and the message says which:

1. **the push refspec**, when the command names one. `git push origin src:dst` publishes `dst`, and
   `dst` is what a PR has as its head branch, so this is the only authoritative answer - and it is
   free, because both hooks had already tokenised the command for other reasons.
2. otherwise the HEAD of a directory, chosen from a leading `cd <path> &&`, then the tool call's own
   `cwd` from the payload, then the hook process's directory.

Anything but (1) is a guess about where the command runs, so the refusal now says so - *"THE COMMAND
DOES NOT NAME A BRANCH, so this hook used X, the current HEAD of Y, reached from Z"* - and the
found-PR message names the branch it measured, not only the PR number. An amend has no refspec to
read, so (2) plus naming the directory that answered is the whole of what is available there.

`.claude/hooks/remind-inflight-on-push.sh` carries the same defect at push time - it opened with
*"You are pushing to astubbs/parallel-consumer#N"*, a flat claim about a branch the command need not
touch - and gets the same treatment via `hook_push_head_ref` in `.claude/hooks/lib/hook-common.sh`.

## 2. The pre-commit gate gated the wrong working tree

`.claude/hooks/pre-commit-gate.sh` resolved both the gate script and its working directory from
`$CLAUDE_PROJECT_DIR`, so what got checked was the tree the **session** is rooted in. The hazard was
raised in review once and dismissed with the wrong argument: that `if: Bash(git commit *)` matches the
command as written, so only bare commits *"in the session's own cwd, where session repo and commit
repo are the same one"* reach the hook. That premise is false for a **subagent**, which has its own
working directory while `$CLAUDE_PROJECT_DIR` still names the session's most recent worktree - and a
subagent's `git commit ...` is bare, so it matches the registration and arrives anyway.

Observed 2026-08-31: a subagent committing in `.claude/worktrees/proxy-server-shell` was gated against
`.claude/worktrees/bench-harness`. `bin/check-file-refs.sh` failed on citations to `bench/` files that
do not exist on the agent's branch while the agent's own tree ran the same gate at exit 0, and five
commits went through with `--no-verify`.

**The dangerous half is the mirror image, and it leaves no trace**: a RED tree passes because the
session's tree is green, so a violation lands with the gate reporting success. Nobody investigates a
commit that was allowed.

**The fix.** The working tree comes from the command - `git -C <path>` (used only when every commit in
the payload names the same one), then a leading `cd`, then the payload's `cwd`, with
`$CLAUDE_PROJECT_DIR` and the hook's own directory as **labelled** last resorts named in the refusal.
That directory then climbs to its repository root, and both the gate script and its working directory
come from there - running it with the hook's own directory was the second half of the same defect,
since `.githooks/pre-commit` opens with its own `git rev-parse --show-toplevel`.

**It reproduced while the fixing commit was being made**, which is the best arm on this PR. The harness
ran the hook out of the bench-harness worktree and blocked this commit on that tree's citations, while
this worktree's own `.githooks/pre-commit` exits 0. Same payload, same `CLAUDE_PROJECT_DIR`, the hook
file the only variable:

```
pre-fix hook, cwd = guard-diagnostics  ->  exit 2, blocked on the other tree
fixed hook,   cwd = guard-diagnostics  ->  exit 0, gated this tree, nothing to say
```

That commit was therefore made with `--no-verify`, against a tree already run past the same gate,
green. **One half is stated rather than fixed**: `settings.json` registers the hook as
`"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-gate.sh"`, so *which script* runs is still the
session's - only the tree it gates is now the command's. That split is also the safer one, since a
hook script taken from whichever branch is being committed would let a branch ship itself a permissive
gate.

## 3. The quarantine registry gate refused silently, in the case it exists to catch

`bin/check-quarantine-registry.sh` looked the annotated file up with
`f=$(quarantined_files | while read -r qf; do [ ... ] && { echo "$qf"; break; }; done)`. When no
annotated class matches the entry - **which is the drift** - the final test fails, the `while` carries
that status out, `pipefail` promotes it, the assignment takes it, and `set -e` kills the script before
the `DRIFT:` line can print. Exit 1 was right; the explanation was destroyed.

Control arm, same fixture, one term changed and everything else identical:

```
set -euo pipefail  ->  no output, exit 1
set -uo pipefail   ->  the full DRIFT line, exit 1
```

The gate is not weakened: the exit stays 1 and the message now prints. The lookup moved into
`quarantined_file_for_class` in `bin/lib/quarantine-common.sh`, written with a herestring instead of a
pipeline and an `if` instead of a `&&` list.

## Other instances of the same defect classes

**Silent-abort shape** - grepped `bin/` and `.claude/hooks/` for `| while` bodies containing `break`.
Two more, both in `bin/quarantine-lane-report.sh` (`is_flapping`, `annotation_location`), both now on
the shared helper. **Measured honestly: they do not abort today** - there the assignment sits inside a
function invoked from a command substitution rather than as a statement of the script, and a probe of
both shapes under `set -euo pipefail` on bash 3.2 confirms the standalone form dies and the substituted
form does not. The lane report's output is byte-identical before and after. What they did carry is the
other half: `break` makes the `while` an early-exiting pipe reader, so the writer takes EPIPE and
`pipefail` promotes 141 - the hazard `bin/check-shell-sigpipe.sh` polices for `grep -q`, which hides
until the file list outgrows one pipe buffer. `bin/check-quarantine-owners.sh` was checked and does not
use the shape.

**Session-not-command shape** - `.claude/hooks/check-merge-outstanding-work.sh` was judged and **left
alone**: it reads the PR number out of `gh pr merge <n>` first, and only falls back to HEAD for a bare
`gh pr merge`, which resolves the current branch exactly as the fallback does. Correct, rather than
merely untouched. Per `docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md`, the three copies of
the PR *lookup* are deliberately NOT unified here - astubbs/parallel-consumer#341 argues the fail-open
risk by name - and that note now records all three incidents, the new fourth duplicate (the refspec
rule, in bash and in python), and the generalisation the eventual fold-in inherits.

## How red was proven

- **The wrong-branch cases.** Twelve new assertions in `bin/test-check-agent-hooks.sh`, run against
  `origin/master`'s copies of the three files: all twelve fail, and each wrong answer is literally the
  pre-fix one - the fixture's own branch name where the branch the command named should be
  (`expected 'feats/elsewhere', got 'selftest/push-fixture'`). Each pair also asserts the two branch
  names *differ*, so a fixture that stopped reaching the defect fails instead of passing vacuously.
- **The wrong-tree cases.** Fourteen more, built on two real git repos whose stub gates announce which
  one ran and in what directory. Against `origin/master`'s hook, nine fail - **both directions of the
  incident included**: the commit's red tree returning 0 where it must return 2, and the session's red
  tree returning 2 where the commit's clean tree must return 0. The five that pass are the fallback
  cases, which pin the pre-fix behaviour this deliberately keeps.
- **The silent-gate case.** `bin/test-check-quarantine-registry.sh` now runs the gate against a fixture
  whose registry names a vanished class, asserting both that the `DRIFT:` line names the entry and that
  the exit stays 1. Its negative control patches the *shipped pre-fix loop* back into a copy of the
  gate and asserts that copy refuses with no output at all - and fails loudly if the line it patches
  ever stops existing.

`bin/check-all.sh` is green on its real exit code; the touched self-tests
(`test-check-agent-hooks.sh`, `test-check-quarantine-registry.sh`, `test-check-shell-sigpipe.sh`,
`test-check-shell-hazards.sh`, `test-check-shell-lint.sh`) all pass.

## The review round, folded in

`ce-simplify` and a full `ce-code-review` (seven local reviewers plus an independent cross-model
adversarial pass via Codex) ran against this branch, and their findings are fixed here rather than
reported:

- **The simplify commit collapsed the push reminder to one tokeniser spawn - and its first version
  regressed the compound push.** `git push && git status` never fired the reminder; three reviewers
  found it independently. The per-line match that fixes it is pinned by new fixtures.
- **Both refspec readers and the shared tokeniser now lex like a shell**: a newline is a command
  boundary (so `git push -f<newline>git log -1` no longer names `log` as the branch), unspaced
  operators stay operators, the value-taking push-option list is complete, and an unexpanded `$VAR`
  refspec falls back with the inferred label instead of being asserted as a literal branch.
- **`git -C <path> push --force` was a total silent bypass of the history guard** - the `-C` value
  landed where the subcommand should be and the guard matched nothing. The subcommand locator now
  skips value-flags, records `-C` as the strongest working-directory statement, and stops at
  operators. Pre-existing, but exactly this PR's defect class, so it lands here.
- **Ambiguity is now honest in both guards**: two command-position `cd`s fall through to the
  labelled payload-cwd tier instead of presenting the first `cd` as measured fact, and relative
  `cd`/`-C` paths resolve against the payload cwd - never the hook process's own directory, where a
  same-named subdirectory exists in every worktree and the wrong resolution succeeds.
- **`remind-master-drift-on-push.sh` now uses the same refspec-first derivation**, which makes the
  `docs/agent-harness.md` claim that the derivation is shared by both push hooks true - and its
  measurement follows the name, so a refspec-named branch is measured by its own local ref rather
  than pairing another branch's name with the session tree's drift.
- **The review's sweep for surviving instances found one more**, deliberately not fixed here:
  `check-branch-behind-its-own-remote.sh` still derives its branch from the session. It has no
  refspec to read, so the fix is the directory-derivation treatment with its own test surface -
  recorded in `docs/inflight/ci-branch-behind-guard-answers-for-the-sessions-branch.md`.

Two further review rounds ran on GitHub and are also folded in:

- **The requested Codex review** returned six inline findings; all six held and are fixed with
  pinning fixtures (per-invocation `-C` state, the python parser's missing `--recurse-submodules`,
  composed repeated `-C` paths, the cwd-preserving-joiner rule for a leading `cd`, payload-cwd
  repository derivation in both push reminders, and src-side measurement of a `src:dst` push).
  Each thread carries the fix and commit in-reply and is resolved. Notably, two of the six were
  violations of rules this branch itself states - caught within one round of being written.
- **The Claude review** verified every Codex fix at head, ran its own adversarial probes, found no
  additional bypass, and passed the PR clean.

The campaign's lesson is captured on the branch as a durable learning:
`docs/solutions/best-practices/a-guard-that-lexes-shell-commands-must-lex-like-the-shell.md`
(grounding-validated against the tree), with the agent-harness vocabulary it leans on - Guard,
Advisory reminder, Labelled fallback, Gate - added to `CONCEPTS.md`.

Known, accepted limitation: a `git -C /third/repo push` names a repository neither the session nor
the payload cwd points at; the `-C` value is consumed by the shared tokenizer's flag walk and not
currently emitted, so carrying it into the push reminders is a contract change left with the
tracked dedup work in `docs/inflight/ci-pr-lookup-is-copied-into-three-hooks.md`. Both reminders
are non-blocking and fail open.

## Checklist

- [x] Docs updated - `docs/agent-harness.md` (the `hook-common.sh` bullet, the `pre-commit-gate.sh`
      bullet and its row in the registration table), the affected script headers, and the inflight note
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - agent-harness and
      CI gate internals, nothing reaches a library user`
- [x] Tests added/updated - every fix in the original change and in each review round carries its
      own fixture in the hook/gate self-test suites, the originals proven red against the pre-fix
      code and the review-round ones pinning the exact adversarial shape each finding describes
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - both ran in full (simplify: three
      reviewers, two findings applied; code review: seven local reviewers, an independent
      cross-model adversarial pass, and a validation batch), and every actionable finding is fixed
      on this branch - see "The review round, folded in"



