### PR TITLE
feat(proxy) astubbs#242: the sidecar as a real process - binds, serves its lifecycle, and shuts down cleanly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,7 @@ bin/performance-test.sh      # performance tests (substantial hardware)
 | `parallel-consumer-reactor` | Project Reactor integration |
 | `parallel-consumer-mutiny` | SmallRye Mutiny integration (Quarkus) |
 | `parallel-consumer-proxy-protocol` | The **frozen** v1 wire contract for the language proxy: `proxy.proto`, its specification and client-authoring guide, and the tests and `buf` gates that keep it frozen. The wire may only gain - `bin/check-proto-breaking.sh` enforces it, and that module's `README.md` owns the detail |
+| `parallel-consumer-proxy` | The sidecar. **Packaging and process boundary only today** - an executable that binds loopback, admits one connection under the transport's rules, and dies with its parent; it hosts no engine, so a session is answered `UNIMPLEMENTED`. That module's `README.md` owns the detail, including what is not there yet |
 | `parallel-consumer-proxy-clients` | Eleven language client modules. **Build scaffolding only today** - toolchain, compile, run, one fixture line; no Kafka and no PC semantics. The eight non-JVM ones are outside the reactor unless `-Dpc.foreignClients` is passed, and an absent toolchain is reported and skipped rather than failing. That directory's `README.md` owns the detail |
 | `parallel-consumer-examples` | Example implementations for each module |
 

--- a/docs/data/module-maturity.yaml
+++ b/docs/data/module-maturity.yaml
@@ -88,14 +88,36 @@ modules:
       bin/check-proto-breaking.sh fails a change that tries. A capability token, not a version
       number, is how a client learns what an addition means.
     support_posture: >-
-      Experimental. Published to no registry, and the sidecar and client libraries this schema exists
-      for are not on master yet, so there is nothing yet to be compatible with.
+      Experimental. Published to no registry; no client library speaks it, and the sidecar on master
+      hosts no engine, so nothing has yet had to be compatible with it.
     evidence_id: proxy-protocol
     tracking: astubbs#242
     use_this_if: >-
       You are writing a client against the proxy protocol. The two artifacts to work from are the
       schema and parallel-consumer-proxy-protocol/docs/protocol-specification.md; the client-authoring
       guide beside them says what an implementation must do.
+  - artifact: parallel-consumer-proxy
+    maturity: alpha
+    minimum_java: 17
+    reliability_confidence: >-
+      What is evidenced is the process boundary, and only that: the sidecar binds loopback on an
+      ephemeral port, announces it, admits exactly one stream, rejects an unlisted declared authority
+      before the service method runs, and releases the socket when its parent dies. It hosts NO
+      Parallel Consumer engine - a session is answered UNIMPLEMENTED - so nothing here evidences a
+      record being processed, an offset being committed, or any protocol behaviour beyond the
+      handshake being refused.
+    api_expectation: >-
+      Pre-1.0 and expected to change substantially: the engine, its connect-time configuration and
+      the shutdown drain are still to arrive, and the seam they plug into is the one thing here most
+      likely to move.
+    support_posture: >-
+      Experimental. Published to no registry, and there is no supported way to run it against a
+      broker yet because it cannot be configured.
+    evidence_id: proxy-sidecar
+    tracking: astubbs#242
+    use_this_if: >-
+      You are reviewing or extending the sidecar's packaging and process lifecycle. There is no
+      user-facing reason to depend on it yet.
   - artifact: parallel-consumer-examples
     maturity: reference-example
     reliability_confidence: Exercises supported module use cases; it is not a runtime library dependency.

--- a/docs/data/testing-evidence.yaml
+++ b/docs/data/testing-evidence.yaml
@@ -173,7 +173,27 @@ module_evidence:
     limitation: >-
       This is evidence about a CONTRACT, not about behaviour. It proves the schema encodes, decodes and
       is documented as it claims; it proves nothing about a proxy serving it or a client speaking it,
-      because neither exists on master yet.
+      because no engine and no client library exists on master yet.
+  - id: proxy-sidecar
+    artifact: parallel-consumer-proxy
+    coverage: >-
+      The process lifecycle end to end, driven through the entry point rather than asserted on its
+      parts: arguments refused with a message naming where configuration actually goes; an ephemeral
+      loopback port bound, announced on stdout line one and proven to answer; two sidecars binding
+      different ports so one host running two applications is not a bind race; a real gRPC session
+      reaching the hosted service and being refused with a status that names what is missing; and the
+      listener proven GONE after parent death, which is what separates "run returned" from "the
+      server was shut down". Plus the transport's own admission rules - loopback-only bind, the
+      non-loopback opt-in and its warning, the authority allowlist and the one-connection slot -
+      each asserted with service-invocation counters rather than on the client-visible status alone.
+    inspect:
+      - parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/MainTest.java
+      - parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/ProxyServerTest.java
+      - parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/lifecycle/ParentDeathWatchdogTest.java
+    limitation: >-
+      Evidence about a PROCESS, not about processing. No engine is hosted, so no record has been
+      dispatched, no verdict returned and no offset committed; and the sidecar has never run against
+      a broker, because it cannot be configured to reach one.
   - id: streams-alpha
     artifact: parallel-consumer-streams-spike
     coverage: Planned alpha evidence must exercise the release artifact's opt-in boundary, comparison switch and supported topology/recovery claims.

--- a/parallel-consumer-proxy/README.md
+++ b/parallel-consumer-proxy/README.md
@@ -1,0 +1,62 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# The proxy sidecar - Parallel Consumer for languages that are not the JVM
+
+> **⚠️ EXPERIMENTAL - not for production use.** Nothing here is published to any package registry,
+> the API may change without notice, and none of it has carried production traffic. Build it from
+> this checkout, read it, test it - do not depend on it. Tracking: astubbs#242, upstream
+> confluentinc#154.
+
+The intended end state is a process that runs Parallel Consumer, holds the Kafka connection, and
+hands records to a worker in another language over the frozen
+[v1 protocol](../parallel-consumer-proxy-protocol). The worker returns verdicts; the engine decides
+everything else - shard selection, retry scheduling and offset tracking all stay here, which is what
+keeps a client a facade rather than a second implementation of Parallel Consumer in every language.
+
+## What is actually in this module today
+
+**The packaging and runtime boundary, and nothing above it.** The sidecar builds, starts, binds,
+admits or rejects a connection under its own rules, and shuts down cleanly when its parent dies.
+There is no engine: a client that opens a session is answered `UNIMPLEMENTED` with a description
+saying which piece is missing. That is the honest state of this build rather than a stub pretending
+to work, and it is asserted by a test rather than left to be discovered.
+
+- `Main` - the executable. It binds an ephemeral loopback port, prints `port: <n>` as the first line
+  of stdout, and serves until its parent dies. **It parses no configuration and refuses arguments**:
+  bootstrap servers, credentials, ordering, concurrency and subscription all arrive connect-time in
+  `Configure` over the protocol, so a flag here would be a flag that did nothing.
+- `lifecycle/ParentDeathWatchdog` - an orphaned sidecar holds a group membership on behalf of an
+  application that no longer exists, so parent-death detection is correctness rather than
+  housekeeping. EOF on the inherited pipe is the primary signal; a pid poll backs it up for the case
+  where a wrapper process holds the write end open. **Launch the sidecar directly, never through a
+  shell.**
+- `transport/` - `ProxyServer` and the two things that make loopback-only safe:
+  `AuthorityAllowlistInterceptor` and `SingleConnectionGuard`. **The connection is the session**; one
+  worker per sidecar is a design constraint, not a limitation waiting to be lifted.
+
+The transport's contract with what it hosts is `io.grpc.BindableService` and nothing more, so it
+compiles against no engine type at all. `NoEngineSessionService` is what fills that slot until the
+engine arrives, and `Main#sessionServiceFactory` is the one call site that changes when it does.
+
+## Security posture
+
+Loopback-only, and that is what removes the need for authentication: only the spawning process can
+reach it, and one application per sidecar means no multi-tenancy. Those constraints are load-bearing
+- a shared multi-tenant server would discard all of them at once and is a different product. A
+non-loopback bind refuses to start unless the opt-in named in the refusal is set, and when it is set
+the server warns with the full surface it is exposing.
+
+## Not here yet
+
+Connect-time configuration and the options mapping, the dispatch engine and its waves, the in-flight
+registry, epochs, leases and heartbeats, reconnect with manifest reconciliation, the produce path,
+the shutdown drain that waits on records held in a foreign process, capability negotiation, the
+native image, and the client libraries. Those are reviewed as their own changes; astubbs#242 tracks
+the whole.
+
+## Related
+
+- [`parallel-consumer-proxy-protocol`](../parallel-consumer-proxy-protocol) - the wire contract, its
+  specification, the client-authoring guide and the freeze gate.
+- [`parallel-consumer-proxy-clients`](../parallel-consumer-proxy-clients) - the client module
+  scaffolding.

