### PR TITLE
feat(native) astubbs#242: the sidecar shell compiles and runs as a GraalVM native executable

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -1,0 +1,103 @@
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# Builds the proxy sidecar as a GraalVM native executable and drives it through its whole lifecycle
+# (astubbs#242).
+#
+# WHY THIS IS ITS OWN WORKFLOW AND NOT A STEP ON maven.yml. It needs a second JDK - a GraalVM one,
+# alongside the project's JDK 17 - and it is the only lane in the repository that does. Bolting that
+# onto a lane already near its timeout is what pushes it over, and it would make every ordinary build
+# provision a toolchain nothing else uses.
+#
+# TWO ROWS, AND THEY ANSWER DIFFERENT QUESTIONS. macOS/arm64 is where the sidecar's native build was
+# first proven by hand, so that row is a regression guard. Linux is where a sidecar actually gets
+# deployed and had never been tried at all - the branch this work was re-cut from recorded "untried:
+# Linux" as one of its own gaps, and this row is what closes it.
+#
+# PC_NATIVE_IMAGE_STRICT IS SET, and it is the half that keeps the other half honest. On a developer
+# box bin/native-image-sidecar.sh prints a banner and exits 0 when GraalVM is absent, because absence
+# there is normal. Here the row installs the toolchain itself, so absence means the setup step did not
+# do what it claimed, and a green skip would be
+# docs/solutions/workflow-issues/a-check-that-reports-success-without-having-run.md again.
+#
+# THE PROJECT'S JDK IS INSTALLED SECOND ON PURPOSE. Maven must run on JDK 17 - the reactor is built
+# and cross-compiled for it, and an unrelated module's delombok step fails on a newer one - so the
+# GraalVM JDK is never allowed to become JAVA_HOME. It is reached by path, through PC_NATIVE_IMAGE,
+# which is exactly the separation the script's header describes.
+#
+# Caching: restore-only, the same discipline as maven.yml and clients.yml - never a setup action's
+# built-in `cache:`, whose immutable keys can freeze an incomplete cache permanently.
+
+name: Native Image
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # See the header: the row provisions its own toolchain, so an absent one is a provisioning bug.
+  PC_NATIVE_IMAGE_STRICT: '1'
+
+jobs:
+
+  native-sidecar:
+    name: "native sidecar: ${{ matrix.platform }}"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      # Fail the row, not the matrix: a Linux-only or macOS-only failure is the finding.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            runner: ubuntu-latest
+          - platform: macos
+            runner: macos-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # GraalVM first, and captured by path rather than left as JAVA_HOME - see the header.
+      - uses: actions/setup-java@v5
+        id: graalvm
+        with:
+          distribution: 'graalvm'
+          java-version: '23'
+      - name: Point the script at this row's native-image
+        run: echo "PC_NATIVE_IMAGE=${{ steps.graalvm.outputs.path }}/bin/native-image" >> "$GITHUB_ENV"
+
+      # The project's JDK, installed last so JAVA_HOME is the one Maven must build on.
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          # No `cache: maven` - see the caching note in the header and in maven.yml.
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          # The Linux key on the macOS row too, as clients.yml's macOS row does: a Maven repository
+          # holds platform-independent jars, and maven.yml's prepare-deps job saves only this key -
+          # a platform-specific key here would simply never hit anything.
+          key: setup-java-Linux-x64-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            setup-java-Linux-x64-maven-
+
+      # Say what was installed before using it. A setup action that silently resolves something else
+      # leaves a row whose only symptom is a red build several steps later blaming the module.
+      - name: Which toolchains are these?
+        run: |
+          java -version
+          "$PC_NATIVE_IMAGE" --version
+
+      # Builds the image and runs the lifecycle exercise; its exit code is the row's. The script owns
+      # the recipe, so nothing about the build lives in this file.
+      - name: Build the native sidecar and drive its lifecycle
+        run: bin/native-image-sidecar.sh

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -63,6 +63,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # The Maven build this row runs includes the copyright header check, which classifies
+          # provenance against the fork-point commit and SKIPS ITSELF with a warning on a shallow
+          # clone - a check reporting success without having run, which is the class this file's
+          # header already cites. copyright.yml sets this for the same reason.
+          fetch-depth: 0
 
       # GraalVM first, and captured by path rather than left as JAVA_HOME - see the header.
       - uses: actions/setup-java@v5

--- a/bin/native-image-sidecar.sh
+++ b/bin/native-image-sidecar.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+
+# Builds the parallel-consumer-proxy sidecar as a GraalVM native executable, then drives the result
+# through the sidecar's whole lifecycle (astubbs#242).
+#
+# Usage: bin/native-image-sidecar.sh [--output <path>] [--build-only]
+#
+# NOTHING IN THE ORDINARY BUILD REACHES THIS SCRIPT, and that is deliberate. There is no Maven
+# profile, no plugin and no reactor module that runs native-image, so `./mvnw install`,
+# bin/build.sh and every CI lane except the one named below work exactly as they did on a machine
+# that has never heard of GraalVM. A native image is a packaging question asked on demand; making it
+# a build step would put a 1GB toolchain in the path of every developer who wants to run a unit test.
+#
+# WHAT AN ABSENT TOOLCHAIN MEANS - the same three-way answer, and the same exit codes, as
+# bin/foreign-client-step.sh, whose header owns the reasoning:
+#
+#   - native-image present -> build it, verify it; the verification's verdict is this script's
+#   - absent               -> print a banner naming what is missing and how to get it, and exit 0
+#   - absent, and PC_NATIVE_IMAGE_STRICT is set -> exit 2
+#
+# STRICT IS WHAT KEEPS THE LENIENT DEFAULT HONEST: .github/workflows/native-image.yml installs the
+# toolchain in the row itself, so absence there is a provisioning bug and must be red rather than a
+# green skip. The lenient default is for the developer box, where not having GraalVM is normal.
+#
+# --no-fallback IS THE LOAD-BEARING FLAG. Without it, native-image quietly emits a FALLBACK IMAGE:
+# a launcher that still requires a JVM at run time. It builds green, runs fine on the build machine,
+# and destroys the entire proposition, which is handing a Go or Python team an executable. With it,
+# a build that cannot close the world FAILS instead - which is the outcome you want, because it is
+# the one you can see.
+#
+# THE CLASSPATH IS RUNTIME SCOPE, AND GETTING THAT WRONG IS SILENT. `dependency:build-classpath`
+# takes -DincludeScope, NOT -Dmdep.includeScope (that spelling is accepted and ignored), and the
+# ignored spelling yields the TEST classpath: JUnit, Mockito, ArchUnit and - worse - the core
+# test-jar's logback.xml all get compiled into the shipped binary, which then carries this
+# repository's test logging configuration as its own. The build stays green either way. Assert the
+# jar count if you ever change this line.
+#
+# WHAT THIS DOES NOT PROVE, kept short here because the verifier's javadoc owns it: the lifecycle
+# exercise establishes that the artifact behaves like the sidecar and needs nothing from its
+# environment. It does NOT establish that the artifact is a native image - a shell wrapper around a
+# JVM sidecar passes every arm, which was measured rather than assumed. --no-fallback is what rules
+# a JVM out, at build time, and the "is it a real executable" check below is what notices a wrapper.
+#
+# Exit codes:
+#   0  built and verified, or the toolchain is absent and strict mode is off
+#   1  the Maven build, the native-image build, or the lifecycle exercise failed
+#   2  the toolchain is absent and PC_NATIVE_IMAGE_STRICT is set
+#   3  usage error
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+MODULE_DIR="$REPO_ROOT/parallel-consumer-proxy"
+MAIN_CLASS="bz.stub.parallelconsumer.proxy.Main"
+VERIFIER_CLASS="bz.stub.parallelconsumer.proxy.NativeSidecarLifecycle"
+
+OUTPUT="$MODULE_DIR/target/pc-sidecar"
+BUILD_ONLY=0
+
+die() { # <exit code> <message...>
+    local code="$1"
+    shift
+    printf 'native-image-sidecar: %s\n' "$*" >&2
+    exit "$code"
+}
+
+usage() {
+    printf 'Usage: bin/native-image-sidecar.sh [--output <path>] [--build-only]\n'
+}
+
+strict_mode() {
+    case "${PC_NATIVE_IMAGE_STRICT:-}" in
+        "" | 0 | false | FALSE | no | NO) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Bracketed and multi-line for the same reason bin/foreign-client-step.sh's is: it has to survive
+# being read in a log where every other line is also progress output, and it has to name the fix.
+report_absent() {
+    local verdict
+    if strict_mode; then
+        verdict='FAILING, because PC_NATIVE_IMAGE_STRICT is set - a CI row provisions its own toolchain, so absence here is a provisioning bug'
+    else
+        verdict='SKIPPED - set PC_NATIVE_IMAGE_STRICT=1 to make this red instead'
+    fi
+    printf '\n'
+    printf '========================================================================\n'
+    printf '  NATIVE SIDECAR BUILD %s\n' "$verdict"
+    printf '  missing : native-image (not on PATH, not under GRAALVM_HOME or JAVA_HOME)\n'
+    printf '  get it  : install a GraalVM JDK (sdkman: `sdk install java 23-graal`), then\n'
+    printf '            re-run, or point PC_NATIVE_IMAGE at the executable directly\n'
+    printf '  nothing was built, compiled or asserted for the native sidecar\n'
+    printf '========================================================================\n'
+    printf '\n'
+    # `printf --` is load-bearing: the format string starts with a hyphen and bash printf would
+    # read it as an option. bin/foreign-client-step.sh's header records the CI row this cost.
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        printf -- '- **native sidecar**: `native-image` not on PATH - %s\n' "$verdict" >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
+
+# PC_NATIVE_IMAGE first so a machine with several GraalVMs can name one; then the two homes GraalVM
+# itself sets, then PATH. JAVA_HOME is checked LAST and never exported anywhere - the Maven build
+# below must run on the project's JDK 17, and a GraalVM JAVA_HOME exported for the whole build is
+# how an unrelated module's delombok step starts failing.
+resolve_native_image() {
+    local candidate
+    if [ -n "${PC_NATIVE_IMAGE:-}" ]; then
+        [ -x "$PC_NATIVE_IMAGE" ] || die 3 "PC_NATIVE_IMAGE is set to '$PC_NATIVE_IMAGE', which is not executable"
+        printf '%s' "$PC_NATIVE_IMAGE"
+        return 0
+    fi
+    for candidate in "${GRAALVM_HOME:-}/bin/native-image" "${JAVA_HOME:-}/bin/native-image"; do
+        if [ -x "$candidate" ]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    if command -v native-image > /dev/null 2>&1; then
+        command -v native-image
+        return 0
+    fi
+    return 1
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --output)
+            [ "$#" -ge 2 ] || { usage >&2; die 3 "--output needs a path"; }
+            OUTPUT="$2"
+            shift 2
+            ;;
+        --build-only)
+            BUILD_ONLY=1
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            die 3 "unexpected argument '$1'"
+            ;;
+    esac
+done
+
+NATIVE_IMAGE=""
+if ! NATIVE_IMAGE="$(resolve_native_image)"; then
+    report_absent
+    # Spelled as an `if` rather than an AND-list, for the reason bin/foreign-client-step.sh states:
+    # under `set -e` the list's status can make the lenient path exit 1, the outcome it exists to
+    # avoid.
+    if strict_mode; then
+        exit 2
+    fi
+    exit 0
+fi
+
+printf 'native-image-sidecar: using %s\n' "$NATIVE_IMAGE"
+"$NATIVE_IMAGE" --version
+
+# The Maven half runs on whatever JDK the caller has - the project's JDK 17 - because compiling the
+# module is an ordinary build. Only the image step uses GraalVM. test-compile rather than compile:
+# the lifecycle verifier lives in the module's test sources, since it is a verification tool and not
+# something the sidecar ships.
+printf 'native-image-sidecar: building the module and its runtime classpath\n'
+CLASSPATH_FILE="$MODULE_DIR/target/native-image-runtime-classpath.txt"
+(
+    cd "$REPO_ROOT"
+    ./mvnw --batch-mode -q -pl parallel-consumer-proxy -am -DskipTests test-compile
+    # -DincludeScope, NOT -Dmdep.includeScope. See the header: the wrong spelling is ignored and
+    # yields the test classpath, which compiles JUnit and a test logback.xml into the binary.
+    ./mvnw --batch-mode -q -pl parallel-consumer-proxy dependency:build-classpath \
+        -DincludeScope=runtime "-Dmdep.outputFile=$CLASSPATH_FILE"
+)
+
+RUNTIME_CP="$(cat "$CLASSPATH_FILE")"
+IMAGE_CP="$MODULE_DIR/target/classes:$RUNTIME_CP"
+
+# The recipe is deliberately this short, and the shortness is a finding rather than an omission.
+# The same build against astubbs/parallel-consumer#293's tree needed logback initialised at build
+# time and a vendored reachability metadata file, because that tree's sidecar carries an engine and
+# the Kafka client. This module carries neither: slf4j-api is its only logging dependency, no
+# provider is on its runtime classpath, and nothing here builds an object from a configuration
+# string. Adding configuration "just in case" is not free - on that branch, adding reachability
+# metadata BROKE a build that had already passed, by letting logback's XML configurator run during
+# the build and strand a SAX object in the image heap. If a logging backend or the engine later
+# joins the runtime classpath, expect the Logger.name analysis failure back, and reach for
+# --initialize-at-build-time=ch.qos.logback,org.slf4j,org.xml.sax,com.sun.org.apache.xerces,javax.xml
+# then rather than now.
+printf 'native-image-sidecar: building %s\n' "$OUTPUT"
+"$NATIVE_IMAGE" --no-fallback -cp "$IMAGE_CP" -o "$OUTPUT" "$MAIN_CLASS"
+
+[ -x "$OUTPUT" ] || die 1 "native-image reported success but produced no executable at $OUTPUT"
+
+# The cheapest thing that separates an executable image from a launcher script wrapping a JVM. It is
+# not a proof of nativeness - nothing short of inspecting the binary's linkage is - but a text file
+# starting with `#!` is the failure mode a hand-rolled "native build" actually has, and it costs one
+# read to rule out.
+if [ "$(head -c 2 "$OUTPUT")" = '#!' ]; then
+    die 1 "$OUTPUT is a script, not a native executable - --no-fallback should have prevented this"
+fi
+
+printf 'native-image-sidecar: built %s\n' "$OUTPUT"
+ls -lh "$OUTPUT"
+
+if [ "$BUILD_ONLY" -eq 1 ]; then
+    printf 'native-image-sidecar: --build-only, so the lifecycle exercise was NOT run\n'
+    exit 0
+fi
+
+# The verifier deliberately uses nothing but the JDK, gRPC and the generated stubs, so the module's
+# test-classes plus the RUNTIME classpath is enough to run it - no test dependency resolution, and
+# no second classpath to keep in step with the first.
+#
+# The verifier runs on the project's JDK, never on GraalVM's - $JAVA_HOME when the caller set one,
+# so the JDK that compiled the class is the JDK that loads it.
+printf 'native-image-sidecar: driving the executable through the sidecar lifecycle\n'
+JAVA="java"
+if [ -x "${JAVA_HOME:-}/bin/java" ]; then
+    JAVA="$JAVA_HOME/bin/java"
+fi
+"$JAVA" -cp "$MODULE_DIR/target/test-classes:$IMAGE_CP" "$VERIFIER_CLASS" "$OUTPUT"