--- a/parallel-consumer-proxy/docs/simplifications-declined.md
+++ b/parallel-consumer-proxy/docs/simplifications-declined.md
@@ -1,0 +1,23 @@
+<!-- Copyright (C) 2026 Antony Stubbs and contributors -->
+
+# Simplifications considered and declined - do not re-propose without new evidence
+
+From the 2026-08-17 simplification pass over the proxy (astubbs#242). **The declined ones are
+recorded because the next pass will find them again**, and re-deriving why each is wrong costs more
+than reading it. None is deferred work; each is a decision that the current code is better.
+
+**Where the reason is subtle, the code should carry it too** - a note here stops a human, a comment
+at the site stops an automated pass. The one marked **(comment)** below is where the diff looks
+strictly better and only the reasoning says otherwise.
+
+This file lists only the candidates whose subject is in this module today. The pass covered the whole
+sidecar; each remaining entry travels with the code it is about, as that code arrives.
+
+Transport:
+
+- **(comment)** Swapping `AuthorityAllowlistInterceptor`'s hand-written host normaliser for Guava's
+  `HostAndPort`. Guava **throws** on bare unbracketed IPv6, which that method deliberately admits - a
+  security-posture change wearing a library swap.
+- A shared logback-capture test helper; the two call sites do different jobs.
+- Any change to `AuthorityAllowlistInterceptor` or `SingleConnectionGuard` - security posture, and
+  their apparent simplicity is the point.

--- a/parallel-consumer-proxy/pom.xml
+++ b/parallel-consumer-proxy/pom.xml
@@ -49,6 +49,11 @@
         it to the root would impose gRPC's transitive graph on every module in the repository to fix a problem
         only gRPC's consumers have.
 
+        It is 2.48.0 here where the protocol module says 2.47.0, and the difference is not drift: the gson
+        pinned below asks for 2.48.0, so this module has a higher requester than that one does. The rule is
+        "manage it up to what the highest requester asks for", which resolves to a different number per module
+        by design - the two are not meant to be kept equal, and equalising them would break one of them.
+
         NOT the root pom's ${error-prone.version}: that pins the Error Prone COMPILER, deliberately below
         current for an unrelated and temporary reason.
     -->
@@ -57,7 +62,28 @@
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.47.0</version>
+                <version>2.48.0</version>
+            </dependency>
+            <!--
+                gson arrives at runtime through grpc-core (JSON service-config parsing) and grpc 1.75
+                resolves 2.11.0, which OSS Index flags for CVE-2025-53864 (CVSS 6.9). That advisory's
+                affected product is actually com.nimbusds:nimbus-jose-jwt, which nothing here depends
+                on; its text mentions "the Gson 2.11.0 issue" while saying the flaw is independent of
+                it, and Sonatype's matcher has taken the version from that sentence.
+
+                It is pinned forward rather than excluded anyway. An exclusion is repo-wide debt
+                carrying a retirement condition nobody can discharge - the record will never be
+                withdrawn, because it is correct about a library we do not use - whereas moving off
+                the matched version costs one line, removes the finding at its source, and is an
+                upgrade we would want regardless. gson is transitive and not independently upgradable,
+                so a managed version is the only lever.
+
+                Drop this once the gRPC we depend on resolves a gson newer than 2.11.0 itself.
+            -->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.14.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parallel-consumer-proxy/pom.xml
+++ b/parallel-consumer-proxy/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2026 Antony Stubbs and contributors
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>parallel-consumer-parent</artifactId>
+        <groupId>bz.stub.parallelconsumer</groupId>
+        <version>0.6.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Parallel Consumer - Language Proxy</name>
+    <artifactId>parallel-consumer-proxy</artifactId>
+
+    <properties>
+        <!--
+            This module's real runtime floor is Java 17, and it must say so.
+
+            The project-wide release.target is 8: the build compiles Java 17 source down to Java 8
+            bytecode via Jabel, so anything the Java 8 platform API does not expose is invisible to
+            this module even though the source language allows it. A wire-protocol module cannot live
+            there - the transport stack and the modern networking API surface it needs are Java 9+.
+
+            The failure mode this override prevents is not a compile error, which is why it has to be
+            deliberate. The release level constrains the platform API, not what javac will read off the
+            classpath, so a module set too low compiles happily and ships bytecode claiming a JVM it
+            does not actually run on - the mistake surfaces as an UnsupportedClassVersionError on first
+            use, in the downstream consumer's runtime rather than in our build.
+            parallel-consumer-mutiny records the same trap after paying for it.
+
+            Only this module and mutiny are affected - core, vertx and reactor remain Java 8 (major 52).
+        -->
+        <release.target>17</release.target>
+
+        <!-- ${grpc.version} is NOT declared here. The generated stubs this module serves and the
+             transport runtime must agree on one gRPC version, and the root pom owns that single
+             property for every module that speaks the protocol - a comment asking three poms to
+             stay equal is not a guard. -->
+    </properties>
+
+    <!--
+        MODULE-LOCAL, and it must stay module-local - the same pin, for the same reason, as
+        parallel-consumer-proxy-protocol's, whose comment carries the full reasoning: gRPC drags
+        error_prone_annotations in twice at different versions, resolution settles on the lower one, and the
+        root pom's requireUpperBoundDeps fails the build. It is repeated rather than hoisted because hoisting
+        it to the root would impose gRPC's transitive graph on every module in the repository to fix a problem
+        only gRPC's consumers have.
+
+        NOT the root pom's ${error-prone.version}: that pins the Error Prone COMPILER, deliberately below
+        current for an unrelated and temporary reason.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>2.47.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>bz.stub.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--
+            The protocol module: proxy.proto's generated messages and gRPC stubs. Per the
+            language-proxy plan's KTD34, the dependency arrow runs engine -> protocol and never
+            the reverse - the protocol module must stay consumable by codegen alone, with no
+            engine on the classpath.
+        -->
+        <dependency>
+            <groupId>bz.stub.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-proxy-protocol</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--
+            The transport's server stack, U1's cleared gate: grpc-netty-shaded is the artifact the
+            feasibility probe proved end to end (loopback bind, :authority interception before the
+            service method, native-image build), so the transport uses it rather than unshaded
+            grpc-netty. It also serves as the client stack in this module's own transport tests.
+        -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>bz.stub.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-core</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Declared explicitly rather than leaned on transitively: core's test-jar reaches for
+            commons-lang3, and test scope is not transitive, so relying on core to supply it here
+            would break the moment core stopped using it.
+        -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/parallel-consumer-proxy/pom.xml
+++ b/parallel-consumer-proxy/pom.xml
@@ -63,11 +63,15 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>bz.stub.parallelconsumer</groupId>
-            <artifactId>parallel-consumer-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+        <!--
+            parallel-consumer-core is DELIBERATELY ABSENT from compile scope, and it is absent as
+            evidence rather than as an oversight: what this module contains today is a process and a
+            gRPC listener, and neither needs an engine. The transport's contract with the service it
+            hosts is io.grpc.BindableService, so nothing here references a Parallel Consumer type at
+            all - which is the whole reason this module can be reviewed without reading one. It comes
+            back with the engine that needs it. (The test-jar below is a different artifact and is
+            used, for the shared ArchUnit convention rules.)
+        -->
         <!--
             The protocol module: proxy.proto's generated messages and gRPC stubs. Per the
             language-proxy plan's KTD34, the dependency arrow runs engine -> protocol and never

--- a/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/Main.java
+++ b/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/Main.java
@@ -1,0 +1,155 @@
+package bz.stub.parallelconsumer.proxy;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.lifecycle.ParentDeathWatchdog;
+import bz.stub.parallelconsumer.proxy.transport.ProxyServer;
+import io.grpc.BindableService;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/**
+ * The sidecar (KTD4, R47, R52): the application's child process, which serves one client over gRPC and dies
+ * when that client does.
+ *
+ * <h2>The spawning contract</h2>
+ *
+ * Bind an ephemeral loopback port, print {@code port: <n>} as the first line of stdout, then serve until the
+ * parent dies. Everything a spawning client needs to find this process is on that one line, so the client
+ * side of the contract is a line read rather than a discovery protocol.
+ *
+ * <h2>It parses no configuration, and that is a rule rather than an omission</h2>
+ *
+ * Everything - bootstrap servers, credentials, ordering, concurrency, subscription - arrives connect-time in
+ * {@code Configure} over the protocol (R39, U7). Nothing is read from a file, an environment variable, or the
+ * command line beyond what the lifecycle itself needs, which is currently nothing. An argument is therefore a
+ * caller misunderstanding, and this refuses to start rather than ignoring it: a sidecar that silently
+ * discarded {@code --bootstrap-servers} would be configured over the protocol anyway and the operator would
+ * be left debugging why their flag did nothing.
+ *
+ * <h2>Launch it directly, never through a shell</h2>
+ *
+ * Parent death is detected by EOF on the inherited pipe (KTD19). A wrapper process - a shell, a launcher -
+ * inherits the write end and holds it open, which defeats that signal.
+ * {@link ParentDeathWatchdog}'s pid poll is the backstop, but the backstop has an interval and the pipe does
+ * not.
+ *
+ * <h2>What this build serves, and what it does not</h2>
+ *
+ * This is the packaging and runtime boundary only. The session service it hosts is
+ * {@link NoEngineSessionService}, which refuses every session with {@code UNIMPLEMENTED} because there is no
+ * engine in this module yet - so what a reviewer can hold this to is exactly the lifecycle: it binds, it
+ * announces, it admits or rejects a connection under the transport's own rules, and it stops cleanly. The
+ * engine, its connect-time configuration, and the shutdown drain that waits on records held in a foreign
+ * process all arrive with later rungs; {@link #sessionServiceFactory} is the single seam they replace.
+ *
+ * @author Antony Stubbs
+ * @see ParentDeathWatchdog
+ * @see NoEngineSessionService
+ */
+@Slf4j
+public final class Main {
+
+    /** Argument or usage error: the caller asked for something this binary does not do. */
+    public static final int EXIT_USAGE = 2;
+
+    /** Could not bind the listener. Distinct from a usage error: the invocation was fine, the socket was not. */
+    public static final int EXIT_BIND_FAILED = 4;
+
+    /** The port line, as the spawning client parses it. */
+    public static final String PORT_LINE_PREFIX = "port: ";
+
+    /** Brisk enough that an orphan is short-lived, slow enough not to spin on a healthy parent. */
+    private static final Duration PARENT_POLL_INTERVAL = Duration.ofMillis(250);
+
+    /**
+     * What the production entry point always asks for: let the OS choose, so no well-known port is guessable
+     * and two sidecars on one host cannot race for the same number. Only a test names a port, and only so
+     * that a bind failure can be provoked.
+     */
+    private static final int EPHEMERAL_PORT = 0;
+
+    private Main() {
+    }
+
+    public static void main(String[] args) {
+        System.exit(run(args, System.out, System.err, System.in));
+    }
+
+    /**
+     * The testable core of {@link #main}: returns the exit code rather than calling {@code System.exit}, and
+     * takes the parent lifeline as a parameter so a test can end it without killing a process.
+     *
+     * @param parentLifeline the inherited pipe; {@code System.in} in the real sidecar
+     */
+    public static int run(String[] args, PrintStream out, PrintStream err, InputStream parentLifeline) {
+        return run(args, out, err, parentLifeline, sessionServiceFactory(), EPHEMERAL_PORT);
+    }
+
+    /**
+     * The two seams this class has, both package-private because neither is a knob the sidecar exposes.
+     * <p>
+     * {@code sessionService} is what the engine rung fills: the transport's contract with the thing it hosts
+     * is {@link BindableService} and nothing more - the whole reason the transport can be reviewed without an
+     * engine - and it is a factory rather than an instance because each run owns its own service for the life
+     * of one server. {@code port} exists only so a bind failure can be provoked deliberately; production
+     * always passes {@link #EPHEMERAL_PORT}, and an untestable exit code is one nobody can rely on.
+     */
+    static int run(String[] args, PrintStream out, PrintStream err, InputStream parentLifeline,
+                   Supplier<BindableService> sessionService, int port) {
+        if (args.length > 0) {
+            return usage(err, "this binary takes no arguments (got '" + args[0] + "')");
+        }
+
+        try (var server = ProxyServer.builder().sessionService(sessionService.get()).port(port).build().start()) {
+            out.println(PORT_LINE_PREFIX + server.port());
+            log.info("Sidecar listening on loopback port {}; waiting for the client to configure it",
+                    server.port());
+
+            try (var watchdog = ParentDeathWatchdog.watchingParentOf(parentLifeline, PARENT_POLL_INTERVAL)) {
+                watchdog.start();
+                watchdog.awaitDeath();
+                log.info("Shutting down: {}", watchdog.cause());
+            }
+            return 0;
+        } catch (IOException bindFailed) {
+            err.println("sidecar: could not bind the loopback listener: " + bindFailed.getMessage());
+            return EXIT_BIND_FAILED;
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while serving; shutting down");
+            return 0;
+        }
+    }
+
+    /**
+     * What a sidecar with no engine hosts. Named rather than inlined so the thing a later rung replaces is
+     * one greppable call site.
+     */
+    static Supplier<BindableService> sessionServiceFactory() {
+        return NoEngineSessionService::new;
+    }
+
+    private static int usage(PrintStream err, String problem) {
+        err.println("sidecar: " + problem);
+        err.println();
+        err.println("usage: Main");
+        err.println();
+        err.println("It takes no arguments. Bootstrap servers, credentials, ordering, concurrency and");
+        err.println("subscription all arrive connect-time in the Configure message over the protocol, so");
+        err.println("there is no flag or environment variable to set here.");
+        err.println();
+        err.println("Prints '" + PORT_LINE_PREFIX + "<n>' on stdout line one, then serves one client on that");
+        err.println("loopback port until the parent process dies (observed as EOF on stdin).");
+        err.println();
+        err.println("Launch it DIRECTLY, not through a shell: a wrapper process inherits the pipe's write");
+        err.println("end and holds it open, which defeats the primary parent-death signal.");
+        return EXIT_USAGE;
+    }
+}

--- a/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/NoEngineSessionService.java
+++ b/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/NoEngineSessionService.java
@@ -1,0 +1,66 @@
+package bz.stub.parallelconsumer.proxy;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.protocol.v1.ClientMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyServiceGrpc;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The session service a sidecar built without an engine hosts: it accepts nothing and says so.
+ *
+ * <p>This exists because the shell has to host <em>something</em> - the transport's contract with the thing
+ * it serves is {@link io.grpc.BindableService}, and a server with no service is not a server. It is not a
+ * stub of the engine and deliberately implements none of the protocol's semantics: a client that connects
+ * gets {@link Status#UNIMPLEMENTED} with a description saying which piece is missing, which is the literal
+ * truth of this build rather than a placeholder pretending to work. Answering a {@code Configure} with a
+ * fabricated {@code Configured} would be the alternative, and it would let a client believe it had
+ * configured an engine that does not exist.
+ *
+ * <p><b>It is replaced, not extended.</b> The engine rung supplies the real
+ * {@code ProxyServiceGrpc.ProxyServiceImplBase} - the connect-time configuration handler - to
+ * {@code Main#sessionServiceFactory()}, and this class goes away with it. Nothing should come to depend on
+ * it; the reason it is a named class rather than an anonymous subclass at the call site is so that
+ * replacement is one grep rather than a reading exercise.
+ *
+ * @author Antony Stubbs
+ */
+@Slf4j
+class NoEngineSessionService extends ProxyServiceGrpc.ProxyServiceImplBase {
+
+    /**
+     * What a rejected client is told. Stated in full because the failure it describes is a build-time
+     * omission, and a bare {@code UNIMPLEMENTED} would send the client author looking for their own bug.
+     */
+    static final String NO_ENGINE_DESCRIPTION =
+            "this sidecar build hosts no Parallel Consumer engine: the transport, its admission rules and the "
+                    + "process lifecycle are present, but connect-time configuration and record dispatch are "
+                    + "not, so there is nothing for a session to do";
+
+    @Override
+    public StreamObserver<ClientMessage> session(StreamObserver<ProxyMessage> responseObserver) {
+        log.warn("Refusing a session: {}", NO_ENGINE_DESCRIPTION);
+        responseObserver.onError(Status.UNIMPLEMENTED.withDescription(NO_ENGINE_DESCRIPTION).asRuntimeException());
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(ClientMessage message) {
+                // The call is already closed; anything still in flight from the client is discarded rather
+                // than parsed, because parsing it would be the first semantic this class must not have.
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                // The peer went away, which is the expected next thing to happen here.
+            }
+
+            @Override
+            public void onCompleted() {
+                // Already terminated by onError above; completing again would be an IllegalStateException.
+            }
+        };
+    }
+}

--- a/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/lifecycle/ParentDeathWatchdog.java
+++ b/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/lifecycle/ParentDeathWatchdog.java
@@ -1,0 +1,205 @@
+package bz.stub.parallelconsumer.proxy.lifecycle;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Dies when its parent dies (KTD19, R52). The sidecar is the application's child, and an orphaned sidecar is
+ * a process holding a group membership on behalf of an application that no longer exists - so this is a
+ * correctness mechanism, not housekeeping.
+ *
+ * <h2>Why an inherited pipe, and not {@code PR_SET_PDEATHSIG}</h2>
+ *
+ * The parent holds the write end and never writes down it. When the parent dies <b>for any reason, including
+ * SIGKILL</b>, the kernel closes the last write end and this side's read returns -1. That is pure Java,
+ * identical on Linux and macOS, and unchanged between the JVM jar and the native image.
+ * <p>
+ * {@code PR_SET_PDEATHSIG} was rejected on the merits as well as on reach: it needs {@code java.lang.foreign},
+ * which is unavailable at this module's Java 17 release level; it fires on parent <em>thread</em> death; it is
+ * cleared across {@code fork} and {@code setuid}; and it races a parent that died before the call.
+ *
+ * <h2>Why there is a second signal</h2>
+ *
+ * The pipe signal has one hole, and it is a hole the client can fall into by accident: <b>a wrapper process
+ * between the application and the sidecar inherits the write end and holds it open</b> after the real parent
+ * is gone, so EOF never arrives and this watchdog would wait forever. Launching through a shell is the
+ * everyday way to create one.
+ * <p>
+ * So the client must launch the proxy <b>directly, never through a shell</b> - and because "must" is not a
+ * mechanism, a {@link ProcessHandle} parent-pid poll runs beside the pipe and catches the case anyway. The
+ * pipe stays primary because it is immediate; the poll is a backstop with a visible interval.
+ *
+ * <h2>What it does not do</h2>
+ *
+ * It reports death. It does not decide what happens next - today that is
+ * {@code bz.stub.parallelconsumer.proxy.Main}, which closes the listener; once there is an engine it is the
+ * shutdown drain's. Separating the signal from the response is what lets either be tested without killing a
+ * process.
+ *
+ * @author Antony Stubbs
+ */
+@Slf4j
+public final class ParentDeathWatchdog implements AutoCloseable {
+
+    /** Which signal fired, so a shutdown can say why it is shutting down rather than merely that it is. */
+    public enum Cause {
+        /** EOF or an error on the inherited pipe: the primary signal. */
+        LIFELINE_CLOSED,
+        /** The parent pid is no longer alive: the backstop, and evidence a wrapper process held the pipe. */
+        PARENT_PROCESS_GONE
+    }
+
+    private final InputStream parentLifeline;
+
+    private final BooleanSupplier parentAlive;
+
+    private final Duration pollInterval;
+
+    private final CountDownLatch died = new CountDownLatch(1);
+
+    private final AtomicReference<Cause> cause = new AtomicReference<>();
+
+    /** Set before the threads are torn down, so a deliberate close is never mistaken for the parent dying. */
+    private volatile boolean closing;
+
+    private Thread lifelineWatcher;
+
+    private ScheduledExecutorService parentPoller;
+
+    private ParentDeathWatchdog(InputStream parentLifeline, BooleanSupplier parentAlive, Duration pollInterval) {
+        this.parentLifeline = parentLifeline;
+        this.parentAlive = parentAlive;
+        this.pollInterval = pollInterval;
+    }
+
+    /**
+     * The seam form: both signals are supplied, so a test can exercise either one without a real process.
+     *
+     * @param parentLifeline the inherited pipe - {@code System.in} in the real sidecar
+     * @param parentAlive    the second signal; consulted every {@code pollInterval}
+     */
+    public static ParentDeathWatchdog watching(InputStream parentLifeline, BooleanSupplier parentAlive,
+                                               Duration pollInterval) {
+        return new ParentDeathWatchdog(parentLifeline, parentAlive, pollInterval);
+    }
+
+    /**
+     * The production form: watches the pipe it was given and the pid that started this JVM.
+     * <p>
+     * The parent handle is captured <b>once, now</b>, rather than re-read on each poll. Re-reading is the
+     * subtle bug: once the real parent dies this process is re-parented (to init, or to a subreaper), so a
+     * fresh lookup would find a living process and report the parent healthy forever - the poll would answer
+     * "does this process have a parent" when the question is "is the parent it started with still alive".
+     * <p>
+     * A JVM with no visible parent gets a poll that always says alive: unable to tell is not the same as
+     * dead, and killing the sidecar on that basis would be a fabricated signal.
+     */
+    public static ParentDeathWatchdog watchingParentOf(InputStream parentLifeline, Duration pollInterval) {
+        var parent = ProcessHandle.current().parent();
+        if (parent.isEmpty()) {
+            log.warn("No parent process is visible, so the pid poll is disabled and EOF on the lifeline is the "
+                    + "only parent-death signal. A wrapper process holding the write end would now go unnoticed.");
+            return watching(parentLifeline, () -> true, pollInterval);
+        }
+        var handle = parent.get();
+        log.debug("Watching parent pid {}", handle.pid());
+        return watching(parentLifeline, handle::isAlive, pollInterval);
+    }
+
+    /** Starts both watchers. Daemon threads throughout: neither may keep a shutting-down JVM alive. */
+    public synchronized void start() {
+        if (lifelineWatcher != null) {
+            throw new IllegalStateException("already started");
+        }
+
+        lifelineWatcher = new Thread(this::watchLifeline, "pc-proxy-parent-lifeline");
+        lifelineWatcher.setDaemon(true);
+        lifelineWatcher.start();
+
+        parentPoller = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            var thread = new Thread(runnable, "pc-proxy-parent-poll");
+            thread.setDaemon(true);
+            return thread;
+        });
+        long intervalMs = Math.max(1, pollInterval.toMillis());
+        parentPoller.scheduleWithFixedDelay(this::pollParent, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    /** Blocks until the parent dies. */
+    public void awaitDeath() throws InterruptedException {
+        died.await();
+    }
+
+    /**
+     * @return true if the parent died within the bound, false if it is still alive - so a caller can assert
+     * that nothing happened, which is the property a spurious-fire regression breaks
+     */
+    public boolean awaitDeath(Duration timeout) throws InterruptedException {
+        return died.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /** Which signal fired, or null while the parent is alive. */
+    public Cause cause() {
+        return cause.get();
+    }
+
+    private void watchLifeline() {
+        try {
+            while (parentLifeline.read() != -1) {
+                // The parent never writes; only its death matters. Anything it does send is discarded rather
+                // than parsed - this pipe is a lifetime signal and deliberately not a second control channel.
+                log.trace("Ignoring a byte on the parent lifeline; it carries no protocol");
+            }
+            signal(Cause.LIFELINE_CLOSED);
+        } catch (IOException parentGone) {
+            // A broken pipe reads the same as EOF. Propagating it would leave a sidecar running with no
+            // supervisor, which is the exact state this class exists to prevent.
+            signal(Cause.LIFELINE_CLOSED);
+        }
+    }
+
+    private void pollParent() {
+        try {
+            if (!parentAlive.getAsBoolean()) {
+                signal(Cause.PARENT_PROCESS_GONE);
+            }
+        } catch (RuntimeException e) {
+            // A poll that throws must not kill the scheduled task - that would silently retire the backstop
+            // and leave the wrapper-process case uncovered for the rest of the run.
+            log.warn("Parent liveness poll failed; the pipe signal still stands", e);
+        }
+    }
+
+    private void signal(Cause observed) {
+        if (closing) {
+            return;
+        }
+        if (cause.compareAndSet(null, observed)) {
+            log.info("Parent death detected: {}", observed);
+            died.countDown();
+        }
+    }
+
+    @Override
+    public void close() {
+        closing = true;
+        if (parentPoller != null) {
+            parentPoller.shutdownNow();
+        }
+        if (lifelineWatcher != null) {
+            lifelineWatcher.interrupt();
+        }
+    }
+}

--- a/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/transport/AuthorityAllowlistInterceptor.java
+++ b/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/transport/AuthorityAllowlistInterceptor.java
@@ -1,0 +1,119 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Rejects any connection whose declared target authority is not in the allowlist - R29 of the language-proxy
+ * plan (astubbs#242), enforced on every connection including loopback binds.
+ * <p>
+ * The threat is a browser page the operator happens to visit reaching the loopback listener cross-origin: a
+ * browser always names the origin it thinks it is talking to in the {@code :authority} pseudo-header, so a
+ * request that arrived via {@code evil.example.com} declares it. A well-behaved local client either declares
+ * a loopback host form or declares nothing, which is why a connection declaring <b>no</b> authority is
+ * accepted while one declaring an unlisted authority is rejected.
+ * <p>
+ * The mechanism is U1's cleared gate (KTD11): read {@link ServerCall#getAuthority()} in
+ * {@code interceptCall}, close an unlisted authority with {@link Status#PERMISSION_DENIED} and return a
+ * no-op listener - so the service method <b>never runs</b> for a rejected connection. The tests prove that
+ * with counters (service invocations and application messages both unchanged across a rejection), not by
+ * inspection, because a test asserting only the returned status can pass after the service method has
+ * already run.
+ * <p>
+ * Matching is by host: the authority's port, IPv6 brackets and case are stripped before comparison, so an
+ * allowlist entry {@code localhost} admits {@code localhost:41234}, and {@code ::1} admits {@code [::1]:80}.
+ */
+@Slf4j
+public class AuthorityAllowlistInterceptor implements ServerInterceptor {
+
+    /** Normalized (lowercase, portless, bracketless) host forms this listener will accept. */
+    private final Set<String> allowedHosts;
+
+    /**
+     * @param allowedHostForms host forms to accept; each is normalized the same way declared authorities are
+     */
+    public AuthorityAllowlistInterceptor(Collection<String> allowedHostForms) {
+        Set<String> normalized = new LinkedHashSet<>();
+        for (var hostForm : allowedHostForms) {
+            normalized.add(normalizeToHost(hostForm));
+        }
+        this.allowedHosts = Set.copyOf(normalized);
+    }
+
+    /**
+     * The default allowlist R29 specifies: the loopback host forms plus the configured bind address, plus any
+     * operator-configured additions.
+     * <p>
+     * Both textual forms of the IPv6 loopback are listed because {@link InetAddress#getHostAddress()} renders
+     * it expanded ({@code 0:0:0:0:0:0:0:1}) while clients conventionally declare it compressed ({@code ::1}).
+     */
+    public static AuthorityAllowlistInterceptor defaultAllowlist(InetAddress bindAddress,
+                                                                 Collection<String> operatorAdditions) {
+        Set<String> hosts = new LinkedHashSet<>(Set.of("localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1"));
+        hosts.add(bindAddress.getHostAddress());
+        hosts.addAll(operatorAdditions);
+        return new AuthorityAllowlistInterceptor(hosts);
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+                                                                 Metadata headers,
+                                                                 ServerCallHandler<ReqT, RespT> next) {
+        String authority = call.getAuthority();
+        if (authority == null) {
+            // Accept-on-absent, per R29: the browser threat this interceptor exists for always declares an
+            // authority, so absence is not evidence of it.
+            return next.startCall(call, headers);
+        }
+        String host = normalizeToHost(authority);
+        if (allowedHosts.contains(host)) {
+            return next.startCall(call, headers);
+        }
+        log.warn("Rejecting connection declaring unlisted authority '{}' (normalized host '{}') - not in "
+                + "the allowlist {} (R29)", authority, host, allowedHosts);
+        call.close(Status.PERMISSION_DENIED
+                        .withDescription("declared authority '" + authority + "' is not in the allowlist"),
+                new Metadata());
+        return new ServerCall.Listener<>() {
+        };
+    }
+
+    /**
+     * Reduces an authority to its host: lowercase, port stripped, IPv6 brackets stripped. Handles the four
+     * shapes an authority takes - {@code host}, {@code host:port}, {@code [v6]}, {@code [v6]:port} - and
+     * leaves a bare unbracketed IPv6 literal (more than one colon) intact rather than mistaking its last
+     * segment for a port.
+     */
+    // DO NOT swap this for Guava's HostAndPort. It throws on a bare unbracketed IPv6 authority,
+    // which this method deliberately admits - so the swap would narrow what the allowlist accepts,
+    // which is a security-posture change wearing a library upgrade. Declined 2026-08-17; see
+    // parallel-consumer-proxy/docs/simplifications-declined.md.
+    static String normalizeToHost(String authority) {
+        String a = authority.trim().toLowerCase(Locale.ROOT);
+        if (a.startsWith("[")) {
+            int closing = a.indexOf(']');
+            if (closing > 0) {
+                return a.substring(1, closing);
+            }
+            return a;
+        }
+        int firstColon = a.indexOf(':');
+        if (firstColon >= 0 && a.indexOf(':', firstColon + 1) < 0) {
+            return a.substring(0, firstColon);
+        }
+        return a;
+    }
+}

--- a/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/transport/ProxyServer.java
+++ b/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/transport/ProxyServer.java
@@ -1,0 +1,186 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import io.grpc.BindableService;
+import io.grpc.Server;
+import io.grpc.ServerInterceptors;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The proxy's gRPC listener: binds loopback only by default, on an ephemeral port, admits exactly one live
+ * stream, and rejects an unlisted declared authority before the service method runs. U5 of the language-proxy
+ * plan (astubbs#242); requirements R17, R18, R29, R41; decisions KTD3 and KTD11.
+ * <p>
+ * <b>The engine-facing boundary is {@link BindableService}.</b> The transport hosts a session service; it
+ * does not know what one says. The engine (the {@code engine} package's {@code ProxyProcessor} work) supplies
+ * its {@code ProxyServiceGrpc.ProxyServiceImplBase} implementation to {@link Builder#sessionService}, and the
+ * transport wraps it with the authority allowlist and the single-connection guard - so every admission rule
+ * has already run by the time the engine's {@code session(..)} method is invoked, and the engine can rely on
+ * R41's one-connection invariant without enforcing it. That wiring is the connect-time configuration unit's
+ * job (U7); this class deliberately compiles against no generated protocol type so the seam stays one-way.
+ * <p>
+ * <b>Bind posture (R17/R18).</b> The bind address is {@link InetAddress#getLoopbackAddress()} unless
+ * configured otherwise, and the bind is {@link NettyServerBuilder#forAddress(java.net.SocketAddress)} with an
+ * explicit address - never {@code ServerBuilder.forPort}, which binds the wildcard address. The port defaults
+ * to ephemeral so no well-known port is guessable; {@link #port()} reports the chosen one, and
+ * {@code bz.stub.parallelconsumer.proxy.Main} is what prints it to the parent process. A non-loopback bind
+ * address refuses to start
+ * unless {@link Builder#exposeUnauthenticatedSurfaceBeyondLoopback()} was called - the opt-in's name states
+ * what it does, per R18 - and when it is present the server starts but warns with the surface's full recorded
+ * capability: no authentication, offset advancement, and receipt of the Kafka credentials and a
+ * class-instantiating property map (KTD11).
+ */
+@Slf4j
+public class ProxyServer implements AutoCloseable {
+
+    /**
+     * The name of the R18 opt-in, as refusal messages must state it: without this setting, a non-loopback
+     * bind address refuses to start.
+     */
+    public static final String NON_LOOPBACK_OPT_IN = "exposeUnauthenticatedSurfaceBeyondLoopback";
+
+    private final InetAddress bindAddress;
+    private final int requestedPort;
+    private final BindableService sessionService;
+    private final List<String> operatorAllowedAuthorities;
+    private final boolean exposeUnauthenticatedSurfaceBeyondLoopback;
+
+    private Server server;
+
+    private ProxyServer(Builder builder) {
+        this.bindAddress = builder.bindAddress;
+        this.requestedPort = builder.port;
+        this.sessionService = Objects.requireNonNull(builder.sessionService, "sessionService is required");
+        this.operatorAllowedAuthorities = List.copyOf(builder.operatorAllowedAuthorities);
+        this.exposeUnauthenticatedSurfaceBeyondLoopback = builder.exposeUnauthenticatedSurfaceBeyondLoopback;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Binds and starts serving.
+     *
+     * @throws IllegalStateException if the bind address is non-loopback and the R18 opt-in is absent
+     */
+    public synchronized ProxyServer start() throws IOException {
+        if (server != null) {
+            throw new IllegalStateException("already started");
+        }
+        if (!bindAddress.isLoopbackAddress()) {
+            if (!exposeUnauthenticatedSurfaceBeyondLoopback) {
+                throw new IllegalStateException("refusing to bind non-loopback address " + bindAddress
+                        + ": the proxy binds loopback only by default (R17). To bind beyond loopback, set "
+                        + "the opt-in '" + NON_LOOPBACK_OPT_IN + "' - its name states what it does: this "
+                        + "listener has no authentication");
+            }
+            // R18's full statement, per KTD11: a warning naming only offsets would understate the surface.
+            log.warn("Binding non-loopback address {} under the '{}' opt-in: this listener has NO "
+                            + "AUTHENTICATION, and any peer that can reach the socket can advance the "
+                            + "application's consumer offsets. The listener also receives the Kafka client "
+                            + "credentials and a property map whose class-valued entries Kafka instantiates "
+                            + "reflectively, which escalates to arbitrary class instantiation inside this JVM "
+                            + "- and beyond loopback both travel the network in cleartext.",
+                    bindAddress, NON_LOOPBACK_OPT_IN);
+        }
+        var authorityAllowlist = AuthorityAllowlistInterceptor
+                .defaultAllowlist(bindAddress, operatorAllowedAuthorities);
+        var connectionGuard = new SingleConnectionGuard();
+        // interceptForward runs interceptors in listed order: the authority check first, so a rejected
+        // authority is turned away with PERMISSION_DENIED before it can consume the admission slot.
+        server = NettyServerBuilder
+                .forAddress(new InetSocketAddress(bindAddress, requestedPort))
+                .addService(ServerInterceptors.interceptForward(sessionService, authorityAllowlist, connectionGuard))
+                .build()
+                .start();
+        log.info("Proxy transport listening on {}:{}", bindAddress.getHostAddress(), server.getPort());
+        return this;
+    }
+
+    /**
+     * The port actually bound - the ephemeral choice when the default port 0 was requested. This is the value
+     * the lifecycle channel (U10) reports to the parent process.
+     */
+    public synchronized int port() {
+        if (server == null) {
+            throw new IllegalStateException("not started");
+        }
+        return server.getPort();
+    }
+
+    @Override
+    public synchronized void close() {
+        if (server == null) {
+            return;
+        }
+        server.shutdownNow();
+        try {
+            server.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        server = null;
+    }
+
+    public static class Builder {
+        private InetAddress bindAddress = InetAddress.getLoopbackAddress();
+        private int port = 0;
+        private BindableService sessionService;
+        private final List<String> operatorAllowedAuthorities = new ArrayList<>();
+        private boolean exposeUnauthenticatedSurfaceBeyondLoopback = false;
+
+        /**
+         * The session service the transport hosts - the engine's {@code ProxyServiceImplBase}
+         * implementation. Required.
+         */
+        public Builder sessionService(BindableService sessionService) {
+            this.sessionService = sessionService;
+            return this;
+        }
+
+        /** Defaults to {@link InetAddress#getLoopbackAddress()}; anything else needs the R18 opt-in. */
+        public Builder bindAddress(InetAddress bindAddress) {
+            this.bindAddress = Objects.requireNonNull(bindAddress);
+            return this;
+        }
+
+        /** Defaults to 0 - an ephemeral port, so no well-known port is guessable. */
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        /** Operator additions to R29's default authority allowlist (loopback forms + bind address). */
+        public Builder allowAuthorities(Collection<String> hostForms) {
+            this.operatorAllowedAuthorities.addAll(hostForms);
+            return this;
+        }
+
+        /**
+         * The R18 opt-in: permit a non-loopback bind address, accepting that it exposes an unauthenticated
+         * surface. Absent this call, {@link ProxyServer#start()} refuses a non-loopback bind and names this
+         * setting in the refusal.
+         */
+        public Builder exposeUnauthenticatedSurfaceBeyondLoopback() {
+            this.exposeUnauthenticatedSurfaceBeyondLoopback = true;
+            return this;
+        }
+
+        public ProxyServer build() {
+            return new ProxyServer(this);
+        }
+    }
+}

--- a/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/transport/SingleConnectionGuard.java
+++ b/parallel-consumer-proxy/src/main/java/bz/stub/parallelconsumer/proxy/transport/SingleConnectionGuard.java
@@ -1,0 +1,132 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.OptionalLong;
+
+/**
+ * Admits exactly one live stream at a time - the single-connection invariant of R41 (see the language-proxy
+ * plan, astubbs#242).
+ * <p>
+ * The proxy serves one client connection: fan-out to workers happens inside the client library (KTD3), so a
+ * second concurrent stream is never legitimate and is <b>rejected, not adopted in place of the first</b>.
+ * Rejecting rather than replacing is what makes the invariant something the engine can rely on - the engine
+ * never observes its peer silently swapped mid-session. Reconnection after connection loss is U8's concern
+ * and re-uses this same admission slot: the slot is released when the admitted stream terminates, so the next
+ * stream to arrive may claim it.
+ * <p>
+ * <b>The admission slot is a two-state machine with a generation counter.</b> The slot is either
+ * {@code HELD} (a stream owns it) or {@code RELEASED}. Each successful acquisition increments the generation
+ * and hands the new value back as the holder's ticket; release requires the ticket. The generation exists
+ * because release is driven by stream-termination callbacks, which are asynchronous: a <em>late</em>
+ * termination callback from the stream of generation N must not release the slot once generation N+1 holds
+ * it, or a stale disconnect would open the door to a second concurrent stream. {@link #release(long)} is
+ * therefore a no-op unless the ticket names the current generation.
+ * <p>
+ * A rejected stream is closed with {@link Status#RESOURCE_EXHAUSTED} - the slot is a quota of one, and the
+ * condition is retryable once the holder terminates. {@code PERMISSION_DENIED} is deliberately left to
+ * {@link AuthorityAllowlistInterceptor}, so a client can tell "you are not allowed" from "the slot is taken"
+ * by status code alone.
+ * <p>
+ * As with the authority check, rejection happens in {@code interceptCall} by closing the call and returning a
+ * no-op listener, so the service method never runs for a rejected stream - proven by the service-invocation
+ * counter in this class's tests, not by inspection.
+ */
+@Slf4j
+public class SingleConnectionGuard implements ServerInterceptor {
+
+    /** Whether the slot is currently held. Guarded by {@code this}. */
+    private boolean held = false;
+
+    /**
+     * Incremented on every successful acquisition; the current value is the live holder's ticket.
+     * Guarded by {@code this}.
+     */
+    private long generation = 0;
+
+    /**
+     * Claims the admission slot if it is released.
+     *
+     * @return the new generation as the holder's ticket, or empty if the slot is already held
+     */
+    synchronized OptionalLong tryAcquire() {
+        if (held) {
+            return OptionalLong.empty();
+        }
+        held = true;
+        generation++;
+        return OptionalLong.of(generation);
+    }
+
+    /**
+     * Releases the slot, but only if {@code ticket} names the current generation - a late termination
+     * callback from a superseded stream must not release the slot out from under the live holder.
+     *
+     * @return true if this call released the slot; false if the ticket was stale and nothing changed
+     */
+    synchronized boolean release(long ticket) {
+        if (held && generation == ticket) {
+            held = false;
+            return true;
+        }
+        return false;
+    }
+
+    /** Whether a stream currently holds the admission slot. */
+    synchronized boolean isHeld() {
+        return held;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call,
+                                                                 Metadata headers,
+                                                                 ServerCallHandler<ReqT, RespT> next) {
+        OptionalLong ticket = tryAcquire();
+        if (ticket.isEmpty()) {
+            log.warn("Rejecting a second concurrent stream: the admission slot is held (R41 - the proxy "
+                    + "serves exactly one client connection; fan-out belongs inside the client library)");
+            call.close(Status.RESOURCE_EXHAUSTED
+                    .withDescription("the proxy serves exactly one client connection at a time and its "
+                            + "admission slot is held; retry after the current connection terminates"),
+                    new Metadata());
+            return new ServerCall.Listener<>() {
+            };
+        }
+        long heldTicket = ticket.getAsLong();
+        ServerCall.Listener<ReqT> delegate;
+        try {
+            delegate = next.startCall(call, headers);
+        } catch (RuntimeException | Error e) {
+            release(heldTicket);
+            throw e;
+        }
+        return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(delegate) {
+            @Override
+            public void onComplete() {
+                try {
+                    super.onComplete();
+                } finally {
+                    release(heldTicket);
+                }
+            }
+
+            @Override
+            public void onCancel() {
+                try {
+                    super.onCancel();
+                } finally {
+                    release(heldTicket);
+                }
+            }
+        };
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/MainTest.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/MainTest.java
@@ -1,0 +1,275 @@
+package bz.stub.parallelconsumer.proxy;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.protocol.v1.ClientMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.Configure;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyServiceGrpc;
+import com.google.common.base.Splitter;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The sidecar's process lifecycle end to end: refuse arguments, bind, announce the port, serve a real gRPC
+ * call, then stop - releasing the socket - when the parent dies.
+ * <p>
+ * <b>Why the listener-is-gone assertion is here rather than left to the exit code.</b> A run that returns 0
+ * proves the method returned; it proves nothing about whether the gRPC server was shut down, because a
+ * leaked one lives on daemon-free Netty threads and would keep the port bound long after {@code run}
+ * returned. The port is the observable that separates "returned" from "shut down", so the close is asserted
+ * against the socket rather than against the return value.
+ */
+class MainTest {
+
+    /** Generous enough that only a genuine failure reaches it, short enough that a hang is not a wait. */
+    private static final long AWAIT_SECONDS = 30;
+
+    /**
+     * R39/U7: the sidecar is configured over the protocol, not the command line. Every knob arrives in
+     * {@code Configure}, so an argument here is a caller misunderstanding worth failing loudly on rather than
+     * a forward-compatible thing to ignore.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void argumentsAreRefusedBecauseConfigurationTravelsTheProtocol() {
+        var out = new ByteArrayOutputStream();
+        var err = new ByteArrayOutputStream();
+
+        int exit = Main.run(new String[]{"--bootstrap-servers", "localhost:9092"},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8),
+                new PipedInputStream());
+
+        assertThat(exit).isEqualTo(Main.EXIT_USAGE);
+        assertWithMessage("the refusal must say where configuration actually goes")
+                .that(err.toString(StandardCharsets.UTF_8)).contains("Configure");
+        assertWithMessage("a refused start must not announce a port it never bound")
+                .that(out.toString(StandardCharsets.UTF_8)).doesNotContain(Main.PORT_LINE_PREFIX);
+    }
+
+    /**
+     * The whole spawning contract in one run: the port is announced on stdout line one so the parent can
+     * connect, the socket really answers while the sidecar is up, the process returns cleanly the moment its
+     * parent's write end closes, and the socket stops answering once it has.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void announcesItsPortServesOnItAndReleasesItWhenTheParentDies() throws Exception {
+        var out = new ByteArrayOutputStream();
+        var writeEnd = new PipedOutputStream();
+        var lifeline = new PipedInputStream(writeEnd);
+
+        var pool = Executors.newSingleThreadExecutor();
+        try {
+            var exit = runInBackground(pool, out, lifeline);
+
+            int port = awaitAnnouncedPort(out);
+            assertWithMessage("an ephemeral port was requested, so it must be a real bound port")
+                    .that(port).isGreaterThan(0);
+            try (var probe = new Socket()) {
+                probe.connect(loopback(port), 2_000);
+                assertWithMessage("the announced port must be the one actually serving")
+                        .that(probe.isConnected()).isTrue();
+            }
+
+            writeEnd.close(); // the parent dies
+
+            assertThat(exit.get(AWAIT_SECONDS, TimeUnit.SECONDS)).isEqualTo(0);
+            assertThrows(IOException.class, () -> {
+                try (var probe = new Socket()) {
+                    probe.connect(loopback(port), 2_000);
+                }
+            }, "the listener must be gone once the sidecar has shut down, not merely unattended");
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * The shell hosts a real service on that port, and it says what it is: a client that opens a session is
+     * answered with {@code UNIMPLEMENTED} naming the missing engine. That is the honest state of this build
+     * and it is asserted rather than assumed, because the alternative failure - a call that hangs, or one
+     * that is silently accepted and answers nothing - looks identical to a working sidecar from the outside.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void aSessionIsAnsweredWithUnimplementedNamingTheMissingEngine() throws Exception {
+        var out = new ByteArrayOutputStream();
+        var writeEnd = new PipedOutputStream();
+        var lifeline = new PipedInputStream(writeEnd);
+
+        var pool = Executors.newSingleThreadExecutor();
+        ManagedChannel channel = null;
+        try {
+            var exit = runInBackground(pool, out, lifeline);
+            int port = awaitAnnouncedPort(out);
+
+            channel = NettyChannelBuilder.forAddress(InetAddress.getLoopbackAddress().getHostAddress(), port)
+                    .usePlaintext()
+                    .build();
+
+            var terminated = new CountDownLatch(1);
+            var failure = new AtomicReference<Throwable>();
+            List<ProxyMessage> replies = Collections.synchronizedList(new ArrayList<>());
+            StreamObserver<ClientMessage> session = ProxyServiceGrpc.newStub(channel)
+                    .session(new StreamObserver<>() {
+                        @Override
+                        public void onNext(ProxyMessage message) {
+                            replies.add(message);
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            failure.set(t);
+                            terminated.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            terminated.countDown();
+                        }
+                    });
+            session.onNext(ClientMessage.newBuilder()
+                    .setConfigure(Configure.newBuilder().addTopics("input"))
+                    .build());
+
+            assertWithMessage("the session must terminate rather than hang")
+                    .that(terminated.await(AWAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+            Throwable observed = failure.get();
+            assertThat(observed).isInstanceOf(StatusRuntimeException.class);
+            var status = ((StatusRuntimeException) observed).getStatus();
+            assertThat(status.getCode()).isEqualTo(Status.Code.UNIMPLEMENTED);
+            assertWithMessage("the refusal must name what is missing, or a client author debugs their own code")
+                    .that(status.getDescription()).contains("hosts no Parallel Consumer engine");
+            assertWithMessage("a build with no engine must not answer a Configure with anything")
+                    .that(replies).isEmpty();
+
+            writeEnd.close();
+            assertThat(exit.get(AWAIT_SECONDS, TimeUnit.SECONDS)).isEqualTo(0);
+        } finally {
+            if (channel != null) {
+                channel.shutdownNow();
+            }
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * Two sidecars on one host must not collide. Each binds its own ephemeral port and announces that port on
+     * its own stdout - so a machine running two applications gets two working sidecars, not a bind race.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void twoSidecarsBindDifferentPortsAndEachAnnouncesItsOwn() throws Exception {
+        var pool = Executors.newFixedThreadPool(2);
+        var firstOut = new ByteArrayOutputStream();
+        var secondOut = new ByteArrayOutputStream();
+        var firstWrite = new PipedOutputStream();
+        var secondWrite = new PipedOutputStream();
+
+        try {
+            var first = runInBackground(pool, firstOut, new PipedInputStream(firstWrite));
+            var second = runInBackground(pool, secondOut, new PipedInputStream(secondWrite));
+
+            int firstPort = awaitAnnouncedPort(firstOut);
+            int secondPort = awaitAnnouncedPort(secondOut);
+            assertThat(firstPort).isNotEqualTo(secondPort);
+
+            firstWrite.close();
+            secondWrite.close();
+            assertThat(first.get(AWAIT_SECONDS, TimeUnit.SECONDS)).isEqualTo(0);
+            assertThat(second.get(AWAIT_SECONDS, TimeUnit.SECONDS)).isEqualTo(0);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * A port it cannot bind is a distinguishable failure, and a different one from a caller who mistyped an
+     * argument: the invocation was fine, the socket was not. An operator who sees a usage exit code goes
+     * looking at the command line for what is actually a port collision.
+     * <p>
+     * Provoked through the package-private overload, because the production entry point deliberately has no
+     * way to name a port - and an exit code no test can reach is one nobody can rely on.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void aPortItCannotBindIsADistinguishableNonZeroExit() throws Exception {
+        try (var occupier = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            var out = new ByteArrayOutputStream();
+            var err = new ByteArrayOutputStream();
+
+            int exit = Main.run(new String[0],
+                    new PrintStream(out, true, StandardCharsets.UTF_8),
+                    new PrintStream(err, true, StandardCharsets.UTF_8),
+                    new PipedInputStream(),
+                    NoEngineSessionService::new,
+                    occupier.getLocalPort());
+
+            assertThat(exit).isEqualTo(Main.EXIT_BIND_FAILED);
+            assertWithMessage("a bind failure must not be mistaken for a usage error")
+                    .that(Main.EXIT_BIND_FAILED).isNotEqualTo(Main.EXIT_USAGE);
+            assertWithMessage("nothing was bound, so nothing may be announced")
+                    .that(out.toString(StandardCharsets.UTF_8)).doesNotContain(Main.PORT_LINE_PREFIX);
+            assertThat(err.toString(StandardCharsets.UTF_8)).contains("could not bind");
+        }
+    }
+
+    private static Future<Integer> runInBackground(ExecutorService pool, ByteArrayOutputStream out,
+                                                   PipedInputStream lifeline) {
+        return pool.submit(() -> Main.run(new String[0],
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8),
+                lifeline));
+    }
+
+    private static InetSocketAddress loopback(int port) {
+        return new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
+    }
+
+    /** Polls the captured stdout for the port line rather than sleeping a guessed interval. */
+    private static int awaitAnnouncedPort(ByteArrayOutputStream out) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(AWAIT_SECONDS);
+        while (System.nanoTime() < deadline) {
+            var text = out.toString(StandardCharsets.UTF_8);
+            for (var line : Splitter.on('\n').split(text)) {
+                if (line.startsWith(Main.PORT_LINE_PREFIX)) {
+                    return Integer.parseInt(line.substring(Main.PORT_LINE_PREFIX.length()).trim());
+                }
+            }
+            Thread.sleep(20);
+        }
+        throw new AssertionError("no '" + Main.PORT_LINE_PREFIX + "' line appeared on stdout");
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/TestConventionsArchTest.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/TestConventionsArchTest.java
@@ -1,0 +1,21 @@
+package bz.stub.parallelconsumer.proxy;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import bz.stub.parallelconsumer.TestConventionRules;
+
+/**
+ * Applies the shared {@link TestConventionRules} to this module's test classes - the rule logic lives once in
+ * {@link TestConventionRules} (core test-jar); this only points ArchUnit at this module's packages.
+ */
+@AnalyzeClasses(packages = "bz.stub.parallelconsumer.proxy", importOptions = ImportOption.OnlyIncludeTests.class)
+class TestConventionsArchTest {
+
+    @ArchTest
+    static final ArchTests conventions = ArchTests.in(TestConventionRules.class);
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/lifecycle/ParentDeathWatchdogTest.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/lifecycle/ParentDeathWatchdogTest.java
@@ -1,0 +1,146 @@
+package bz.stub.parallelconsumer.proxy.lifecycle;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * KTD19's two signals, and the case that must NOT fire.
+ * <p>
+ * No wall-clock sleeps anywhere: every wait is a bounded latch await, so a slow machine makes the test
+ * slower rather than red, and a watchdog that never fires fails on the bound instead of hanging the suite.
+ */
+class ParentDeathWatchdogTest {
+
+    /** Long enough to be reached only by a genuine failure, short enough that a hang is not a coffee break. */
+    private static final Duration GENEROUS = Duration.ofSeconds(10);
+
+    /** The poll must be brisk, or the second signal costs more than the first is worth. */
+    private static final Duration POLL = Duration.ofMillis(20);
+
+    /**
+     * The primary signal. The parent holds the write end and never writes; when it dies the kernel closes
+     * the last write end and the read returns -1.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void eofOnTheLifelineIsParentDeath() throws Exception {
+        var writeEnd = new PipedOutputStream();
+        var lifeline = new PipedInputStream(writeEnd);
+
+        try (var watchdog = ParentDeathWatchdog.watching(lifeline, () -> true, POLL)) {
+            watchdog.start();
+
+            assertWithMessage("a live parent that simply has nothing to say is not death")
+                    .that(watchdog.awaitDeath(Duration.ofMillis(200)))
+                    .isFalse();
+
+            writeEnd.close(); // the parent dies: its write end goes with it
+
+            assertThat(watchdog.awaitDeath(GENEROUS)).isTrue();
+            assertThat(watchdog.cause()).isEqualTo(ParentDeathWatchdog.Cause.LIFELINE_CLOSED);
+        }
+    }
+
+    /**
+     * The second signal, and the reason it exists: a wrapper process - a shell between the client and the
+     * sidecar - inherits the write end and holds it open after the real parent is gone, so EOF never
+     * arrives. The pid poll is what notices. This is why the client must launch the proxy directly.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void thePidPollCatchesDeathWhenAWrapperHoldsThePipeOpen() throws Exception {
+        var writeEnd = new PipedOutputStream();
+        var lifeline = new PipedInputStream(writeEnd); // deliberately never closed: the wrapper still holds it
+        var parentAlive = new AtomicBoolean(true);
+
+        try (var watchdog = ParentDeathWatchdog.watching(lifeline, parentAlive::get, POLL)) {
+            watchdog.start();
+
+            assertWithMessage("the pipe is open and the parent is alive - nothing has happened yet")
+                    .that(watchdog.awaitDeath(Duration.ofMillis(200)))
+                    .isFalse();
+
+            parentAlive.set(false);
+
+            assertThat(watchdog.awaitDeath(GENEROUS)).isTrue();
+            assertThat(watchdog.cause()).isEqualTo(ParentDeathWatchdog.Cause.PARENT_PROCESS_GONE);
+        }
+    }
+
+    /**
+     * The negative control. A watchdog that reports death when neither signal fired would pass both tests
+     * above and kill every healthy sidecar in production - so "does not fire" is asserted, not assumed.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void aLivingParentOnAnOpenPipeIsNeverDeath() throws Exception {
+        var writeEnd = new PipedOutputStream();
+        var lifeline = new PipedInputStream(writeEnd);
+
+        try (var watchdog = ParentDeathWatchdog.watching(lifeline, () -> true, POLL)) {
+            watchdog.start();
+
+            // many poll intervals, so a spurious fire has every chance to happen
+            assertThat(watchdog.awaitDeath(POLL.multipliedBy(25))).isFalse();
+            assertThat(watchdog.cause()).isNull();
+        } finally {
+            writeEnd.close();
+        }
+    }
+
+    /**
+     * An IOException on the lifeline reads the same as EOF - the parent is gone either way, and a watchdog
+     * that propagated it instead would leave the sidecar running with no supervisor.
+     * <p>
+     * <b>Not a {@link PipedInputStream}</b>, deliberately. Closing one from another thread does not wake a
+     * reader already blocked in {@code read()}: that wait loop only re-checks whether the WRITE side died,
+     * and {@code writeSide} is never set here because the parent never writes. The stub below can actually
+     * raise the condition being asserted, where the pipe would only ever time out and look like a defect in
+     * this class.
+     */
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    void aBrokenLifelineReadsAsDeathRatherThanAnError() throws Exception {
+        var breakNow = new CountDownLatch(1);
+        var lifeline = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                try {
+                    breakNow.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("interrupted", e);
+                }
+                throw new IOException("Broken pipe");
+            }
+        };
+
+        try (var watchdog = ParentDeathWatchdog.watching(lifeline, () -> true, POLL)) {
+            watchdog.start();
+
+            assertWithMessage("the read is still blocked - nothing has gone wrong yet")
+                    .that(watchdog.awaitDeath(Duration.ofMillis(200)))
+                    .isFalse();
+
+            breakNow.countDown();
+
+            assertThat(watchdog.awaitDeath(GENEROUS)).isTrue();
+            assertThat(watchdog.cause()).isEqualTo(ParentDeathWatchdog.Cause.LIFELINE_CLOSED);
+        }
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/AuthorityAllowlistInterceptorTest.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/AuthorityAllowlistInterceptorTest.java
@@ -1,0 +1,169 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.protocol.v1.ClientMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * R29's allowlist, proven at both altitudes: over the wire through a real loopback server (a connection
+ * declaring {@code localhost} is admitted, one declaring {@code evil.example.com} is rejected with
+ * {@code PERMISSION_DENIED} - and, per AE12, with the service-invocation and application-message counters
+ * both unchanged), and directly against the interceptor for the shapes a channel cannot conveniently produce
+ * (a null authority, the port and bracket forms).
+ */
+@Timeout(value = 30)
+class AuthorityAllowlistInterceptorTest extends WireTestBase {
+
+    @Test
+    void connectionDeclaringLocalhostIsAdmitted() throws Exception {
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", server.port())
+                .usePlaintext()
+                .build();
+        try {
+            var responses = new RecordingProxyMessageObserver();
+            StreamObserver<ClientMessage> requests = ProxyServiceGrpc.newStub(channel).session(responses);
+            requests.onNext(configure("in"));
+
+            await().atMost(10, SECONDS).until(() -> !responses.messages.isEmpty());
+            assertThat(responses.messages.get(0).hasConfigured()).isTrue();
+            assertThat(service.serviceInvocations.get()).isEqualTo(1);
+            requests.onCompleted();
+        } finally {
+            channel.shutdownNow();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Covers AE12. The proof is the counters, not the client-visible status: a rejection that arrived only
+     * after the service method ran would return the same status to the client, so the assertion that matters
+     * is that neither the service-invocation counter nor the application-message counter moved - even though
+     * the client pushed a Configure at the stream.
+     */
+    @Test
+    void connectionDeclaringUnlistedAuthorityIsRejectedBeforeTheServiceMethodRuns() throws Exception {
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", server.port())
+                .usePlaintext()
+                .overrideAuthority("evil.example.com")
+                .build();
+        try {
+            var responses = new RecordingProxyMessageObserver();
+            StreamObserver<ClientMessage> requests = ProxyServiceGrpc.newStub(channel).session(responses);
+            try {
+                requests.onNext(configure("never-delivered"));
+            } catch (IllegalStateException alreadyClosed) {
+                // The rejection can land before the client's send - equally fine: the message never
+                // reached the application either way, which is what the counters below prove.
+            }
+
+            assertWithMessage("stream should terminate with the rejection")
+                    .that(responses.terminated.await(10, SECONDS)).isTrue();
+            Status status = Status.fromThrowable(responses.error.get());
+            assertThat(status.getCode()).isEqualTo(Status.Code.PERMISSION_DENIED);
+            assertWithMessage("service method must never have run for a rejected connection")
+                    .that(service.serviceInvocations.get()).isEqualTo(0);
+            assertWithMessage("no application message may reach the service across a rejected connection")
+                    .that(service.applicationMessages.get()).isEqualTo(0);
+        } finally {
+            channel.shutdownNow();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void connectionDeclaringNoAuthorityIsAdmitted() {
+        var interceptor = defaultInterceptor();
+        var call = this.<String, String>callDeclaring(null);
+        ServerCallHandler<String, String> handler = handlerReturningNoopListener();
+
+        interceptor.interceptCall(call, new Metadata(), handler);
+
+        verify(handler).startCall(eq(call), any());
+        verify(call, never()).close(any(), any());
+    }
+
+    @Test
+    void portAndBracketAuthorityFormsAreAdmitted() {
+        var interceptor = defaultInterceptor();
+        for (var authority : List.of("localhost:41234", "LOCALHOST", "127.0.0.1:1", "[::1]:8080", "[::1]")) {
+            var call = this.<String, String>callDeclaring(authority);
+            ServerCallHandler<String, String> handler = handlerReturningNoopListener();
+
+            interceptor.interceptCall(call, new Metadata(), handler);
+
+            verify(handler).startCall(eq(call), any());
+            verify(call, never()).close(any(), any());
+        }
+    }
+
+    @Test
+    void unlistedAuthorityIsClosedWithPermissionDeniedAndTheHandlerNeverInvoked() {
+        var interceptor = defaultInterceptor();
+        var call = this.<String, String>callDeclaring("evil.example.com:443");
+        @SuppressWarnings("unchecked")
+        ServerCallHandler<String, String> handler = mock(ServerCallHandler.class);
+
+        interceptor.interceptCall(call, new Metadata(), handler);
+
+        verify(handler, never()).startCall(any(), any());
+        var status = ArgumentCaptor.forClass(Status.class);
+        verify(call).close(status.capture(), any());
+        assertThat(status.getValue().getCode()).isEqualTo(Status.Code.PERMISSION_DENIED);
+    }
+
+    @Test
+    void normalizationStripsPortBracketsAndCaseButNotBareIpv6Segments() {
+        assertThat(AuthorityAllowlistInterceptor.normalizeToHost("localhost:41234")).isEqualTo("localhost");
+        assertThat(AuthorityAllowlistInterceptor.normalizeToHost("LocalHost")).isEqualTo("localhost");
+        assertThat(AuthorityAllowlistInterceptor.normalizeToHost("[::1]:8080")).isEqualTo("::1");
+        assertThat(AuthorityAllowlistInterceptor.normalizeToHost("[::1]")).isEqualTo("::1");
+        // A bare unbracketed IPv6 literal: the last segment is not a port.
+        assertThat(AuthorityAllowlistInterceptor.normalizeToHost("0:0:0:0:0:0:0:1")).isEqualTo("0:0:0:0:0:0:0:1");
+    }
+
+    private static AuthorityAllowlistInterceptor defaultInterceptor() {
+        return AuthorityAllowlistInterceptor
+                .defaultAllowlist(java.net.InetAddress.getLoopbackAddress(), List.of());
+    }
+
+    private <ReqT, RespT> ServerCall<ReqT, RespT> callDeclaring(String authority) {
+        @SuppressWarnings("unchecked")
+        ServerCall<ReqT, RespT> call = mock(ServerCall.class);
+        when(call.getAuthority()).thenReturn(authority);
+        return call;
+    }
+
+    private static ServerCallHandler<String, String> handlerReturningNoopListener() {
+        @SuppressWarnings("unchecked")
+        ServerCallHandler<String, String> handler = mock(ServerCallHandler.class);
+        when(handler.startCall(any(), any())).thenReturn(new ServerCall.Listener<>() {
+        });
+        return handler;
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/CountingSessionService.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/CountingSessionService.java
@@ -1,0 +1,53 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.protocol.v1.ClientMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.Configured;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyServiceGrpc;
+import io.grpc.stub.StreamObserver;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A stand-in session service carrying AE12's two counters: how many times the service method ran, and how
+ * many application messages it received. The transport tests prove rejection <b>before the service method</b>
+ * by asserting both counters unchanged across a rejected connection - a counter-based proof, per the U1 gate,
+ * because a test asserting only the client-visible status can pass after the service method has already run.
+ * <p>
+ * On {@code Configure} it echoes a {@code Configured}, so an admitted stream can be proven live end to end.
+ */
+class CountingSessionService extends ProxyServiceGrpc.ProxyServiceImplBase {
+
+    final AtomicInteger serviceInvocations = new AtomicInteger();
+    final AtomicInteger applicationMessages = new AtomicInteger();
+
+    @Override
+    public StreamObserver<ClientMessage> session(StreamObserver<ProxyMessage> responseObserver) {
+        serviceInvocations.incrementAndGet();
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(ClientMessage message) {
+                applicationMessages.incrementAndGet();
+                if (message.hasConfigure()) {
+                    responseObserver.onNext(ProxyMessage.newBuilder()
+                            .setConfigured(Configured.newBuilder()
+                                    .addAllTopics(message.getConfigure().getTopicsList()))
+                            .build());
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                // The peer went away; nothing to answer.
+            }
+
+            @Override
+            public void onCompleted() {
+                responseObserver.onCompleted();
+            }
+        };
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/ProxyServerTest.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/ProxyServerTest.java
@@ -1,0 +1,136 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * The bind posture of R17 and R18: loopback and an ephemeral port by default, a socket a non-loopback local
+ * address cannot reach, and - covering AE6 - a non-loopback bind that refuses to start without the opt-in
+ * (naming the missing setting) and starts with it while logging the full unauthenticated-surface warning.
+ */
+@Timeout(value = 30)
+class ProxyServerTest {
+
+    @Test
+    void bindsLoopbackOnAnEphemeralPortByDefault() throws Exception {
+        try (ProxyServer server = ProxyServer.builder()
+                .sessionService(new CountingSessionService())
+                .build()
+                .start()) {
+            assertWithMessage("an ephemeral port was requested, so a real one must have been chosen")
+                    .that(server.port()).isGreaterThan(0);
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), server.port()), 2_000);
+                assertThat(socket.isConnected()).isTrue();
+            }
+        }
+    }
+
+    @Test
+    void serverSocketIsNotReachableFromANonLoopbackLocalAddress() throws Exception {
+        Optional<InetAddress> nonLoopback = aNonLoopbackLocalAddress();
+        assumeTrue(nonLoopback.isPresent(), "this host has no non-loopback address to probe from");
+
+        try (ProxyServer server = ProxyServer.builder()
+                .sessionService(new CountingSessionService())
+                .build()
+                .start()) {
+            int port = server.port();
+            assertThrows(IOException.class, () -> {
+                try (Socket socket = new Socket()) {
+                    socket.connect(new InetSocketAddress(nonLoopback.get(), port), 2_000);
+                }
+            }, "the server bound loopback only, so its port must not answer on " + nonLoopback.get());
+        }
+    }
+
+    /** Covers AE6, refusal half: without the opt-in, a non-loopback bind refuses and names the setting. */
+    @Test
+    void nonLoopbackBindWithoutTheOptInRefusesToStartAndNamesTheSetting() throws Exception {
+        ProxyServer server = ProxyServer.builder()
+                .sessionService(new CountingSessionService())
+                .bindAddress(InetAddress.getByName("0.0.0.0"))
+                .build();
+
+        IllegalStateException refusal = assertThrows(IllegalStateException.class, server::start);
+
+        assertWithMessage("the refusal must name the missing opt-in setting")
+                .that(refusal).hasMessageThat().contains(ProxyServer.NON_LOOPBACK_OPT_IN);
+        assertThrows(IllegalStateException.class, server::port, "nothing may have been bound");
+    }
+
+    /**
+     * Covers AE6, opt-in half: with the opt-in the server starts, and warns with R18's full statement - not
+     * just the missing authentication, but the offset-advancement capability and the receipt of credentials
+     * and a class-instantiating property map. A warning naming only offsets understates the surface (KTD11).
+     */
+    @Test
+    void nonLoopbackBindWithTheOptInStartsAndLogsTheUnauthenticatedSurfaceWarning() throws Exception {
+        var warnings = captureLogFor(ProxyServer.class);
+        try (ProxyServer server = ProxyServer.builder()
+                .sessionService(new CountingSessionService())
+                .bindAddress(InetAddress.getByName("0.0.0.0"))
+                .exposeUnauthenticatedSurfaceBeyondLoopback()
+                .build()
+                .start()) {
+            assertThat(server.port()).isGreaterThan(0);
+
+            String warning;
+            synchronized (warnings.list) {
+                warning = warnings.list.stream()
+                        .filter(event -> event.getLevel().toString().equals("WARN"))
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .filter(message -> message.contains("NO AUTHENTICATION"))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("no unauthenticated-surface warning was logged"));
+            }
+            assertThat(warning).contains("offsets");
+            assertThat(warning).contains("credentials");
+            assertThat(warning).contains("class-valued");
+        } finally {
+            ((Logger) LoggerFactory.getLogger(ProxyServer.class)).detachAppender(warnings);
+        }
+    }
+
+    private static ListAppender<ILoggingEvent> captureLogFor(Class<?> loggerOwner) {
+        var appender = new ListAppender<ILoggingEvent>();
+        // the server's own threads write this capture while the test reads it, so the backing list must be
+        // synchronized - a bare ArrayList here races the logging thread and fails intermittently
+        appender.list = Collections.synchronizedList(new ArrayList<>());
+        appender.start();
+        ((Logger) LoggerFactory.getLogger(loggerOwner)).addAppender(appender);
+        return appender;
+    }
+
+    private static Optional<InetAddress> aNonLoopbackLocalAddress() throws IOException {
+        for (NetworkInterface networkInterface : Collections.list(NetworkInterface.getNetworkInterfaces())) {
+            for (InetAddress address : Collections.list(networkInterface.getInetAddresses())) {
+                if (!address.isLoopbackAddress() && !address.isLinkLocalAddress()) {
+                    return Optional.of(address);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/RecordingProxyMessageObserver.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/RecordingProxyMessageObserver.java
@@ -1,0 +1,40 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyMessage;
+import io.grpc.stub.StreamObserver;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Client-side observer that records what the proxy said and how the stream ended, so wire tests can await a
+ * reply or a terminal status without hand-rolling latches per test.
+ */
+class RecordingProxyMessageObserver implements StreamObserver<ProxyMessage> {
+
+    final List<ProxyMessage> messages = Collections.synchronizedList(new ArrayList<>());
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    final CountDownLatch terminated = new CountDownLatch(1);
+
+    @Override
+    public void onNext(ProxyMessage message) {
+        messages.add(message);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        error.set(t);
+        terminated.countDown();
+    }
+
+    @Override
+    public void onCompleted() {
+        terminated.countDown();
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/SingleConnectionGuardTest.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/SingleConnectionGuardTest.java
@@ -1,0 +1,152 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.protocol.v1.ClientMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * R41's single-connection admission: the slot's state machine unit-tested directly (including the
+ * generation-counter scenario - a late release from a superseded stream must not free the live holder's
+ * slot), and the wire-level behaviour through a real server (a second concurrent stream is rejected while the
+ * first is live, with the service-invocation counter proving the service method never ran for it; the slot
+ * releases on stream termination, so the next stream is admitted - the seam U8's reconnection re-uses).
+ */
+@Timeout(value = 30)
+class SingleConnectionGuardTest extends WireTestBase {
+
+    // --- the state machine, directly ---
+
+    @Test
+    void firstAcquireWinsAndTheSlotRejectsASecondWhileHeld() {
+        var guard = new SingleConnectionGuard();
+
+        OptionalLong first = guard.tryAcquire();
+        assertThat(first.isPresent()).isTrue();
+        assertThat(guard.isHeld()).isTrue();
+
+        assertWithMessage("a second acquire while the slot is held must be rejected")
+                .that(guard.tryAcquire().isPresent()).isFalse();
+    }
+
+    @Test
+    void releaseFreesTheSlotForReacquisitionWithANewGeneration() {
+        var guard = new SingleConnectionGuard();
+
+        long first = guard.tryAcquire().orElseThrow();
+        assertThat(guard.release(first)).isTrue();
+        assertThat(guard.isHeld()).isFalse();
+
+        long second = guard.tryAcquire().orElseThrow();
+        assertThat(second).isGreaterThan(first);
+        assertThat(guard.isHeld()).isTrue();
+    }
+
+    /**
+     * The generation-counter scenario: a late termination callback from the stream of generation N arrives
+     * after generation N+1 has claimed the slot. Releasing on the stale ticket must be a no-op, or the stale
+     * disconnect would open the door to a second concurrent stream under the live holder.
+     */
+    @Test
+    void aLateReleaseFromASupersededGenerationCannotFreeTheLiveHoldersSlot() {
+        var guard = new SingleConnectionGuard();
+
+        long generationN = guard.tryAcquire().orElseThrow();
+        assertThat(guard.release(generationN)).isTrue();
+        long generationN1 = guard.tryAcquire().orElseThrow();
+
+        // The late callback from generation N fires now, while N+1 holds the slot.
+        assertWithMessage("a stale ticket must not release the slot")
+                .that(guard.release(generationN)).isFalse();
+        assertWithMessage("the slot must still be held by generation N+1")
+                .that(guard.isHeld()).isTrue();
+        assertWithMessage("no new stream may be admitted while N+1 holds the slot")
+                .that(guard.tryAcquire().isPresent()).isFalse();
+
+        // The live holder's own release still works.
+        assertThat(guard.release(generationN1)).isTrue();
+        assertThat(guard.isHeld()).isFalse();
+    }
+
+    @Test
+    void releasingAnAlreadyReleasedSlotIsANoop() {
+        var guard = new SingleConnectionGuard();
+
+        long ticket = guard.tryAcquire().orElseThrow();
+        assertThat(guard.release(ticket)).isTrue();
+        assertThat(guard.release(ticket)).isFalse();
+        assertThat(guard.isHeld()).isFalse();
+    }
+
+    // --- the wire, through a real loopback server (fixture: WireTestBase) ---
+
+    @Test
+    void aSecondConcurrentStreamIsRejectedWhileTheFirstIsLiveAndAdmittedOnceItTerminates() throws Exception {
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", server.port())
+                .usePlaintext()
+                .build();
+        try {
+            // First stream wins the slot, and is proven live by a Configure/Configured round trip.
+            var firstResponses = new RecordingProxyMessageObserver();
+            StreamObserver<ClientMessage> first = ProxyServiceGrpc.newStub(channel).session(firstResponses);
+            first.onNext(configure("first"));
+            await().atMost(10, SECONDS).until(() -> !firstResponses.messages.isEmpty());
+            assertThat(service.serviceInvocations.get()).isEqualTo(1);
+
+            // A second concurrent stream is rejected - and the counter proves the service method never
+            // ran for it, not merely that the client saw an error.
+            var secondResponses = new RecordingProxyMessageObserver();
+            StreamObserver<ClientMessage> second = ProxyServiceGrpc.newStub(channel).session(secondResponses);
+            try {
+                second.onNext(configure("second"));
+            } catch (IllegalStateException alreadyClosed) {
+                // The rejection can land before the client's send; the counters below are the proof.
+            }
+            assertWithMessage("second stream should terminate with the rejection")
+                    .that(secondResponses.terminated.await(10, SECONDS)).isTrue();
+            assertThat(Status.fromThrowable(secondResponses.error.get()).getCode())
+                    .isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
+            assertWithMessage("the service method must not have run for the rejected stream")
+                    .that(service.serviceInvocations.get()).isEqualTo(1);
+
+            // The first stream is unharmed by the rejected second: another round trip still works.
+            first.onNext(configure("first-again"));
+            await().atMost(10, SECONDS).until(() -> firstResponses.messages.size() >= 2);
+
+            // Termination releases the slot, so the next stream is admitted - the mechanism U8's
+            // reconnection re-uses.
+            first.onCompleted();
+            assertWithMessage("first stream should complete cleanly")
+                    .that(firstResponses.terminated.await(10, SECONDS)).isTrue();
+            var thirdResponses = new RecordingProxyMessageObserver();
+            await().atMost(10, SECONDS).untilAsserted(() -> {
+                var reconnectResponses = new RecordingProxyMessageObserver();
+                StreamObserver<ClientMessage> reconnect =
+                        ProxyServiceGrpc.newStub(channel).session(reconnectResponses);
+                reconnect.onNext(configure("reconnect"));
+                await().atMost(2, SECONDS).until(() -> !reconnectResponses.messages.isEmpty());
+                reconnect.onCompleted();
+                thirdResponses.messages.addAll(reconnectResponses.messages);
+            });
+            assertThat(thirdResponses.messages).isNotEmpty();
+        } finally {
+            channel.shutdownNow();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/WireTestBase.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/WireTestBase.java
@@ -1,0 +1,43 @@
+package bz.stub.parallelconsumer.proxy.transport;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.protocol.v1.ClientMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.Configure;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+
+/**
+ * The wire-test fixture the interceptor tests share: a default-configured {@link ProxyServer} hosting one
+ * {@link CountingSessionService} per test, plus the {@code Configure} opener every admitted stream leads with.
+ * Sits beside the package's other shared fixtures ({@link CountingSessionService},
+ * {@link RecordingProxyMessageObserver}). {@code ProxyServerTest} deliberately does not extend this - its
+ * scenarios each build a differently configured server, which is the very thing under test there.
+ *
+ * @author Antony Stubbs
+ */
+abstract class WireTestBase {
+
+    CountingSessionService service;
+    ProxyServer server;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        service = new CountingSessionService();
+        server = ProxyServer.builder().sessionService(service).build().start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.close();
+    }
+
+    static ClientMessage configure(String topic) {
+        return ClientMessage.newBuilder()
+                .setConfigure(Configure.newBuilder().addTopics(topic))
+                .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
              Maven Central itself, so it needs nothing installed and there is nothing for
              -Dpc.foreignClients to guard. -->
         <module>parallel-consumer-proxy-protocol</module>
+        <!-- Same reasoning as the protocol module above: an ordinary JVM module, in the default reactor. -->
+        <module>parallel-consumer-proxy</module>
         <module>parallel-consumer-proxy-clients</module>
         <module>parallel-consumer-examples</module>
     </modules>


### PR DESCRIPTION
Part of astubbs/parallel-consumer#242.

depends on astubbs/parallel-consumer#383

## Description

The **`parallel-consumer-proxy` module: a sidecar that is a real process**, and nothing above that.
It builds, it starts, it binds a loopback port and announces it, it admits or rejects a connection
under its own rules, it hosts a service a client can actually reach, and it shuts down cleanly -
releasing the socket - when its parent dies. There is no engine in it.

**The claim this PR makes, and what to check it against:** the packaging and runtime boundary exists
and is exercised end to end through the entry point, and the failure modes that would make that
claim hollow - a server that never shut down, a session that hangs, a bind failure that looks like a
clean exit - each go red when the term responsible is broken. The sabotage arms are below.

**The honest state of the build is a first-class part of it.** A client that opens a session is
answered `UNIMPLEMENTED` with a description naming the piece that is missing. The alternative -
answering a `Configure` with a fabricated `Configured` - would let a client believe it had
configured an engine that does not exist, which is a worse failure than a clear refusal, and it
would also make this rung unreviewable: a reader could not tell a real engine from a mock.

### Where this came from

Extracted from **astubbs/parallel-consumer#293**, the language-proxy god PR, as extraction **A5** of
`docs/plans/2026-08-31-001-process-god-branch-decomposition-plan.md` - the rung above
astubbs/parallel-consumer#383, whose "deliberately left for the rungs above" list names exactly this
content ("the proxy module, its executable and its gRPC lifecycle (A5)"). Taken by path-scoped
checkout rather than rewritten.

**The entry point is not on that branch.** astubbs/parallel-consumer#293 has no production `main` at
all - its only one is `TestModeMain`, in `src/test`, booting on `MockConsumer`. The production
sidecar entry point was written on **`feats/sidecar-entry-point`** (unit U10), which is a *sibling*
of astubbs/parallel-consumer#293 stacked above it, not an extraction of it, and which has no PR. See
"the prior-art branch" below.

### What is in it, and why each piece is in the minimal cut

**The transport - and the three classes are inseparable, which is a fact about the code rather than
a judgement.** `ProxyServer.start()` constructs `AuthorityAllowlistInterceptor` and
`SingleConnectionGuard` itself and wraps the hosted service in both, in that order, so a rejected
authority is turned away before it can consume the admission slot. A "server" without them is a
different server with a different security posture. What they assert:

- Loopback-only by default on an ephemeral port; the bind is `forAddress` with an explicit address
  and never `forPort`, which binds the wildcard. A non-loopback address refuses to start unless the
  opt-in is set, the refusal names the setting, and when set the warning states the whole surface.
- One live stream, **rejected rather than replaced**, with a generation counter so a late
  termination callback from a superseded stream cannot release the slot out from under the holder.
- An unlisted declared `:authority` refused with `PERMISSION_DENIED`, distinct from the slot's
  `RESOURCE_EXHAUSTED` so a client can tell "not allowed" from "taken" by status code alone.

Both rejections are proven to happen **before the service method** by counters on the stand-in
service, because a test asserting only the client-visible status passes just as well after the
method has already run.

**`Main`.** Refuses arguments - configuration travels the protocol, and a sidecar that silently
discarded `--bootstrap-servers` would leave the operator debugging why their flag did nothing.
Prints `port: <n>` as stdout line one. Serves until the parent dies. Closes the listener.

**`ParentDeathWatchdog`.** An orphaned sidecar holds a consumer-group membership on behalf of an
application that no longer exists, so this is correctness rather than housekeeping - and without it
`Main` has nothing to wait on and no way to stop. EOF on the inherited pipe is the primary signal;
a `ProcessHandle` pid poll backs it up for the wrapper-process case, with the parent handle captured
**once** because a re-parented process would otherwise report a living parent forever.

**`NoEngineSessionService`.** The transport's contract with what it hosts is `BindableService`, but
a server with no service is not a server. `Main#sessionServiceFactory` is the one call site the
engine rung replaces, and this class goes with it.

### Deliberately NOT in this rung

Named so neither side reads as an oversight: connect-time configuration and the options mapping,
dispatch waves and the remote-execution semantics, the in-flight registry, epochs, the manifest and
reconnect reconciliation, leases and heartbeats, the produce path, capability negotiation, the
shutdown drain that waits on records held in a foreign process, conformance, the clients, and the
native image. The engine semantics remain astubbs/parallel-consumer#293's residue.

Also left behind: this module's `src/test/CLAUDE.md` write-time bridge, for the same reason
astubbs/parallel-consumer#383 left its own - the document it imports and the file-reference gate's
parser fix both arrive with astubbs/parallel-consumer#378.

### The prior-art branch, and what it turned out to be

`feats/sidecar-entry-point` was checked before anything was cut, on the possibility that it was
already a shell extraction to build on rather than duplicate. **It is not.** It is unit U10 stacked
on top of astubbs/parallel-consumer#293's whole tree - forward work that ADDS the production entry
point, the parent-death watchdog and a shutdown drain to a module that already has an engine. Its
commit bodies say so outright, and one of them names the seam it deliberately leaves open.

So it is built on rather than duplicated: `ParentDeathWatchdog` and its four tests are taken from it
unchanged, and `Main` is its `Main` minus the engine, the configuration handler and the drain.
Writing a fresh EOF loop beside a reviewed one on a sibling branch would have been the
parallel-implementation antipattern this repository names by name. **That branch has no PR yet, and
whoever opens it reconciles against this rung** - its remaining content is the drain, the
integration test that spawns a real sidecar against a real broker, and the shared spawn helper.

`feats/graalvm-sidecar-virtual-threads` was read too: it is inflight notes and benchmark arms about
GraalVM and virtual threads, with no module shell in it. Nothing to reconcile.

### Four places this differs from its sources on purpose

1. **`parallel-consumer-core` is dropped from compile scope.** astubbs/parallel-consumer#293
   declares it because the module it belongs to has an engine. This one does not reference a
   Parallel Consumer type anywhere, so carrying it would be an unused declaration - and its absence
   is the shortest possible proof of the rung's whole claim. The pom says so at the site so nobody
   adds it back as a fix. The core test-jar stays and is used, for the shared ArchUnit rules.
2. **A bind failure exits 4, not the usage code.** `feats/sidecar-entry-point` returns the usage code
   for both; a port collision that reports a usage error sends an operator to the command line for a
   socket problem. Its exit code 3 - a drain that timed out with records still held - is not here,
   because there is nothing to drain until there is an engine.
3. **`error_prone_annotations` managed module-locally** - the same pin, for the same reason, as the
   protocol module's: gRPC drags it in twice at different versions and master's
   `requireUpperBoundDeps` fails the resolved graph. Repeated rather than hoisted, because hoisting
   would impose gRPC's transitive graph on every module in the repository. It sits a version above
   the protocol module's, and the pom says why - see the CVE finding below.
4. **`docs/simplifications-declined.md` is trimmed to the candidates whose subject is in this
   module.** It has to come now rather than later because `AuthorityAllowlistInterceptor` cites it
   by path, at the one site where the diff looks strictly better and only the reasoning says
   otherwise (Guava's `HostAndPort` throws on a bare unbracketed IPv6 authority that method
   deliberately admits - a security-posture change wearing a library swap). The rest of the pass
   travels with the code it is about.

Two smaller ones: `MainTest` moves out of the `lifecycle` package to sit beside its subject, and
`ProxyServerTest`'s comment on why its log capture needs a synchronized list cited a test in a module
that is not here, so it now states the race directly.

## Three sabotage arms, with a control on either side

Each arm changes one term, runs the one test that should break, and restores from a pristine copy.
Same-magnitude-different-position, not a bigger hammer.

```
=== CONTROL: untouched tree, all five lifecycle assertions ===
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- MainTest
EXIT=0

=== ARM 1: leak the server instead of closing it (try-with-resources -> plain assignment) ===
MainTest.announcesItsPortServesOnItAndReleasesItWhenTheParentDies
  the listener must be gone once the sidecar has shut down, not merely unattended
  ==> Expected java.io.IOException to be thrown, but nothing was thrown.
EXIT=1

=== ARM 2: the no-engine service accepts the session silently instead of refusing it ===
MainTest.aSessionIsAnsweredWithUnimplementedNamingTheMissingEngine -- Time elapsed: 30.34 s
  the session must terminate rather than hang
EXIT=1

=== ARM 3: a bind failure exits 0, indistinguishable from a clean shutdown ===
MainTest.aPortItCannotBindIsADistinguishableNonZeroExit
  expected: 4
EXIT=1

=== RESTORED: control arm again, tree byte-identical ===
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- MainTest
EXIT=0
```

**Arm 1 is the one that matters most**, because it is the assertion a reviewer would most reasonably
expect to be redundant. A run that returns 0 proves the method returned; it proves nothing about
whether the gRPC server was shut down, because a leaked one lives on its own Netty threads and keeps
the port bound afterwards. The port is the observable that separates "returned" from "shut down", so
the close is asserted against the socket rather than against the return value - and the arm shows
that without it the test passes on a sidecar that never released anything.

**Arm 2's shape is the finding, not just its colour.** Removing the refusal does not fail fast; it
hangs, and the test lands on its bounded latch after 30 seconds. That is the behaviour a client
author would hit against a silently-accepting sidecar, and it is why the refusal is explicit rather
than left to gRPC's generated default.

## How it was verified

JDK 17, macOS, on this branch:

- `./mvnw clean` then a full-reactor `install` - **BUILD SUCCESS**, seventeen modules, the new one
  among them.
- The module's own suite green: transport (bind posture, the non-loopback opt-in and its warning,
  the authority allowlist, the one-connection slot), the watchdog's two signals plus its negative
  control, the entry point's five, and the ArchUnit conventions wrapper.
- `bin/check-all.sh` on its **real exit code: 0**. Two gates report CANNOT RUN -
  `check-proto-breaking.sh` and `check-proto-lint.sh`, both wanting a `buf` this machine does not
  have. Both belong to the base rung, neither is affected by this diff, and CI is where they run.
- `COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1 bin/check-copyright-headers.sh` - 0 violations against a
  real fork point, with `--report` showing every new file classified `enforce` rather than skipped.

**Two dependency questions were settled by experiment rather than by reading imports**, since both
answers looked obvious in opposite directions: removing `parallel-consumer-core` from compile scope
and rebuilding the whole reactor (green - so it is genuinely unused, and it went); and removing the
`commons-lang3` test dependency, which also passes but was **kept**, because its declaration carries
an inherited reason about what core's test-jar needs and "today's tests do not reach that path" is
not evidence against it.

**Does this compile against a `master` that does not have astubbs/parallel-consumer#295?** Yes, and
the clean reactor build above is that arm: this branch's base contains current `master`, and
astubbs/parallel-consumer#295 is open and unmerged. Nothing here touches `WorkContainer` or the
verdict-free abandonment path - the module has no `bz.stub.parallelconsumer` import outside the
proxy packages at all, except the ArchUnit rules from core's test-jar. **So there is no
`depends on astubbs/parallel-consumer#295` line, deliberately.**

## What CI added that the local runs could not

**The whole-tree CVE scan went red, and it was right to.** `com.google.code.gson:gson:2.11.0`,
CVE-2025-53864, CVSS 6.9 - reaching the tree for the first time because gRPC brings gson in at
runtime for JSON service-config parsing and this is the first module to depend on gRPC's transport.

The advisory's affected product is `com.nimbusds:nimbus-jose-jwt`, which nothing here depends on;
its own text says the flaw is "independent of the Gson 2.11.0 issue", and Sonatype's matcher has
taken a version out of the sentence that exists to distinguish the two. It was **pinned forward to
gson 2.14.0 rather than excluded** anyway: an `excludeVulnerabilityIds` entry has to carry a
retirement condition, and this one would have none that anybody could ever discharge - the record is
correct about a library we do not use, so it will never be withdrawn. Moving off the matched version
costs one managed line and is an upgrade wanted regardless. Verified by re-running the same scan
with the one term changed: `Detected 1 vulnerable components` before, none after.

`error_prone_annotations` moves to 2.48.0 in the same change, because gson 2.14.0 asks for it. That
leaves this module a version above the protocol module's 2.47.0 pin, which is not drift - the rule
is "manage up to the highest requester", and the two modules have different highest requesters. The
pom says so, since two near-identical pins a version apart is exactly what a later reader would
"fix".

## The duplication reports, read

**`dups: clones` passes both engines** - PMD CPD and jscpd each report **zero new clones** and a
duplication percentage at or below the base branch's.

**`dups: similarity` is red on the `TestConventionsArchTest.java` family**, at ~77-83% against the
nine that already exist. That duplication is deliberate and required by a different gate:
`EveryModuleWiresUpArchUnitTest` fails any module with a `src/test/java` and no wired wrapper, and
its javadoc records why the wrapper cannot be inherited instead (surefire's `dependenciesToScan`
pulls the whole test-jar into every module). Those nine already sit at similar percentages against
each other on `master`; this is the tenth, and it only reads as new because the file is. Same
finding and same answer as astubbs/parallel-consumer#380 and astubbs/parallel-consumer#383.

## The analysis surfaces, read

`bin/check-pr-analysis-surfaces.sh 384` reports **13 findings on lines this diff wrote and none
inherited**, all from SpotBugs, which passes as a check - they are advisory. Every one is declined,
in four groups, with a reason rather than silently:

- **`UNENCRYPTED_SOCKET` / `UNENCRYPTED_SERVER_SOCKET` (5, all in tests).** Every one is a test
  connecting to this sidecar's own loopback listener, which is plaintext **by design**: loopback-only
  plus one-connection admission is what this module offers *instead* of transport security, and the
  reasoning is in `ProxyServer`'s javadoc and the module README. A test that used TLS would be
  testing a listener that does not exist.
- **`USO_UNSAFE_METHOD_SYNCHRONIZATION` (4).** `synchronized` methods on `ProxyServer` and
  `ParentDeathWatchdog` lock `this`, which a caller holding the instance could also lock. The threat
  model here is entirely out-of-process - anything in this JVM holding a `ProxyServer` can already
  call `close()` on it - so a private lock object would buy nothing against any attacker this module
  has, at the cost of diverging from astubbs/parallel-consumer#293's copy of both classes.
- **`PSC_PRESIZE_COLLECTIONS` (1).** A `LinkedHashSet` in `AuthorityAllowlistInterceptor` built
  without a capacity hint, once per server start, over an allowlist of about five entries. This
  module's `docs/simplifications-declined.md` records "any change to `AuthorityAllowlistInterceptor`
  or `SingleConnectionGuard`" as declined - security posture, and their apparent simplicity is the
  point - and a presize is not the exception that earns.
- **`LO_SUSPECT_LOG_CLASS` and `SLF4J_ILLEGAL_PASSED_CLASS` (2, in `ProxyServerTest`).** The test
  asks `LoggerFactory` for `ProxyServer`'s logger on purpose: it is asserting on what `ProxyServer`
  logs. Fixing the finding would remove the test's subject. Same for
  `USO_UNSAFE_OBJECT_SYNCHRONIZATION` on the capture list, which is synchronized deliberately because
  the server's own threads write it while the test reads it.

## Known-red, and not a fault

- **`Check PR Dependencies` is red until astubbs/parallel-consumer#383 and its own parent merge.**
  That is the dependency gate doing its job on a stack rung, not something to fix.
- **`claude-review`** is red until somebody asks for a review; both rungs below are in the same
  state.

roadmap-stage: N/A - the `language-proxy-sidecar` entry names astubbs/parallel-consumer#293 as its carrier and sits at `limited-poc` on the strength of that PR's content. Landing a sidecar that hosts no engine on master makes no more advanced artifact exist - it cannot process a record or reach a broker - so its stage is unchanged.

## Checklist

- [x] Docs updated - the module `README.md` rewritten to describe what is actually in it and what is
  not, `AGENTS.md`'s module table, `docs/simplifications-declined.md` trimmed to this module's
  entries, and the module-maturity and testing-evidence records. The protocol module's
  support-posture row said the sidecar was not on master at all, which this change makes false, so
  it is corrected rather than left to rot.
- [x] User-facing feature documentation data added under `docs/features/` - N/A - nothing here is a
  user-facing feature. The module publishes to no registry and cannot be configured to reach a
  broker; the release-documentation records it does earn are the maturity and evidence rows, which
  are in this PR and say in both directions what is and is not evidenced.
- [x] Tests added/updated - the transport's suite comes with it; the entry point's five and the
  watchdog's four are new to `master`. Three were proven able to fail by sabotage, with control arms
  on either side, above.
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - neither was run. Most of the diff is
  code taken from astubbs/parallel-consumer#293 and `feats/sidecar-entry-point` where it was already
  reviewed, and the changes this rung made to it are named one by one above; the cheaper place to
  spend a review is `@claude review this` on the PR, which is also the only route that opens inline
  threads.