--- a/bin/native-image-sidecar.sh
+++ b/bin/native-image-sidecar.sh
@@ -165,14 +165,23 @@ printf 'native-image-sidecar: using %s\n' "$NATIVE_IMAGE"
 "$NATIVE_IMAGE" --version
 
 # The Maven half runs on whatever JDK the caller has - the project's JDK 17 - because compiling the
-# module is an ordinary build. Only the image step uses GraalVM. test-compile rather than compile:
-# the lifecycle verifier lives in the module's test sources, since it is a verification tool and not
-# something the sidecar ships.
-printf 'native-image-sidecar: building the module and its runtime classpath\n'
+# module is an ordinary build. Only the image step uses GraalVM.
+#
+# INSTALL, NOT test-compile, and the difference is what a warm ~/.m2 hides. The classpath step below
+# runs on this module ALONE - it has to, because -am would run the goal on every module in the
+# reactor and each would overwrite the same output file - so it resolves the sibling snapshots
+# (proxy-protocol, and core's test-jar) from the local repository rather than from the reactor. On a
+# developer box those are usually already installed and the weaker `test-compile` appears to work;
+# on a clean CI runner it fails with "Could not find artifact ... in central", which is how this was
+# found. `install` is what makes the two machines behave the same.
+#
+# It reaches test-compile on the way past, which is what the lifecycle verifier needs: it lives in
+# the module's test sources, being a verification tool rather than something the sidecar ships.
+printf 'native-image-sidecar: building and installing the module and its dependencies\n'
 CLASSPATH_FILE="$MODULE_DIR/target/native-image-runtime-classpath.txt"
 (
     cd "$REPO_ROOT"
-    ./mvnw --batch-mode -q -pl parallel-consumer-proxy -am -DskipTests test-compile
+    ./mvnw --batch-mode -q -pl parallel-consumer-proxy -am -DskipTests install
     # -DincludeScope, NOT -Dmdep.includeScope. See the header: the wrong spelling is ignored and
     # yields the test classpath, which compiles JUnit and a test logback.xml into the binary.
     ./mvnw --batch-mode -q -pl parallel-consumer-proxy dependency:build-classpath \

--- a/docs/data/module-maturity.yaml
+++ b/docs/data/module-maturity.yaml
@@ -102,17 +102,21 @@ modules:
     reliability_confidence: >-
       What is evidenced is the process boundary, and only that: the sidecar binds loopback on an
       ephemeral port, announces it, admits exactly one stream, rejects an unlisted declared authority
-      before the service method runs, and releases the socket when its parent dies. It hosts NO
-      Parallel Consumer engine - a session is answered UNIMPLEMENTED - so nothing here evidences a
-      record being processed, an offset being committed, or any protocol behaviour beyond the
-      handshake being refused.
+      before the service method runs, and releases the socket when its parent dies. That same
+      lifecycle is evidenced twice - once in the JVM and once against a GraalVM native executable of
+      the same entry point - so the transport surviving closed-world compilation is evidenced, not
+      assumed. It hosts NO Parallel Consumer engine - a session is answered UNIMPLEMENTED - so
+      nothing here evidences a record being processed, an offset being committed, or any protocol
+      behaviour beyond the handshake being refused.
     api_expectation: >-
       Pre-1.0 and expected to change substantially: the engine, its connect-time configuration and
       the shutdown drain are still to arrive, and the seam they plug into is the one thing here most
       likely to move.
     support_posture: >-
       Experimental. Published to no registry, and there is no supported way to run it against a
-      broker yet because it cannot be configured.
+      broker yet because it cannot be configured. A native executable can be built from a checkout
+      with bin/native-image-sidecar.sh, but no binary is distributed and building one is not part of
+      the ordinary build.
     evidence_id: proxy-sidecar
     tracking: astubbs#242
     use_this_if: >-

--- a/docs/data/testing-evidence.yaml
+++ b/docs/data/testing-evidence.yaml
@@ -186,14 +186,23 @@ module_evidence:
       server was shut down". Plus the transport's own admission rules - loopback-only bind, the
       non-loopback opt-in and its warning, the authority allowlist and the one-connection slot -
       each asserted with service-invocation counters rather than on the client-visible status alone.
+      The same lifecycle claims are then driven a second time against a GraalVM NATIVE EXECUTABLE of
+      the same entry point, from outside a process the exercise spawned - which is the only thing
+      that can evidence the transport, the generated stubs and protobuf surviving closed-world
+      compilation, since the JVM suite would pass regardless.
     inspect:
       - parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/MainTest.java
       - parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/ProxyServerTest.java
       - parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/lifecycle/ParentDeathWatchdogTest.java
+      - parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/NativeSidecarLifecycle.java
+      - bin/native-image-sidecar.sh
     limitation: >-
       Evidence about a PROCESS, not about processing. No engine is hosted, so no record has been
       dispatched, no verdict returned and no offset committed; and the sidecar has never run against
-      a broker, because it cannot be configured to reach one.
+      a broker, because it cannot be configured to reach one. The native arm runs only where a
+      GraalVM toolchain exists - the Native Image workflow, and a developer box that has one - and it
+      evidences the SHELL in an image: an engine and a Kafka client are exactly the parts that make
+      closed-world analysis hard, and neither is on this module's classpath.
   - id: streams-alpha
     artifact: parallel-consumer-streams-spike
     coverage: Planned alpha evidence must exercise the release artifact's opt-in boundary, comparison switch and supported topology/recovery claims.

--- a/docs/inflight/core-the-native-sidecar-is-easy-only-while-it-has-no-engine.md
+++ b/docs/inflight/core-the-native-sidecar-is-easy-only-while-it-has-no-engine.md
@@ -1,0 +1,51 @@
+# The native sidecar builds with no reachability configuration - and only because it has no engine
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: coordination -->
+
+`bin/native-image-sidecar.sh` builds `parallel-consumer-proxy`'s `Main` into a GraalVM native
+executable with **one flag** - `--no-fallback` - and no `META-INF/native-image` configuration of any
+kind. That is a real result and it is also a trap for whoever lands the engine rung, because the
+reason it is easy is not that native image is easy here.
+
+## Why it is easy today
+
+The module's runtime classpath is gRPC, protobuf, Guava and `slf4j-api`. Nothing on it builds an
+object from a **configuration string**, which is the one thing closed-world analysis cannot follow,
+and nothing on it is a logging backend, which is the other thing that fights build-time
+initialisation.
+
+## What changes when the engine arrives
+
+Both of those stop being true in the same commit, and **neither failure appears at build time**:
+
+- **The Kafka client instantiates serializers and partitioners by reflection from configuration
+  strings** (`key.deserializer=...ByteArrayDeserializer`). Reading the code does not find them. The
+  build stays green and the binary fails at *runtime*, inside connect-time configuration - which is
+  precisely where it failed on the branch this work was re-cut from.
+- **A logging backend on the runtime classpath brings the analysis failure back.** With logback
+  present, the plain build fails on `Logger.name` not being available during analysis; the fix is
+  `--initialize-at-build-time=ch.qos.logback,org.slf4j,org.xml.sax,com.sun.org.apache.xerces,javax.xml`,
+  and the script's header carries that recipe waiting for the day it is needed.
+
+The prior work is worth reading before rediscovering either:
+`git show ca05c7185:docs/inflight/perf-native-image-sidecar-works.md` on
+`feats/native-image-sidecar` records five build attempts, the fact that **adding** reachability
+configuration once broke a build that had already passed, and the captured metadata itself at
+`git show ca05c7185:parallel-consumer-proxy/src/main/resources/META-INF/native-image/reachability-metadata.json`.
+That capture is a starting point and not an answer: it was traced over one unordered 20-record run
+with no failures, retries, rebalance or transactional commit, so every path it did not walk is still
+invisible.
+
+## What that rung actually owes
+
+Not "copy the metadata file across". A capture is only as good as the session that produced it, so
+the trace has to cross the retry path, the failure path, each commit mode and a rebalance - or,
+better, the module gets something that **asserts** reachability rather than trusting a one-off
+capture, which is the only version of this that does not rot silently.
+
+## Related
+
+- `bin/native-image-sidecar.sh` - the build recipe, the absent-toolchain contract and the exit codes.
+- `.github/workflows/native-image.yml` - the two rows that run it, one of them Linux, which the
+  earlier work never tried.

--- a/docs/inflight/core-the-sidecar-ships-no-logging-backend-so-its-own-logs-go-nowhere.md
+++ b/docs/inflight/core-the-sidecar-ships-no-logging-backend-so-its-own-logs-go-nowhere.md
@@ -1,0 +1,34 @@
+# The sidecar logs to nothing - `slf4j-api` is on its runtime classpath and no provider is
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: blind-spot -->
+
+`parallel-consumer-proxy`'s runtime classpath carries `slf4j-api` and no SLF4J provider, so every
+`@Slf4j` call in the sidecar reaches a no-op logger. Started from a plain classpath, the JVM sidecar
+says so out loud - `SLF4J(W): No SLF4J providers were found` on stderr - and then runs perfectly,
+which is why nobody has noticed: stdout carries the port line exactly as the spawning contract
+requires, and the process behaves correctly in every respect that is asserted.
+
+The lines that go nowhere are the ones an operator would want most: `Sidecar listening on loopback
+port ...`, the non-loopback opt-in's warning about the surface it is exposing, and
+`NoEngineSessionService`'s refusal. A client author debugging a sidecar that "does nothing" has the
+gRPC status and no server-side record of anything.
+
+Found while building the native executable, but it is **not** a native-image problem - the JVM
+sidecar behaves identically, and the native build is if anything cleaner about it, because with no
+backend on the classpath there is nothing for build-time initialisation to fight.
+
+## Why it is not a one-line fix
+
+A library must not bind a logging backend; an **executable** normally must. This module is both -
+the jar is a library-shaped artifact in a reactor whose other modules are libraries, and `Main` is a
+program. So the decision is which of these the module is being packaged as, and it wants making
+rather than assuming:
+
+- a provider at runtime scope, which every downstream consumer of this jar then inherits;
+- a provider only in whatever assembles the distributable, once one exists;
+- or deliberately none, in which case the sidecar should not be calling `log` at all and the
+  operator-facing lines belong on stderr, where the usage text already goes.
+
+Nothing is blocked on it today: there is no distributable and no supported way to run this against a
+broker. It should be settled by the rung that first ships something an operator runs.

--- a/parallel-consumer-proxy/README.md
+++ b/parallel-consumer-proxy/README.md
@@ -38,6 +38,26 @@ The transport's contract with what it hosts is `io.grpc.BindableService` and not
 compiles against no engine type at all. `NoEngineSessionService` is what fills that slot until the
 engine arrives, and `Main#sessionServiceFactory` is the one call site that changes when it does.
 
+## Building it as a native executable
+
+`bin/native-image-sidecar.sh` builds this module's `Main` into a GraalVM native executable and then
+drives that executable through the whole lifecycle above - the port line, a real gRPC session
+answered `UNIMPLEMENTED`, a clean exit on parent death, the socket released. It needs a GraalVM JDK;
+without one it prints a banner saying so and exits 0, unless `PC_NATIVE_IMAGE_STRICT` is set, which
+is what the `Native Image` workflow does on rows that install the toolchain themselves.
+
+**Nothing in the ordinary build runs it.** There is no Maven profile and no plugin, so `./mvnw
+install` and every other CI lane are unchanged on a machine that has never heard of GraalVM.
+
+Why it matters here rather than as a packaging detail: **the proposition is that a Go, Python or Ruby
+team is handed an executable, not a JVM dependency**. The engine's guarantees stop being a JVM
+feature only if the artifact stops being a JVM artifact. What the script proves today is that the
+*shell* survives closed-world compilation - the transport, the generated stubs and protobuf all still
+work in the image. What it cannot yet prove is anything about an engine that is not in this module.
+
+The recipe is one flag, `--no-fallback`, and the script's header says why that one is load-bearing
+and why there is deliberately no reachability metadata here.
+
 ## Security posture
 
 Loopback-only, and that is what removes the need for authentication: only the spawning process can
@@ -50,9 +70,12 @@ the server warns with the full surface it is exposing.
 
 Connect-time configuration and the options mapping, the dispatch engine and its waves, the in-flight
 registry, epochs, leases and heartbeats, reconnect with manifest reconciliation, the produce path,
-the shutdown drain that waits on records held in a foreign process, capability negotiation, the
-native image, and the client libraries. Those are reviewed as their own changes; astubbs#242 tracks
-the whole.
+the shutdown drain that waits on records held in a foreign process, capability negotiation, and the
+client libraries. Those are reviewed as their own changes; astubbs#242 tracks the whole.
+
+Also not here: the `--shared` C-ABI build that embeds the engine in the host process with no gRPC at
+all. That is a different artifact from the executable above and is proven separately in
+astubbs#340.
 
 ## Related
 

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/NativeSidecarLifecycle.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/NativeSidecarLifecycle.java
@@ -1,0 +1,266 @@
+package bz.stub.parallelconsumer.proxy;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.proxy.protocol.v1.ClientMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.Configure;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyMessage;
+import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.StreamObserver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Drives an already-built <b>native executable</b> of {@link Main} through the sidecar's whole lifecycle, and
+ * fails loudly if any part of it does not hold.
+ *
+ * <h2>Why this is a program and not a JUnit test</h2>
+ *
+ * Its subject does not exist until something has run a GraalVM toolchain, and this repository's rule is that a
+ * test which quietly does not run is not a passing test. A JUnit test would have to skip itself on every
+ * machine without GraalVM, which is nearly all of them, and a skip is indistinguishable from a pass in a
+ * surefire summary. So the decision about an absent toolchain is made once, out loud, in
+ * {@code bin/native-image-sidecar.sh} - the same place and the same way the eleven foreign client modules make
+ * it - and this program is only ever handed a binary that exists.
+ *
+ * <h2>What it asserts, and why it is the same list as {@link MainTest}</h2>
+ *
+ * {@link MainTest} asserts the lifecycle by calling {@code Main.run} inside the test JVM. That proves the code
+ * is right and proves nothing about the image: closed-world analysis can drop a class the JVM would have
+ * loaded, and the failure appears only in the binary. So this drives the identical claims from outside a
+ * process it spawned - the port line, a real gRPC round trip, the {@code UNIMPLEMENTED} refusal, a clean exit
+ * on parent death, and the socket actually released - which is the point of the exercise rather than
+ * duplication of it.
+ *
+ * <p>The gRPC round trip is the load-bearing arm. A bind proves Netty allocated a socket; only a call that
+ * reaches the service and comes back with a status proves the transport, the generated stubs and protobuf all
+ * survived into the image.
+ *
+ * <h2>The environment is cleared on purpose - and what that does NOT prove</h2>
+ *
+ * The second arm spawns the binary with an empty environment: no {@code JAVA_HOME}, no {@code PATH}, nothing.
+ * A sidecar handed to a Go or Python team runs under whatever environment that application happens to have,
+ * which may be none of ours, so needing nothing from it is a real property worth holding.
+ *
+ * <p><b>It is not a test that the binary is a native image, and it was checked rather than assumed.</b> The
+ * control arm - the same exercise pointed at a shell wrapper that execs a JVM sidecar by absolute path -
+ * <em>passes every arm</em>, because a hard-coded path needs no environment either. What keeps a JVM out of
+ * the artifact is {@code --no-fallback} at build time, which makes the build fail rather than emit a
+ * fallback image that still needs one; {@code bin/native-image-sidecar.sh} owns that flag and the reasoning
+ * for it.
+ *
+ * @author Antony Stubbs
+ * @see MainTest
+ */
+public final class NativeSidecarLifecycle {
+
+    /** Long enough that only a real hang reaches it; a native sidecar starts in milliseconds. */
+    private static final long AWAIT_SECONDS = 30;
+
+    /** The exercise failed: the binary exists, and something it must do it did not do. */
+    private static final int EXIT_FAILED = 1;
+
+    /** Called wrong - no executable named, or the path is not one. */
+    private static final int EXIT_USAGE = 3;
+
+    private NativeSidecarLifecycle() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            System.err.println("usage: NativeSidecarLifecycle <path to the native sidecar executable>");
+            System.exit(EXIT_USAGE);
+        }
+        Path executable = Path.of(args[0]);
+        if (!Files.isExecutable(executable)) {
+            System.err.println("native-sidecar-lifecycle: not an executable file: " + executable);
+            System.exit(EXIT_USAGE);
+        }
+
+        try {
+            argumentsAreRefusedBecauseConfigurationTravelsTheProtocol(executable);
+            announcesItsPortRefusesASessionAndReleasesTheSocket(executable);
+        } catch (AssertionError failed) {
+            System.err.println();
+            System.err.println("NATIVE SIDECAR LIFECYCLE FAILED: " + failed.getMessage());
+            System.exit(EXIT_FAILED);
+        }
+        System.out.println("native sidecar lifecycle: all arms passed against " + executable);
+    }
+
+    /**
+     * The same rule the JVM entry point keeps (R39/U7): configuration arrives in {@code Configure} over the
+     * protocol, so an argument is a caller misunderstanding and the binary refuses to start. Asserted here
+     * because it is the cheapest possible proof that the image contains <em>this</em> {@code Main} rather than
+     * something that merely starts.
+     */
+    private static void argumentsAreRefusedBecauseConfigurationTravelsTheProtocol(Path executable)
+            throws Exception {
+        var process = new ProcessBuilder(executable.toString(), "--bootstrap-servers", "localhost:9092").start();
+        String stdout = readFully(process.getInputStream());
+        String stderr = readFully(process.getErrorStream());
+        assertTrue(process.waitFor(AWAIT_SECONDS, TimeUnit.SECONDS), "the refusal must exit rather than serve");
+
+        assertEquals(Main.EXIT_USAGE, process.exitValue(), "an argument must be a usage exit");
+        assertTrue(stderr.contains("Configure"),
+                "the refusal must say where configuration actually goes, but stderr was: " + stderr);
+        assertTrue(!stdout.contains(Main.PORT_LINE_PREFIX), "a refused start must not announce a port");
+        pass("arguments refused with exit " + Main.EXIT_USAGE + ", naming Configure");
+    }
+
+    /**
+     * The spawning contract end to end, against a process with no JVM in its environment: the port on stdout
+     * line one, a real gRPC session answered {@code UNIMPLEMENTED} and naming the missing engine, a clean exit
+     * when the parent's write end closes, and the socket gone afterwards.
+     */
+    private static void announcesItsPortRefusesASessionAndReleasesTheSocket(Path executable) throws Exception {
+        var builder = new ProcessBuilder(executable.toString());
+        // Nothing inherited: no JAVA_HOME, no PATH, no TMPDIR. See the class javadoc for what this does and
+        // does not establish - it is a "needs nothing from its environment" arm, not a native-image test.
+        builder.environment().clear();
+        var process = builder.start();
+
+        ManagedChannel channel = null;
+        try {
+            int port = awaitAnnouncedPort(process);
+            assertTrue(port > 0, "an ephemeral port was requested, so it must be a real bound port");
+            pass("started with an empty environment and announced port " + port + " on stdout line one");
+
+            try (var probe = new Socket()) {
+                probe.connect(loopback(port), 2_000);
+                assertTrue(probe.isConnected(), "the announced port must be the one actually serving");
+            }
+
+            channel = NettyChannelBuilder.forAddress(InetAddress.getLoopbackAddress().getHostAddress(), port)
+                    .usePlaintext()
+                    .build();
+            assertSessionRefused(channel);
+            pass("a session is answered UNIMPLEMENTED, naming the missing engine");
+
+            // The parent dies: closing the write end of the inherited pipe is the primary signal.
+            process.getOutputStream().close();
+
+            assertTrue(process.waitFor(AWAIT_SECONDS, TimeUnit.SECONDS),
+                    "the sidecar must stop when its parent does, rather than outliving it");
+            assertEquals(0, process.exitValue(), "a parent death is an ordinary shutdown, not a failure");
+
+            assertSocketRefused(port);
+            pass("exited 0 on parent death and released the socket");
+        } finally {
+            if (channel != null) {
+                channel.shutdownNow();
+            }
+            process.destroyForcibly();
+        }
+    }
+
+    /** Opens a session and requires it to terminate with {@code UNIMPLEMENTED} rather than hang or answer. */
+    private static void assertSessionRefused(ManagedChannel channel) throws InterruptedException {
+        var terminated = new CountDownLatch(1);
+        var failure = new AtomicReference<Throwable>();
+        List<ProxyMessage> replies = Collections.synchronizedList(new ArrayList<>());
+
+        StreamObserver<ClientMessage> session = ProxyServiceGrpc.newStub(channel).session(new StreamObserver<>() {
+            @Override
+            public void onNext(ProxyMessage message) {
+                replies.add(message);
+            }
+
+            @Override
+            public void onError(Throwable thrown) {
+                failure.set(thrown);
+                terminated.countDown();
+            }
+
+            @Override
+            public void onCompleted() {
+                terminated.countDown();
+            }
+        });
+        session.onNext(ClientMessage.newBuilder().setConfigure(Configure.newBuilder().addTopics("input")).build());
+
+        assertTrue(terminated.await(AWAIT_SECONDS, TimeUnit.SECONDS), "the session must terminate rather than hang");
+        Throwable observed = failure.get();
+        assertTrue(observed instanceof StatusRuntimeException,
+                "the session must fail with a gRPC status, but was: " + observed);
+        Status status = ((StatusRuntimeException) observed).getStatus();
+        assertEquals(Status.Code.UNIMPLEMENTED.value(), status.getCode().value(),
+                "the refusal must be UNIMPLEMENTED, but was " + status);
+        String description = String.valueOf(status.getDescription());
+        assertTrue(description.contains("hosts no Parallel Consumer engine"),
+                "the refusal must name what is missing, but said: " + description);
+        assertTrue(replies.isEmpty(), "a build with no engine must not answer a Configure with anything");
+    }
+
+    /** The socket is the observable that separates "the process returned" from "the server shut down". */
+    private static void assertSocketRefused(int port) {
+        try (var probe = new Socket()) {
+            probe.connect(loopback(port), 2_000);
+            throw new AssertionError("the listener must be gone once the sidecar has shut down, not merely "
+                    + "unattended - port " + port + " still answers");
+        } catch (IOException expected) {
+            // The refused connection is the assertion.
+        }
+    }
+
+    /**
+     * Reads the sidecar's stdout until the port line appears, rather than sleeping a guessed interval. Reading
+     * the stream is also what proves the line arrives FIRST: a client parses line one, so anything the process
+     * printed before it would show up here as a parse failure rather than being skipped over.
+     */
+    private static int awaitAnnouncedPort(Process process) throws IOException {
+        var reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+        String line = reader.readLine();
+        if (line == null) {
+            throw new AssertionError("the sidecar printed nothing before exiting; exit value "
+                    + (process.isAlive() ? "(still running)" : String.valueOf(process.exitValue())));
+        }
+        if (!line.startsWith(Main.PORT_LINE_PREFIX)) {
+            throw new AssertionError("stdout line one must be the port line, but was: " + line);
+        }
+        return Integer.parseInt(line.substring(Main.PORT_LINE_PREFIX.length()).trim());
+    }
+
+    private static InetSocketAddress loopback(int port) {
+        return new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
+    }
+
+    private static String readFully(java.io.InputStream stream) throws IOException {
+        return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private static void assertTrue(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+
+    private static void assertEquals(int expected, int actual, String message) {
+        if (expected != actual) {
+            throw new AssertionError(message + " (expected " + expected + ", got " + actual + ")");
+        }
+    }
+
+    private static void pass(String what) {
+        System.out.println("  ok: " + what);
+    }
+}

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/NativeSidecarLifecycle.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/NativeSidecarLifecycle.java
@@ -135,8 +135,12 @@ public final class NativeSidecarLifecycle {
         var process = builder.start();
 
         ManagedChannel channel = null;
-        try {
-            int port = awaitAnnouncedPort(process);
+        // The reader wraps the process's stdout, so it is opened and closed alongside the process rather than
+        // abandoned inside the helper that reads one line from it. Closing it closes that pipe, which is why
+        // it happens here at the end and not the moment the port line has been parsed.
+        try (var announced = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            int port = awaitAnnouncedPort(process, announced);
             assertTrue(port > 0, "an ephemeral port was requested, so it must be a real bound port");
             pass("started with an empty environment and announced port " + port + " on stdout line one");
 
@@ -209,9 +213,8 @@ public final class NativeSidecarLifecycle {
      * the stream is also what proves the line arrives FIRST: a client parses line one, so anything the process
      * printed before it would show up here as a parse failure rather than being skipped over.
      */
-    private static int awaitAnnouncedPort(Process process) throws IOException {
-        var reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
-        String line = reader.readLine();
+    private static int awaitAnnouncedPort(Process process, BufferedReader stdout) throws IOException {
+        String line = stdout.readLine();
         if (line == null) {
             throw new AssertionError("the sidecar printed nothing before exiting; exit value "
                     + (process.isAlive() ? "(still running)" : String.valueOf(process.exitValue())));

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/NativeSidecarLifecycle.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/NativeSidecarLifecycle.java
@@ -5,8 +5,8 @@ package bz.stub.parallelconsumer.proxy;
 
 import bz.stub.parallelconsumer.proxy.protocol.v1.ClientMessage;
 import bz.stub.parallelconsumer.proxy.protocol.v1.Configure;
-import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyMessage;
 import bz.stub.parallelconsumer.proxy.protocol.v1.ProxyServiceGrpc;
+import bz.stub.parallelconsumer.proxy.transport.RecordingProxyMessageObserver;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -22,12 +22,7 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Drives an already-built <b>native executable</b> of {@link Main} through the sidecar's whole lifecycle, and
@@ -173,33 +168,20 @@ public final class NativeSidecarLifecycle {
         }
     }
 
-    /** Opens a session and requires it to terminate with {@code UNIMPLEMENTED} rather than hang or answer. */
+    /**
+     * Opens a session and requires it to terminate with {@code UNIMPLEMENTED} rather than hang or answer.
+     * <p>
+     * The observer is the transport tests' {@link RecordingProxyMessageObserver} rather than a third
+     * hand-rolled copy of the same three fields.
+     */
     private static void assertSessionRefused(ManagedChannel channel) throws InterruptedException {
-        var terminated = new CountDownLatch(1);
-        var failure = new AtomicReference<Throwable>();
-        List<ProxyMessage> replies = Collections.synchronizedList(new ArrayList<>());
-
-        StreamObserver<ClientMessage> session = ProxyServiceGrpc.newStub(channel).session(new StreamObserver<>() {
-            @Override
-            public void onNext(ProxyMessage message) {
-                replies.add(message);
-            }
-
-            @Override
-            public void onError(Throwable thrown) {
-                failure.set(thrown);
-                terminated.countDown();
-            }
-
-            @Override
-            public void onCompleted() {
-                terminated.countDown();
-            }
-        });
+        var recorder = new RecordingProxyMessageObserver();
+        StreamObserver<ClientMessage> session = ProxyServiceGrpc.newStub(channel).session(recorder);
         session.onNext(ClientMessage.newBuilder().setConfigure(Configure.newBuilder().addTopics("input")).build());
 
-        assertTrue(terminated.await(AWAIT_SECONDS, TimeUnit.SECONDS), "the session must terminate rather than hang");
-        Throwable observed = failure.get();
+        assertTrue(recorder.terminated.await(AWAIT_SECONDS, TimeUnit.SECONDS),
+                "the session must terminate rather than hang");
+        Throwable observed = recorder.error.get();
         assertTrue(observed instanceof StatusRuntimeException,
                 "the session must fail with a gRPC status, but was: " + observed);
         Status status = ((StatusRuntimeException) observed).getStatus();
@@ -208,7 +190,7 @@ public final class NativeSidecarLifecycle {
         String description = String.valueOf(status.getDescription());
         assertTrue(description.contains("hosts no Parallel Consumer engine"),
                 "the refusal must name what is missing, but said: " + description);
-        assertTrue(replies.isEmpty(), "a build with no engine must not answer a Configure with anything");
+        assertTrue(recorder.messages.isEmpty(), "a build with no engine must not answer a Configure with anything");
     }
 
     /** The socket is the observable that separates "the process returned" from "the server shut down". */

--- a/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/RecordingProxyMessageObserver.java
+++ b/parallel-consumer-proxy/src/test/java/bz/stub/parallelconsumer/proxy/transport/RecordingProxyMessageObserver.java
@@ -15,12 +15,16 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Client-side observer that records what the proxy said and how the stream ended, so wire tests can await a
  * reply or a terminal status without hand-rolling latches per test.
+ * <p>
+ * <b>Public because it is used from outside this package</b> - {@code NativeSidecarLifecycle} drives a spawned
+ * native sidecar and needs the same three fields for the same reason. It was made public rather than copied
+ * when the duplicate-code check flagged the copy, which is what that check is for.
  */
-class RecordingProxyMessageObserver implements StreamObserver<ProxyMessage> {
+public class RecordingProxyMessageObserver implements StreamObserver<ProxyMessage> {
 
-    final List<ProxyMessage> messages = Collections.synchronizedList(new ArrayList<>());
-    final AtomicReference<Throwable> error = new AtomicReference<>();
-    final CountDownLatch terminated = new CountDownLatch(1);
+    public final List<ProxyMessage> messages = Collections.synchronizedList(new ArrayList<>());
+    public final AtomicReference<Throwable> error = new AtomicReference<>();
+    public final CountDownLatch terminated = new CountDownLatch(1);
 
     @Override
     public void onNext(ProxyMessage message) {


### PR DESCRIPTION
Part of astubbs/parallel-consumer#242.

depends on astubbs/parallel-consumer#384

## Description

**The sidecar shell compiles and runs as a native executable.** `bin/native-image-sidecar.sh`
builds `parallel-consumer-proxy`'s `Main` into a GraalVM native image and then drives *that binary*
through the whole spawning contract astubbs/parallel-consumer#384 established in the JVM: it refuses
arguments, binds an ephemeral loopback port, announces it on stdout line one, answers a real gRPC
session with `UNIMPLEMENTED` naming the missing engine, exits 0 when its parent's write end closes,
and leaves the socket released.

**Why that is worth its own rung.** The whole proposition of the sidecar is that a Go, Python or Ruby
team is handed an executable rather than a JVM dependency. Until something builds one, that is a
claim. The JVM suite cannot substitute: closed-world analysis can drop a class the JVM would have
loaded, and the failure appears only in the binary - so the transport, the generated stubs and
protobuf surviving into an image is a distinct thing to evidence, and this evidences it.

### Where this came from

Extraction **A6** of `docs/plans/2026-08-31-001-process-god-branch-decomposition-plan.md`, re-cut
against the no-engine shell. The source is `feats/native-image-sidecar`, a sibling of
astubbs/parallel-consumer#340 stacked on the demo chain rather than a free-standing branch, which is
why the plan says it can only land on `master` after the shell exists.

**Almost none of that branch's delta ported, and the reason is the finding below.** Its two commits
are a vendored 1,049-line `reachability-metadata.json` and an inflight note; its proof was a Python
demo driving a sidecar with a real engine and a real broker. There is no engine and no demo here, so
the proof became the lifecycle instead - which is the claim this rung can actually make - and the
metadata turned out not to be needed at all.

### It re-parents the story astubbs/parallel-consumer#340 tells

That PR currently has to make two arguments at once: "the sidecar can be a native image" *and* "the
engine can be embedded in the host process over a C ABI, with no gRPC anywhere". The first is now
this rung's, evidenced against `master`-bound code. What astubbs/parallel-consumer#340 is left
asking is the sharper question: native distribution is settled, so now **eliminate the process
boundary too**. The module README says which artifact is which, so a reader arriving at either one
finds the other.

## The recipe is one flag, and the shortness is the finding

```
native-image --no-fallback -cp <module classes>:<runtime deps> bz.stub.parallelconsumer.proxy.Main
```

No `--initialize-at-build-time`, no `META-INF/native-image` configuration of any kind. That is not
this rung being clever; **it is this rung having no engine**. The same build on
`feats/native-image-sidecar` needed logback initialised at build time and the vendored reachability
capture, because that tree carries the Kafka client and a logging backend - the two things
closed-world analysis cannot follow. Neither is on this module's runtime classpath.

Reproduced rather than assumed: the plain build against a classpath *with* logback fails exactly as
that branch's table records it, on `Logger.name` not being available during analysis. The script's
header carries the flag list for the day it is needed, and the inflight note tells the engine rung
what it inherits.

**`--no-fallback` is the load-bearing flag.** Without it native-image quietly emits a fallback image
that still requires a JVM: it builds green, runs fine on the build machine, and destroys the whole
proposition.

## Measured

macOS/arm64, Oracle GraalVM 23, JDK 17 for the Maven half:

```
native-image-sidecar: building .../parallel-consumer-proxy/target/pc-sidecar
Finished generating 'pc-sidecar' in ~40s          (27M Mach-O 64-bit executable arm64)
native-image-sidecar: driving the executable through the sidecar lifecycle
  ok: arguments refused with exit 2, naming Configure
  ok: started with an empty environment and announced port 60054 on stdout line one
  ok: a session is answered UNIMPLEMENTED, naming the missing engine
  ok: exited 0 on parent death and released the socket
native sidecar lifecycle: all arms passed
```

Whole script, including the Maven build: about a minute.

## Sabotage, with a control on either side

```
=== CONTROL: untouched tree ===
  ok: arguments refused ... ok: announced port ... ok: UNIMPLEMENTED ... ok: released the socket
EXIT=0

=== ARM: delete the UNIMPLEMENTED refusal from NoEngineSessionService, rebuild the image ===
  ok: arguments refused with exit 2, naming Configure
  ok: started with an empty environment and announced port 60038 on stdout line one
NATIVE SIDECAR LIFECYCLE FAILED: the session must terminate rather than hang
EXIT=1

=== RESTORED from a pristine copy: control arm again, tree byte-identical ===
EXIT=0

=== SECOND CONTROL: the exercise pointed at /bin/cat ===
NATIVE SIDECAR LIFECYCLE FAILED: an argument must be a usage exit (expected 2, got 1)
```

The arm's **shape** is the finding, not its colour: removing the refusal does not fail fast, it
hangs, and the run lands on its bounded latch - the same shape astubbs/parallel-consumer#384 reported
for the equivalent JVM arm, now confirmed to survive into the image.

## A prediction that was refuted

The empty-environment arm was written believing it would catch a fallback image or a JVM in disguise.
**It does not.** The control - the same exercise pointed at a shell wrapper that `exec`s the JVM
sidecar by absolute path - **passes every arm**, because a hard-coded path needs no environment
either. So the claim was narrowed rather than kept: the arm establishes that the binary needs nothing
from its environment, and the class javadoc now names `--no-fallback` as the thing that actually
keeps a JVM out, at build time. The script additionally refuses an output that starts `#!`, which is
the failure a hand-rolled "native build" really has.

## What CI added that the local runs could not

**Both rows failed on their first push, for a real reason the developer box structurally cannot
show.** The classpath step runs on this module alone - it has to, since `-am` would run
`dependency:build-classpath` on every module and each would overwrite the same output file - so it
resolves the sibling snapshots from the LOCAL REPOSITORY, and `test-compile` never puts them there.
Every machine that has ever built this project has them already; a clean runner does not, and went
to Central looking for a snapshot. Fixed by installing rather than test-compiling, which makes the
two environments behave the same. The lane earned its keep before it had run green once.

`fetch-depth: 0` went on the checkout in the same change: the Maven build these rows run includes
the copyright header check, and on a shallow clone it cannot find the fork-point commit, so it warns
and skips itself - a check reporting success without having run.

**Then both rows passed, and Linux is the result worth having:**

```
native sidecar: linux    Finished generating 'pc-sidecar' in 2m 6s
native sidecar: macos    Finished generating 'pc-sidecar' in 1m 41s
  ok: arguments refused with exit 2, naming Configure
  ok: started with an empty environment and announced port ... on stdout line one
  ok: a session is answered UNIMPLEMENTED, naming the missing engine
  ok: exited 0 on parent death and released the socket
native sidecar lifecycle: all arms passed
```

Same one-flag recipe on linux/x64 as on macOS/arm64, GraalVM 23.0.2 on both.

## The duplication reports, read

Both engines flagged **one new clone this PR introduced** - `NativeSidecarLifecycle` had hand-rolled
the same `StreamObserver` that the transport tests' `RecordingProxyMessageObserver` already is - and
they were right. That class is now public and reused, rather than a third copy of nine lines that
must all agree about how a session ends. After the change **PMD CPD and jscpd each report zero new
clones** and duplication at or below the base branch's.

**`dups: similarity` still lists `MainTest` <-> `NativeSidecarLifecycle` at ~45%, and that one is
vocabulary rather than code.** The two files talk about the same five things - a port line, a
session, `UNIMPLEMENTED`, parent death, a released socket - because they assert the same claims
against two different subjects, which is the entire point of the second file existing. Both clone
detectors, which compare token sequences rather than word bags, find nothing between them. The
`TestConventionsArchTest` family moves +0.8 for the mechanical reason it always does: the proxy
module gained a file, and that wrapper is required by `EveryModuleWiresUpArchUnitTest` and cannot be
inherited - the same finding and the same answer as astubbs/parallel-consumer#380,
astubbs/parallel-consumer#383 and astubbs/parallel-consumer#384.

## Optional by construction

**No Maven profile, no plugin, no reactor module runs native-image.** `./mvnw install`, `bin/build.sh`
and every existing CI lane behave identically on a machine that has never heard of GraalVM. An absent
toolchain prints a banner and exits 0, or exits 2 under `PC_NATIVE_IMAGE_STRICT` - the same three-way
contract and the same exit codes as `bin/foreign-client-step.sh`, which
astubbs/parallel-consumer#380 established for exactly this question, reused rather than reinvented.

`.github/workflows/native-image.yml` sets strict on both rows, which is what keeps the lenient default
honest. **Linux is the new information**: the source branch recorded "untried: Linux" among its own
gaps, and Linux is where a sidecar is actually deployed. macOS/arm64 is the regression guard for the
build proven above. Two JDKs per row, GraalVM reached by path so the project's JDK 17 stays
`JAVA_HOME`.

## The verifier is a program, not a JUnit test

Its subject does not exist until a GraalVM toolchain has run, so a test would have to skip itself on
nearly every machine - and a skip is indistinguishable from a pass in a surefire summary, which this
repository treats as the failure mode rather than the convenience. The decision about an absent
toolchain is made once, out loud, in the script. `NativeSidecarLifecycle` uses nothing but the JDK,
gRPC and the generated stubs, so the module's test-classes plus the runtime classpath is enough to
run it.

## A trap worth naming, because it is silent

`dependency:build-classpath` takes `-DincludeScope`, **not** `-Dmdep.includeScope`; the ignored
spelling yields the TEST classpath. The first image built here contained JUnit, Mockito, ArchUnit
and - worse - the core test-jar's `logback.xml`, so the shipped binary carried this repository's test
logging configuration as its own. The build is green either way.

## The analysis surfaces, read

`bin/check-pr-analysis-surfaces.sh 385` reported **three findings on lines this diff wrote and none
inherited**, all SpotBugs, all in the lifecycle verifier. One was real and is fixed; two are
declined with a reason:

- **`OBL_UNSATISFIED_OBLIGATION` - "may fail to close stream". Correct, and fixed at the site rather
  than suppressed.** `awaitAnnouncedPort` wrapped the process's stdout in a `BufferedReader`, read
  one line and dropped it. The reader is now opened beside the process it belongs to and closed with
  it, with the helper taking it as a parameter - which is also why it is not closed the moment the
  port line is parsed: closing it closes that pipe, and the pipe must outlive the parse.
- **`UNENCRYPTED_SOCKET` (2).** Both are connections to this sidecar's own loopback listener, which
  is plaintext **by design**: loopback-only plus one-connection admission is what this module offers
  *instead* of transport security, and `ProxyServer`'s javadoc and the module README carry the
  reasoning. A probe that used TLS would be probing a listener that does not exist. Same finding and
  same answer as the five astubbs/parallel-consumer#384 declines.

## Two gaps recorded rather than glossed

- `docs/inflight/core-the-native-sidecar-is-easy-only-while-it-has-no-engine.md` - addressed to the
  engine rung. Both things that make this build a one-flag affair stop being true in that one commit,
  and **neither failure appears at build time**. It names the prior capture as a starting point and
  says why it is not an answer: traced over one unordered 20-record run with no failures, retries,
  rebalance or transactional commit.
- `docs/inflight/core-the-sidecar-ships-no-logging-backend-so-its-own-logs-go-nowhere.md` - found
  while building the image and belonging to neither. `slf4j-api` is on the runtime classpath and no
  provider is, so every line the sidecar logs reaches a no-op logger. **The JVM sidecar behaves
  identically**, so it is not a native-image problem; it is left open because the fix is a packaging
  decision and nothing is blocked on it yet.

## Deliberately NOT in this rung

Named so neither side reads as an oversight: the engine and everything downstream of it; the FFI
`--shared` C-ABI embedding, which is a different artifact and stays astubbs/parallel-consumer#340's;
the eleven language demos, including the Python one that drove the source branch's proof; the
conformance suite; and any distributed binary - nothing is published, and building one is not part of
the ordinary build.

## How it was verified

- `bin/check-all.sh` on its **real exit code: 0**. Two gates report CANNOT RUN,
  `check-proto-breaking.sh` and `check-proto-lint.sh`, both wanting a `buf` this machine does not
  have; both belong to a base rung, neither is affected by this diff, and CI is where they run.
- `COPYRIGHT_CHECK_REQUIRE_FORK_POINT=1 bin/check-copyright-headers.sh` - 0 violations against a real
  fork point.
- `./mvnw -pl parallel-consumer-proxy -am test` - **BUILD SUCCESS**, core and both proxy modules
  green.
- The native build and its lifecycle exercise, plus the sabotage and control arms above - locally
  on macOS/arm64, and on both CI rows.

## Known-red, and not a fault

- **`Check PR Dependencies`** is red until astubbs/parallel-consumer#384 and its parents merge. That
  is the dependency gate doing its job on a stack rung.
- **`claude-review`** is red until somebody asks for a review; the rungs below are in the same state.

roadmap-stage: N/A - `language-proxy-sidecar` sits at `limited-poc` on the strength of
astubbs/parallel-consumer#293's content, and its `done_when` is clients validated by the conformance
suite. A native executable of an engine-less shell moves neither, so the stage is unchanged.

## Checklist

- [x] Docs updated - the module `README.md` gains the build section and stops listing the native
  image among what is not here; `docs/data/module-maturity.yaml` and
  `docs/data/testing-evidence.yaml` record what the second lifecycle arm evidences and what it does
  not; two `docs/inflight/` notes carry the open gaps.
- [x] User-facing feature documentation data added under `docs/features/` - N/A - nothing here is a
  user-facing feature. No binary is distributed, the module publishes to no registry, and the sidecar
  still cannot be configured to reach a broker. The release-documentation records it does earn are
  the maturity and evidence rows, which are in this PR.
- [x] Tests added/updated - the lifecycle exercise is new, and it was proven able to fail by
  sabotaging the code it asserts on, with control arms on either side. The module's existing suite is
  untouched and green.
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - neither was run. The diff is one script,
  one verification program and documentation, and the reasoning behind each decision is written at
  the site; the cheaper place to spend a review is `@claude review this` on the PR, which is also the
  only route that opens inline threads.
