### PR TITLE
feat(streams) astubbs#255: run a Kafka Streams topology on PC per-key concurrency, behind an opt-in switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,7 +315,7 @@ bin/performance-test.sh      # performance tests (substantial hardware)
 | `parallel-consumer-vertx` | Vert.x integration for async HTTP |
 | `parallel-consumer-reactor` | Project Reactor integration |
 | `parallel-consumer-mutiny` | SmallRye Mutiny integration (Quarkus) |
-| `parallel-consumer-streams` | Kafka Streams (alpha, **unpublished**) - build-time patching of Kafka's internals; its own README owns the mechanism |
+| `parallel-consumer-streams` | Kafka Streams (alpha, **unpublished**, seam **off by default**) - runs a topology's processor chain on PC's worker pool via build-time patching of Kafka's internals; its own README owns the mechanism and the switch |
 | `parallel-consumer-examples` | Example implementations for each module |
 
 ## Key Architecture Decisions

--- a/NOTICE
+++ b/NOTICE
@@ -15,6 +15,8 @@ from Apache Kafka:
   org.apache.kafka.streams.processor.internals.AbstractProcessorContext
   org.apache.kafka.streams.processor.internals.ProcessorContextImpl
   org.apache.kafka.streams.processor.internals.RecordCollectorImpl
+  org.apache.kafka.streams.processor.internals.StreamTask
+  org.apache.kafka.streams.processor.internals.StreamThread
 
 Apache Kafka
 Copyright 2024 The Apache Software Foundation
@@ -22,7 +24,9 @@ Licensed under the Apache License, Version 2.0.
 https://kafka.apache.org
 
 These files have been CHANGED by Antony Stubbs and contributors, to make Kafka Streams'
-processor context and record collector safe to drive from more than one thread. The
-changes are expressed as, and limited to, the patch tracked at
+processor context and record collector safe to drive from more than one thread, to let a
+task dispatch its records through Parallel Consumer instead of its own partition group,
+and to let a worker completion end the stream thread's poll wait. The changes are
+expressed as, and limited to, the patch tracked at
 parallel-consumer-streams/src/main/patch/pc-streams.patch; no Apache Kafka source is
 redistributed in this repository. See parallel-consumer-streams/README.md.

--- a/docs/inflight/branch-ks-streams-workstream.md
+++ b/docs/inflight/branch-ks-streams-workstream.md
@@ -4,13 +4,17 @@
 <!-- inflight-impact: coordination -->
 
 
-A signpost, not a handover. **What is on `master` is the fork/build machinery only** - the
-`parallel-consumer-streams` module shell, its patch/regenerate discipline and the upstream-suite
-oracle, landed as the base of a reconstructed stack. It patches Kafka's processor context and record
-collector for thread safety and stops there: no PC execution seam, no dispatcher, no records through
-PC, and the module is **not published**. Everything else - the seam, the semantics, the measurements,
-the plan documents and the workstream's own in-flight notes - is still off `master`, so an agent
-listing this directory sees only sideways references to it and no way in.
+A signpost, not a handover. **What is on `master` is the machinery and the minimal execution seam** -
+the `parallel-consumer-streams` module, its patch/regenerate discipline, the upstream-suite oracle,
+and (second rung) `PcTaskDispatcher`, wake-on-work and the `StreamTask`/`StreamThread` hunks that
+reach them. Records do go through PC, **with the seam switched on**, which it is not by default.
+
+**What is still off `master`** is most of what makes that seam usable: refusing unsupported topology
+shapes (so today an unsupported one is dispatched rather than refused - the reason the seam defaults
+off), task lifecycle and rebalance, stream time and punctuation, the benchmarks and the seam-on
+upstream evidence lane, the example module, and the plan documents and in-flight notes of the
+workstream. The module is **not published** either way. So an agent listing this directory still
+sees sideways references to most of the work and no way in.
 
 **What it is.** Give a Kafka Streams topology PC's per-key concurrency by replacing Streams' record
 selection with PC's `WorkManager` and running the processor chain on PC's worker pool, applied as a
@@ -27,8 +31,8 @@ Reading the PR head as the state of the work is the mistake this note exists to 
 (`docs/plans/2026-08-31-001-process-god-branch-decomposition-plan.md`, Wagon B) reconstructs it as a
 fresh stack cut from `master`, taking content from the forest by copy: the forest stays as the
 evidence record, and the PRs document what the design *is* rather than how it was discovered. The
-machinery described above is the first rung; the seam is the second. The forest branches are not
-retired by any of this and are still where the unlanded work lives.
+machinery described above is the first rung; the seam is the second, and both have landed. The forest
+branches are not retired by any of this and are still where the unlanded work lives.
 <!-- file-refs: N/A - the decomposition plan arrives on master with its own PR, not with the first rung -->
 
 

--- a/docs/inflight/streams-dispatch-switch-is-jvm-wide-not-per-instance.md
+++ b/docs/inflight/streams-dispatch-switch-is-jvm-wide-not-per-instance.md
@@ -1,0 +1,46 @@
+# The Kafka Streams dispatch switch is JVM-wide, not per `KafkaStreams` instance
+
+<!-- inflight-type: feature -->
+<!-- inflight-impact: misdirection -->
+<!-- inflight-state: deferred - an implementation exists and is unproven; see "What is already written" -->
+
+`parallel-consumer-streams` decides whether a `StreamTask` dispatches through Parallel Consumer by
+reading process-wide static state (`PcDispatchSwitch`), set by a system property or by a test. **Two
+`KafkaStreams` instances in one JVM therefore cannot be configured differently** - the second one
+silently inherits whatever the first arranged.
+
+Shipped that way deliberately with the execution seam (astubbs/parallel-consumer#255). The seam
+defaults **off**, so the JVM-wide reading is "this JVM opted in", which is a coherent thing for a
+preview to mean; and there is no seam through `KafkaStreams` to hand a `StreamTask` a collaborator,
+which is why the static exists at all rather than being an oversight. It stops being coherent the
+moment anyone embeds two topologies with different requirements, which is ordinary in a service.
+
+## What is already written, and what is missing
+
+Branch `feats/streams-dispatch-streamsconfig-property` carries an implementation: a
+`PcDispatchSettings` type read off `StreamsConfig`, with precedence *config > system property >
+default*. It is **unfinished in the way that matters** - it has no test showing two `KafkaStreams`
+instances in one JVM getting different settings, which is the entire claim. Every single-instance
+test passes against the process-global design too, so the suite it has cannot distinguish the new
+design from the old one.
+
+Two things to know before picking it up:
+
+- **The branch was cut from the feasibility study, not from wake-on-work**, so it predates
+  `PcWorkSignal` and its diff against today's module *removes* the split poll wait. It is a merge,
+  not a cherry-pick, and the patch must be reconciled as generated Java and re-derived - never merged
+  as a patch file. `parallel-consumer-streams/bin/regen-patch.sh`'s header owns that procedure.
+- **The missing test is a known blocker, not merely unwritten.** Three agents stopped at exactly that
+  test on an API content filter. Wording it prosaically - two instances, two settings, assert each
+  reads its own - is what gets through; describing it in terms of what it defeats does not.
+
+## Why it was not folded into the seam
+
+Judged at the seam rung: taking it would have meant reconciling three files and the patch against a
+different base, and then either shipping the per-instance switch without its proof or blocking the
+seam on the test that has already stopped three attempts. Neither is a minimal execution seam. The
+seam's own default being off lowers the cost of waiting - nobody gets PC dispatch they did not ask
+for while this is outstanding.
+
+Related: the module README's "Turning it on, and why it is off" section points here, and
+`PcDispatchSwitch`'s javadoc states why the static is the only thing that reaches the call site.

--- a/docs/inflight/test-streamthreadtest-invalid-timestamps-flake.md
+++ b/docs/inflight/test-streamthreadtest-invalid-timestamps-flake.md
@@ -1,0 +1,74 @@
+# `StreamThreadTest` invalid-timestamps case is flaky, and it breaks the gate this module rests on
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+`StreamThreadTest.shouldLogAndRecordSkippedRecordsForInvalidTimestamps[3]` fails intermittently in the
+upstream-Kafka suite that `parallel-consumer-streams` runs against its patched classes. Diagnosed
+2026-08-11 with a control arm; carried onto the reconstructed stack when it was sighted again on the
+refusal-envelope branch.
+
+**Mechanism.** The test embeds `Thread.currentThread().getName()` in an expected log line, while with
+`processingThreadsEnabled=true` the line is logged from Kafka's own processing thread. The names do not
+match, so the assertion depends on which thread got there. It is Kafka's test, on Kafka's code, and no
+patch in this module touches either side of that race.
+
+**Established pre-existing, with a control arm.** Two failures in five runs at the then-HEAD *without*
+the investigating agent's changes, against three in seven with them. The control arm itself needed a
+second attempt: the first re-ran already-built binaries and would have "proved" the flake pre-existing
+on no evidence at all. What made it real was asserting the changed symbol was absent from the compiled
+class before trusting the run.
+
+<!-- post-merge: checked-begin -->
+<!-- Reads the same after the merge: the PR is cited as the landed change that recorded this sighting,
+     which is a permanent link, and no live branch is named. -->
+**Sighted again while the refusal envelope was being verified** (astubbs/parallel-consumer#389),
+seam off: once in seven consecutive runs of the module's whole `test` phase on one machine - green on
+the immediate re-run, and green in every other run, including both arms of that work's before/after
+control. Lower than the original rate, on one machine, which is a data point rather than a new
+measurement.
+
+**And then on CI, on the very next run** - the `Unit Tests` lane of the same PR, failing on
+parameterisation `[3]` with the whole upstream execution otherwise clean. That is worth more than
+another tally mark: every sighting until now had been on a developer machine, so "a loaded laptop"
+was still available as an explanation. It is not any more. This flake reaches the shared lane, where
+it costs every branch in the chain a red build and a re-run, and where the temptation to re-run until
+green is strongest.
+<!-- post-merge: checked-end -->
+
+**Sighted twice more on the example rung's CI** (astubbs/parallel-consumer#391): across four
+attempts of its Unit lane, the sequence was flake, Maven Central timeout, green, flake - two
+failures in the three attempts that actually ran the suite, at the full run count the oracle
+produces on this stack. Consistent with the forest's originally measured rate rather than below it.
+The example agent deliberately stopped re-running to chase green, which is the habit this note
+exists to prevent.
+
+## Why this matters more than one flaky test
+
+**Every agent working on this module is told that "Kafka's own suites, zero failures with the seam
+off" is a non-negotiable gate.** That instruction is not satisfiable as stated: it will go red some of
+the time on any branch in this chain, through no fault of the change under test. An unsatisfiable gate
+is worse than no gate - it teaches people to re-run until green, which is exactly the habit that lets a
+real regression through.
+
+So the gate needs restating rather than repeating. Options, in rough order of preference:
+
+- **Quarantine it** through the repo's `@Quarantined` mechanism with this diagnosis attached, so the
+  count becomes deterministic and the exclusion is visible. It is not obvious this is even reachable -
+  the case is in Apache Kafka's own compiled test class, which this module runs unmodified and does not
+  recompile, so the annotation has nowhere to go without an exclude in the surefire execution. That is
+  the first thing to establish. Note also that the release gate forbids shipping while the quarantine
+  registry is non-empty, which is a real cost to weigh.
+- **Fix it upstream-style** by not asserting on a thread name, and carry that in the test-fixtures
+  patch - which is where a change to a Kafka test class can actually live.
+- **State the gate as "zero failures other than this named case"**, which is honest but relies on every
+  future agent knowing the exception.
+
+Until then, when this case fails: **do not chase it, and do not "fix" the code under test.** Confirm it
+is this test and this parameterisation, then re-run. Anything else that fails is real.
+
+## Delete when
+
+The outcome is deterministic - the test is fixed, excluded with this diagnosis attached, or the gate is
+restated in the places agents actually read (the module README's verification section, and the surefire
+execution's own comment).

--- a/parallel-consumer-streams/README.md
+++ b/parallel-consumer-streams/README.md
@@ -1,21 +1,54 @@
-# `parallel-consumer-streams` - patching Kafka Streams without vendoring or forking it
+# `parallel-consumer-streams` - a Kafka Streams topology on Parallel Consumer's worker pool
 
-> ## ALPHA. EXPERIMENTAL. NOT PUBLISHED.
+> ## ALPHA. EXPERIMENTAL. NOT PUBLISHED. SEAM OFF BY DEFAULT.
 > This module is in the reactor so the machinery below can be built and reviewed. It is **not**
 > published to Maven Central, deliberately - see
 > [The classpath hazard this module does not solve](#the-classpath-hazard-this-module-does-not-solve).
 > Tracking issue: [astubbs#255](https://github.com/astubbs/parallel-consumer/issues/255).
 
-**What is here today is the build machinery and its oracle, and nothing else.** Apache Kafka Streams'
-`processor.internals` package is package-private, explicitly not an API, and has no seam at the point
-Parallel Consumer needs one. This module establishes a repeatable way to change those internals - one
-that keeps no Apache source in this repository, states the size of the change as a reviewable number,
-and fails at build time rather than at runtime when the change stops applying.
+Apache Kafka Streams parallelises across *partitions*. Inside one partition,
+`PartitionGroup.nextRecord()` hands records over strictly one at a time, so one slow record delays
+everything queued behind it whatever key it carries. That serialisation has no semantic justification
+when the records are on different keys, and removing it is what this module is for: `StreamTask`'s
+record selection is replaced by Parallel Consumer's `WorkManager` and a worker pool, so records on
+distinct keys of one partition run concurrently through the *unmodified* processor chain. A topology's
+own code does not change.
 
-**What is not here: the Parallel Consumer execution seam.** No record goes through Parallel Consumer
-in this module today. `StreamTask` is not patched, there is no dispatcher, and there is no switch. That
-work arrives in the PR stacked on this one, and it is what
-[astubbs#271](https://github.com/astubbs/parallel-consumer/pull/271) was cut from.
+`processor.internals` is package-private, explicitly not an API, and offers no seam where this needs
+one - so the module also carries a repeatable way to change those internals that keeps no Apache
+source in this repository, states the size of the change as a reviewable number, and fails at build
+time rather than at runtime when the change stops applying.
+
+## Turning it on, and why it is off
+
+```
+-Dpc.streams.dispatch.enabled=true
+```
+
+**The seam is OFF by default. This is an opt-in preview, and the reason is a missing refusal rather
+than caution.** Joins, windows, suppression, exactly-once and stream-time punctuation are unsupported
+on the PC path *and are not yet refused* - a topology using one of them is dispatched anyway and gets
+wrong behaviour, with nothing in the log to say so. Until that refusal envelope exists, the only
+honest default is one that cannot silently mis-run a topology nobody checked.
+
+Two further switches, both process-wide for the reason given in
+[`PcDispatchSwitch`](src/main/java/bz/stub/parallelconsumer/streams/PcDispatchSwitch.java) (there is
+no seam through `KafkaStreams` to inject a collaborator):
+
+| Property | Default | What it does |
+|---|---|---|
+| `pc.streams.dispatch.enabled` | `false` | the seam itself |
+| `pc.streams.dispatch.poolSize` | `4` | worker threads per task, and PC's `maxConcurrency` |
+| `pc.streams.wakeOnWork.enabled` | `true` | the split poll wait; unreachable while the seam is off |
+
+A value that is neither `true` nor `false` throws rather than being read as the default - a typo in
+the property that selects an arm would otherwise produce a run that looks like the arm you asked for
+and is not.
+
+**Being process-wide is a real limitation, not a simplification.** Two `KafkaStreams` instances in one
+JVM cannot be configured differently. What that would take, and the unfinished implementation of it,
+is recorded in
+[`docs/inflight/streams-dispatch-switch-is-jvm-wide-not-per-instance.md`](../docs/inflight/streams-dispatch-switch-is-jvm-wide-not-per-instance.md).
 
 ---
 
@@ -48,6 +81,8 @@ through a second, smaller patch, for the reason given below.
 | `AbstractProcessorContext` | the current record context and current processor node move from two `protected` fields to thread-confined ones | stock Streams holds one of these per task and gets away with it because exactly one thread is ever inside the task |
 | `ProcessorContextImpl` | reads and writes them through the accessors instead of the inherited fields | it is a subclass doing `getfield`/`putfield` on those fields, so leaving it alone defeats the confinement *with no compile error to say so* |
 | `RecordCollectorImpl` | two `HashMap`s become `ConcurrentHashMap`s | written from the producer's I/O thread for every in-flight send; the compiler would never have demanded this class, so it is named rather than discovered |
+| `StreamTask` | record selection and the commit gates ask the dispatcher instead of the partition group; the processor chain runs on a worker | **the seam itself**, and the only class here that references Parallel Consumer - which is what let the machinery rung land the three above without it |
+| `StreamThread` | the poll wait is split: a short poll, then a wait on our own condition that a worker completion ends | it owns the only blocking wait in the run loop, and nothing else can split it - see [wake-on-work](#wake-on-work-why-the-poll-wait-is-split) |
 
 That is the whole patch. The set is **named in the pom, not discovered**
 (`patched.classes`), and the stop-threshold is stated there: if it has to grow much past a dozen, the
@@ -69,14 +104,19 @@ itself, beautifully. So each claim here has a control.
 
 [`ShadowedClassLoadingTest`](src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java)
 asserts it directly rather than inferring it from behaviour: each generated class loads from a code
-source under `/classes/` and not a `.jar`; `StreamTask` and `StreamThread`, which are deliberately
-*not* generated, still load from the jar - which is what makes this shadowing rather than a fork; and
-every generated class shares both a package name and a **classloader** with them, because different
-classloaders split the package and break package-private access while the names still match.
+source under `/classes/` and not a `.jar`; `PartitionGroup`, `RecordQueue` and `TaskManager`, which
+are deliberately *not* generated, still load from the jar - which is what makes this shadowing rather
+than a fork; and every generated class shares both a package name and a **classloader** with them,
+because different classloaders split the package and break package-private access while the names
+still match.
 
-`StreamTask` is the sharp one. It is the immediate neighbour of all three patched classes and the
-class the seam will patch next, so "it still comes from the jar" is the tightest available statement
-that the generated set is exactly what the pom declares.
+The jar-resident three are chosen for adjacency, not convenience: `PartitionGroup` is the buffer the
+seam bypasses, `RecordQueue` is reached into by the seam's own record preparation, and `TaskManager`
+constructs `StreamTask`. If generation ever sprawled past the declared set, those are the first three
+it would reach.
+
+`StreamTask` and `StreamThread` used to be that list, on the machinery rung, precisely so the
+assertion would have to flip *visibly* on the day the generated set grew. It flipped here.
 
 ### An empty patch is a no-op, and that is checked by the tooling
 
@@ -89,22 +129,58 @@ between the technique and the change.
 ### Apache Kafka's own test suite, run against the patched classes
 
 Kafka publishes its **compiled** tests to Maven Central. This module takes them as a `test`-classifier
-dependency and points a dedicated surefire execution at them, so Kafka's own
-`StreamTaskTest`, `RecordCollectorTest` and `ProcessorContextImplTest` exercise **our**
-`AbstractProcessorContext`, **our** `ProcessorContextImpl` and **our** `RecordCollectorImpl`. Nothing
-is excluded, rewritten, recompiled or relaxed. It runs in the module's normal `test` phase, on every
-build, with no profile and no flag.
+dependency and points a dedicated surefire execution at them, so Kafka's own `StreamTaskTest`,
+`StreamThreadTest`, `RecordCollectorTest` and `ProcessorContextImplTest` exercise **our** copies of
+the five patched classes. Nothing is excluded, rewritten, recompiled or relaxed. It runs in the
+module's normal `test` phase, on every build, with no profile and no flag.
 
 That is the behaviour-preservation claim, and it is the strongest one available: **anything the patch
 broke that Kafka tested, fails here.**
 
-> **Re-derive the counts; never copy them.** They move with the patch, with `kafka.version`, and they
-> will move again when the seam arrives. Run the module's whole `test` phase and read the per-class
-> numbers out of `target/surefire-reports-kafka-upstream/`.
+**The claim is about the patch, and it only means anything with the seam OFF**, so that execution
+pins `pc.streams.dispatch.enabled=false` rather than inheriting whatever the default happens to be.
+The pin is not redundant with the default being off today - deleting it would make the oracle
+silently follow the default the day it moves.
+
+Some of `StreamThreadTest` is skipped, by Kafka's own `assumeTrue`/`assumeFalse` on its
+`stateUpdaterEnabled` x `processingThreadsEnabled` parameter matrix. Those assumptions are evaluated
+on the first line of each method, from the test's own parameters, before any patched code runs -
+so nothing in this patch can influence them. That is a mechanism, not a measurement, which is why it
+is stated here without a number.
+
+> **Re-derive the counts; never copy them.** They move with the patch, with `kafka.version`, and with
+> the seam. Run the module's whole `test` phase and read the per-class numbers out of
+> `target/surefire-reports-kafka-upstream/`.
 >
 > **Do not scope the run with `-Dtest=`.** It silently overrides that execution's `<includes>`, so
 > Kafka's suite does not run at all - and the build still goes green, with the number you were
 > checking never computed. It has cost several people a whole run.
+
+### Wake-on-work: why the poll wait is split
+
+`StreamThread` polls the consumer and runs the topology on **one** thread, so blocking in
+`Consumer#poll()` for the full `poll.ms` costs stock Kafka Streams nothing - there is by definition no
+processing it could be doing instead. Hand records to a worker pool and that inverts: records complete
+*during* the poll wait, and neither their completions nor the records they unblock can move until poll
+returns. Worse, the inner work loop breaks back out to poll whenever a pass dispatched nothing - which
+under an asynchronous dispatcher also means "the pool is full" or "every available key is already in
+flight", states that resolve on a worker completion and never on a broker fetch. The loop therefore
+chooses to block at precisely the moments a completion is imminent.
+
+So the patched `StreamThread` polls briefly to collect whatever the broker already has, then waits on
+[`PcWorkSignal`](src/main/java/bz/stub/parallelconsumer/streams/PcWorkSignal.java) for the rest of its
+budget, and a worker completion ends that wait immediately. It is deliberately **not**
+`KafkaConsumer#wakeup()`: that word already means *shutdown* to Kafka Streams, and a wake delivered
+while the thread is not polling arms the *next* poll instead, so a stray completion could swallow a
+shutdown - a failure that shows up once in a thousand shutdowns and never reproduces on demand.
+
+**Wake-on-work was measured as roughly two thirds of the backlog benefit**, by ablating it rather than
+by arguing from mechanism - which had predicted the opposite, that a saturated topic would leave the
+split wait idle. That measurement, its refuted prediction and its arms are owned by
+[`docs/solutions/best-practices/ablate-your-own-change-not-only-the-baseline.md`](../docs/solutions/best-practices/ablate-your-own-change-not-only-the-baseline.md);
+**this rung does not re-derive it and no figure is repeated here**, because the benchmark that
+produces one is a separate unit and a number copied out of its write-up drifts silently from it. What
+this rung ships is the mechanism and the tests that show it is load-bearing.
 
 ---
 

--- a/parallel-consumer-streams/pom.xml
+++ b/parallel-consumer-streams/pom.xml
@@ -18,16 +18,22 @@
     <description>
         ALPHA / EXPERIMENTAL - NOT PRODUCTION READY, AND NOT PUBLISHED.
 
-        Build machinery for patching Apache Kafka Streams internals without vendoring or forking them:
-        the named classes are unpacked from the published kafka-streams sources jar, a tracked patch is
-        applied, and the result is compiled into this module's own target/classes, which precedes the
-        kafka-streams jar on the classpath. Apache Kafka's own compiled test suite is then run against
-        the patched classes as the behaviour-preservation oracle.
+        Runs a Kafka Streams processor chain on Parallel Consumer's WorkManager and worker pool instead
+        of the serial PartitionGroup.nextRecord() -> StreamTask.process() loop, so records on distinct
+        keys of one partition execute concurrently through the unmodified ProcessorNode chain. A
+        topology's own code does not change.
 
-        NO PARALLEL CONSUMER EXECUTION SEAM LIVES HERE YET. The patch carried by this module is limited
-        to the concurrency-safety groundwork inside Kafka's processor context and record collector -
-        changes that Kafka's own suite proves behaviour-preserving. StreamTask's dispatch seam, and the
-        PC dispatcher it calls into, arrive in the PR stacked on this one (issue astubbs#255).
+        THE SEAM IS OFF BY DEFAULT - this is an opt-in preview. Turn it on for a JVM with
+        -Dpc.streams.dispatch.enabled=true. It is off because the refusal envelope that would make it
+        safe for an arbitrary topology does not exist yet: joins, windows, suppression, EOS and
+        stream-time punctuation are NOT supported and are NOT yet refused, so a topology using one
+        gets wrong behaviour rather than an error. PcDispatchSwitch's javadoc owns that reasoning.
+
+        Build machinery: the named classes are unpacked from the published kafka-streams sources jar,
+        a tracked patch is applied, and the result is compiled into this module's own target/classes,
+        which precedes the kafka-streams jar on the classpath. Apache Kafka's own compiled test suite
+        is then run against the patched classes, with the seam OFF, as the behaviour-preservation
+        oracle. Issue astubbs#255.
 
         NO APACHE KAFKA SOURCE IS COMMITTED TO THIS REPOSITORY. The patched Kafka classes are generated
         at build time; only src/main/patch/*.patch is tracked. README.md owns the mechanism and the
@@ -72,9 +78,18 @@
              demanded: it is constructed outside StreamTask, and its non-concurrent maps are written from
              the producer's I/O thread for every in-flight send.
 
+             StreamTask is the execution seam itself - the point where a record is selected and the processor
+             chain is run. It is the only class here that references Parallel Consumer, which is what let the
+             rung below this one (astubbs#379) carry the three above without it.
+
+             StreamThread owns the poll wait, and nothing else can split it. Wake-on-work needs a worker
+             completion to end that wait instead of letting it run out; see PcWorkSignal. It has the widest
+             blast radius of the five if a future Kafka reshapes the poll phase, which is why it has its own
+             kill switch and why StreamThreadTest joins the upstream oracle below.
+
              If this list has to grow much past a dozen, that sprawl is itself the answer to "how little had
              to change" - see the "Do not apply when" section of the technique write-up. -->
-        <patched.classes>org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java,org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java,org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java</patched.classes>
+        <patched.classes>org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java,org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java,org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java,org/apache/kafka/streams/processor/internals/StreamTask.java,org/apache/kafka/streams/processor/internals/StreamThread.java</patched.classes>
 
         <!-- Module-local and explicitly versioned on purpose: pinning jackson-databind in root
              dependencyManagement forces WireMock (parallel-consumer-vertx) onto an incompatible Jackson and
@@ -110,9 +125,14 @@
     </properties>
 
     <dependencies>
-        <!-- No parallel-consumer-core dependency at compile scope, deliberately: nothing in this module's
-             main output is Parallel Consumer code. It arrives with the execution seam that needs it. The
-             test-scoped core test-jar below is only for the shared ArchUnit convention rules. -->
+        <!-- The seam's own dependency, and the reason this module stopped being pure build machinery: the
+             generated StreamTask calls into PcTaskDispatcher, which drives core's WorkManager directly. -->
+        <dependency>
+            <groupId>bz.stub.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
@@ -140,7 +160,12 @@
 
         <!-- Tests -->
 
-        <!-- The shared TestConventionRules that TestConventionsArchTest points ArchUnit at. -->
+        <!-- The shared TestConventionRules that TestConventionsArchTest points ArchUnit at, and
+             BrokerIntegrationTest, which is what BrokerStreamsIntegrationTest extends to reach a
+             TestContainers broker. Core's MAIN classes come from the compile-scope declaration above, which
+             the test jar also needs at runtime: a test-scoped dependency's own dependencies do not come
+             with it, and the core tests jar registers MyRunListener as a JUnit TestExecutionListener
+             through ServiceLoader, which reaches into core's StringUtils. -->
         <dependency>
             <groupId>bz.stub.parallelconsumer</groupId>
             <artifactId>parallel-consumer-core</artifactId>
@@ -148,21 +173,40 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
-        <!-- Core's MAIN classes, test scope only, because the test-jar above needs them at runtime and a
-             test-scoped dependency's own dependencies do not come with it. The core tests jar registers
-             MyRunListener as a JUnit TestExecutionListener through ServiceLoader, and that listener reaches
-             into core's StringUtils - so without this every single test EVENT logs a
-             NoClassDefFoundError warning and a full stack trace. Nothing fails, which is the point: the
-             build stays green and the log becomes unreadable. -->
-        <dependency>
-            <groupId>bz.stub.parallelconsumer</groupId>
-            <artifactId>parallel-consumer-core</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- The broker-backed arms: BrokerIntegrationTest starts a TestContainers Kafka, and the seam-on
+             proofs need a real StreamThread against a real broker - a TopologyTestDriver runs the topology
+             on the calling thread and so cannot exercise either the worker pool or the poll wait. -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- BrokerIntegrationTest (core test-jar) uses commons-lang3, and test-scope dependencies are not
+             transitive - without this the container fails to start with NoClassDefFoundError. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -421,23 +465,29 @@
                             <dependenciesToScan>
                                 <dependency>org.apache.kafka:kafka-streams</dependency>
                             </dependenciesToScan>
-                            <!-- Only the tests of the classes we patch, plus the task that drives them.
-                                 Scanning the whole jar would run ~2500 tests of code this module never
-                                 touches, and drown the signal. -->
+                            <!-- Only the tests of the classes we patch. Scanning the whole jar would run
+                                 ~2500 tests of code this module never touches, and drown the signal.
+
+                                 StreamThreadTest joined this list with the fifth patched class. The rule is
+                                 "the tests of the classes we patch", so patching StreamThread without it
+                                 would have left the widest-blast-radius class as the one part of the patch
+                                 with no upstream suite behind it. -->
                             <includes>
                                 <include>org/apache/kafka/streams/processor/internals/StreamTaskTest.java</include>
+                                <include>org/apache/kafka/streams/processor/internals/StreamThreadTest.java</include>
                                 <include>org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java</include>
                                 <include>org/apache/kafka/streams/processor/internals/RecordCollectorTest.java</include>
                             </includes>
                             <reportsDirectory>${project.build.directory}/surefire-reports-kafka-upstream</reportsDirectory>
-                            <!-- The oracle's independence from the seam, pinned here rather than
-                                 inherited. Nothing in this module reads this property yet - the PC
-                                 dispatch seam and its switch arrive in the PR stacked on this one, and a
-                                 switch with nothing to switch would be dead code. What must never happen
-                                 is for this execution to acquire its seam state from whatever default the
-                                 seam later picks: the behaviour-preservation claim only means anything
-                                 with the seam OFF, and it is a claim about the patch, not about a
-                                 default. So the pin is written now, ahead of its reader. -->
+                            <!-- The oracle's independence from the seam. Written by the rung below this one
+                                 (astubbs#379) ahead of any reader; PcDispatchSwitch is now that reader, and
+                                 the pin stays exactly as it was.
+
+                                 It is deliberately NOT redundant with the seam defaulting off. This
+                                 execution's claim - Kafka's own suite passes against the patched classes -
+                                 only means anything with the seam OFF, and it is a claim about the PATCH,
+                                 not about a default. Deleting the pin because the default agrees with it
+                                 today would make the oracle silently follow the default the day it moves. -->
                             <systemPropertyVariables>
                                 <pc.streams.dispatch.enabled>false</pc.streams.dispatch.enabled>
                             </systemPropertyVariables>
@@ -474,10 +524,10 @@
                  Apache code for a rule Apache never adopted, growing the change-set that this module's
                  whole design exists to keep small and re-derivable.
 
-                 Anything of ours that lands in this module later - the execution seam and its
-                 dispatcher - will sit under bz.stub and will NOT be excluded by this pattern, so it
-                 gets the same analysis as every other module. The same scoping decision, for the same
-                 reason, is already made for ArchUnit in TestConventionsArchTest. -->
+                 Everything of ours in this module - PcTaskDispatcher, PcWorkSignal and the rest of the
+                 seam - sits under bz.stub and is NOT matched by this pattern, so it gets the same
+                 analysis as every other module. The same scoping decision, for the same reason, is
+                 already made for ArchUnit in TestConventionsArchTest. -->
             <plugin>
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcDispatchCounters.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcDispatchCounters.java
@@ -1,0 +1,139 @@
+package bz.stub.parallelconsumer.streams;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The dispatch marker, and the registration accounting that goes with it.
+ * <p>
+ * The interesting failures here are silent, so output correctness is not evidence that the seam
+ * worked. Two ways a green test could lie:
+ * <ul>
+ *   <li>Records quietly took the <em>stock</em> path and produced perfect output - the seam was never
+ *       exercised. {@link #getRecordsDispatchedToPool()} is incremented at exactly one place, the submission
+ *       to the worker pool in {@link PcTaskDispatcher}, so a non-zero reading cannot be produced by any
+ *       other route.</li>
+ *   <li>Records were handed to {@code WorkManager} and silently dropped. {@code EpochAndRecordsMap}'s
+ *       constructor skips any partition whose assignment epoch is null with nothing but a {@code log.warn},
+ *       so a missing {@code onPartitionsAssigned} registers <em>zero</em> records and looks like an idle
+ *       topology. {@link #getRecordsOfferedToWorkManager()} counts what went in and
+ *       {@link #getRecordsAcceptedByWorkManager()} counts what survived; a gap between them is that bug.</li>
+ * </ul>
+ * Static for the same reason {@link PcDispatchSwitch} is - there is no seam through {@code KafkaStreams} to
+ * hand a task a collaborator.
+ *
+ * @author Antony Stubbs
+ */
+public final class PcDispatchCounters {
+
+    private static final AtomicLong RECORDS_OFFERED_TO_WORK_MANAGER = new AtomicLong();
+    private static final AtomicLong RECORDS_ACCEPTED_BY_WORK_MANAGER = new AtomicLong();
+    private static final AtomicLong RECORDS_DISPATCHED_TO_POOL = new AtomicLong();
+    private static final AtomicLong RECORDS_COMPLETED_SUCCESSFULLY = new AtomicLong();
+    private static final AtomicLong RECORDS_FAILED = new AtomicLong();
+    private static final AtomicLong SPLIT_POLL_WAITS = new AtomicLong();
+    private static final AtomicLong WAKES_ON_WORK = new AtomicLong();
+
+    private PcDispatchCounters() {
+    }
+
+    /**
+     * Records handed to {@code WorkManager.registerWork} by {@code StreamTask.addRecords}.
+     */
+    public static long getRecordsOfferedToWorkManager() {
+        return RECORDS_OFFERED_TO_WORK_MANAGER.get();
+    }
+
+    /**
+     * Records that survived {@code EpochAndRecordsMap}'s epoch filter. Must equal
+     * {@link #getRecordsOfferedToWorkManager()}; anything less is the silent-drop bug.
+     */
+    public static long getRecordsAcceptedByWorkManager() {
+        return RECORDS_ACCEPTED_BY_WORK_MANAGER.get();
+    }
+
+    /**
+     * <b>The dispatch marker.</b> Incremented only where a {@code WorkContainer} is submitted to the worker
+     * pool - so it is zero unless records genuinely travelled the PC path.
+     */
+    public static long getRecordsDispatchedToPool() {
+        return RECORDS_DISPATCHED_TO_POOL.get();
+    }
+
+    public static long getRecordsCompletedSuccessfully() {
+        return RECORDS_COMPLETED_SUCCESSFULLY.get();
+    }
+
+    public static long getRecordsFailed() {
+        return RECORDS_FAILED.get();
+    }
+
+    /**
+     * <b>The wake-on-work marker.</b> How many times a {@code StreamThread} took the split-wait branch -
+     * short poll, then wait on {@link PcWorkSignal} - instead of blocking in {@code Consumer#poll()} for the
+     * whole {@code poll.ms}.
+     * <p>
+     * Zero means the mechanism never ran, which makes any timing improvement in the same run somebody else's
+     * doing. A benchmark that reads zero here has measured something other than what it claims to measure,
+     * however good the number looks.
+     */
+    public static long getSplitPollWaits() {
+        return SPLIT_POLL_WAITS.get();
+    }
+
+    /**
+     * How many of those waits ended because work became available rather than because the budget ran out.
+     * <p>
+     * Deliberately a second field rather than a flag on the first: {@link #getSplitPollWaits()} answers "did
+     * the code path run", this answers "did it help", and one counter cannot say both. A run with many split
+     * waits and no wakes is the mechanism firing and never paying - a real finding, and invisible if the two
+     * were merged.
+     */
+    public static long getWakesOnWork() {
+        return WAKES_ON_WORK.get();
+    }
+
+    static void onOfferedToWorkManager(final long count) {
+        RECORDS_OFFERED_TO_WORK_MANAGER.addAndGet(count);
+    }
+
+    static void onAcceptedByWorkManager(final long count) {
+        RECORDS_ACCEPTED_BY_WORK_MANAGER.addAndGet(count);
+    }
+
+    static void onDispatchedToPool() {
+        RECORDS_DISPATCHED_TO_POOL.incrementAndGet();
+    }
+
+    static void onCompletedSuccessfully() {
+        RECORDS_COMPLETED_SUCCESSFULLY.incrementAndGet();
+    }
+
+    static void onFailed() {
+        RECORDS_FAILED.incrementAndGet();
+    }
+
+    static void onSplitPollWait() {
+        SPLIT_POLL_WAITS.incrementAndGet();
+    }
+
+    static void onWakeOnWork() {
+        WAKES_ON_WORK.incrementAndGet();
+    }
+
+    /**
+     * Tests reset before each scenario - the counters are process-wide, and surefire reuses forks.
+     */
+    public static void reset() {
+        RECORDS_OFFERED_TO_WORK_MANAGER.set(0);
+        RECORDS_ACCEPTED_BY_WORK_MANAGER.set(0);
+        RECORDS_DISPATCHED_TO_POOL.set(0);
+        RECORDS_COMPLETED_SUCCESSFULLY.set(0);
+        RECORDS_FAILED.set(0);
+        SPLIT_POLL_WAITS.set(0);
+        WAKES_ON_WORK.set(0);
+    }
+}

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcDispatchSwitch.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcDispatchSwitch.java
@@ -1,0 +1,186 @@
+package bz.stub.parallelconsumer.streams;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+/**
+ * The one switch that decides whether a {@code StreamTask} feeds records to Parallel Consumer's
+ * {@code WorkManager} or to Kafka Streams' own {@code PartitionGroup}.
+ * <p>
+ * <b>Single path, switched - never both.</b> The plan's KTD8 forbids registering records into both: nothing
+ * would drain the partition group, {@code StreamTask.addRecords} pauses a partition once its buffer passes
+ * {@code maxBufferedSize}, and the run stalls with the consumer paused and no error anywhere to say why.
+ * So this is a switch, not a fan-out.
+ * <p>
+ * <h2>It defaults to OFF, and this is an opt-in preview</h2>
+ * Turn it on for a whole JVM with {@code -Dpc.streams.dispatch.enabled=true}, or per test with
+ * {@link #enable(int)}.
+ * <p>
+ * <b>The reason is a missing refusal, not caution.</b> Joins, windows, suppression, exactly-once and
+ * stream-time punctuation are unsupported on the PC path <em>and are not yet refused</em> - a topology using
+ * one of them is dispatched anyway and gets wrong behaviour with nothing in the log to say so. Until the
+ * refusal envelope exists, the only honest default is one that cannot silently mis-run a topology nobody
+ * checked. When it lands, the default becomes a real choice again rather than a hedge.
+ * <p>
+ * <b>This reverses an inherited decision, and the argument it reverses was a different one.</b> The seam
+ * defaulted <em>on</em> in the feasibility study (astubbs#271) on the grounds that depending on a separate,
+ * loudly-labelled alpha artifact <em>is</em> the opt-in, so demanding a system property as well is friction
+ * that buys nothing. That is still a good argument, and it is why this is not written as "on is unsafe":
+ * it beats the objection it was aimed at, which was that an earlier revision defaulted off merely so a
+ * control-arm test would stay stock without having to say so. A test concern must never be paid for by
+ * every user of the artifact, and it is not being paid for here - the arms below still state their
+ * requirement at each site. What the artifact-is-the-opt-in argument does not cover is a user who opts in
+ * to <em>per-key concurrency</em> and gets <em>silently altered semantics</em> on a topology shape nobody
+ * refused. Restore the on-by-default the moment that gap closes; do not restore it merely because this
+ * paragraph looks like timidity.
+ * <p>
+ * Tests that want the stock path still say so explicitly with {@link #disable()} rather than leaning on the
+ * default, because a control arm that is only a control by default stops being one the moment the default
+ * moves - which it has now done twice.
+ * <p>
+ * Global mutable static state is normally a smell. Here it is the only thing that reaches the call site:
+ * {@code StreamTask} is constructed several layers inside {@code KafkaStreams}, with no seam through which a
+ * test could hand it a collaborator. An alpha gets to pay that price; a stable product would not.
+ *
+ * @author Antony Stubbs
+ * @see PcTaskDispatcher
+ */
+public final class PcDispatchSwitch {
+
+    /**
+     * Set {@code -Dpc.streams.dispatch.enabled=true} to turn the seam on for a whole JVM. Unset, or
+     * {@code =false}, leaves stock Kafka Streams dispatch in place. Tests should call
+     * {@link #enable(int)} / {@link #disable()} instead, so they can put it back afterwards.
+     */
+    public static final String ENABLED_PROPERTY = "pc.streams.dispatch.enabled";
+
+    /**
+     * Worker threads per task, and simultaneously PC's {@code maxConcurrency} - see
+     * {@link PcTaskDispatcher}, which uses it for both so that PC never hands out more work than the pool
+     * can start.
+     */
+    public static final String POOL_SIZE_PROPERTY = "pc.streams.dispatch.poolSize";
+
+    /**
+     * Set {@code -Dpc.streams.wakeOnWork.enabled=false} to put the patched {@code StreamThread} back on a
+     * single full-budget {@code Consumer#poll()} - see {@link PcWorkSignal} for what that costs.
+     * <p>
+     * Two reasons this exists rather than the seam being the only switch. It is an escape hatch on a fifth
+     * patched Kafka class, which is the one with the widest blast radius if a future Kafka changes the poll
+     * phase under us. And it is the <b>control arm</b>: the before/after measurement for wake-on-work has to
+     * vary exactly one term, and flipping this leaves the build, the JVM, the broker and the warm-up
+     * identical in a way that comparing against a parent commit never can.
+     */
+    public static final String WAKE_ON_WORK_PROPERTY = "pc.streams.wakeOnWork.enabled";
+
+    private static final int DEFAULT_POOL_SIZE = 4;
+
+    /**
+     * Absent means OFF for the seam, and absent means ON for wake-on-work. The two defaults differ because
+     * the questions differ: the seam asks "may this JVM run topologies through PC at all", which nothing has
+     * yet made safe to answer yes by default, while wake-on-work asks "given that it is running through PC,
+     * should the poll wait be split", where the stock answer is measurably the wrong one and the whole
+     * mechanism exists to fix it. Wake-on-work is unreachable while the seam is off, so it never applies to
+     * a JVM that did not ask for the seam - see {@link #isWakeOnWorkEnabled()}.
+     */
+    private static final boolean SEAM_DEFAULT = false;
+    private static final boolean WAKE_ON_WORK_DEFAULT = true;
+
+    private static volatile boolean enabled = readBooleanProperty(ENABLED_PROPERTY, SEAM_DEFAULT);
+
+    private static volatile int poolSize = Integer.getInteger(POOL_SIZE_PROPERTY, DEFAULT_POOL_SIZE);
+
+    private static volatile boolean wakeOnWork = readBooleanProperty(WAKE_ON_WORK_PROPERTY, WAKE_ON_WORK_DEFAULT);
+
+    private PcDispatchSwitch() {
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Whether the patched {@code StreamThread} should split its poll wait and let a worker completion end it.
+     * <p>
+     * Reports false whenever the seam is off, unconditionally: with records going through Kafka's own
+     * {@code PartitionGroup} there are no workers, nothing can raise the signal, and a split wait would be
+     * pure cost. That keeps the patch's condition to a single call - a seam-off run takes the stock poll
+     * without the patch having to ask two questions.
+     */
+    public static boolean isWakeOnWorkEnabled() {
+        return enabled && wakeOnWork;
+    }
+
+    /**
+     * Turn wake-on-work off (or back on) for this JVM. Intended for the control arm of the benchmark; the
+     * system property is the equivalent for a whole run.
+     */
+    public static void setWakeOnWork(final boolean wakeOnWorkEnabled) {
+        wakeOnWork = wakeOnWorkEnabled;
+    }
+
+    public static int getPoolSize() {
+        return poolSize;
+    }
+
+    /**
+     * Turn PC dispatch on for tasks created from now on. Existing tasks keep whatever they were built with -
+     * the decision is taken once, in the {@code StreamTask} constructor, so that a task cannot change record
+     * paths halfway through a run and leave records stranded in the path it abandoned.
+     *
+     * @param workerPoolSize threads per task; must be at least 1
+     */
+    public static void enable(final int workerPoolSize) {
+        if (workerPoolSize < 1) {
+            throw new IllegalArgumentException("Worker pool size must be at least 1, was " + workerPoolSize);
+        }
+        poolSize = workerPoolSize;
+        enabled = true;
+    }
+
+    /**
+     * Back to stock Kafka Streams dispatch.
+     */
+    public static void disable() {
+        enabled = false;
+    }
+
+    /**
+     * Put the switch back to what this JVM started with - each property if it was set, its default
+     * otherwise. Intended as a test teardown: leaving the switch wherever the last test left it re-creates
+     * exactly the implicit-default coupling that stating each arm's requirement was meant to remove.
+     */
+    public static void resetToDefault() {
+        poolSize = Integer.getInteger(POOL_SIZE_PROPERTY, DEFAULT_POOL_SIZE);
+        enabled = readBooleanProperty(ENABLED_PROPERTY, SEAM_DEFAULT);
+        wakeOnWork = readBooleanProperty(WAKE_ON_WORK_PROPERTY, WAKE_ON_WORK_DEFAULT);
+    }
+
+    /**
+     * Absent takes {@code whenAbsent}; anything that is not {@code true}/{@code false} throws rather than
+     * being silently read as the default. A typo in a property whose whole job is to move the seam would
+     * otherwise leave it wherever it already was, and the run would look like the arm it was asked for while
+     * being nothing of the kind.
+     * <p>
+     * Shared by both switches rather than copied, because that loud-failure rule is the whole point and two
+     * copies is how one of them quietly stops enforcing it. The default is a parameter for the same reason:
+     * the two switches genuinely differ (see {@link #SEAM_DEFAULT}), and a second reader is how they would
+     * drift.
+     */
+    private static boolean readBooleanProperty(final String property, final boolean whenAbsent) {
+        final String raw = System.getProperty(property);
+        if (raw == null) {
+            return whenAbsent;
+        }
+        if ("true".equalsIgnoreCase(raw)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(raw)) {
+            return false;
+        }
+        throw new IllegalArgumentException("System property " + property + " must be 'true' or "
+                + "'false', was '" + raw + "'. Absent, it is "
+                + (whenAbsent ? "ON" : "OFF") + ".");
+    }
+}

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcTaskDispatcher.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcTaskDispatcher.java
@@ -316,15 +316,22 @@ public class PcTaskDispatcher implements Closeable {
         EpochAndRecordsMap<byte[], byte[]> epochTagged =
                 new EpochAndRecordsMap<>(new ConsumerRecords<>(byPartition), workManager.getPm());
 
-        recordsOffered.addAndGet(batch.size());
-        recordsAccepted.addAndGet(epochTagged.count());
-        PcDispatchCounters.onOfferedToWorkManager(batch.size());
-        PcDispatchCounters.onAcceptedByWorkManager(epochTagged.count());
-        if (epochTagged.count() != batch.size()) {
+        // Counted once. EpochAndRecordsMap.count() sums a stream over every partition's record list, so it is
+        // O(records) with an allocation, and this is the poll-batch hot path - it was being called four
+        // times for one answer that cannot change in between. SpotBugs flagged the repetition on the lines
+        // this diff wrote.
+        final int offered = batch.size();
+        final int accepted = epochTagged.count();
+
+        recordsOffered.addAndGet(offered);
+        recordsAccepted.addAndGet(accepted);
+        PcDispatchCounters.onOfferedToWorkManager(offered);
+        PcDispatchCounters.onAcceptedByWorkManager(accepted);
+        if (accepted != offered) {
             // Loud, because the thing being guarded against is silence.
             log.error("PC dropped {} of {} records for {} for want of a partition-assignment epoch - " +
                             "onPartitionsAssigned was not driven for this partition",
-                    batch.size() - epochTagged.count(), batch.size(), partition);
+                    offered - accepted, offered, partition);
         }
 
         workManager.registerWork(epochTagged);

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcTaskDispatcher.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcTaskDispatcher.java
@@ -1,0 +1,742 @@
+package bz.stub.parallelconsumer.streams;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import bz.stub.parallelconsumer.internal.EpochAndRecordsMap;
+import bz.stub.parallelconsumer.internal.PCModule;
+import bz.stub.parallelconsumer.state.WorkContainer;
+import bz.stub.parallelconsumer.state.WorkManager;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * One Parallel Consumer {@code WorkManager}, and the worker pool that drains it, standing in for a
+ * {@code StreamTask}'s {@code PartitionGroup} and the StreamThread that used to walk it.
+ * <p>
+ * The seam is deliberately narrow. Everything that needs Kafka Streams' package-private internals -
+ * deserialisation, timestamp extraction, finding the source node, running the processor chain - stays in the
+ * patched {@code StreamTask}, handed over as an opaque {@link WorkPreparer}. Everything that is Parallel
+ * Consumer's - assignment lifecycle, sharding, ordering, in-flight accounting - lives here, in fork-original
+ * code that is tracked in the repository like any other source file.
+ *
+ * <h2>Threading contract, which is not optional</h2>
+ * {@code WorkManager} is not thread-safe. In real PC, every call into it comes from the single controller
+ * thread; workers report back through a mailbox that the controller drains. This class keeps that discipline
+ * exactly:
+ * <ul>
+ *   <li>{@link #registerRecords} and {@link #dispatchAvailable} are called <b>only from the StreamThread</b>
+ *       (from {@code addRecords} and {@code process} respectively), and only they touch the WorkManager.</li>
+ *   <li>Workers never call the WorkManager. They set the outcome on their own {@code WorkContainer} and drop
+ *       it into {@link #completed}, which the StreamThread drains at the top of the next
+ *       {@link #dispatchAvailable}. That mirrors PC's own {@code workMailBox}.</li>
+ * </ul>
+ *
+ * <h3>The commit surface really is driven from two threads</h3>
+ * The three commit methods once said "StreamThread only" in their javadoc, and {@link #ownerThread} turned
+ * that comment into a check. The comment was false, and the check is what proved it: Kafka Streams'
+ * {@code DefaultStateUpdater} calls {@code StreamTask.maybeCheckpoint} <b>from its own thread</b> for every
+ * task it is restoring, and the patched {@code maybeCheckpoint} asks whether a commit is outstanding before
+ * it refreshes changelog offsets. The honest model, established by walking every caller in
+ * {@code kafka-streams} 3.9.2:
+ * <ul>
+ *   <li>{@link #hasCommitDataOutstanding()} - <b>any thread</b>. The StreamThread reaches it through
+ *       {@code prepareCommit}, {@code validateClean} and {@code commitNeeded()}; the state-updater thread
+ *       reaches it through {@code maybeCheckpoint} on a RESTORING task. It is therefore written as a genuine
+ *       query - it reads two counters and touches neither {@code WorkManager} nor the mailbox.</li>
+ *   <li>{@link #collectCommitData()} and {@link #onCommitSuccess} - <b>owner thread only</b>, still enforced
+ *       by {@link #assertOwnerThread}. Both reach {@code WorkManager}, and Streams only reaches them through
+ *       {@code StreamTask.prepareCommit} and {@code StreamTask.updateCommittedOffsets}, which the state
+ *       updater cannot call: it holds tasks as {@code ReadOnlyTask}, whose {@code prepareCommit} throws and
+ *       whose {@code commitNeeded} throws for an active task. {@code maybeCheckpoint} is the one method it
+ *       calls on the real object.</li>
+ *   <li>{@link #registerRecords} and {@link #dispatchAvailable} - StreamThread, and unguarded because
+ *       {@code addRecords} and {@code process} are hot-path. One known exception, out of scope here and not
+ *       reachable by default: with Streams' private {@code __processing.threads.enabled__} config on,
+ *       {@code DefaultTaskExecutor} calls {@code task.process} from its own thread, which would drive
+ *       {@link #dispatchAvailable} off the owner thread.</li>
+ * </ul>
+ *
+ * <h2>Decisions taken here, and what they cost</h2>
+ * <ul>
+ *   <li><b>KEY ordering, explicitly.</b> This is the whole reason the seam is interesting: a KEY-ordered
+ *       shard hands out at most one record per key at a time, so a Streams topology keeps its per-key
+ *       sequencing while distinct keys run concurrently. Set explicitly rather than left to the default so
+ *       that a future default change cannot silently invalidate the result.</li>
+ *   <li><b>A stub {@code Consumer}, not the Streams consumer.</b> {@code ParallelConsumerOptions.validate()}
+ *       demands a Consumer, and although nothing here calls {@code validate()}, PC's
+ *       {@code onPartitionsAssigned} really does use one: it calls {@code consumer.committed(...)} to
+ *       bootstrap each partition's completed-offset map. Handing it the live Streams consumer would be worse
+ *       than useless - a group that ran stock Streams carries <em>Streams-format</em> metadata in its
+ *       commits, and PC's bootstrap would try to decode that as PC's incomplete-offset payload and fail
+ *       under the default {@code invalidOffsetMetadataPolicy} (FAIL). A {@link MockConsumer} with no
+ *       committed offsets gives every partition a clean state and every record is accepted.
+ *       <p>
+ *       <b>Since U9 the group's commits really do carry PC's data</b> - {@link #collectCommitData} feeds the
+ *       patched {@code StreamTask}'s committable offsets - and the mock bootstrap stays sound even so:
+ *       PC's bootstrap truncation ({@code PartitionState.maybeTruncateBelowOrAbove}) aligns the frontier to
+ *       the first record Streams actually polls after a resume, and only <em>dirty</em> partitions are ever
+ *       collected, so a first commit from a fresh dispatcher cannot regress the group's committed offset.
+ *       What the mock costs is read-back: PC starts blank, so records a previous run completed beyond the
+ *       frontier are replayed rather than skipped - a permitted at-least-once duplicate, recorded in the
+ *       plan as the follow-up.</li>
+ *   <li><b>Retries disabled.</b> PC's answer to a failure is to re-dispatch the record. Here that would
+ *       re-run the entire processor chain, including {@code forward()} calls that already emitted records
+ *       downstream - duplicates stock Streams never produces, since it surfaces the exception to the
+ *       uncaught-exception handler instead. The retry delay is set far beyond any run's lifetime, so a
+ *       failed record is never handed out again. Under KEY ordering that leaves its key's shard blocked
+ *       while every other key keeps flowing, and {@link #pollFailure()} lets the StreamThread surface the
+ *       exception the way stock does.</li>
+ * </ul>
+ *
+ * @author Antony Stubbs
+ * @see PcDispatchSwitch
+ * @see PcDispatchCounters
+ */
+@Slf4j
+public class PcTaskDispatcher implements Closeable {
+
+    /**
+     * Turns a raw record into the work to run on a worker thread.
+     * <p>
+     * {@link #prepare} runs on the <b>StreamThread</b>, inside {@link #dispatchAvailable}, and the
+     * {@link Runnable} it returns runs on a <b>worker</b>. That split is load-bearing: deserialisation and
+     * timestamp extraction go through Kafka Streams' {@code RecordQueue}, which is no more thread-safe than
+     * anything else in {@code processor.internals}, so it has to happen while we are still single-threaded.
+     */
+    public interface WorkPreparer {
+        /**
+         * @return the chain execution to run on a worker, or null if the record was dropped during
+         *         preparation (a bad timestamp, say) and there is nothing to run - it still counts as
+         *         consumed.
+         */
+        Runnable prepare(ConsumerRecord<byte[], byte[]> record);
+    }
+
+    /**
+     * Long enough that no run outlives it. See the retry note in the class javadoc - this is how "disabled"
+     * is expressed, because PC has no "never retry" setting.
+     */
+    static final Duration RETRIES_DISABLED_DELAY = Duration.ofDays(3650);
+
+    /**
+     * The thread that constructed this dispatcher, and the only one allowed to touch {@link WorkManager}
+     * through it.
+     *
+     * <p>Several methods here already document "StreamThread only" in prose. This turns that comment into
+     * a check, because the cost of getting it wrong is silent: {@code WorkManager} and its partition state
+     * are not thread-safe, so a second thread calling in corrupts offset bookkeeping without throwing, and
+     * the damage surfaces later as a commit that covers work which never completed.
+     *
+     * <p>Worth the guard specifically now that the commit surface exists. {@link #collectCommitData} and
+     * {@link #onCommitSuccess} reach {@code WorkManager} directly and sit exactly where a caller wiring up
+     * its own commit path is most likely to call from a commit or scheduler thread rather than the owner.
+     *
+     * <p>{@link #hasCommitDataOutstanding()} was guarded too, and is not any more - not because the rule was
+     * relaxed for it, but because the method no longer breaks it. Kafka Streams asks that question from the
+     * state-updater thread (see the class javadoc), so the answer had to stop coming from a mailbox drain.
+     */
+    private final Thread ownerThread;
+
+    private final Set<TopicPartition> inputPartitions;
+
+    @Getter
+    private final WorkManager<byte[], byte[]> workManager;
+
+    private final ExecutorService workerPool;
+
+    @Getter
+    private final int poolSize;
+
+    /**
+     * Workers' outbox. Drained by the StreamThread only - see the threading contract above.
+     */
+    private final Queue<WorkContainer<byte[], byte[]>> completed = new ConcurrentLinkedQueue<>();
+
+    private final AtomicInteger inFlight = new AtomicInteger();
+
+    private final AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+
+    /**
+     * The condition the StreamThread waits on instead of sitting out the rest of {@code poll.ms}. Captured at
+     * construction, which runs on the StreamThread, so the signal this dispatcher's workers raise is the one
+     * that thread waits on. See {@link PcWorkSignal} for what happens if that ever stops being true (nothing
+     * bad: the thread reverts to the stock poll).
+     */
+    private final PcWorkSignal workSignal;
+
+    /**
+     * Successful completions <b>published</b> into {@link #completed}, counted by whichever thread publishes
+     * one, before it publishes it. With {@link #successesCommitted} this is what lets
+     * {@link #hasCommitDataOutstanding()} answer from any thread without touching {@link WorkManager}.
+     * <p>
+     * Not a second copy of PC's dirty flag that could drift out of step with it: this dispatcher owns both of
+     * that flag's edges. PC turns a partition dirty on exactly the successes that pass through
+     * {@link #completed} ({@code PartitionState.onSuccess}) and clean on exactly the acknowledgements that
+     * pass through {@link #onCommitSuccess} ({@code PartitionState.onOffsetCommitSuccess}). Counting those two
+     * events is the same information as the flag, published where a second thread may read it safely.
+     * <p>
+     * Counted at publication rather than at drain on purpose: the whole point is that a worker finishing must
+     * make the answer true <em>immediately</em>, with no owner-thread drain in between. A count taken at drain
+     * would be thread-safe and wrong, which is worse than the crash it replaced.
+     */
+    private final AtomicLong successesPublished = new AtomicLong();
+
+    /**
+     * Successes {@link #drainCompletions} has fed back to PC. Owner thread only, so a plain field.
+     * <p>
+     * Counted at the drain rather than assumed equal to {@link #successesPublished}, so that a collection can
+     * mark covered exactly what it collected: a worker publishing between the drain and the collection is not
+     * in the collected map, and must stay outstanding.
+     */
+    private long successesDrained;
+
+    /** {@link #successesDrained} as of the last {@link #collectCommitData()}. Owner thread only. */
+    private long successesCollected;
+
+    /**
+     * The completed work a successful commit has actually covered: {@link #successesCollected} as of the last
+     * {@link #onCommitSuccess}. Volatile because {@link #hasCommitDataOutstanding()} reads it from whichever
+     * thread asks; only the owner thread ever writes it.
+     */
+    private volatile long successesCommitted;
+
+    /**
+     * How many records the last {@link #dispatchAvailable} consumed - dispatched to the pool, dropped, or
+     * failed during preparation - or -1 before the first one.
+     * <p>
+     * This, and not "does PC still hold records", is what defines {@link #isQuiescent()}. With retries
+     * disabled a failed record's KEY shard stays blocked forever, and the records queued behind it stay
+     * <em>available</em> in PC's accounting even though PC will never hand them out - so asking the
+     * WorkManager whether work is waiting reports a permanently busy dispatcher and every wait times out.
+     * Asking instead "did the last pump produce anything, and is anything still running" answers the question
+     * actually being asked: is there any point pumping again.
+     */
+    private volatile int lastDispatchCount = -1;
+
+    private final AtomicLong recordsOffered = new AtomicLong();
+    private final AtomicLong recordsAccepted = new AtomicLong();
+    private final AtomicLong recordsDispatched = new AtomicLong();
+    private final AtomicLong recordsSucceeded = new AtomicLong();
+    private final AtomicLong recordsFailed = new AtomicLong();
+
+    private volatile boolean closed;
+
+    /**
+     * @return a dispatcher, or null when the switch is off - null being the patched {@code StreamTask}'s
+     *         signal to keep using its own {@code PartitionGroup}.
+     */
+    public static PcTaskDispatcher createIfEnabled(final String taskName, final Set<TopicPartition> inputPartitions) {
+        if (!PcDispatchSwitch.isEnabled()) {
+            return null;
+        }
+        return new PcTaskDispatcher(taskName, inputPartitions, PcDispatchSwitch.getPoolSize());
+    }
+
+    public PcTaskDispatcher(final String taskName, final Set<TopicPartition> inputPartitions, final int poolSize) {
+        this.inputPartitions = new LinkedHashSet<>(inputPartitions);
+        this.poolSize = poolSize;
+        this.ownerThread = Thread.currentThread();
+
+        ParallelConsumerOptions<byte[], byte[]> options = ParallelConsumerOptions.<byte[], byte[]>builder()
+                .consumer(new MockConsumer<byte[], byte[]>(OffsetResetStrategy.NONE))
+                .ordering(ParallelConsumerOptions.ProcessingOrder.KEY)
+                .maxConcurrency(poolSize)
+                .defaultMessageRetryDelay(RETRIES_DISABLED_DELAY)
+                .build();
+
+        PCModule<byte[], byte[]> module = new PCModule<>(options);
+        this.workManager = module.workManager();
+
+        // Without this, nothing works and nothing says so. WorkManager is a ConsumerRebalanceListener, but
+        // Kafka Streams owns the consumer, so no rebalance callback ever reaches PC. Skip it and
+        // PartitionStateManager.getPartitionState returns null (NPE inside maybeRegisterNewRecordAsWork),
+        // while EpochAndRecordsMap quietly drops every partition whose epoch is null. The second failure is
+        // the dangerous one: zero records registered, no exception, a topology that just looks idle.
+        this.workManager.onPartitionsAssigned(this.inputPartitions);
+
+        AtomicInteger threadCounter = new AtomicInteger();
+        ThreadFactory threadFactory = runnable -> {
+            Thread thread = new Thread(runnable, "pc-streams-" + taskName + "-" + threadCounter.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        };
+        this.workerPool = Executors.newFixedThreadPool(poolSize, threadFactory);
+
+        // Registered LAST, so that a StreamThread can never see a half-built dispatcher through the gate.
+        this.workSignal = PcWorkSignal.registerForCurrentThread(this);
+
+        ACTIVE.add(this);
+        log.info("PC dispatch active for task {} over {} with a pool of {}, KEY ordering, retries disabled",
+                taskName, this.inputPartitions, poolSize);
+    }
+
+    /**
+     * Hand a poll batch to PC instead of to the partition group. Called from the StreamThread only.
+     */
+    public void registerRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
+        List<ConsumerRecord<byte[], byte[]>> batch = new ArrayList<>();
+        for (ConsumerRecord<byte[], byte[]> record : records) {
+            batch.add(record);
+        }
+        if (batch.isEmpty()) {
+            return;
+        }
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> byPartition = new HashMap<>();
+        byPartition.put(partition, batch);
+        EpochAndRecordsMap<byte[], byte[]> epochTagged =
+                new EpochAndRecordsMap<>(new ConsumerRecords<>(byPartition), workManager.getPm());
+
+        recordsOffered.addAndGet(batch.size());
+        recordsAccepted.addAndGet(epochTagged.count());
+        PcDispatchCounters.onOfferedToWorkManager(batch.size());
+        PcDispatchCounters.onAcceptedByWorkManager(epochTagged.count());
+        if (epochTagged.count() != batch.size()) {
+            // Loud, because the thing being guarded against is silence.
+            log.error("PC dropped {} of {} records for {} for want of a partition-assignment epoch - " +
+                            "onPartitionsAssigned was not driven for this partition",
+                    batch.size() - epochTagged.count(), batch.size(), partition);
+        }
+
+        workManager.registerWork(epochTagged);
+    }
+
+    /**
+     * Take whatever PC will hand out, prepare each record on this thread, and run it on a worker. Called from
+     * the StreamThread only.
+     *
+     * @return how many records were CONSUMED from the WorkManager this time round - dispatched to the pool,
+     *         dropped during preparation, or failed at preparation. Not merely pool submissions: the patched
+     *         {@code process()} returns this as its progress signal, and stock's contract is "did the task
+     *         make progress", which a consumed-by-drop record satisfies. Counting only pool submissions made
+     *         {@code process()} report false after consuming a batch of corrupted records - a lie that
+     *         StreamTaskTest catches with assertTrue(task.process(...)) and that stock's TaskExecutor paces
+     *         on.
+     */
+    public int dispatchAvailable(final WorkPreparer preparer) {
+        drainCompletions();
+
+        if (closed) {
+            lastDispatchCount = 0;
+            return 0;
+        }
+
+        // Never ask for more than the pool can start (checked per loop pass below): PC would happily hand
+        // out its full target and the surplus would sit in the executor's queue marked in-flight, which
+        // inflates the concurrency being measured and delays every completion behind it.
+
+        // The pump loops while preparation consumes records SYNCHRONOUSLY (corrupted or dropped records:
+        // completed on this thread, no worker involved). Under KEY ordering a synchronously-consumed
+        // record's key-mate only becomes available once that completion is fed back, and deferring the
+        // feed-back to the next pump would stall the key by a full poll cycle - a poison pill would hold up
+        // its whole key for ~poll.ms. Stock consumes such records inline, so this loop restores parity.
+        // Terminates: every iteration either consumes at least one record from a finite backlog or exits.
+        int consumed = 0;
+        while (true) {
+            int capacity = poolSize - inFlight.get();
+            if (capacity < 1) {
+                break;
+            }
+            List<WorkContainer<byte[], byte[]>> available = workManager.getWorkIfAvailable(capacity);
+            int syncCompleted = 0;
+            for (WorkContainer<byte[], byte[]> work : available) {
+                consumed++;
+                Runnable chainExecution;
+                try {
+                    chainExecution = preparer.prepare(work.getCr());
+                } catch (RuntimeException e) {
+                    // Preparation failed on the StreamThread - deserialisation, most likely. Treat it exactly
+                    // as a processing failure so the record does not vanish from PC's accounting.
+                    recordFailure(work, e);
+                    syncCompleted++;
+                    continue;
+                }
+
+                if (chainExecution == null) {
+                    // Dropped during preparation - consumed, nothing to run. Still a success as far as PC is
+                    // concerned, and so still commit-outstanding, hence publishSuccess and not a bare add.
+                    work.onUserFunctionSuccess();
+                    publishSuccess(work);
+                    syncCompleted++;
+                    continue;
+                }
+
+                inFlight.incrementAndGet();
+                recordsDispatched.incrementAndGet();
+                PcDispatchCounters.onDispatchedToPool();
+                workerPool.execute(() -> runOnWorker(work, chainExecution));
+            }
+            if (syncCompleted == 0) {
+                break;
+            }
+            // Feed the synchronous outcomes back so their key-mates become available to this same pump.
+            drainCompletions();
+        }
+        lastDispatchCount = consumed;
+        return consumed;
+    }
+
+    private void runOnWorker(final WorkContainer<byte[], byte[]> work, final Runnable chainExecution) {
+        try {
+            chainExecution.run();
+            work.onUserFunctionSuccess();
+            recordsSucceeded.incrementAndGet();
+            PcDispatchCounters.onCompletedSuccessfully();
+            publishSuccess(work);
+        } catch (Throwable t) {
+            recordFailure(work, t);
+        } finally {
+            inFlight.decrementAndGet();
+            // ORDER MATTERS, and it looks arbitrary: the signal goes AFTER the decrement, not with the
+            // completion above. Signal first and the woken StreamThread drains the completion, then computes
+            // capacity = poolSize - inFlight against a count this thread has not yet decremented, dispatches
+            // nothing, and parks again - a full poll-budget stall, microseconds wide, that would never
+            // reproduce on demand.
+            // Raised on the failure path too, via this finally: a failed record frees a pool slot exactly like
+            // a successful one, and the failure branch is the one a later refactor forgets.
+            //
+            // KNOWN RESIDUAL, and this ordering narrows it rather than closing it. A StreamThread that
+            // reaches PcWorkSignal's wait between the add and the decrement above leaves on the pending
+            // outcome without any signal, and still reads the stale count.
+            //
+            // AN EARLIER VERSION OF THIS COMMENT UNDERSTATED THE BOUND, and code review caught it: it said
+            // "only bites at poolSize 1 - at poolSize >= 2 the spare slot absorbs it". That is wrong. The
+            // stale read overstates inFlight by exactly one, so it bites whenever the OTHER poolSize - 1
+            // slots are already busy, at any pool size - which under load is the normal state, not a corner.
+            // At poolSize 1 that condition is vacuously true, which is what made it look like a poolSize-1
+            // defect. What IS bounded is the cost: dispatchAvailable reads capacity 0, dispatches nothing,
+            // and the next wait takes a poll budget before trying again with a correct count. One poll
+            // budget, no hang, no lost record.
+            //
+            // Closing it properly means splitting this counter in two - a pool-capacity count the worker owns
+            // and decrements BEFORE enqueuing, and an outstanding count the StreamThread owns and decrements
+            // as it drains - so that neither question is ever answered from the other's window. Note that
+            // simply hoisting this decrement above completed.add does NOT work: it moves the identical window
+            // onto PcWorkSignal's gate instead, where a zero inFlight with an undrained outcome is the state
+            // hasActiveWork() exists to catch. Deliberately not done here: it re-keys every reader of
+            // getInFlightCount(), and the defect costs one poll budget and cannot hang.
+            workSignal.signalWorkAvailable();
+        }
+    }
+
+    /**
+     * Publish a successful outcome to the owner thread, and make it visible to
+     * {@link #hasCommitDataOutstanding()} in the same movement.
+     * <p>
+     * The count goes up <b>before</b> the container is queued, never after: the invariant the commit query
+     * rests on is that nothing sits in {@link #completed} uncounted. Reversed, a completion could be drained
+     * and folded into PC while the counter still said nothing had happened.
+     * <p>
+     * The single publication point for successes is the point. Failures deliberately do not come through here
+     * - see {@link #recordFailure}.
+     */
+    private void publishSuccess(final WorkContainer<byte[], byte[]> work) {
+        successesPublished.incrementAndGet();
+        completed.add(work);
+    }
+
+    /**
+     * A failure is published to the owner thread like a success, but is <b>not</b> counted towards
+     * {@link #hasCommitDataOutstanding()}, because it does not make a commit worth attempting: PC leaves the
+     * offset incomplete and {@code PartitionState.onFailure} is a no-op, so the partition never turns dirty.
+     * <p>
+     * That asymmetry is why the query counts successes and not the mailbox's size. Counting the mailbox would
+     * report a commit outstanding after a poison pill - forever, since retries are disabled and the record
+     * never succeeds - and {@code validateClean} would turn that into a spurious {@code TaskMigratedException}
+     * on an otherwise clean close.
+     */
+    private void recordFailure(final WorkContainer<byte[], byte[]> work, final Throwable cause) {
+        work.onUserFunctionFailure(cause);
+        recordsFailed.incrementAndGet();
+        PcDispatchCounters.onFailed();
+        firstFailure.compareAndSet(null, cause);
+        completed.add(work);
+    }
+
+    /**
+     * Feed worker outcomes back to PC. Owner thread only - {@code handleFutureResult} mutates shard and
+     * partition state and PC's in-flight counter, none of which tolerate concurrent callers. This is the one
+     * place that reaches PC on behalf of another thread's work, which is why every caller of it carries the
+     * owner-thread rule, and why {@link #hasCommitDataOutstanding()} is no longer one of them.
+     */
+    private void drainCompletions() {
+        WorkContainer<byte[], byte[]> work;
+        while ((work = completed.poll()) != null) {
+            // Read the outcome before handing the container over - handleFutureResult ends the flight and
+            // hands the container to shard and partition state, and nothing promises it stays readable.
+            final boolean succeeded = work.isUserFunctionSucceeded();
+            workManager.handleFutureResult(work);
+            if (succeeded) {
+                successesDrained++;
+            }
+        }
+    }
+
+    /**
+     * The first processing failure since the last call, cleared as it is returned, so the caller can surface
+     * it the way stock Kafka Streams surfaces one - out of the thread that drives processing.
+     *
+     * @return the failure, or null
+     */
+    public Throwable pollFailure() {
+        return firstFailure.getAndSet(null);
+    }
+
+    /**
+     * The frontier and its encoded holes, for every dirty partition - what the consumer-group commit should
+     * carry. Owner thread only, like every WorkManager touch: Streams reaches this only through
+     * {@code StreamTask.prepareCommit}, which the state updater cannot call.
+     * <p>
+     * Completions are drained first, so work that has already finished is folded into the answer - but
+     * nothing waits: records still in flight stay incomplete, which is precisely what keeps the frontier
+     * below them. A commit-time drain would reintroduce the head-of-line stall this module exists to remove.
+     * <p>
+     * Collection does not clear anything. PC's dirty state clears only on {@link #onCommitSuccess}, so a
+     * commit that fails after collection simply leaves the partition dirty and the next collection returns
+     * the same (or newer) data - nothing is stranded.
+     */
+    public Map<TopicPartition, OffsetAndMetadata> collectCommitData() {
+        assertOwnerThread("collectCommitData");
+        drainCompletions();
+        // What this collection covers is what the drain just folded in - the DRAINED count, never the
+        // published one. A worker that publishes from here on is not in the map below, so pinning the
+        // published count instead would let onCommitSuccess mark its record covered by a commit that never
+        // carried it, and the record would be lost on the next crash.
+        successesCollected = successesDrained;
+        return workManager.collectCommitDataForDirtyPartitions();
+    }
+
+    /**
+     * Whether a commit is worth attempting: completed work exists that no successful commit has covered.
+     * <p>
+     * <b>Callable from any thread</b>, alone on this surface, and the only reason it may be is that it is a
+     * genuine query - it compares two counters and touches neither {@link WorkManager} nor the completion
+     * mailbox, so it mutates nothing and races nothing. It has to be: Kafka Streams' {@code DefaultStateUpdater}
+     * asks a restoring task this question from its own thread, through {@code StreamTask.maybeCheckpoint}.
+     * While the answer came from a mailbox drain, that call reached non-thread-safe {@code WorkManager} and
+     * partition state from a second thread, concurrently with the StreamThread.
+     * <p>
+     * The drain stays where it belongs, on the owner-thread paths - {@link #dispatchAvailable} every pump, and
+     * {@link #collectCommitData()} immediately before it reads the frontier - so removing it from here strands
+     * nothing. Kafka Streams always follows a true answer here with {@code prepareCommit}, which collects, and
+     * collection drains.
+     * <p>
+     * Still PC's dirty question rather than a parallel answer to it (KTD-S7's grain): see
+     * {@link #successesPublished} for why counting these two events is the same information as PC's flag, and
+     * why the count is taken at publication rather than at drain.
+     */
+    public boolean hasCommitDataOutstanding() {
+        return successesPublished.get() > successesCommitted;
+    }
+
+    /**
+     * The other half of the commit protocol: report a <em>successful</em> commit back, so PC can mark the
+     * covered work clean. The only caller of PC's {@code setClean} - skip this and every partition stays
+     * dirty forever, which turns "commit when needed" into "commit every interval, unconditionally".
+     * Owner thread only.
+     * <p>
+     * Marks covered only what {@link #collectCommitData()} last collected, never what has completed since.
+     * That is the same window PC protects internally with
+     * {@code PartitionState.stateChangedSinceCommitStart}: a worker finishing between collection and this
+     * acknowledgement was not in the committed map, so it stays outstanding and the next cycle commits it.
+     */
+    public void onCommitSuccess(final Map<TopicPartition, OffsetAndMetadata> committed) {
+        assertOwnerThread("onCommitSuccess");
+        workManager.onOffsetCommitSuccess(committed);
+        successesCommitted = successesCollected;
+    }
+
+    /**
+     * Fails fast when a {@link WorkManager}-touching method is called off the owning thread.
+     *
+     * <p>Deliberately an {@link IllegalStateException} naming both threads rather than an assertion: an
+     * assertion disappears without {@code -ea}, and this is exactly the class of mistake that produces no
+     * symptom at the call site.
+     */
+    private void assertOwnerThread(final String method) {
+        final Thread current = Thread.currentThread();
+        if (current != ownerThread) {
+            // Locale.ROOT, not the default locale: forbiddenapis rejects the one-argument overload, and the
+            // Kafka exclusion that covers the generated sources deliberately does not cover ours.
+            throw new IllegalStateException(String.format(Locale.ROOT,
+                    "%s touches WorkManager and is owner-thread-only, but was called from '%s'; the owner is '%s'",
+                    method, current.getName(), ownerThread.getName()));
+        }
+    }
+
+    /** Whether either close path has run. A closed dispatcher hands out no work and accepts no more. */
+    public boolean isClosed() {
+        return closed;
+    }
+
+    public int getInFlightCount() {
+        return inFlight.get();
+    }
+
+    /**
+     * Whether a worker outcome is sitting in the mailbox waiting for the StreamThread to feed it back to PC.
+     * <p>
+     * This is half of {@link PcWorkSignal}'s wake predicate, and it is level-triggered on purpose - the
+     * drain runs on owner-thread paths only, and the one that runs on a normal pass is inside
+     * {@link #dispatchAvailable}, so a StreamThread that is waiting is by definition not draining and a
+     * completion enqueued at any point before or during the wait is still here to be seen. That is what makes
+     * a lost wakeup impossible without any extra state.
+     * <p>
+     * <b>It is only half.</b> Level-triggering assumes the woken thread goes on to reach the drain, and Kafka
+     * can decline to let it - a paused topology skips {@code process()} entirely while the thread stays
+     * RUNNING and keeps polling, so this stays true forever and a wait released on it alone would spin. The
+     * other half is the release generation in {@link PcWorkSignal}; see the {@code workSignals} field there.
+     */
+    public boolean hasPendingCompletions() {
+        return !completed.isEmpty();
+    }
+
+    /** Records this dispatcher handed to {@code registerWork}. */
+    public long getRecordsOffered() {
+        return recordsOffered.get();
+    }
+
+    /** Records that survived {@code EpochAndRecordsMap}'s epoch filter. A shortfall is the silent drop. */
+    public long getRecordsAccepted() {
+        return recordsAccepted.get();
+    }
+
+    /** This dispatcher's share of the dispatch marker - see {@link PcDispatchCounters}. */
+    public long getRecordsDispatched() {
+        return recordsDispatched.get();
+    }
+
+    public long getRecordsSucceeded() {
+        return recordsSucceeded.get();
+    }
+
+    public long getRecordsFailed() {
+        return recordsFailed.get();
+    }
+
+    /**
+     * True when the last pump produced nothing, nothing is running, and no outcome is waiting to be reported
+     * back to PC - which is to say, there is no point pumping again.
+     * <p>
+     * Deliberately <em>not</em> "PC holds no more records". With retries disabled a failed record blocks its
+     * KEY shard permanently while the records behind it stay available in PC's counters, so that definition
+     * reports a busy dispatcher forever and turns a handled failure into a hang.
+     */
+    public boolean isQuiescent() {
+        return lastDispatchCount == 0 && inFlight.get() == 0 && completed.isEmpty();
+    }
+
+    /**
+     * Pump until quiescent or out of time. Only safe from the thread that owns the WorkManager.
+     *
+     * @return true if quiescence was reached
+     */
+    public boolean pumpUntilQuiescent(final WorkPreparer preparer, final Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            dispatchAvailable(preparer);
+            if (isQuiescent()) {
+                return true;
+            }
+            try {
+                Thread.sleep(2);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        drainCompletions();
+        return isQuiescent();
+    }
+
+    /**
+     * Every dispatcher currently alive in this JVM. Exists so a test can reach dispatchers buried inside
+     * running {@code StreamTask}s to {@link #abortClose()} them - the crash-injection surface for the R10
+     * kill-restart proof. Registered at construction, removed on either close path.
+     * <p>
+     * <b>Invariant for callers: any test that constructs a dispatcher must run {@code @Isolated}</b>, because
+     * {@link #abortAllActive()} reaches every live instance in this JVM - including one belonging to a
+     * concurrently running test class. This module inherits concurrent test execution from core's test jar,
+     * so that isolation is load-bearing rather than decorative.
+     */
+    private static final Set<PcTaskDispatcher> ACTIVE = ConcurrentHashMap.newKeySet();
+
+    /** Crash-injection for tests: {@link #abortClose()} every live dispatcher in the JVM. */
+    public static void abortAllActive() {
+        for (PcTaskDispatcher dispatcher : ACTIVE) {
+            dispatcher.abortClose();
+        }
+    }
+
+    /**
+     * A crash, not a shutdown: no drain, no completion feed-back, no revocation, workers interrupted
+     * immediately. Exists for the kill-restart proof (R10) - the orderly {@link #close()} path drains via
+     * the patched {@code suspend()} and commits on the way down, which would hand a simulated crash exactly
+     * the repair pass a real one never gets, and park each test repetition on the pool-termination wait.
+     */
+    public void abortClose() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        ACTIVE.remove(this);
+        // Deregistered on BOTH close paths: a closed dispatcher that still answered PcWorkSignal's gate would
+        // keep its StreamThread on the split-wait branch for work that can never complete.
+        workSignal.deregister(this);
+        workerPool.shutdownNow();
+        log.info("PC dispatch ABORTED over {} - simulating a crash, nothing drained, nothing reported",
+                inputPartitions);
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        ACTIVE.remove(this);
+        workSignal.deregister(this);
+        workerPool.shutdown();
+        try {
+            if (!workerPool.awaitTermination(30, TimeUnit.SECONDS)) {
+                log.warn("PC dispatch worker pool did not drain within 30s; forcing shutdown");
+                workerPool.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            workerPool.shutdownNow();
+        }
+        drainCompletions();
+        workManager.onPartitionsRevoked(new ArrayList<>(inputPartitions));
+        log.info("PC dispatch closed over {}", inputPartitions);
+    }
+}

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcWorkSignal.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcWorkSignal.java
@@ -1,0 +1,404 @@
+package bz.stub.parallelconsumer.streams;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+/**
+ * The condition a {@code StreamThread} waits on instead of sitting out the rest of {@code poll.ms} while
+ * Parallel Consumer workers finish behind its back. <b>Wake-on-work</b> (astubbs#255, item 3).
+ *
+ * <h2>The problem this exists for</h2>
+ * {@code StreamThread} polls the consumer and runs the topology on one thread. Under stock Kafka Streams
+ * blocking in {@code Consumer#poll()} for up to {@code poll.ms} is free - while the thread is parked there
+ * is by definition no processing it could be doing instead, because it is the same thread. Hand records to a
+ * worker pool and that assumption inverts: records complete <em>during</em> the poll wait, and neither their
+ * completions nor the records they unblock can move until poll returns. Throughput starts tracking poll
+ * cadence rather than the work. Measured: at the default {@code poll.ms} of 100ms the single-key control arm
+ * ran at <b>0.69x</b> against stock - the asynchronous path <em>slower</em> than the synchronous one, which
+ * absence of concurrency can never explain.
+ * <p>
+ * It is worse than "an idle loop waits a bit". {@code StreamThread}'s inner work loop breaks back out to poll
+ * whenever a pass dispatched nothing. Under stock that means "the buffers are empty and blocking is correct".
+ * Under an asynchronous dispatcher it <em>also</em> means "the pool is full" or "every available key is
+ * already in flight" - states that resolve on a worker completion and never on a broker fetch. So the loop
+ * reliably chooses to block at exactly the moments a completion is imminent.
+ *
+ * <h2>What this is, and what it deliberately is not</h2>
+ * The patched {@code StreamThread} polls briefly to collect whatever the broker already has, and then waits
+ * <em>here</em> for the rest of its configured budget. A worker completion ends that wait immediately.
+ * <p>
+ * <b>It is not {@code KafkaConsumer#wakeup()}</b>, which is the obvious mechanism and the wrong one.
+ * {@code wakeup()} throws {@code WakeupException} and is the framework's word for <em>shutdown</em>; a wake
+ * delivered while the thread is not polling arms the <em>next</em> poll instead, so a stray completion signal
+ * can swallow a shutdown one - a failure that shows up once in a thousand shutdowns and never reproduces on
+ * demand. Owning the condition costs one small class and removes that entire failure mode.
+ *
+ * <h2>Why no "work is ready" flag</h2>
+ * Both questions below are answered by <b>reading live dispatcher state</b>, never by a boolean this class
+ * maintains alongside it. An edge-triggered flag would have to be armed before the wait and cleared after,
+ * and the arming point necessarily sits <em>after</em> the previous dispatch pass - so a completion landing
+ * in that gap sets a flag nobody reads, gets cleared, and the thread waits out the full budget with work in
+ * hand. That is the same shape as this repository's own silent-stall defect, where a shadow copy of the run
+ * state made a long-poll quietly stop happening and the loop span at ~10kHz
+ * ({@code docs/solutions/test-flakiness/pc-silent-stall-under-contention-2026-07-29.md}). One source of
+ * truth, read directly:
+ * <ul>
+ *   <li><b>Should the wait be split at all?</b> {@link #hasActiveWorkOnCurrentThread()} - is anything in
+ *       flight, or is an outcome waiting to be fed back. If not, the thread takes the stock full-budget poll,
+ *       because nothing can wake it and shortening the poll would only delay broker records.</li>
+ *   <li><b>Should the wait end?</b> An outcome is pending <em>and</em> this wait has not already been
+ *       released for it. The first half is level-triggered and therefore impossible to lose: the completions
+ *       queue is drained <em>only</em> by the StreamThread inside
+ *       {@code PcTaskDispatcher.dispatchAvailable}, and a StreamThread that is waiting here is by definition
+ *       not draining it. A worker enqueues its outcome before it signals, so a signal that races the waiter
+ *       either finds the predicate already true or is delivered under this monitor.</li>
+ * </ul>
+ * The second half - {@link #workSignals} - is not a retreat to an edge-triggered flag, and it is not a
+ * shadow of "is there work": it records only <em>which raises this waiter has already been let out on</em>,
+ * and nothing consults it to decide whether to dispatch. It exists because a level-triggered predicate alone
+ * assumes the woken thread goes on to clear the state, and Kafka does not always let it. See the field for
+ * the paused-topology case that turns that assumption into a pinned core.
+ *
+ * <h2>Scoped per owning thread, and safe when the scoping is wrong</h2>
+ * A single JVM-wide monitor would let one StreamThread's wait be ended by an unrelated task's completion:
+ * correct, but a spin. So signals are keyed by the thread that constructed the dispatcher, which is the
+ * StreamThread - {@code StreamTask} is built by {@code TaskManager} on it.
+ * <p>
+ * If that ever stops being true the lookup simply finds nothing, the gate reads "no work in flight", and the
+ * thread takes the stock poll. <b>The failure mode of mis-scoping is today's behaviour, not a stall</b> -
+ * which is the property that makes it acceptable to depend on a construction thread at all. Owners and
+ * dispatchers are held <b>weakly</b>, so a dispatcher that is never deregistered (Kafka has teardown paths
+ * that drop a task without closing it) cannot turn this registry into a leak; a live dispatcher is always
+ * strongly reachable from its {@code StreamTask} and from {@code PcTaskDispatcher}'s own active set.
+ *
+ * <h2>Raised by work becoming available - not by "a worker finished"</h2>
+ * {@link #signalWorkAvailable()} is named for the condition, not for today's only raiser. Three things can
+ * make work dispatchable and only one arrives through the consumer: broker records (the poll handles those),
+ * a worker completion, and - once retries return - a <b>retry timer</b>, where a record sitting out its
+ * backoff becomes dispatchable with no poll and no completion involved. Retries are disabled today, so the
+ * timer cannot raise this yet; the method is shaped so that it will not need a second one when they return.
+ *
+ * @author Antony Stubbs
+ * @see PcTaskDispatcher
+ * @see PcDispatchSwitch#isWakeOnWorkEnabled()
+ */
+@Slf4j
+public final class PcWorkSignal {
+
+    /**
+     * How long the patched {@code StreamThread} blocks in {@code Consumer#poll()} before handing the rest of
+     * its budget to this class.
+     * <p>
+     * Long enough to collect what the consumer has already fetched - the fetch requests are in flight
+     * regardless, so this is a collection step rather than a wait - and short enough that it contributes
+     * nothing measurable per dispatch. The controlled experiment that found this whole problem ran the entire
+     * {@code poll.ms} at 1ms and brought the single-key overhead from ~1695ms to ~24ms, so 1ms of genuine
+     * polling per pass is demonstrably affordable.
+     * <p>
+     * It is deliberately not {@code Duration.ZERO}: zero is already Kafka's own value for the
+     * "unblock something else" poll phases, and a millisecond gives the fetcher a chance to hand over a
+     * response that landed moments ago rather than deferring it to the next pass.
+     */
+    public static final Duration SHORT_POLL = Duration.ofMillis(1);
+
+    /**
+     * Weak in both directions. The key is the owning {@code StreamThread}, so a dead thread's entry
+     * disappears with it; see the class javadoc on why this registry must never be the thing that keeps a
+     * dispatcher alive.
+     */
+    private static final Map<Thread, PcWorkSignal> BY_OWNER =
+            Collections.synchronizedMap(new WeakHashMap<Thread, PcWorkSignal>());
+
+    /**
+     * The dispatchers whose work this signal speaks for - normally one, since this module's proven shape is
+     * one task per thread, but a thread with several tasks gets one signal covering all of them.
+     */
+    private final Set<PcTaskDispatcher> dispatchers =
+            Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<PcTaskDispatcher, Boolean>()));
+
+    private final Object monitor = new Object();
+
+    /**
+     * Counts requests to <em>abandon</em> the wait outright - shutdown, and a dispatcher going away - as
+     * opposed to work having arrived. A waiter captures this on entry and leaves as soon as it changes, so
+     * there is no flag to arm or clear and no way to consume someone else's wake.
+     * <p>
+     * This is not the "is there work" flag the class javadoc rules out: it never answers whether work exists,
+     * and nothing reads it to decide whether to dispatch. It exists because {@code notifyAll} alone cannot end
+     * a wait whose predicate is still false, and shutdown needs exactly that.
+     * <p>
+     * Guarded by {@link #monitor}.
+     */
+    private long wakeRequests;
+
+    /**
+     * Counts raised work signals, and how many this thread has already left a wait on.
+     * <p>
+     * <b>This is what stops a level-triggered predicate becoming a spin when the caller does not drain.</b>
+     * The wait's predicate is "an outcome is pending", which is true until the StreamThread feeds it back -
+     * and the StreamThread only does that inside {@code dispatchAvailable}, which Kafka does not always
+     * reach. {@code KafkaStreams.pause()} is the plain example: {@code TaskExecutor} consults
+     * {@code TaskExecutionMetadata.canProcessTask}, a paused topology answers no, and {@code process()} is
+     * skipped entirely while the thread stays RUNNING and keeps polling. A purely level-triggered wait would
+     * then return instantly on every pass, and the poll phase would become a ~1kHz loop of
+     * {@code poll(1ms)} - one core pinned and a thousand fetches a second - until the commit interval
+     * happened to drain it.
+     * <p>
+     * So a wait leaves early only for work it has <em>not already been released for</em>. A completion that
+     * landed before the wait began still counts, because raising it bumped the counter - which is the
+     * lost-wakeup property this class exists for. A second pass with nothing new simply takes the full
+     * budget, which is exactly stock behaviour and the right answer when nobody is draining.
+     * <p>
+     * Guarded by {@link #monitor}.
+     */
+    private long workSignals;
+    private long workSignalsReleasedOn;
+
+    private PcWorkSignal() {
+    }
+
+    /**
+     * Called from {@link PcTaskDispatcher}'s constructor, which runs on the StreamThread. Whatever thread it
+     * really is becomes this dispatcher's signal owner.
+     *
+     * @return the signal the dispatcher's workers should raise
+     */
+    static PcWorkSignal registerForCurrentThread(final PcTaskDispatcher dispatcher) {
+        final Thread owner = Thread.currentThread();
+        final PcWorkSignal signal;
+        synchronized (BY_OWNER) {
+            signal = BY_OWNER.computeIfAbsent(owner, ignored -> new PcWorkSignal());
+        }
+        signal.dispatchers.add(dispatcher);
+        log.debug("PC wake-on-work: dispatcher registered to owner thread {}", owner.getName());
+        return signal;
+    }
+
+    /**
+     * Both close paths call this. A closed dispatcher must stop contributing to
+     * {@link #hasActiveWorkOnCurrentThread()}, or a StreamThread would keep taking the split-wait branch for
+     * work that can never complete.
+     */
+    void deregister(final PcTaskDispatcher dispatcher) {
+        dispatchers.remove(dispatcher);
+        // An abandon, not a "work arrived": if this was the last dispatcher, no completion is ever coming and
+        // a waiter would otherwise sit out its whole budget for work that no longer exists.
+        requestWake();
+    }
+
+    /**
+     * <b>The gate.</b> True when a completion can still arrive for this thread - so splitting the poll wait
+     * can pay for itself - and false when nothing is running, which is the case where the stock full-budget
+     * poll is exactly right and shortening it would only delay broker records for no gain.
+     * <p>
+     * Note that it deliberately includes <em>pending completions</em> as well as in-flight work: a worker
+     * enqueues its outcome and only then decrements the in-flight count, so an outcome can be sitting
+     * undrained with nothing in flight. Asking only "is anything running" would send the thread into a full
+     * {@code poll.ms} block with a completion already in hand.
+     *
+     * @return whether the calling thread should split its poll wait
+     */
+    public static boolean hasActiveWorkOnCurrentThread() {
+        if (!PcDispatchSwitch.isWakeOnWorkEnabled()) {
+            return false;
+        }
+        final PcWorkSignal signal = BY_OWNER.get(Thread.currentThread());
+        return signal != null && signal.hasActiveWork();
+    }
+
+    /**
+     * Wait out the remainder of the caller's poll budget, or return the instant an outcome is ready to be fed
+     * back to Parallel Consumer.
+     * <p>
+     * Called from the patched {@code StreamThread} only, and only after {@link #hasActiveWorkOnCurrentThread()}
+     * said yes and a {@link #SHORT_POLL} returned nothing from the broker.
+     *
+     * @param fullPollBudget the {@code poll.ms} the thread would otherwise have spent blocked in the consumer
+     */
+    public static void awaitWorkForRemainderOf(final Duration fullPollBudget) {
+        final PcWorkSignal signal = BY_OWNER.get(Thread.currentThread());
+        if (signal == null) {
+            return;
+        }
+        // Re-checked here, not just at the gate. Between the two, the caller ran a short poll - and a poll
+        // runs ConsumerRebalanceListener callbacks inline, which on a revocation tear this thread's tasks
+        // down and deregister their dispatchers. Without this the thread would then wait out its budget for
+        // work that no longer exists, in the middle of a rebalance, which is when the consumer most needs
+        // polling.
+        if (!signal.hasActiveWork()) {
+            return;
+        }
+        final long remainingMillis = fullPollBudget.toMillis() - SHORT_POLL.toMillis();
+        if (remainingMillis <= 0) {
+            return;
+        }
+        signal.await(remainingMillis);
+    }
+
+    /**
+     * End the given thread's wait now, from another thread, whether or not work has arrived.
+     * <p>
+     * Exists so that a shutdown does not have to sit out the remaining budget:
+     * {@code StreamThread.shutdown()} only sets {@code PENDING_SHUTDOWN} and lets the loop notice, so without
+     * this the close would pay up to {@code poll.ms} - the same bill stock pays, but there is no reason to pay
+     * it once we own the wait.
+     * <p>
+     * A wake that arrives just <em>before</em> the wait starts is not lost in any way that matters: shutdown
+     * sets the state first, and the split wait only happens on the {@code RUNNING}/{@code STARTING} branch, so
+     * the next pass takes the {@code PENDING_SHUTDOWN} branch and does not wait at all. The residual window
+     * costs one poll budget, which is exactly what stock pays.
+     */
+    public static void wakeOwner(final Thread owner) {
+        final PcWorkSignal signal = BY_OWNER.get(owner);
+        if (signal != null) {
+            signal.requestWake();
+        }
+    }
+
+    /**
+     * Raised whenever something became dispatchable - today a worker outcome, and a retry timer once retries
+     * return. See the class javadoc on why this is not called {@code signalCompletion}.
+     * <p>
+     * Deliberately only a {@code notifyAll}: the waiter's predicate is the live completions queue, which the
+     * caller has already written to, so there is nothing to record here. That is what makes this safe to call
+     * from a worker on every outcome, whether or not anyone is waiting.
+     */
+    void signalWorkAvailable() {
+        synchronized (monitor) {
+            workSignals++;
+            monitor.notifyAll();
+        }
+    }
+
+    /** Abandon the wait, regardless of the work predicate. See {@link #wakeRequests}. */
+    private void requestWake() {
+        synchronized (monitor) {
+            wakeRequests++;
+            monitor.notifyAll();
+        }
+    }
+
+    private boolean hasActiveWork() {
+        return anyDispatcherMatches(dispatcher ->
+                dispatcher.getInFlightCount() > 0 || dispatcher.hasPendingCompletions());
+    }
+
+    private boolean hasPendingCompletions() {
+        return anyDispatcherMatches(PcTaskDispatcher::hasPendingCompletions);
+    }
+
+    /**
+     * The two questions this class asks of its dispatchers differ only in their predicate, so the lock and the
+     * short-circuiting walk live here once. Holding {@link #dispatchers} for the whole walk rather than
+     * copying it is deliberate: the answer is a point-in-time reading either way, and a copy would allocate on
+     * the gate, which every poll phase crosses.
+     */
+    private boolean anyDispatcherMatches(final Predicate<PcTaskDispatcher> predicate) {
+        synchronized (dispatchers) {
+            for (PcTaskDispatcher dispatcher : dispatchers) {
+                if (predicate.test(dispatcher)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Loops on the predicate against a deadline, so a spurious wakeup cannot end the wait early and a real
+     * signal cannot be missed. Interruption ends the wait and restores the flag - the caller is the
+     * StreamThread, and swallowing an interrupt there would strand a shutdown.
+     * <p>
+     * A wait that finds the predicate already true counts as both a split wait and a wake: the thread did take
+     * this branch, and it did leave it because work was ready rather than because time ran out, which is what
+     * the two counters are asked to distinguish.
+     */
+    private void await(final long remainingMillis) {
+        PcDispatchCounters.onSplitPollWait();
+        // nanoTime, not currentTimeMillis: this loop recomputes its remaining time from the clock on every
+        // pass, so a wall clock stepping backwards would re-extend the wait by the size of the step. The
+        // StreamThread is not calling Consumer#poll() while it is here, and a step larger than
+        // max.poll.interval.ms would get the member evicted from the group.
+        final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(remainingMillis);
+        boolean workArrived = false;
+        synchronized (monitor) {
+            final long wakeRequestsAtEntry = wakeRequests;
+            while (true) {
+                // Both halves are load-bearing. The pending outcome is what makes leaving USEFUL; the
+                // unreleased signal is what stops a caller that never drains from turning this into a spin.
+                if (workSignals != workSignalsReleasedOn && hasPendingCompletions()) {
+                    workSignalsReleasedOn = workSignals;
+                    workArrived = true;
+                    break;
+                }
+                if (wakeRequests != wakeRequestsAtEntry) {
+                    // Shutdown, or the last dispatcher going away. Not work, so it does not count as a wake.
+                    break;
+                }
+                final long leftNanos = deadlineNanos - System.nanoTime();
+                // Never call wait(0) - that means "wait forever", and the whole point here is a bounded wait.
+                // Sub-millisecond remainders round down to zero, so they end the wait rather than start an
+                // unbounded one.
+                final long leftMillis = leftNanos / 1_000_000L;
+                if (leftMillis <= 0) {
+                    break;
+                }
+                try {
+                    monitor.wait(leftMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        if (workArrived) {
+            PcDispatchCounters.onWakeOnWork();
+        }
+    }
+
+    /**
+     * Test seam: how many dispatchers this thread's signal still speaks for.
+     * <p>
+     * Exists because the gate is <em>not</em> a usable proxy for "did it deregister". An orderly
+     * {@code close()} drains and awaits its pool, so the gate reads false afterwards whether or not the
+     * dispatcher was ever removed - a test asserting on the gate there passes with the deregistration
+     * deleted.
+     *
+     * @return -1 when no signal belongs to the calling thread
+     */
+    static int registeredDispatchersOnCurrentThread() {
+        final PcWorkSignal signal = BY_OWNER.get(Thread.currentThread());
+        if (signal == null) {
+            return -1;
+        }
+        synchronized (signal.dispatchers) {
+            return signal.dispatchers.size();
+        }
+    }
+
+    /**
+     * Test seam. The registry is process-wide and surefire reuses forks, so a signal left behind by one test
+     * would answer the gate for the next one.
+     */
+    static void resetRegistryForTests() {
+        synchronized (BY_OWNER) {
+            for (PcWorkSignal signal : new HashSet<>(BY_OWNER.values())) {
+                signal.dispatchers.clear();
+                signal.requestWake();
+            }
+            BY_OWNER.clear();
+        }
+    }
+}

--- a/parallel-consumer-streams/src/main/patch/pc-streams.patch
+++ b/parallel-consumer-streams/src/main/patch/pc-streams.patch
@@ -1,6 +1,6 @@
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java kafka-patched/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
 --- a/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java	2026-08-31 13:51:00.760206957 +1200
++++ b/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java	2026-08-31 23:37:36.155425717 +1200
 @@ -44,8 +44,13 @@
      private final Serde<?> keySerde;
      private final Serde<?> valueSerde;
@@ -129,7 +129,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/AbstractPr
      @Override
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java kafka-patched/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
 --- a/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java	2026-08-31 13:51:00.760915375 +1200
++++ b/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java	2026-08-31 23:37:36.156122264 +1200
 @@ -243,7 +243,11 @@
                      "multiple times.");
          }
@@ -175,7 +175,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/ProcessorC
      }
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java kafka-patched/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
 --- a/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java	2026-08-31 13:51:00.761925919 +1200
++++ b/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java	2026-08-31 23:37:36.157220189 +1200
 @@ -64,6 +64,7 @@
  import java.util.Objects;
  import java.util.Optional;
@@ -207,3 +207,514 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/RecordColl
      }
  
      @Override
+diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask.java kafka-patched/org/apache/kafka/streams/processor/internals/StreamTask.java
+--- a/org/apache/kafka/streams/processor/internals/StreamTask.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/processor/internals/StreamTask.java	2026-08-31 23:37:36.158979953 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.processor.internals;
+ 
++import bz.stub.parallelconsumer.streams.PcTaskDispatcher;
+ import org.apache.kafka.clients.consumer.Consumer;
+ import org.apache.kafka.clients.consumer.ConsumerConfig;
+ import org.apache.kafka.clients.consumer.ConsumerRecord;
+@@ -52,6 +53,7 @@
+ import org.apache.kafka.streams.state.internals.ThreadCache;
+ 
+ import java.io.IOException;
++import java.time.Duration;
+ import java.util.Collections;
+ import java.util.HashMap;
+ import java.util.HashSet;
+@@ -60,6 +62,7 @@
+ import java.util.Objects;
+ import java.util.Optional;
+ import java.util.Set;
++import java.util.concurrent.atomic.LongAdder;
+ import java.util.function.Function;
+ import java.util.stream.Collectors;
+ 
+@@ -84,7 +87,12 @@
+     private final int maxBufferedSize;
+     private final AbstractPartitionGroup partitionGroup;
+     private final RecordCollector recordCollector;
+-    private final AbstractPartitionGroup.RecordInfo recordInfo;
++    // PC dispatch (astubbs#255): one RecordInfo per record, not one per task. partitionGroup.nextRecord() WRITES
++    // into this object and process() reads partition()/queue() back out of it AFTER the record has been
++    // processed - so with a single shared instance, a second thread entering nextRecord() mid-process makes the
++    // first thread attribute its offset to the wrong partition. Non-final because it is now re-assigned per
++    // record, and it must survive the call that fetched it (a retained record keeps its own info).
++    private AbstractPartitionGroup.RecordInfo recordInfo;
+     private final Map<TopicPartition, Long> consumedOffsets;
+     private final Map<TopicPartition, Long> committedOffsets;
+     private final Map<TopicPartition, Long> highWatermark;
+@@ -94,7 +102,8 @@
+     private final PunctuationQueue systemTimePunctuationQueue;
+     private final StreamsMetricsImpl streamsMetrics;
+ 
+-    private long processTimeMs = 0L;
++    // PC dispatch (astubbs#255): accumulated by every worker thread that processes a batch for this task.
++    private final LongAdder processTimeMs = new LongAdder();
+ 
+     private final Sensor closeTaskSensor;
+     private final Sensor processRatioSensor;
+@@ -113,8 +122,32 @@
+     private final ProcessingExceptionHandler processingExceptionHandler;
+ 
+     private StampedRecord record;
++
++    /**
++     * PC dispatch (astubbs#255): non-null when this task feeds Parallel Consumer instead of its own
++     * {@link #partitionGroup}. Decided once, in the constructor, so a task cannot change record paths
++     * mid-run and strand records in the path it abandoned. Null is the stock path.
++     */
++    private final PcTaskDispatcher pcDispatcher;
++
++
++    /** PC dispatch (astubbs#255): how long {@link #suspend()} waits for in-flight work before giving up. */
++    private static final Duration PC_DRAIN_TIMEOUT = Duration.ofSeconds(30);
++
++    /**
++     * PC dispatch (astubbs#255): the PC path bypasses {@link #partitionGroup} entirely (KTD8 - one path,
++     * switched, never both), but it still needs what a {@link RecordQueue} does for a record on the way in:
++     * deserialisation, timestamp extraction, and the source node to start the chain at. So the PC path keeps
++     * its own queues and uses them as one-record converters. Touched only from the StreamThread, in
++     * {@link #pcPrepare}, which is why a plain HashMap is right here and wrong three fields up.
++     */
++    private final Map<TopicPartition, RecordQueue> pcRecordQueues = new HashMap<>();
++
+     private boolean commitNeeded = false;
+-    private boolean commitRequested = false;
++    // PC dispatch (astubbs#255, U9 review): volatile because context.commit() runs on PC WORKER threads
++    // (ProcessorContextImpl.commit -> requestCommit), making this the one sanctioned cross-thread
++    // commit-state write on the PC path. Every other commit signal is StreamThread-only.
++    private volatile boolean commitRequested = false;
+     private boolean hasPendingTxCommit = false;
+     private Optional<Long> timeCurrentIdlingStarted;
+ 
+@@ -191,8 +224,6 @@
+ 
+         recordQueueCreator = new RecordQueueCreator(this.logContext, config.timestampExtractor, config.deserializationExceptionHandler);
+ 
+-        recordInfo = new RecordInfo();
+-
+         final Sensor enforcedProcessingSensor;
+         enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics);
+         final long maxTaskIdleMs = config.maxTaskIdleMs;
+@@ -225,6 +256,10 @@
+         }
+         timeCurrentIdlingStarted = Optional.empty();
+         processingExceptionHandler = config.processingExceptionHandler;
++
++        // PC dispatch (astubbs#255): the switch. Off by default, so the stock path above stays the one that
++        // runs unless a test or a system property says otherwise.
++        pcDispatcher = PcTaskDispatcher.createIfEnabled(id.toString(), inputPartitions);
+     }
+ 
+     // create queues for each assigned partition and associate them
+@@ -314,8 +349,45 @@
+         }
+     }
+ 
++    /**
++     * PC dispatch (astubbs#255): refuse revival rather than hang.
++     * <p>
++     * {@code closeDirtyAndRevive} resurrects <em>this same instance</em> after a dirty close, but the
++     * dispatcher is final and was closed on the way down - so a revived task would register records into a
++     * dispatcher that never hands them out again: no progress, no exception, nothing in the log. That silent
++     * stall costs whoever hits it a day before they suspect the seam. Failing here converts it into an
++     * immediate, named error.
++     * <p>
++     * Recreating the dispatcher instead is the real fix and belongs with the rebalance work; this is the
++     * loud-failure floor until then.
++     */
++    @Override
++    public void revive() {
++        if (pcDispatcher != null && pcDispatcher.isClosed()) {
++            throw new IllegalStateException(
++                "PC dispatch (astubbs#255): task " + id + " cannot be revived - its PC dispatcher was closed "
++                    + "with the task and would accept records without ever dispatching them. Revival under PC "
++                    + "dispatch is not supported yet; run with the seam off "
++                    + "(-Dpc.streams.dispatch.enabled=false) if this path is required.");
++        }
++        super.revive();
++    }
++
+     @Override
+     public void suspend() {
++        // PC dispatch (astubbs#255): drain before suspending. Suspension is where Streams stops feeding the
++        // task and starts tearing down around it, and a worker still inside the chain would be forwarding
++        // into a record collector that is about to close. Pumping here (we are on the StreamThread, which is
++        // the only thread allowed to touch the WorkManager) also gets every consumed offset recorded before
++        // the final commit reads them.
++        if (pcDispatcher != null) {
++            final long wallClockTime = time.milliseconds();
++            if (!pcDispatcher.pumpUntilQuiescent(rawRecord -> pcPrepare(wallClockTime, rawRecord), PC_DRAIN_TIMEOUT)) {
++                log.warn("PC dispatch did not quiesce within {} before suspend; {} record(s) still in flight",
++                    PC_DRAIN_TIMEOUT, pcDispatcher.getInFlightCount());
++            }
++        }
++
+         switch (state()) {
+             case CREATED:
+                 transitToSuspend();
+@@ -437,7 +509,23 @@
+                 // the commitNeeded flag just indicates whether we have reached RUNNING and processed any new data,
+                 // so it only indicates whether the record collector should be flushed or not, whereas the state
+                 // manager should always be flushed; either there is newly restored data or the flush will be a no-op
+-                if (commitNeeded) {
++                // PC dispatch (astubbs#255, U9): on the PC path this gate asks the dispatcher, not the field -
++                // workers no longer write commitNeeded, so the field alone would leave this permanently
++                // false and nothing would ever commit. The same gate covers the pre-commit flush().
++                if (pcAwareCommitNeeded()) {
++                    // PC dispatch (astubbs#255, U9 review): COLLECT BEFORE FLUSH, and return PC's map directly.
++                    // Workers complete records DURING flush, and KafkaProducer.flush() does not cover sends
++                    // enqueued after it was invoked - collecting afterwards could commit a record whose
++                    // output is not yet durable, which is the crash-loss window this unit exists to close.
++                    // Collecting first is safe because a worker's order is send -> success -> mailbox: every
++                    // offset in the collected map had its sends in the producer before this line ran.
++                    if (pcDispatcher != null) {
++                        final Map<TopicPartition, OffsetAndMetadata> pcCommitData = pcDispatcher.collectCommitData();
++                        flush();
++                        hasPendingTxCommit = eosEnabled;
++                        log.debug("Prepared {} task for committing (PC frontier)", state());
++                        return pcCommitData;
++                    }
+                     // we need to flush the store caches before flushing the record collector since it may cause some
+                     // cached records to be processed and hence generate more records to be sent out
+                     //
+@@ -645,7 +733,9 @@
+     public void maybeCheckpoint(final boolean enforceCheckpoint) {
+         // commitNeeded indicates we may have processed some records since last commit
+         // and hence we need to refresh checkpointable offsets regardless whether we should checkpoint or not
+-        if (commitNeeded || enforceCheckpoint) {
++        // PC dispatch (astubbs#255, U9 review): same dispatcher-aware gate as prepareCommit - the raw field
++        // is stock-path-only and would leave PC-processed work invisible to checkpoint refresh.
++        if (pcAwareCommitNeeded() || enforceCheckpoint) {
+             stateMgr.updateChangelogOffsets(checkpointableOffsets());
+         }
+ 
+@@ -655,7 +745,9 @@
+     private void validateClean() {
+         // It may be that we failed to commit a task during handleRevocation, but "forgot" this and tried to
+         // closeClean in handleAssignment. We should throw if we detect this to force the TaskManager to closeDirty
+-        if (commitNeeded) {
++        // PC dispatch (astubbs#255, U9 review): dispatcher-aware, or a clean close could silently discard
++        // completed-but-uncommitted PC work that the raw field no longer reflects.
++        if (pcAwareCommitNeeded()) {
+             log.debug("Tried to close clean but there was pending uncommitted data, this means we failed to"
+                           + " commit and should close as dirty instead");
+             throw new TaskMigratedException("Tried to close dirty task as clean");
+@@ -673,6 +765,12 @@
+      * You must commit a task and checkpoint the state manager before closing as this will release the state dir lock
+      */
+     private void close(final boolean clean) {
++        // PC dispatch (astubbs#255): shut the worker pool down and give PC's partition state back, before the
++        // partition group and the record collector go.
++        if (pcDispatcher != null) {
++            TaskManager.executeAndMaybeSwallow(clean, pcDispatcher::close, "PC dispatch close", log);
++        }
++
+         switch (state()) {
+             case SUSPENDED:
+                 TaskManager.executeAndMaybeSwallow(
+@@ -765,12 +863,20 @@
+      */
+     @SuppressWarnings("unchecked")
+     public boolean process(final long wallClockTime) {
++        // PC dispatch (astubbs#255): the other half of the switch. On the PC path there is nothing in the
++        // partition group to select from - records went to the WorkManager instead - so selection, ordering
++        // and concurrency all come from PC and this method's job shrinks to pumping.
++        if (pcDispatcher != null) {
++            return pcProcess(wallClockTime);
++        }
++
+         if (record == null) {
+             if (!isProcessable(wallClockTime)) {
+                 return false;
+             }
+ 
+             // get the next record to process
++            recordInfo = new RecordInfo();
+             record = partitionGroup.nextRecord(recordInfo, wallClockTime);
+ 
+             // if there is no record to process, return immediately
+@@ -780,10 +886,13 @@
+         }
+ 
+         try {
+-            final TopicPartition partition = recordInfo.partition();
++            // PC dispatch (astubbs#255): pin this thread's RecordInfo for the rest of the call, so a concurrent
++            // fetch cannot swap it out between processing the record and recording where the record came from.
++            final AbstractPartitionGroup.RecordInfo currentRecordInfo = recordInfo;
++            final TopicPartition partition = currentRecordInfo.partition();
+ 
+             if (!(record instanceof CorruptedRecord)) {
+-                doProcess(wallClockTime);
++                doProcess(wallClockTime, currentRecordInfo, record);
+             }
+ 
+             // update the consumed offset map after processing is done
+@@ -792,7 +901,7 @@
+ 
+             // after processing this record, if its partition queue's buffered size has been
+             // decreased to the threshold, we can then resume the consumption on this partition
+-            if (recordInfo.queue().size() <= maxBufferedSize) {
++            if (currentRecordInfo.queue().size() <= maxBufferedSize) {
+                 partitionsToResume.add(partition);
+             }
+ 
+@@ -843,8 +952,15 @@
+         throw error;
+     }
+ 
++    /**
++     * PC dispatch (astubbs#255): {@code record} is now a parameter rather than the shared field of the same
++     * name. On the PC path there is no single "current record" for a task - there are up to poolSize of
++     * them, one per worker - so the record has to travel down the call stack instead of being read out of
++     * task state. The body is untouched: the parameter deliberately shadows the field, so every existing
++     * reference now reads this thread's record and nobody else's.
++     */
+     @SuppressWarnings("unchecked")
+-    private void doProcess(final long wallClockTime) {
++    private void doProcess(final long wallClockTime, final AbstractPartitionGroup.RecordInfo recordInfo, final StampedRecord record) {
+         // process the record by passing to the source node of the topology
+         final ProcessorNode<Object, Object, Object, Object> currNode = (ProcessorNode<Object, Object, Object, Object>) recordInfo.node();
+         log.trace("Start processing one record [{}]", record);
+@@ -870,16 +986,108 @@
+         log.trace("Completed processing one record [{}]", record);
+     }
+ 
++    // ------------------------------------------------------------------------------------------------
++    // PC dispatch (astubbs#255): the Parallel Consumer record path. Reached only when pcDispatcher != null.
++    // ------------------------------------------------------------------------------------------------
++
++    /**
++     * The PC replacement for the select-one-record-and-run-it body of {@link #process(long)}.
++     * <p>
++     * Two things happen here that do not happen on the stock path. First, a failure from a worker is
++     * re-thrown on <em>this</em> thread rather than at the point it occurred - which is how stock Streams
++     * behaves too (the exception reaches the uncaught-exception handler via the StreamThread), except that
++     * here it arrives one or more pump cycles late, and records dispatched in between will have run. Second,
++     * {@code isProcessable} and {@code partitionGroup.readyToProcess} are not consulted: they answer
++     * questions about a buffer this path does not fill. Stream-time punctuation goes with them, since stream
++     * time advances at partition-group selection - noted as a caveat, and irrelevant to the stateless and
++     * non-windowed topologies this module runs.
++     *
++     * @return true if any record was CONSUMED from the WorkManager this call - deliberately not
++     *         "handed to the worker pool". A record resolved without ever reaching the pool, such as a
++     *         corrupted one dropped inline, still counts. The caller reads this as "was there
++     *         progress", and a false sends the StreamThread back into a blocking poll, so counting
++     *         pool submissions instead would report a stall on every route that bypasses the pool.
++     */
++    private boolean pcProcess(final long wallClockTime) {
++        final Throwable failure = pcDispatcher.pollFailure();
++        if (failure != null) {
++            throw new StreamsException(
++                String.format("Exception caught in PC-dispatched processing. taskId=%s", id()), failure);
++        }
++        return pcDispatcher.dispatchAvailable(rawRecord -> pcPrepare(wallClockTime, rawRecord)) > 0;
++    }
++
++    /**
++     * Runs on the StreamThread. Turns one raw record into the chain execution a worker will run.
++     * <p>
++     * The {@link RecordQueue} here is used as a converter, not a buffer: add one record, take it straight
++     * back out. That keeps deserialisation, timestamp extraction and the deserialisation-exception handler
++     * exactly as Kafka Streams implements them - the alternative was to reimplement all three in the bridge
++     * and spend the rest of the effort arguing about whether the reimplementation was faithful.
++     *
++     * @return the work to run, or null if the record was dropped on the way in - a bad timestamp, or a
++     *         deserialisation error the configured handler chose to continue past
++     */
++    private Runnable pcPrepare(final long wallClockTime, final ConsumerRecord<byte[], byte[]> rawRecord) {
++        final TopicPartition partition = new TopicPartition(rawRecord.topic(), rawRecord.partition());
++        final RecordQueue queue = pcRecordQueues.computeIfAbsent(partition, recordQueueCreator::createQueue);
++
++        queue.addRawRecords(Collections.singletonList(rawRecord));
++        if (queue.isEmpty()) {
++            log.debug("Record dropped during preparation, nothing to run: {}", rawRecord);
++            return null;
++        }
++
++        final StampedRecord stamped = queue.poll(wallClockTime);
++
++        // PC dispatch (astubbs#255, U9): a corrupted record is consumed, never processed - stock handles it
++        // synchronously on the processing thread, so shipping it to a worker as a no-op run would make
++        // corruption handling asynchronous for no benefit: commitNeeded() would lag the consumption by a
++        // worker round-trip. Dropping it here keeps the corrupted path synchronous, exactly like the
++        // bad-timestamp drop above, and PC's frontier advances over it the same way.
++        if (stamped instanceof CorruptedRecord) {
++            log.debug("Corrupted record consumed during preparation, nothing to run: {}", rawRecord);
++            return null;
++        }
++
++        final RecordInfo recordInfo = new RecordInfo();
++        recordInfo.queue = queue;
++
++        return () -> pcRunChain(wallClockTime, stamped, recordInfo);
++    }
++
++    /**
++     * Runs on a worker thread, concurrently with up to poolSize-1 siblings on the same task. Everything it
++     * touches is either a parameter (the record, its {@link RecordInfo}) or was made safe for this in U4:
++     * the thread-confined record context and current node. Since U9, workers write no commit state -
++     * {@link #consumedOffsets} and {@link #commitNeeded} are stock-path-only, single-threaded fields
++     * again, and completion reaches the commit through the dispatcher's mailbox alone. The one
++     * sanctioned exception is {@link #commitRequested}: a processor calling {@code context.commit()}
++     * sets it from a worker, which is why that field alone is volatile.
++     * <p>
++     * Completion is reported only through the dispatcher's mailbox (U9): PC's WorkManager tracks which
++     * offsets finished in what order, and the commit takes PC's frontier - so nothing here writes
++     * {@link #consumedOffsets} or {@link #commitNeeded}, and no cross-thread commit state exists at all.
++     * The optimistic-commit divergence this method used to carry is retired; the commit-frontier test is
++     * the proof.
++     */
++    private void pcRunChain(final long wallClockTime, final StampedRecord stamped, final RecordInfo recordInfo) {
++        try {
++            doProcess(wallClockTime, recordInfo, stamped);
++        } finally {
++            processorContext.setCurrentNode(null);
++        }
++    }
++
+     @Override
+     public void recordProcessBatchTime(final long processBatchTime) {
+-        processTimeMs += processBatchTime;
++        processTimeMs.add(processBatchTime);
+     }
+ 
+     @Override
+     public void recordProcessTimeRatioAndBufferSize(final long allTaskProcessMs, final long now) {
+         bufferedRecordsSensor.record(partitionGroup.numBuffered());
+-        processRatioSensor.record((double) processTimeMs / allTaskProcessMs, now);
+-        processTimeMs = 0L;
++        processRatioSensor.record((double) processTimeMs.sumThenReset() / allTaskProcessMs, now);
+     }
+ 
+     /**
+@@ -1102,6 +1310,15 @@
+      */
+     @Override
+     public void addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
++        // PC dispatch (astubbs#255): one path, switched (KTD8). Registering into BOTH would look tempting - "so
++        // they can be compared" - and would hang the run: nothing drains the partition group, the buffer
++        // passes maxBufferedSize, this method pauses the partition, and the consumer sits paused with no
++        // error to explain it.
++        if (pcDispatcher != null) {
++            pcDispatcher.registerRecords(partition, records);
++            return;
++        }
++
+         final int newQueueSize = partitionGroup.addRawRecords(partition, records);
+ 
+         if (log.isTraceEnabled()) {
+@@ -1288,8 +1505,28 @@
+         return sb.toString();
+     }
+ 
++    /**
++     * PC dispatch (astubbs#255, U9): "is there completed work no successful commit has covered yet", answered by
++     * whichever path owns completion. On the PC path that is PC's dirty state; on the stock path it is the raw
++     * {@link #commitNeeded} field, deliberately NOT the {@link #commitNeeded()} override, which also sweeps the
++     * consumer position and mutates state - the three gates below want the plain question.
++     * <p>
++     * One helper rather than the same ternary at three call sites: {@code prepareCommit} (which also gates the
++     * pre-commit flush), {@code maybeCheckpoint}, and {@code validateClean} must always agree about whether
++     * work is outstanding, and three copies is how they would silently stop agreeing.
++     */
++    private boolean pcAwareCommitNeeded() {
++        return pcDispatcher != null ? pcDispatcher.hasCommitDataOutstanding() : commitNeeded;
++    }
++
+     @Override
+     public boolean commitNeeded() {
++        // PC dispatch (astubbs#255, U9): PC's own dirty flag is the answer on the PC path - completed work
++        // exists that no successful commit has covered. The consumer-position sweep below reads
++        // consumedOffsets, which the PC path no longer maintains.
++        if (pcDispatcher != null) {
++            return pcDispatcher.hasCommitDataOutstanding();
++        }
+         // we need to do an extra check if the flag was false, that
+         // if the consumer position has been updated; this is because
+         // there may be non data records such as control markers bypassed
+@@ -1357,6 +1594,16 @@
+ 
+     public void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset) {
+         committedOffsets.put(topicPartition, offset);
++
++        // PC dispatch (astubbs#255, U9 review): the success acknowledgement lives HERE, not in postCommit -
++        // TaskExecutor invokes this only from the success branches of commitOffsetsOrTransaction, whereas
++        // Kafka reaches postCommit after swallowed commit failures (TaskManager.tryCloseCleanActiveTasks)
++        // and with no commit at all (closeDirtyAndRevive). Acking a failed commit would mark work clean
++        // that was never durably committed. PC's onOffsetCommitSuccess reads only the offset, so the
++        // reconstructed OffsetAndMetadata needs no payload.
++        if (pcDispatcher != null) {
++            pcDispatcher.onCommitSuccess(Collections.singletonMap(topicPartition, new OffsetAndMetadata(offset)));
++        }
+     }
+ 
+     public void updateEndOffsets(final TopicPartition topicPartition, final Long offset) {
+diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamThread.java kafka-patched/org/apache/kafka/streams/processor/internals/StreamThread.java
+--- a/org/apache/kafka/streams/processor/internals/StreamThread.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/processor/internals/StreamThread.java	2026-08-31 23:37:36.280299670 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.processor.internals;
+ 
++import bz.stub.parallelconsumer.streams.PcWorkSignal;
+ import org.apache.kafka.clients.admin.Admin;
+ import org.apache.kafka.clients.consumer.Consumer;
+ import org.apache.kafka.clients.consumer.ConsumerConfig;
+@@ -1223,9 +1224,33 @@
+             // other useful work while waiting for the join response
+             records = pollRequests(Duration.ZERO);
+         } else if (state == State.RUNNING || state == State.STARTING || (state == State.PARTITIONS_ASSIGNED && stateUpdaterEnabled)) {
+-            // try to fetch some records with normal poll time
+-            // in order to get long polling
+-            records = pollRequests(pollTime);
++            // PC dispatch (astubbs#255): WAKE ON WORK. This is the only blocking wait in the run loop, and it
++            // is the one that prices everything else. Kafka polls and processes on this one thread, so
++            // blocking here for the full poll.ms costs stock nothing - there is no work it could be doing
++            // instead. Under PC dispatch that is false: workers are completing in the background, and a
++            // blocked poll stalls DISPATCH, not just this thread. Measured at 0.69x against stock on the
++            // single-key arm - the asynchronous path SLOWER than the synchronous one.
++            //
++            // Worse, the inner work loop below breaks back out to poll whenever a pass dispatched nothing,
++            // and under an async dispatcher "dispatched nothing" also means "the pool is full" or "every key
++            // is already in flight" - states that resolve on a worker completion and never on a broker fetch.
++            // So the loop chooses to block precisely when a completion is imminent.
++            //
++            // So: poll briefly to collect whatever the broker already has, then wait on OUR OWN condition for
++            // the rest of the budget, woken the instant a worker completes. Deliberately NOT wakeup(), which
++            // means shutdown to Kafka Streams and would arm the next poll if delivered while not polling.
++            // Only taken while PC actually has work outstanding - idle, the stock full-budget poll below is
++            // exactly right, and shortening it would delay broker records for nothing.
++            if (PcWorkSignal.hasActiveWorkOnCurrentThread()) {
++                records = pollRequests(PcWorkSignal.SHORT_POLL);
++                if (records.isEmpty()) {
++                    PcWorkSignal.awaitWorkForRemainderOf(pollTime);
++                }
++            } else {
++                // try to fetch some records with normal poll time
++                // in order to get long polling
++                records = pollRequests(pollTime);
++            }
+         } else if (state == State.PENDING_SHUTDOWN) {
+             // we are only here because there's rebalance in progress,
+             // just poll with zero to complete it
+@@ -1433,6 +1458,14 @@
+     public void shutdown() {
+         log.info("Informed to shut down");
+         final State oldState = setState(State.PENDING_SHUTDOWN);
++
++        // PC dispatch (astubbs#255): end this thread's wake-on-work wait now rather than letting it run out.
++        // Shutdown here only sets the state and lets the loop notice, so a thread parked in pollPhase would
++        // otherwise sit out the rest of poll.ms - the same bill stock pays while blocked in the consumer, but
++        // there is no reason to pay it once we own the wait. Runs on the CALLING thread, not on this one,
++        // which is why the signal is addressed by owner rather than read from a thread local.
++        PcWorkSignal.wakeOwner(this);
++
+         if (oldState == State.CREATED) {
+             // The thread may not have been started. Take responsibility for shutting down
+             completeShutdown(true);

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/PcTaskDispatcherTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/PcTaskDispatcherTest.java
@@ -1,0 +1,727 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import bz.stub.parallelconsumer.internal.EpochAndRecordsMap;
+import bz.stub.parallelconsumer.internal.PCModule;
+import bz.stub.parallelconsumer.state.WorkManager;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import pl.tlinkowski.unij.api.UniSets;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongFunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The seam itself, with Kafka Streams taken out of the picture.
+ * <p>
+ * Everything asserted here is a property of {@link PcTaskDispatcher} and the Parallel Consumer machinery
+ * behind it - work registration, KEY-ordered selection, the worker pool, failure handling. Running it without
+ * a broker or a topology is deliberate: when the end-to-end run misbehaves, these tests say whether the
+ * dispatcher or the Kafka Streams integration is at fault, and a seam that cannot localise its own failures
+ * produces verdicts nobody can act on.
+ * <p>
+ * The end-to-end half lives in
+ * {@code bz.stub.parallelconsumer.streams.integrationTests.PcDrivenStreamsDispatchTest}.
+ *
+ * @author Antony Stubbs
+ */
+@Slf4j
+// The switch and the process-wide counters in PcDispatchCounters are global by necessity (there is no seam
+// through KafkaStreams to inject a collaborator), and this module inherits the project's concurrent JUnit
+// execution from core's junit-platform.properties. Left concurrent, these methods read each other's counters
+// and toggle each other's switch. Per-dispatcher counters cover most of it; this covers the switch.
+@Execution(ExecutionMode.SAME_THREAD)
+// And @Isolated, not merely same-thread: these tests call PcTaskDispatcher.abortAllActive(), which kills
+// every live dispatcher in the JVM - including one belonging to a concurrently running test class.
+// SAME_THREAD only serialises this class's own methods; the sibling IT classes carry @Isolated for the
+// same process-wide reason.
+@Isolated
+class PcTaskDispatcherTest {
+
+    private static final String TOPIC = "pc-streams-in";
+    private static final TopicPartition PARTITION = new TopicPartition(TOPIC, 0);
+    private static final Set<TopicPartition> INPUT_PARTITIONS = UniSets.of(PARTITION);
+
+    private static final Duration PUMP_TIMEOUT = Duration.ofSeconds(60);
+
+    private PcTaskDispatcher dispatcher;
+
+    @BeforeEach
+    void resetCounters() {
+        PcDispatchCounters.reset();
+    }
+
+    @AfterEach
+    void closeDispatcher() {
+        if (dispatcher != null) {
+            dispatcher.close();
+            dispatcher = null;
+        }
+        // Back to where the JVM found it, not to a value this class prefers - a teardown that parks the
+        // switch somewhere else is exactly the implicit coupling that stating each arm's requirement removes.
+        PcDispatchSwitch.resetToDefault();
+    }
+
+    /**
+     * The first trap. {@code WorkManager} is a {@code ConsumerRebalanceListener}, but here Kafka Streams owns
+     * the consumer, so PC's assignment lifecycle is never driven unless the bridge drives it - and the way it
+     * fails is to register nothing at all, quietly.
+     */
+    @Test
+    void registerWorkAcceptsEveryRecordOnceThePartitionHasAnAssignmentEpoch() {
+        dispatcher = new PcTaskDispatcher("task-epoch", INPUT_PARTITIONS, 4);
+
+        List<ConsumerRecord<byte[], byte[]>> batch = records(20, offset -> "key-" + (offset % 5));
+        dispatcher.registerRecords(PARTITION, batch);
+
+        assertThat(dispatcher.getRecordsOffered())
+                .as("every record in the batch must be offered")
+                .isEqualTo(20);
+        assertThat(dispatcher.getRecordsAccepted())
+                .as("no record may be skipped for want of an epoch - EpochAndRecordsMap drops those with "
+                        + "nothing but a log.warn, so a gap here is a silent zero-record registration")
+                .isEqualTo(20);
+        assertThat(dispatcher.getWorkManager().getNumberOfWorkQueuedInShardsAwaitingSelection())
+                .as("and the records must actually be sitting in PC's shards, ready to be selected")
+                .isEqualTo(20);
+    }
+
+    /**
+     * The control for the test above: the same registration, against a {@code WorkManager} that was never told
+     * about the assignment. This is the failure mode the dispatcher's constructor exists to prevent, asserted
+     * directly so that the bootstrap cannot be quietly deleted by a later refactor without a red test.
+     */
+    @Test
+    void withoutAnAssignmentEpochEveryRecordIsSilentlyDropped() {
+        ParallelConsumerOptions<byte[], byte[]> options = ParallelConsumerOptions.<byte[], byte[]>builder()
+                .consumer(new MockConsumer<byte[], byte[]>(OffsetResetStrategy.NONE))
+                .ordering(ParallelConsumerOptions.ProcessingOrder.KEY)
+                .build();
+        WorkManager<byte[], byte[]> unassigned = new PCModule<>(options).workManager();
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> byPartition = new HashMap<>();
+        byPartition.put(PARTITION, records(20, offset -> "key-" + offset));
+        EpochAndRecordsMap<byte[], byte[]> epochTagged =
+                new EpochAndRecordsMap<>(new ConsumerRecords<>(byPartition), unassigned.getPm());
+
+        assertThat(epochTagged.count())
+                .as("with no assignment epoch, EpochAndRecordsMap keeps nothing - and says so only at WARN. "
+                        + "This is what a missing onPartitionsAssigned looks like: an idle-looking topology.")
+                .isZero();
+    }
+
+    /**
+     * The default, asserted rather than assumed - this is the test that would go red if someone flipped it.
+     * The seam is an opt-in preview while unsupported topology shapes go unrefused, so a {@code StreamTask}
+     * constructed with nothing configured must get <b>no</b> dispatcher and keep its own partition group;
+     * turning the switch on gets one. With the switch off the dispatch marker cannot move, which is what
+     * makes a non-zero marker elsewhere mean something.
+     * <p>
+     * <b>Read the reasoning in {@link PcDispatchSwitch} before flipping this.</b> The default was ON in the
+     * feasibility study and this reverses that, on a different argument from the one that decision beat -
+     * flipping it back to make a test convenient would be the third round trip.
+     * <p>
+     * {@code resetToDefault()} rather than reading {@code isEnabled()} straight off: this class mutates the
+     * process-wide switch, so by the time this method runs the switch holds whatever the last test left, and
+     * an unqualified read here would be asserting on test-ordering rather than on the default.
+     */
+    @Test
+    void theSwitchIsOffByDefaultAndTurningItOnPutsPcInThePath() {
+        PcDispatchSwitch.resetToDefault();
+
+        assertThat(PcDispatchSwitch.isEnabled())
+                .as("PC dispatch must default to OFF while unsupported topology shapes are dispatched rather "
+                        + "than refused - see PcDispatchSwitch for why, and for what would change it back")
+                .isFalse();
+        assertThat(PcTaskDispatcher.createIfEnabled("task-default-off", INPUT_PARTITIONS))
+                .as("so a task built with nothing configured keeps its own partition group - no dispatcher")
+                .isNull();
+
+        PcDispatchSwitch.enable(2);
+        // Assigned to the field so @AfterEach closes its worker pool.
+        dispatcher = PcTaskDispatcher.createIfEnabled("task-on", INPUT_PARTITIONS);
+        assertThat(dispatcher)
+                .as("and opting in must give a dispatcher")
+                .isNotNull();
+        assertThat(dispatcher.getRecordsDispatched())
+                .as("merely existing dispatches nothing")
+                .isZero();
+
+        assertThat(PcDispatchCounters.getRecordsDispatchedToPool())
+                .as("nothing reached a worker pool in either half")
+                .isZero();
+    }
+
+    /**
+     * The property is the only way an application (as opposed to a test) can opt in, so its parsing is worth
+     * an assertion of its own - including that a typo fails loudly rather than being read as the default,
+     * which would silently produce a run that looks like the arm it was asked for and is not.
+     */
+    @Test
+    void theEnabledPropertyTurnsTheSeamOnAndRejectsAnythingItCannotUnderstand() {
+        final String original = System.getProperty(PcDispatchSwitch.ENABLED_PROPERTY);
+        try {
+            System.setProperty(PcDispatchSwitch.ENABLED_PROPERTY, "true");
+            PcDispatchSwitch.resetToDefault();
+            assertThat(PcDispatchSwitch.isEnabled())
+                    .as("-D%s=true is how an application opts a whole JVM in",
+                            PcDispatchSwitch.ENABLED_PROPERTY)
+                    .isTrue();
+
+            System.setProperty(PcDispatchSwitch.ENABLED_PROPERTY, "TRUE");
+            PcDispatchSwitch.resetToDefault();
+            assertThat(PcDispatchSwitch.isEnabled()).as("and case must not matter").isTrue();
+
+            System.setProperty(PcDispatchSwitch.ENABLED_PROPERTY, "false");
+            PcDispatchSwitch.resetToDefault();
+            assertThat(PcDispatchSwitch.isEnabled())
+                    .as("and =false is how an A/B run states the stock arm explicitly")
+                    .isFalse();
+
+            System.setProperty(PcDispatchSwitch.ENABLED_PROPERTY, "ture");
+            assertThatThrownBy(PcDispatchSwitch::resetToDefault)
+                    .as("a typo must not be silently read as the default")
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY);
+        } finally {
+            if (original == null) {
+                System.clearProperty(PcDispatchSwitch.ENABLED_PROPERTY);
+            } else {
+                System.setProperty(PcDispatchSwitch.ENABLED_PROPERTY, original);
+            }
+            PcDispatchSwitch.resetToDefault();
+        }
+    }
+
+    /**
+     * The whole point: records that stock Kafka Streams would run one after another on the StreamThread are in
+     * the chain at the same time.
+     */
+    @Test
+    void aPoolOfFourRunsAtLeastThreeRecordsAtOnce() {
+        dispatcher = new PcTaskDispatcher("task-concurrency", INPUT_PARTITIONS, 4);
+        ConcurrencyProbe probe = new ConcurrencyProbe(Duration.ofMillis(300));
+
+        // Distinct keys, so KEY ordering imposes no serialisation of its own and the pool is the only limit.
+        dispatcher.registerRecords(PARTITION, records(12, offset -> "key-" + offset));
+        pumpToQuiescence(probe);
+
+        assertThat(probe.completed).hasSize(12);
+        assertThat(probe.peakConcurrency.get())
+                .as("a pool of 4 and a 300ms processor must put at least 3 records in the chain at once - "
+                        + "anything less and records are still being run one at a time")
+                .isGreaterThanOrEqualTo(3);
+        assertThat(dispatcher.getRecordsDispatched())
+                .as("the dispatch marker is the only proof these records did not take the stock path")
+                .isEqualTo(12);
+    }
+
+    /**
+     * KEY ordering is what lets a Streams topology survive parallel dispatch: a shard hands out at most one
+     * record per key at a time, so per-key sequencing is preserved even though the run as a whole is
+     * concurrent.
+     */
+    @Test
+    void twoRecordsSharingAKeyAreNeverInFlightAtTheSameTime() {
+        dispatcher = new PcTaskDispatcher("task-key-order", INPUT_PARTITIONS, 4);
+        ConcurrencyProbe probe = new ConcurrencyProbe(Duration.ofMillis(40));
+
+        // Three keys, interleaved, so each key has several records and the pool has room to overlap them.
+        dispatcher.registerRecords(PARTITION, records(24, offset -> "key-" + (offset % 3)));
+        pumpToQuiescence(probe);
+
+        assertThat(probe.completed).hasSize(24);
+        assertThat(probe.keysSeenConcurrentlyWithThemselves)
+                .as("a key found running twice at once means PC's shard invariant did not hold, and every "
+                        + "per-key ordering guarantee a Streams topology relies on is gone")
+                .isEmpty();
+
+        for (Map.Entry<String, List<Long>> perKey : probe.completionOrderByKey().entrySet()) {
+            assertThat(perKey.getValue())
+                    .as("key %s must be processed in offset order", perKey.getKey())
+                    .isSorted();
+        }
+    }
+
+    /**
+     * The other half of the ordering property - it would be trivially satisfiable by never running anything in
+     * parallel at all.
+     */
+    @Test
+    void recordsWithDistinctKeysDoRunConcurrently() {
+        dispatcher = new PcTaskDispatcher("task-distinct-keys", INPUT_PARTITIONS, 4);
+        ConcurrencyProbe probe = new ConcurrencyProbe(Duration.ofMillis(200));
+
+        dispatcher.registerRecords(PARTITION, records(8, offset -> "key-" + offset));
+        pumpToQuiescence(probe);
+
+        assertThat(probe.completed).hasSize(8);
+        assertThat(probe.largestSetOfKeysInFlightTogether.get())
+                .as("distinct keys must overlap - otherwise KEY ordering is being satisfied by serialising "
+                        + "everything, which is stock Streams with extra threads")
+                .isGreaterThanOrEqualTo(2);
+    }
+
+    /**
+     * Failure semantics, and the retry divergence this module deliberately accepts. PC would normally
+     * re-dispatch a failed record, which here would re-run the processor chain including {@code forward()}
+     * calls that already emitted downstream - duplicates stock Streams never produces. Retries are therefore
+     * disabled, and the failure is surfaced instead.
+     */
+    @Test
+    void aFailingRecordSurfacesOnceAndIsNeverRetriedWhileOtherKeysKeepFlowing() {
+        dispatcher = new PcTaskDispatcher("task-failure", INPUT_PARTITIONS, 4);
+
+        String poisonKey = "key-2";
+        AtomicInteger poisonAttempts = new AtomicInteger();
+        List<String> completedKeys = new CopyOnWriteArrayList<>();
+
+        PcTaskDispatcher.WorkPreparer preparer = record -> {
+            String key = new String(record.key(), StandardCharsets.UTF_8);
+            return () -> {
+                if (poisonKey.equals(key)) {
+                    poisonAttempts.incrementAndGet();
+                    throw new IllegalStateException("processor blew up on " + key);
+                }
+                completedKeys.add(key);
+            };
+        };
+
+        dispatcher.registerRecords(PARTITION, records(12, offset -> "key-" + (offset % 4)));
+        boolean quiescent = dispatcher.pumpUntilQuiescent(preparer, PUMP_TIMEOUT);
+
+        assertThat(quiescent)
+                .as("a failed record must not wedge the dispatcher - with retries disabled its key's shard "
+                        + "blocks, and everything else must still drain")
+                .isTrue();
+        assertThat(poisonAttempts.get())
+                .as("exactly one attempt: a retry would re-run the whole chain and re-emit records the first "
+                        + "attempt already forwarded downstream")
+                .isEqualTo(1);
+        assertThat(completedKeys)
+                .as("every record of every other key must still have been processed")
+                .hasSize(9);
+        assertThat(completedKeys).doesNotContain(poisonKey);
+
+        assertThat(dispatcher.pollFailure())
+                .as("the failure must be retrievable so the StreamThread can surface it the way stock does")
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(dispatcher.pollFailure())
+                .as("and cleared once taken, so it is reported once rather than on every pump")
+                .isNull();
+
+        assertThat(dispatcher.getRecordsFailed()).isEqualTo(1);
+        assertThat(dispatcher.getRecordsSucceeded()).isEqualTo(9);
+        // The two later records of the poison key are still queued behind it - blocked, not lost.
+        assertThat(dispatcher.getRecordsDispatched()).isEqualTo(10);
+        assertThat(dispatcher.getRecordsOffered()).isEqualTo(12);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+
+    private void pumpToQuiescence(final ConcurrencyProbe probe) {
+        boolean quiescent = dispatcher.pumpUntilQuiescent(probe, PUMP_TIMEOUT);
+        assertThat(quiescent).as("all work must drain within %s", PUMP_TIMEOUT).isTrue();
+    }
+
+    /**
+     * @param keyForOffset lets a test choose how keys map onto offsets - all-distinct for a concurrency test,
+     *                     modulo-N for an ordering one
+     */
+    private static List<ConsumerRecord<byte[], byte[]>> records(final int count,
+                                                                final LongFunction<String> keyForOffset) {
+        List<ConsumerRecord<byte[], byte[]>> batch = new ArrayList<>();
+        for (long offset = 0; offset < count; offset++) {
+            batch.add(new ConsumerRecord<>(
+                    TOPIC,
+                    PARTITION.partition(),
+                    offset,
+                    keyForOffset.apply(offset).getBytes(StandardCharsets.UTF_8),
+                    ("value-" + offset).getBytes(StandardCharsets.UTF_8)));
+        }
+        return batch;
+    }
+
+    /**
+     * A stand-in processor that records what was running at the same time as what. It is the instrument the
+     * concurrency and ordering assertions read from - output correctness would not distinguish "ran in
+     * parallel" from "ran one at a time, quickly".
+     */
+    private static final class ConcurrencyProbe implements PcTaskDispatcher.WorkPreparer {
+
+        private final Duration workDuration;
+
+        private final AtomicInteger inFlight = new AtomicInteger();
+        private final AtomicInteger peakConcurrency = new AtomicInteger();
+        private final AtomicInteger largestSetOfKeysInFlightTogether = new AtomicInteger();
+
+        private final Map<String, AtomicInteger> inFlightPerKey = new ConcurrentHashMap<>();
+        private final Set<String> keysSeenConcurrentlyWithThemselves =
+                Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+        private final List<Completion> completed = new CopyOnWriteArrayList<>();
+
+        private ConcurrencyProbe(final Duration workDuration) {
+            this.workDuration = workDuration;
+        }
+
+        @Override
+        public Runnable prepare(final ConsumerRecord<byte[], byte[]> record) {
+            String key = new String(record.key(), StandardCharsets.UTF_8);
+            long offset = record.offset();
+            return () -> {
+                int concurrent = inFlight.incrementAndGet();
+                peakConcurrency.accumulateAndGet(concurrent, Math::max);
+
+                int sameKeyConcurrent = inFlightPerKey
+                        .computeIfAbsent(key, ignored -> new AtomicInteger())
+                        .incrementAndGet();
+                if (sameKeyConcurrent > 1) {
+                    keysSeenConcurrentlyWithThemselves.add(key);
+                }
+                largestSetOfKeysInFlightTogether.accumulateAndGet(distinctKeysInFlight(), Math::max);
+
+                try {
+                    Thread.sleep(workDuration.toMillis());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    inFlightPerKey.get(key).decrementAndGet();
+                    inFlight.decrementAndGet();
+                    completed.add(new Completion(key, offset));
+                }
+            };
+        }
+
+        private int distinctKeysInFlight() {
+            int distinct = 0;
+            for (AtomicInteger count : inFlightPerKey.values()) {
+                if (count.get() > 0) {
+                    distinct++;
+                }
+            }
+            return distinct;
+        }
+
+        private Map<String, List<Long>> completionOrderByKey() {
+            Map<String, List<Long>> byKey = new LinkedHashMap<>();
+            for (Completion completion : completed) {
+                byKey.computeIfAbsent(completion.key, ignored -> new ArrayList<>()).add(completion.offset);
+            }
+            return byKey;
+        }
+    }
+
+    // ------- the commit surface -------------------------------------------------------------------------
+
+    /**
+     * The return value is a progress signal the caller paces on, not a count of pool submissions - and the
+     * two only agree on the happy path, which is why every other test here agreed with the broken definition.
+     * The patched {@code process()} returns this, and stock's {@code TaskExecutor} reads a false as "this task
+     * made no progress" and hands the StreamThread back to a blocking poll. So a batch consumed entirely by
+     * routes that never reach the pool must still report its full count: reporting zero there is the lie that
+     * stalls a topology for a poll cycle per batch of corrupted records.
+     * <p>
+     * Both no-pool routes are covered because they are separate branches with separate bookkeeping - a drop
+     * completes the work, a preparation failure records a failure - and a regression could plausibly hit one
+     * and not the other.
+     */
+    @Test
+    void recordsConsumedWithoutReachingThePoolStillCountAsProgress() {
+        dispatcher = new PcTaskDispatcher("task-dropped", INPUT_PARTITIONS, 4);
+        dispatcher.registerRecords(PARTITION, records(6, offset -> "key-" + offset));
+
+        // Returns null for every record: consumed and completed on this thread, nothing handed to a worker.
+        int consumed = dispatcher.dispatchAvailable(record -> null);
+
+        assertThat(consumed)
+                .as("all six were taken off the WorkManager, so all six are progress - counting pool "
+                        + "submissions instead would report 0 and stall the caller that paces on this")
+                .isEqualTo(6);
+        assertThat(PcDispatchCounters.getRecordsDispatchedToPool())
+                .as("and none of them reached the pool, which is precisely why the two definitions differ")
+                .isZero();
+    }
+
+    @Test
+    void recordsThatFailPreparationStillCountAsProgress() {
+        dispatcher = new PcTaskDispatcher("task-prep-failure", INPUT_PARTITIONS, 4);
+        dispatcher.registerRecords(PARTITION, records(6, offset -> "key-" + offset));
+
+        // Throws for every record: preparation failed on the StreamThread, as a deserialisation error would.
+        int consumed = dispatcher.dispatchAvailable(record -> {
+            throw new IllegalStateException("deserialisation blew up");
+        });
+
+        assertThat(consumed)
+                .as("a record consumed by failing preparation has still left the queue, so it is progress")
+                .isEqualTo(6);
+        assertThat(PcDispatchCounters.getRecordsDispatchedToPool())
+                .as("none reached the pool")
+                .isZero();
+        assertThat(PcDispatchCounters.getRecordsFailed())
+                .as("and the failures must be accounted for, not silently swallowed")
+                .isEqualTo(6);
+    }
+
+    /**
+     * The commit protocol's read side, seen from the StreamThread: a worker's completion becomes visible to
+     * hasCommitDataOutstanding and collectCommitData through the mailbox drain those methods perform, and the
+     * collected map carries the frontier - the lowest incomplete offset - not the highest completed one.
+     */
+    @Test
+    void completedWorkBecomesCommitDataAtTheFrontier() {
+        dispatcher = new PcTaskDispatcher("task-commit", INPUT_PARTITIONS, 4);
+
+        // Three same-key records: offsets 0..2. Workers complete them; the frontier follows contiguity.
+        dispatcher.registerRecords(PARTITION, records(3, offset -> "one-key"));
+        assertThat(dispatcher.hasCommitDataOutstanding())
+                .as("nothing has completed yet - registration alone is not commit-worthy")
+                .isFalse();
+
+        boolean quiescent = dispatcher.pumpUntilQuiescent(record -> () -> { }, PUMP_TIMEOUT);
+        assertThat(quiescent).as("three no-op records must drain").isTrue();
+
+        assertThat(dispatcher.hasCommitDataOutstanding())
+                .as("completed, uncommitted work must report as commit-outstanding")
+                .isTrue();
+        assertThat(dispatcher.collectCommitData())
+                .as("the frontier after 0..2 all complete is 3 - the next offset to resume from")
+                .containsKey(PARTITION)
+                .satisfies(map -> assertThat(map.get(PARTITION).offset()).isEqualTo(3L));
+    }
+
+    /**
+     * The write side: only {@link PcTaskDispatcher#onCommitSuccess} clears the dirty state - collection alone
+     * must not, or a failed commit would strand its records (collection is a read, success is the ack).
+     */
+    @Test
+    void collectionDoesNotClearDirtyButTheSuccessAckDoes() {
+        dispatcher = new PcTaskDispatcher("task-ack", INPUT_PARTITIONS, 4);
+        dispatcher.registerRecords(PARTITION, records(2, offset -> "one-key"));
+        dispatcher.pumpUntilQuiescent(record -> () -> { }, PUMP_TIMEOUT);
+
+        var collected = dispatcher.collectCommitData();
+        assertThat(dispatcher.hasCommitDataOutstanding())
+                .as("collecting is a READ - a commit that later fails must find the partition still dirty")
+                .isTrue();
+        assertThat(dispatcher.collectCommitData())
+                .as("and a second collection (the retry after a failed commit) returns the same data")
+                .isEqualTo(collected);
+
+        dispatcher.onCommitSuccess(collected);
+        assertThat(dispatcher.hasCommitDataOutstanding())
+                .as("the success ack is what marks the covered work clean")
+                .isFalse();
+    }
+
+    /**
+     * The crash-injection surface. abortClose is idempotent, deregisters from the registry (abortAllActive
+     * must not abort it twice), and a crashed dispatcher accepts no further dispatch.
+     */
+    @Test
+    void abortCloseIsACrashNotAShutdown() {
+        dispatcher = new PcTaskDispatcher("task-abort", INPUT_PARTITIONS, 4);
+        dispatcher.registerRecords(PARTITION, records(2, offset -> "k"));
+
+        dispatcher.abortClose();
+        dispatcher.abortClose(); // idempotent - a second crash of a dead dispatcher is a no-op
+
+        assertThat(dispatcher.dispatchAvailable(record -> () -> { }))
+                .as("a crashed dispatcher hands out nothing")
+                .isZero();
+
+        // abortAllActive after the abort must not touch this dispatcher again (it deregistered) - and with
+        // no other dispatcher alive in this test, the call is a clean no-op rather than an error.
+        PcTaskDispatcher.abortAllActive();
+    }
+
+    /** abortAllActive reaches every live dispatcher, not only the most recent one. */
+    @Test
+    void abortAllActiveCrashesEveryLiveDispatcher() {
+        dispatcher = new PcTaskDispatcher("task-multi-a", INPUT_PARTITIONS, 4);
+        PcTaskDispatcher second = new PcTaskDispatcher("task-multi-b", INPUT_PARTITIONS, 4);
+        try {
+            PcTaskDispatcher.abortAllActive();
+            assertThat(dispatcher.dispatchAvailable(record -> () -> { }))
+                    .as("first dispatcher crashed")
+                    .isZero();
+            assertThat(second.dispatchAvailable(record -> () -> { }))
+                    .as("second dispatcher crashed too - the registry covers every live instance")
+                    .isZero();
+        } finally {
+            second.close();
+        }
+    }
+
+    /**
+     * The defect that made this method a query rather than a drain, reproduced without Kafka Streams.
+     * <p>
+     * Kafka Streams' {@code DefaultStateUpdater} calls {@code StreamTask.maybeCheckpoint} <b>from its own
+     * thread</b> for every task it is restoring, and the patched {@code maybeCheckpoint} asks the dispatcher
+     * whether a commit is outstanding before refreshing changelog offsets. So this question arrives on a
+     * second thread, concurrently with the StreamThread, and it arrives in production - it is not a
+     * hypothetical a guard invented. While the answer came from a mailbox drain, that meant
+     * {@code WorkManager} and its partition state, neither of them thread-safe, touched by two threads at
+     * once; the owner-thread guard converted that silent race into a deterministic
+     * {@code IllegalStateException} that took the integration suite down.
+     * <p>
+     * Three properties, and the middle one is the one worth guarding: the call must not throw, the answer
+     * must be <em>right</em> from over there, and it must be reached without draining. A thread-safe answer
+     * that reported "nothing to commit" about finished work would be a worse defect than the crash, because
+     * it loses records instead of stopping.
+     */
+    @Test
+    void commitOutstandingIsAnswerableFromAnotherThreadWithoutDraining() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("task-cross-thread-query", INPUT_PARTITIONS, 4);
+        dispatcher.registerRecords(PARTITION, records(1, offset -> "one-key"));
+
+        assertThat(dispatcher.dispatchAvailable(record -> () -> { }))
+                .as("the single record goes to a worker")
+                .isEqualTo(1);
+
+        // inFlight is decremented in runOnWorker's finally block, AFTER the completion has been published,
+        // so zero in flight means the completion is sitting in the mailbox. Nothing has drained it: only the
+        // owner thread drains, and the owner thread is this one, parked here.
+        await().atMost(PUMP_TIMEOUT).until(() -> dispatcher.getInFlightCount() == 0);
+
+        assertThat(dispatcher.getWorkManager().isDirty())
+                .as("precondition: PC itself does not know the record completed yet - which is precisely the "
+                        + "state a draining query would have had to mutate away, from the wrong thread")
+                .isFalse();
+
+        AtomicReference<Boolean> answer = new AtomicReference<>();
+        Throwable thrown = runOffOwnerThread("test-StateUpdater-1",
+                () -> answer.set(dispatcher.hasCommitDataOutstanding()));
+
+        assertThat(thrown)
+                .as("the state updater asks this from its own thread on every restoring task; a query that "
+                        + "throws there takes the application down, deterministically")
+                .isNull();
+        assertThat(answer.get())
+                .as("and the answer must be right from over there: the record has completed and no commit "
+                        + "has covered it, so a thread-safe FALSE would lose it")
+                .isTrue();
+        assertThat(dispatcher.getWorkManager().isDirty())
+                .as("and it must not have drained to work that out - the drain is what reached WorkManager "
+                        + "from the wrong thread")
+                .isFalse();
+
+        assertThat(dispatcher.collectCommitData())
+                .as("the owner-thread path still folds the completion in, so nothing is stranded by the "
+                        + "query staying passive")
+                .containsKey(PARTITION)
+                .satisfies(map -> assertThat(map.get(PARTITION).offset()).isEqualTo(1L));
+    }
+
+    /**
+     * The accuracy trap in the other direction, and the reason the query counts successes rather than the
+     * mailbox's size: a failed record leaves its offset incomplete, PC never turns the partition dirty, and
+     * there is nothing new to commit. Answering "outstanding" here would be permanent - retries are disabled,
+     * so the record never succeeds - and {@code validateClean} would turn it into a spurious
+     * {@code TaskMigratedException} on an otherwise clean close.
+     */
+    @Test
+    void aFailedCompletionIsNotCommitOutstanding() {
+        dispatcher = new PcTaskDispatcher("task-failure-not-outstanding", INPUT_PARTITIONS, 4);
+        dispatcher.registerRecords(PARTITION, records(1, offset -> "one-key"));
+
+        dispatcher.dispatchAvailable(record -> () -> {
+            throw new IllegalStateException("processing blew up");
+        });
+        await().atMost(PUMP_TIMEOUT).until(() -> dispatcher.getRecordsFailed() == 1);
+
+        assertThat(dispatcher.hasCommitDataOutstanding())
+                .as("a failure is not commit data - counting the mailbox rather than its successes would "
+                        + "report true here, and never stop")
+                .isFalse();
+
+        dispatcher.collectCommitData();
+        assertThat(dispatcher.hasCommitDataOutstanding())
+                .as("and still not, once the failure has actually been fed back to PC")
+                .isFalse();
+    }
+
+    /**
+     * The other half of the same rule: the two methods that really do reach {@code WorkManager} keep the
+     * owner-thread guard. {@link PcTaskDispatcher#hasCommitDataOutstanding()} lost it by becoming a query, not
+     * by the rule being relaxed, and the difference is what this pins - deleting the guard would restore the
+     * silent cross-thread corruption it was added to expose.
+     */
+    @Test
+    void theWorkManagerTouchingCommitMethodsStayOwnerThreadOnly() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("task-owner-guard", INPUT_PARTITIONS, 4);
+
+        assertThat(runOffOwnerThread("test-StateUpdater-1", dispatcher::collectCommitData))
+                .as("collecting drains the mailbox into PC, so it stays owner-thread-only")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("collectCommitData");
+
+        assertThat(runOffOwnerThread("test-StateUpdater-1",
+                () -> dispatcher.onCommitSuccess(Collections.emptyMap())))
+                .as("and acknowledging a commit writes partition state, so it does too")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("onCommitSuccess");
+    }
+
+    /**
+     * Runs {@code body} on a thread named after Kafka Streams' state updater - the thread this module's
+     * commit surface is actually reached from - and returns whatever it threw, or null.
+     */
+    private static Throwable runOffOwnerThread(final String threadName, final Runnable body)
+            throws InterruptedException {
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread thread = new Thread(() -> {
+            try {
+                body.run();
+            } catch (Throwable t) { //NOSONAR - the point is to report whatever the call did, including Errors
+                thrown.set(t);
+            }
+        }, threadName);
+        thread.start();
+        thread.join(PUMP_TIMEOUT.toMillis());
+        assertThat(thread.isAlive())
+                .as("the off-thread call must return rather than block - a query that can block is not one")
+                .isFalse();
+        return thrown.get();
+    }
+
+    private static final class Completion {
+        private final String key;
+        private final long offset;
+
+        private Completion(final String key, final long offset) {
+            this.key = key;
+            this.offset = offset;
+        }
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/PcWorkSignalTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/PcWorkSignalTest.java
@@ -1,0 +1,539 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import pl.tlinkowski.unij.api.UniSets;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The wake-on-work condition (astubbs#255, item 3), tested without Kafka Streams in the picture.
+ * <p>
+ * Everything here is about <em>timing</em>, which is the whole point: the defect being fixed is a thread that
+ * waits when it should not, and the failure mode of a broken fix is a thread that waits anyway. So every
+ * assertion below is on observed elapsed time, never on a counter that would read the same whether the wait
+ * blocked or not. The budgets are chosen so that a correct implementation finishes in single-digit
+ * milliseconds against a budget measured in seconds - wide enough for a loaded CI box, far too wide for a
+ * broken implementation to slip through.
+ * <p>
+ * <b>The coincidences are forced, not merely made possible.</b> "A completion arrived while the thread was
+ * parked" is a two-thread race, and a test that only creates the opportunity will pass for the wrong reason
+ * most of the time. The releasing thread here waits on {@link PcDispatchCounters#getSplitPollWaits()}, which
+ * is incremented at the moment the production code enters the wait, so the completion provably lands after
+ * the wait began.
+ *
+ * @author Antony Stubbs
+ * @see PcWorkSignal
+ */
+@Slf4j
+// The registry, the counters and the switch are all process-wide - see PcDispatchSwitch on why there is no
+// injection seam - so a concurrently running class would answer this one's gate and read its counters.
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated
+class PcWorkSignalTest {
+
+    private static final String TOPIC = "pc-streams-wake";
+    private static final TopicPartition PARTITION = new TopicPartition(TOPIC, 0);
+    private static final Set<TopicPartition> INPUT_PARTITIONS = UniSets.of(PARTITION);
+
+    /**
+     * Deliberately far larger than any real {@code poll.ms}. A correct early wake returns in milliseconds, so
+     * the gap between "woke on work" and "waited it out" is three orders of magnitude and cannot be confused
+     * with scheduler noise.
+     */
+    private static final Duration GENEROUS_BUDGET = Duration.ofSeconds(10);
+
+    /** Used where the test wants the wait to actually run out, so it has to be short enough to be bearable. */
+    private static final Duration SHORT_BUDGET = Duration.ofMillis(400);
+
+    private PcTaskDispatcher dispatcher;
+
+    /** Matches what {@link PcDispatchSwitch#enable(int)} is given below; the arms build their own pools. */
+    private static final int POOL_SIZE = 4;
+
+    @BeforeEach
+    void reset() {
+        PcDispatchCounters.reset();
+        PcWorkSignal.resetRegistryForTests();
+        PcDispatchSwitch.resetToDefault();
+        // STATED, NOT INHERITED. The seam defaults OFF (an opt-in preview - see PcDispatchSwitch), and
+        // wake-on-work is unreachable while it is: isWakeOnWorkEnabled() is `seam AND wakeOnWork`, so every
+        // gate assertion below would read false for the wrong reason. Saying so here rather than leaning on
+        // a default is also what keeps theKillSwitchShutsTheGateWhileWorkIsStillInFlight a genuine control:
+        // it turns one term off from a known-on state, instead of confirming a default.
+        PcDispatchSwitch.enable(POOL_SIZE);
+    }
+
+    @AfterEach
+    void closeDispatcher() {
+        if (dispatcher != null) {
+            dispatcher.close();
+            dispatcher = null;
+        }
+        PcWorkSignal.resetRegistryForTests();
+        PcDispatchSwitch.resetToDefault();
+    }
+
+    /**
+     * The seam-off / no-dispatcher case, and the most important one to get right: with nothing registered the
+     * StreamThread must take the stock full-budget poll. Splitting the wait when nothing can wake it would
+     * shorten every poll to a millisecond and delay broker records for no gain whatever - a regression against
+     * stock rather than a fix.
+     */
+    @Test
+    void withNoDispatcherOnThisThreadTheGateIsShutAndTheWaitIsANoOp() {
+        assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread())
+                .as("no dispatcher belongs to this thread, so nothing can ever wake a split wait - the "
+                        + "StreamThread must keep its stock poll")
+                .isFalse();
+
+        long elapsed = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(GENEROUS_BUDGET));
+
+        assertThat(elapsed)
+                .as("and awaiting on a thread with no signal must return at once rather than parking for the "
+                        + "budget - a StreamThread that reached here by mistake must not be stalled by it")
+                .isLessThan(1_000L);
+        assertThat(PcDispatchCounters.getSplitPollWaits())
+                .as("no wait was taken, so nothing may be counted as one")
+                .isZero();
+    }
+
+    /** A registered but idle dispatcher is still the stock case: nothing is running, so nothing can complete. */
+    @Test
+    void anIdleDispatcherLeavesTheGateShut() {
+        dispatcher = new PcTaskDispatcher("wake-idle", INPUT_PARTITIONS, 4);
+
+        assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread())
+                .as("nothing in flight and no outcome pending means the full-budget poll is exactly right")
+                .isFalse();
+    }
+
+    /** In-flight work is what makes splitting the wait worth anything. */
+    @Test
+    void workInFlightOpensTheGate() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-inflight", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+
+        awaitWorkerRunning(dispatchOneBlockingOn(release));
+
+        try {
+            assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread())
+                    .as("a record is in the chain, so a completion can arrive and end the wait early")
+                    .isTrue();
+        } finally {
+            release.countDown();
+        }
+    }
+
+    /**
+     * <b>The lost-wakeup case.</b> A completion that landed <em>before</em> the wait began must still end it.
+     * <p>
+     * This is the test that an edge-triggered "a completion happened" flag fails: the flag would be armed at
+     * the start of the wait, after the completion set it, so the signal would be cleared unread and the thread
+     * would park for the whole budget with work already in hand. The predicate here is the live completions
+     * queue, which is why it cannot happen.
+     */
+    @Test
+    void aCompletionThatArrivedBeforeTheWaitStillEndsIt() {
+        dispatcher = new PcTaskDispatcher("wake-prior", INPUT_PARTITIONS, 4);
+
+        dispatchOneBlockingOn(new CountDownLatch(0));
+        await().atMost(Duration.ofSeconds(30))
+                .until(() -> dispatcher.hasPendingCompletions());
+
+        long elapsed = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(GENEROUS_BUDGET));
+
+        assertThat(elapsed)
+                .as("the outcome was already in the mailbox when the wait started, so the wait must not have "
+                        + "blocked at all. Parking here is the lost-wakeup defect, and it costs a full poll "
+                        + "cycle per record.")
+                .isLessThan(1_000L);
+        assertThat(PcDispatchCounters.getWakesOnWork())
+                .as("and it must be recorded as a wake, not as a timeout")
+                .isEqualTo(1);
+    }
+
+    /**
+     * The live case: a worker completes while the thread is parked, and the thread leaves immediately.
+     * <p>
+     * The completion is forced to land after the wait began - see the class javadoc - rather than merely being
+     * likely to.
+     */
+    @Test
+    void aCompletionDuringTheWaitEndsItImmediately() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-during", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+
+        awaitWorkerRunning(dispatchOneBlockingOn(release));
+
+        Thread releaser = runOnceTheWaitHasBegun("wake-on-work-releaser", release::countDown);
+
+        long elapsed = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(GENEROUS_BUDGET));
+        releaser.join(TimeUnit.SECONDS.toMillis(30));
+
+        assertThat(elapsed)
+                .as("the worker finished while the thread was parked, so the thread must leave on the "
+                        + "completion rather than on the %s budget. This IS wake-on-work.", GENEROUS_BUDGET)
+                .isLessThan(GENEROUS_BUDGET.toMillis() / 2);
+        assertThat(PcDispatchCounters.getSplitPollWaits()).isEqualTo(1);
+        assertThat(PcDispatchCounters.getWakesOnWork())
+                .as("and it left because work arrived, which is the distinction the two counters exist to make")
+                .isEqualTo(1);
+        assertThat(dispatcher.getInFlightCount())
+                .as("THE ORDERING INVARIANT. The signal is raised after the in-flight count is decremented, so "
+                        + "a woken thread sees the freed pool slot. Signal first and it would drain the "
+                        + "completion, compute capacity against a count not yet decremented, dispatch nothing, "
+                        + "and park again with an empty mailbox and no further signal coming - a full "
+                        + "poll-budget stall, microseconds wide, that would never reproduce on demand.")
+                .isZero();
+    }
+
+    /**
+     * The failure path raises the signal too. A failed record frees its pool slot exactly like a successful
+     * one, and this is the branch a later refactor forgets - leaving a StreamThread parked for the full budget
+     * after a processor threw.
+     */
+    @Test
+    void aWorkerFailureAlsoEndsTheWait() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-failure", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch started = new CountDownLatch(1);
+
+        registerOneRecord();
+        int dispatched = dispatcher.dispatchAvailable(record -> () -> {
+            started.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            throw new IllegalStateException("processor blew up");
+        });
+        assertThat(dispatched).isEqualTo(1);
+        awaitWorkerRunning(started);
+
+        Thread releaser = runOnceTheWaitHasBegun("wake-on-work-failure-releaser", release::countDown);
+
+        long elapsed = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(GENEROUS_BUDGET));
+        releaser.join(TimeUnit.SECONDS.toMillis(30));
+
+        assertThat(elapsed)
+                .as("a failure is an outcome, and an outcome frees a slot - the thread must wake for it")
+                .isLessThan(GENEROUS_BUDGET.toMillis() / 2);
+        assertThat(dispatcher.getRecordsFailed()).isEqualTo(1);
+        assertThat(dispatcher.getInFlightCount())
+                .as("and the same ordering invariant holds on the failure path")
+                .isZero();
+    }
+
+    /**
+     * The negative control for the test above. With work in flight but no completion coming, the wait must run
+     * to its deadline - if it returned early anyway, the early return in the other test would prove nothing.
+     * <p>
+     * This also covers spurious wakeups: {@code Object.wait} may return without any notify at all, and the
+     * loop re-checks its predicate rather than trusting the return.
+     */
+    @Test
+    void withNothingCompletingTheWaitRunsToItsDeadline() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-timeout", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+
+        awaitWorkerRunning(dispatchOneBlockingOn(release));
+
+        try {
+            long elapsed = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(SHORT_BUDGET));
+
+            assertThat(elapsed)
+                    .as("nothing completed, so the wait must last its budget. A wait that ends early anyway "
+                            + "would make the early return in the wake test meaningless.")
+                    .isGreaterThanOrEqualTo(SHORT_BUDGET.toMillis() - PcWorkSignal.SHORT_POLL.toMillis() - 50);
+            assertThat(PcDispatchCounters.getSplitPollWaits()).isEqualTo(1);
+            assertThat(PcDispatchCounters.getWakesOnWork())
+                    .as("it timed out - counting that as a wake would hide a mechanism that never pays")
+                    .isZero();
+        } finally {
+            release.countDown();
+        }
+    }
+
+    /**
+     * The shutdown path (R5), and the reason the trap this design avoids is a shutdown-path hazard.
+     * <p>
+     * {@code StreamThread.shutdown()} runs on the closing thread, not the parked one, and only sets a state
+     * flag - so the patched shutdown asks this class to end the wait. Note it must end the wait even though
+     * <em>no work arrived</em>, which a plain {@code notifyAll} against the work predicate cannot do.
+     */
+    @Test
+    void wakeOwnerEndsTheWaitEvenWithNoWorkArriving() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-shutdown", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+
+        awaitWorkerRunning(dispatchOneBlockingOn(release));
+
+        Thread owner = Thread.currentThread();
+        Thread shutdowner = runOnceTheWaitHasBegun("wake-on-work-shutdowner", () -> PcWorkSignal.wakeOwner(owner));
+
+        try {
+            long elapsed = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(GENEROUS_BUDGET));
+            shutdowner.join(TimeUnit.SECONDS.toMillis(30));
+
+            assertThat(elapsed)
+                    .as("a shutdown must not have to sit out the remaining poll budget - this is the wait we "
+                            + "own, so we can end it")
+                    .isLessThan(GENEROUS_BUDGET.toMillis() / 2);
+            assertThat(PcDispatchCounters.getWakesOnWork())
+                    .as("but it is NOT a wake-on-work: no completion arrived, and conflating the two would "
+                            + "make a shutdown look like the mechanism paying off")
+                    .isZero();
+        } finally {
+            release.countDown();
+        }
+    }
+
+    /**
+     * A closed dispatcher must stop answering the gate. Left registered, it would keep its StreamThread on the
+     * split-wait branch forever, waiting for completions from a worker pool that is gone - and both close
+     * paths matter, because {@code abortClose} is the crash-injection path a test drives deliberately.
+     */
+    @Test
+    void closingADispatcherShutsTheGateAgain() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-close", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+
+        awaitWorkerRunning(dispatchOneBlockingOn(release));
+        assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread()).isTrue();
+
+        release.countDown();
+        dispatcher.close();
+        dispatcher = null;
+
+        // Asserted on the REGISTRY, not on the gate. An orderly close drains and awaits its pool, so the gate
+        // reads false afterwards whether or not the deregistration happened - an assertion on the gate here
+        // passes with the production deregistration deleted, which makes it worth nothing.
+        assertThat(PcWorkSignal.registeredDispatchersOnCurrentThread())
+                .as("a closed dispatcher must deregister, or it keeps answering the gate for work that can "
+                        + "never arrive")
+                .isZero();
+        assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread()).isFalse();
+    }
+
+    /**
+     * <b>The anti-spin property, and the one that a purely level-triggered wait gets wrong.</b>
+     * <p>
+     * The wake predicate is "an outcome is pending", and outcomes are only cleared by the StreamThread inside
+     * {@code dispatchAvailable}. Kafka does not always get there: {@code KafkaStreams.pause()} makes
+     * {@code TaskExecutionMetadata.canProcessTask} answer no, so {@code process()} is skipped entirely while
+     * the thread stays RUNNING and keeps polling. A wait that left on the pending outcome every time would
+     * then return instantly on every pass, turning the poll phase into a ~1kHz loop of 1ms polls - a pinned
+     * core and a thousand fetches a second - until something else happened to drain it.
+     * <p>
+     * So the second wait, with the outcome still undrained and nothing new signalled, must take its budget.
+     */
+    @Test
+    void aSecondWaitWithNothingNewDrainedMustNotReturnInstantly() {
+        dispatcher = new PcTaskDispatcher("wake-nodrain", INPUT_PARTITIONS, 4);
+
+        dispatchOneBlockingOn(new CountDownLatch(0));
+        await().atMost(Duration.ofSeconds(30))
+                .until(() -> dispatcher.hasPendingCompletions());
+
+        long first = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(SHORT_BUDGET));
+        assertThat(first)
+                .as("the first wait leaves at once - there is a real outcome to feed back")
+                .isLessThan(SHORT_BUDGET.toMillis() / 2);
+
+        // Deliberately NOT draining, which is exactly what a paused topology does to this thread.
+        assertThat(dispatcher.hasPendingCompletions())
+                .as("the fixture only means anything while the outcome is still undrained")
+                .isTrue();
+
+        long second = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(SHORT_BUDGET));
+        assertThat(second)
+                .as("nothing new arrived and nobody drained, so this wait must take its budget. Returning "
+                        + "instantly here is a busy-spin on the StreamThread, not a fast path.")
+                .isGreaterThanOrEqualTo(SHORT_BUDGET.toMillis() - PcWorkSignal.SHORT_POLL.toMillis() - 50);
+    }
+
+    /** The same, through the crash path, which does not drain and must still deregister. */
+    @Test
+    void abortingADispatcherShutsTheGateAgain() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-abort", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+
+        awaitWorkerRunning(dispatchOneBlockingOn(release));
+
+        dispatcher.abortClose();
+        release.countDown();
+
+        assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread())
+                .as("a crashed dispatcher deregisters too - otherwise the crash-injection tests would leave a "
+                        + "phantom contributor holding every later StreamThread on the split-wait branch")
+                .isFalse();
+    }
+
+    /**
+     * <b>The rebalance re-check</b>, which is the one branch the gate cannot cover.
+     * <p>
+     * The StreamThread asks the gate, then runs a short poll, and only then waits - and a poll runs
+     * {@code ConsumerRebalanceListener} callbacks inline. A revocation there tears this thread's tasks down and
+     * deregisters their dispatchers, so by the time the wait begins the work the gate said yes to is gone.
+     * Without the second check inside {@link PcWorkSignal#awaitWorkForRemainderOf} the thread would then park
+     * for its whole budget on work that can never complete, in the middle of a rebalance, which is exactly when
+     * the consumer most needs polling.
+     * <p>
+     * Deleting that check leaves every other test in this class green, because they all reach the wait with
+     * either no signal at all or genuine work still in flight. This is the test that turns red.
+     */
+    @Test
+    void aDispatcherThatWentAwayBeforeTheWaitMakesItANoOp() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-revoked", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+
+        awaitWorkerRunning(dispatchOneBlockingOn(release));
+        assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread())
+                .as("the gate must be open first, or the re-check below is not the thing being tested")
+                .isTrue();
+
+        // The revocation, standing in for the one that would have run inside the short poll: the task goes away
+        // on this very thread, between the gate saying yes and the wait starting.
+        dispatcher.abortClose();
+        release.countDown();
+
+        long elapsed = timeMillis(() -> PcWorkSignal.awaitWorkForRemainderOf(GENEROUS_BUDGET));
+
+        assertThat(elapsed)
+                .as("the work the gate approved no longer exists, so the wait must be a no-op rather than a "
+                        + "%s park during a rebalance", GENEROUS_BUDGET)
+                .isLessThan(GENEROUS_BUDGET.toMillis() / 2);
+        assertThat(PcDispatchCounters.getSplitPollWaits())
+                .as("and it must not even be counted as a split wait - the thread never parked, and a counter "
+                        + "that says otherwise would overstate how often the mechanism ran")
+                .isZero();
+    }
+
+    /**
+     * The kill switch, which is also the benchmark's control arm - so it has to genuinely restore the stock
+     * path rather than merely skip the wait.
+     */
+    @Test
+    void theKillSwitchShutsTheGateWhileWorkIsStillInFlight() throws InterruptedException {
+        dispatcher = new PcTaskDispatcher("wake-killswitch", INPUT_PARTITIONS, 4);
+        CountDownLatch release = new CountDownLatch(1);
+
+        awaitWorkerRunning(dispatchOneBlockingOn(release));
+
+        try {
+            assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread()).isTrue();
+
+            PcDispatchSwitch.setWakeOnWork(false);
+            assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread())
+                    .as("-D%s=false must put the StreamThread back on one full-budget poll, which is what "
+                            + "makes the before/after measurement a one-term control",
+                            PcDispatchSwitch.WAKE_ON_WORK_PROPERTY)
+                    .isFalse();
+
+            PcDispatchSwitch.disable();
+            PcDispatchSwitch.setWakeOnWork(true);
+            assertThat(PcWorkSignal.hasActiveWorkOnCurrentThread())
+                    .as("and with the seam itself off there are no workers at all, so wake-on-work must stay "
+                            + "shut regardless of its own property")
+                    .isFalse();
+        } finally {
+            release.countDown();
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * Registers one record and dispatches it to a worker that blocks until {@code release} opens.
+     *
+     * @return a latch that opens once the worker is genuinely inside the chain. Waiting on it matters:
+     *         {@code inFlight} is incremented on the <em>dispatching</em> thread before submission, so a test
+     *         that only checked the count could set up its race before any worker existed, and the
+     *         "completion arrived during the wait" it thinks it forced would be something else entirely.
+     */
+    private CountDownLatch dispatchOneBlockingOn(final CountDownLatch release) {
+        registerOneRecord();
+
+        CountDownLatch started = new CountDownLatch(1);
+        int dispatched = dispatcher.dispatchAvailable(record -> () -> {
+            started.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertThat(dispatched)
+                .as("the fixture must actually dispatch, or every timing assertion below measures nothing")
+                .isEqualTo(1);
+        return started;
+    }
+
+    private void registerOneRecord() {
+        List<ConsumerRecord<byte[], byte[]>> batch = new ArrayList<>();
+        batch.add(new ConsumerRecord<>(
+                TOPIC,
+                PARTITION.partition(),
+                0L,
+                "the-key".getBytes(StandardCharsets.UTF_8),
+                "the-value".getBytes(StandardCharsets.UTF_8)));
+        dispatcher.registerRecords(PARTITION, batch);
+    }
+
+    /**
+     * Starts a daemon thread that runs {@code action} once the production code has provably entered its wait.
+     * <p>
+     * The gate is {@link PcDispatchCounters#getSplitPollWaits()}, which the production code increments at the
+     * moment it parks - a latch on the real hook rather than sleep arithmetic. That is what turns "a completion
+     * could arrive while the thread is parked" into "a completion did", and it is the reason these tests are
+     * not passing for the wrong reason most of the time. See the class javadoc.
+     * <p>
+     * Named and shared rather than repeated at each site: three tests force the same coincidence and only the
+     * action differs, and a copy that quietly loses the counter gate would still pass while proving nothing.
+     *
+     * @return the started thread, so the caller can join it before asserting
+     */
+    private static Thread runOnceTheWaitHasBegun(final String threadName, final Runnable action) {
+        Thread thread = new Thread(() -> {
+            await().atMost(Duration.ofSeconds(30))
+                    .until(() -> PcDispatchCounters.getSplitPollWaits() > 0);
+            action.run();
+        }, threadName);
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
+    }
+
+    private static void awaitWorkerRunning(final CountDownLatch started) throws InterruptedException {
+        assertThat(started.await(30, TimeUnit.SECONDS))
+                .as("the worker must actually be inside the chain before the race is set up")
+                .isTrue();
+    }
+
+    private static long timeMillis(final Runnable action) {
+        long startNanos = System.nanoTime();
+        action.run();
+        return (System.nanoTime() - startNanos) / 1_000_000L;
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java
@@ -35,21 +35,30 @@ class ShadowedClassLoadingTest {
             AbstractProcessorContext.class,
             ProcessorContextImpl.class,
             RecordCollectorImpl.class,
+            // Moved up from JAR_RESIDENT by the execution seam. The rung below this one (astubbs#379) put
+            // them in the jar-resident set precisely so that this assertion would have to flip, visibly, on
+            // the day the generated set grew - which is today. StreamTask is the seam; StreamThread is the
+            // poll wait wake-on-work splits.
+            StreamTask.class,
+            StreamThread.class,
     };
 
     /**
      * Classes we deliberately do <em>not</em> generate. They must still load from the jar - that is what makes
      * this "shadowing" rather than "a fork": the two sets have to coexist in one runtime package.
      * <p>
-     * {@link StreamTask} is the interesting one, and it is here rather than above on purpose. It is the class
-     * the execution seam will patch next, and it is the immediate neighbour of all three generated classes -
-     * it constructs the context and drives the collector. Asserting that it still comes from the jar is
-     * therefore the sharpest available check that the generated set is exactly what the pom declares, and it
-     * is what will have to change, visibly, when the seam arrives.
+     * Chosen for adjacency, not convenience: {@code PartitionGroup} is the buffer the seam bypasses,
+     * {@code RecordQueue} is reached into by the seam's own record preparation, and {@code TaskManager}
+     * constructs {@code StreamTask} on the StreamThread. If generation were ever to sprawl past the declared
+     * set, these are the first three it would reach.
+     * <p>
+     * Named as strings rather than imported because two of the sharpest neighbours are package-private, and
+     * a check that can only name public classes cannot pick its own subjects.
      */
-    private static final Class<?>[] JAR_RESIDENT = {
-            StreamTask.class,
-            StreamThread.class,
+    private static final String[] JAR_RESIDENT_NAMES = {
+            "org.apache.kafka.streams.processor.internals.PartitionGroup",
+            "org.apache.kafka.streams.processor.internals.RecordQueue",
+            "org.apache.kafka.streams.processor.internals.TaskManager",
     };
 
     @Test
@@ -71,7 +80,7 @@ class ShadowedClassLoadingTest {
 
     @Test
     void unGeneratedSiblingsStillComeFromTheJar() {
-        for (Class<?> resident : JAR_RESIDENT) {
+        for (Class<?> resident : jarResidentClasses()) {
             URL location = codeSourceOf(resident);
             log.info("{} loaded from {}", resident.getSimpleName(), location);
 
@@ -92,7 +101,7 @@ class ShadowedClassLoadingTest {
     @Test
     void generatedAndJarClassesShareOneRuntimePackage() {
         for (Class<?> generated : GENERATED) {
-            for (Class<?> resident : JAR_RESIDENT) {
+            for (Class<?> resident : jarResidentClasses()) {
                 assertThat(generated.getPackage().getName())
                         .as("%s must sit in the same package as the jar-resident classes it reaches into", generated.getName())
                         .isEqualTo(resident.getPackage().getName());
@@ -104,6 +113,26 @@ class ShadowedClassLoadingTest {
                         .isSameAs(resident.getClassLoader());
             }
         }
+    }
+
+    /**
+     * Loads {@link #JAR_RESIDENT_NAMES} through the same classloader that loaded this test, which is the one
+     * whose classpath ordering the whole module depends on. A name that does not resolve fails here rather
+     * than silently shrinking the check to whatever still exists after a Kafka upgrade.
+     */
+    private static Class<?>[] jarResidentClasses() {
+        Class<?>[] resolved = new Class<?>[JAR_RESIDENT_NAMES.length];
+        for (int i = 0; i < JAR_RESIDENT_NAMES.length; i++) {
+            try {
+                resolved[i] = Class.forName(JAR_RESIDENT_NAMES[i], false,
+                        ShadowedClassLoadingTest.class.getClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new AssertionError(JAR_RESIDENT_NAMES[i] + " is named as a jar-resident neighbour but "
+                        + "does not exist - Kafka has moved or renamed it, and this check is now guarding "
+                        + "nothing. Pick another adjacent class rather than deleting the entry.", e);
+            }
+        }
+        return resolved;
     }
 
     private static URL codeSourceOf(Class<?> type) {

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/integrationTests/BrokerStreamsIntegrationTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/integrationTests/BrokerStreamsIntegrationTest.java
@@ -1,0 +1,101 @@
+package bz.stub.parallelconsumer.streams.integrationTests;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.integrationTests.BrokerIntegrationTest;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
+
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The base every broker-backed Kafka Streams arm in this module extends: how a topology is pointed at the test
+ * broker, and how it is started and waited for.
+ * <p>
+ * <b>Only what the arms must agree on lives here.</b> The module's whole method is comparing arms that differ
+ * in one term, so the terms an experiment varies - thread count, commit interval, the dispatch switch, the
+ * topology itself - stay at the call site where they can be read next to the assertions they support. What is
+ * shared is the part where disagreement would silently make two arms incomparable: the same broker, the same
+ * serdes, and the same starting position in the topic.
+ *
+ * @author Antony Stubbs
+ */
+@Slf4j
+abstract class BrokerStreamsIntegrationTest extends BrokerIntegrationTest<String, String> {
+
+    /**
+     * Generous, because a cold broker plus the first rebalance is not quick - but bounded, so a topology that
+     * never reaches RUNNING fails here with its last state rather than timing out much later in some drain.
+     */
+    private static final Duration STARTUP_TIMEOUT = Duration.ofSeconds(60);
+
+    /**
+     * For the arms that ask for it: log the stack trace and take the client down.
+     * <p>
+     * A StreamThread that dies without this leaves nothing but a test timeout to diagnose from, and an arm
+     * that carried on with one thread fewer would be measuring a topology that is no longer the one it
+     * described.
+     */
+    static final StreamsUncaughtExceptionHandler LOG_AND_SHUT_DOWN_CLIENT = throwable -> {
+        log.error("Streams thread died", throwable);
+        return StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
+    };
+
+    /**
+     * The props every arm shares, and nothing else. No thread count and no commit interval: an arm that
+     * inherited either without saying so would be measuring something other than what it claims to.
+     */
+    Properties baseStreamsProps(final String applicationId) {
+        Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        // Start from the beginning so the test is not racing the topology's startup - several arms produce
+        // everything before starting, and every one of those records would otherwise be skipped.
+        props.put(StreamsConfig.consumerPrefix("auto.offset.reset"), "earliest");
+        return props;
+    }
+
+    KafkaStreams startAndAwaitRunning(final StreamsBuilder builder, final Properties props) {
+        return startAndAwaitRunning(new KafkaStreams(builder.build(), props));
+    }
+
+    /**
+     * @param uncaughtHandler installed before {@code start()}, which is the only point at which it can be -
+     *                        see {@link #LOG_AND_SHUT_DOWN_CLIENT}
+     */
+    KafkaStreams startAndAwaitRunning(final StreamsBuilder builder,
+                                      final Properties props,
+                                      final StreamsUncaughtExceptionHandler uncaughtHandler) {
+        KafkaStreams streams = new KafkaStreams(builder.build(), props);
+        streams.setUncaughtExceptionHandler(uncaughtHandler);
+        return startAndAwaitRunning(streams);
+    }
+
+    private static KafkaStreams startAndAwaitRunning(final KafkaStreams streams) {
+        streams.start();
+
+        AtomicInteger polls = new AtomicInteger();
+        await().atMost(STARTUP_TIMEOUT).until(() -> {
+            KafkaStreams.State state = streams.state();
+            // Every tenth poll, not every one: a slow start would otherwise bury the run's own logging under
+            // a line per Awaitility interval, and the state only matters when it stops changing.
+            if (polls.getAndIncrement() % 10 == 0) {
+                log.info("Waiting for Streams to run, state={}", state);
+            }
+            return state == KafkaStreams.State.RUNNING;
+        });
+        return streams;
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/integrationTests/PcDrivenStreamsDispatchTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/integrationTests/PcDrivenStreamsDispatchTest.java
@@ -43,14 +43,16 @@ import static org.awaitility.Awaitility.await;
  * {@link PcDispatchSwitch}. That is what makes the dispatch marker meaningful - correct output is asserted in
  * both, so output alone would prove nothing about which path ran.
  * <p>
- * {@code @Isolated} is not decoration. The switch is process-wide (see {@link PcDispatchSwitch} for why it has
- * to be), and this module runs tests concurrently, so without isolation the flag-on arm could turn PC
- * dispatch on underneath {@link ShadowedStreamsControlTest} - silently converting the control arm into a
- * second PC arm and destroying the only baseline the module has.
+ * {@code @Isolated} is not decoration. The switch and the counters are process-wide (see
+ * {@link PcDispatchSwitch} for why they have to be), and this module runs tests concurrently, so without
+ * isolation the seam-on arm could turn PC dispatch on underneath
+ * {@link #withTheSwitchOffNothingIsDispatchedAndTheOutputIsStillCorrect()} - silently converting the control
+ * arm into a second PC arm, and a control that is only a control when nothing else is running is not one.
+ * The same applies to any other class that touches the switch, which is why they all carry it.
  *
  * @author Antony Stubbs
  * @see bz.stub.parallelconsumer.streams.PcTaskDispatcherTest
- * @see ShadowedStreamsControlTest
+ * @see WakeOnWorkShutdownTest
  */
 @Slf4j
 @Isolated

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/integrationTests/PcDrivenStreamsDispatchTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/integrationTests/PcDrivenStreamsDispatchTest.java
@@ -1,0 +1,358 @@
+package bz.stub.parallelconsumer.streams.integrationTests;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.integrationTests.utils.KafkaClientUtils;
+import bz.stub.parallelconsumer.streams.PcDispatchCounters;
+import bz.stub.parallelconsumer.streams.PcDispatchSwitch;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+import pl.tlinkowski.unij.api.UniLists;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The U5 end-to-end arm: a real broker, a real {@code KafkaStreams} instance, and a real topology, with the
+ * task's records reaching the processor chain through Parallel Consumer's {@code WorkManager} and a worker
+ * pool instead of through {@code partitionGroup.nextRecord()} on the StreamThread.
+ * <p>
+ * The two arms below are the same topology and the same data; the only difference is
+ * {@link PcDispatchSwitch}. That is what makes the dispatch marker meaningful - correct output is asserted in
+ * both, so output alone would prove nothing about which path ran.
+ * <p>
+ * {@code @Isolated} is not decoration. The switch is process-wide (see {@link PcDispatchSwitch} for why it has
+ * to be), and this module runs tests concurrently, so without isolation the flag-on arm could turn PC
+ * dispatch on underneath {@link ShadowedStreamsControlTest} - silently converting the control arm into a
+ * second PC arm and destroying the only baseline the module has.
+ *
+ * @author Antony Stubbs
+ * @see bz.stub.parallelconsumer.streams.PcTaskDispatcherTest
+ * @see ShadowedStreamsControlTest
+ */
+@Slf4j
+@Isolated
+class PcDrivenStreamsDispatchTest extends BrokerStreamsIntegrationTest {
+
+    private static final int KEYS = 6;
+    private static final int RECORDS_PER_KEY = 5;
+    private static final int TOTAL = KEYS * RECORDS_PER_KEY;
+
+    private static final int POOL_SIZE = 4;
+
+    /**
+     * Slow enough that records genuinely overlap in the chain, short enough that the whole run is quick. With
+     * stock serial dispatch, {@link #TOTAL} records at this cost take at least
+     * {@code TOTAL * PROCESSING_COST}; concurrency is what keeps this test from being tedious as well as what
+     * it is asserting.
+     */
+    private static final Duration PROCESSING_COST = Duration.ofMillis(150);
+
+    private static final String SUFFIX = "-processed";
+
+    private final ChainConcurrencyProbe probe = new ChainConcurrencyProbe();
+
+    @BeforeEach
+    void resetDispatchState() {
+        PcDispatchCounters.reset();
+        probe.reset();
+    }
+
+    /** Hand the JVM back at the artifact's default (on), so the next test states its own requirement. */
+    @AfterEach
+    void restoreDefaultDispatch() {
+        PcDispatchSwitch.resetToDefault();
+    }
+
+    @Test
+    void recordsReachTheChainThroughTheWorkManagerAndRunConcurrently() {
+        PcDispatchSwitch.enable(POOL_SIZE);
+
+        Map<String, List<String>> received = runTopology("pc-on");
+        logDispatchEvidence("PC ON");
+
+        assertThat(PcDispatchCounters.getRecordsDispatchedToPool())
+                .as("THE assertion of this unit: records were handed to a worker pool by PcTaskDispatcher. "
+                        + "This counter moves at exactly one place in the codebase, so a non-zero reading "
+                        + "cannot be produced by the stock path however correct its output looks.")
+                .isGreaterThanOrEqualTo(TOTAL);
+
+        assertThat(PcDispatchCounters.getRecordsAcceptedByWorkManager())
+                .as("and none were dropped for want of a partition-assignment epoch on the way in")
+                .isEqualTo(PcDispatchCounters.getRecordsOfferedToWorkManager());
+        assertThat(PcDispatchCounters.getRecordsOfferedToWorkManager())
+                .as("every produced record must have been offered to PC")
+                .isGreaterThanOrEqualTo(TOTAL);
+
+        assertThat(probe.peakConcurrency.get())
+                .as("with a pool of %s and a %s processor, at least 3 records must be inside the processor "
+                                + "chain at once - this is the property the whole module exists to test",
+                        POOL_SIZE, PROCESSING_COST)
+                .isGreaterThanOrEqualTo(3);
+        assertThat(probe.keysSeenConcurrentlyWithThemselves)
+                .as("but never two records of the same key - KEY ordering is what lets a Streams topology "
+                        + "survive parallel dispatch at all")
+                .isEmpty();
+
+        assertOutputIsCorrect(received);
+    }
+
+    /**
+     * The flag-off arm. Same topology, same data, stock Kafka Streams dispatch - the marker must not move.
+     */
+    @Test
+    void withTheSwitchOffNothingIsDispatchedAndTheOutputIsStillCorrect() {
+        // Explicit, and load-bearing: the seam defaults ON, so without this line this arm is not a control.
+        PcDispatchSwitch.disable();
+
+        Map<String, List<String>> received = runTopology("pc-off");
+        logDispatchEvidence("PC OFF");
+
+        assertThat(PcDispatchCounters.getRecordsDispatchedToPool())
+                .as("with the switch off, no record may reach the worker pool")
+                .isZero();
+        assertThat(PcDispatchCounters.getRecordsOfferedToWorkManager())
+                .as("nor may any record be handed to PC at all - addRecords must go to the partition group")
+                .isZero();
+
+        assertThat(probe.peakConcurrency.get())
+                .as("and the chain must be walked one record at a time, on the StreamThread")
+                .isEqualTo(1);
+
+        assertOutputIsCorrect(received);
+    }
+
+    /**
+     * The failure arm, end to end - the half of the retry story the dispatcher-level test cannot reach,
+     * because it exercises the patched {@code StreamTask.pcProcess} re-throw rather than the bridge.
+     * <p>
+     * Stock Kafka Streams answers a processor exception by surfacing it to the uncaught-exception handler and
+     * killing the thread. Parallel Consumer's answer is to re-dispatch, which here would re-run the whole
+     * chain including {@code forward()} calls that already emitted downstream - duplicates stock never
+     * produces. So retries are disabled and the failure is surfaced instead: the assertion below is that the
+     * poison record is attempted <b>exactly once</b>, and that the client reports the failure rather than
+     * hanging.
+     */
+    @Test
+    void aProcessorThatThrowsSurfacesTheFailureAndRunsTheRecordExactlyOnce() {
+        PcDispatchSwitch.enable(POOL_SIZE);
+        probe.poisonKey = "key-3";
+
+        String inputTopic = setupTopic("pc-boom-in");
+        String outputTopic = setupTopic("pc-boom-out");
+        ensureTopic(inputTopic, 1);
+        ensureTopic(outputTopic, 1);
+
+        KafkaStreams streams = startTopology("pc-boom", inputTopic, outputTopic);
+        try {
+            produce(inputTopic);
+
+            await().atMost(Duration.ofSeconds(90)).until(() ->
+                    streams.state() == KafkaStreams.State.ERROR
+                            || streams.state() == KafkaStreams.State.NOT_RUNNING);
+
+            logDispatchEvidence("PC BOOM");
+
+            assertThat(probe.poisonAttempts.get())
+                    .as("exactly one attempt. A retry would re-run the chain from the source node and re-emit "
+                            + "every record the first attempt already forwarded - a duplicate stock Kafka "
+                            + "Streams never produces, which is why PC's retries are disabled here.")
+                    .isEqualTo(1);
+            assertThat(PcDispatchCounters.getRecordsFailed())
+                    .as("and the dispatcher must have counted exactly that one failure")
+                    .isEqualTo(1);
+            assertThat(PcDispatchCounters.getRecordsCompletedSuccessfully())
+                    .as("records of other keys must still have run - a failure blocks its own KEY shard, not "
+                            + "the task")
+                    .isGreaterThan(0);
+        } finally {
+            streams.close(Duration.ofSeconds(60));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * The numbers a result document can quote, printed rather than only asserted - "at least 3 in flight"
+     * passing tells you the bar was cleared, not by how much.
+     */
+    private void logDispatchEvidence(final String arm) {
+        log.info("=== {} arm | offered={} accepted={} dispatchedToPool={} succeeded={} failed={} "
+                        + "peakChainConcurrency={} keysConcurrentWithThemselves={} poisonAttempts={}",
+                arm,
+                PcDispatchCounters.getRecordsOfferedToWorkManager(),
+                PcDispatchCounters.getRecordsAcceptedByWorkManager(),
+                PcDispatchCounters.getRecordsDispatchedToPool(),
+                PcDispatchCounters.getRecordsCompletedSuccessfully(),
+                PcDispatchCounters.getRecordsFailed(),
+                probe.peakConcurrency.get(),
+                probe.keysSeenConcurrentlyWithThemselves.keySet(),
+                probe.poisonAttempts.get());
+    }
+
+    private void assertOutputIsCorrect(final Map<String, List<String>> received) {
+        assertThat(flatten(received))
+                .as("every input record must produce exactly one output record - no drops, no duplicates")
+                .hasSize(TOTAL);
+        assertThat(received.keySet())
+                .as("every key that went in must come out")
+                .hasSize(KEYS);
+
+        for (Map.Entry<String, List<String>> perKey : received.entrySet()) {
+            List<String> expected = new ArrayList<>();
+            for (int i = 0; i < RECORDS_PER_KEY; i++) {
+                expected.add("v" + i + SUFFIX);
+            }
+            assertThat(perKey.getValue())
+                    .as("key %s must come out in the order it went in - under KEY ordering this survives "
+                            + "parallel dispatch, and it is the first thing to break if it does not",
+                            perKey.getKey())
+                    .containsExactlyElementsOf(expected);
+        }
+    }
+
+    private Map<String, List<String>> runTopology(final String namePrefix) {
+        String inputTopic = setupTopic(namePrefix + "-in");
+        String outputTopic = setupTopic(namePrefix + "-out");
+        ensureTopic(inputTopic, 1);
+        ensureTopic(outputTopic, 1);
+
+        KafkaStreams streams = startTopology(namePrefix, inputTopic, outputTopic);
+        try {
+            produce(inputTopic);
+            return consumeByKey(outputTopic);
+        } finally {
+            streams.close(Duration.ofSeconds(60));
+        }
+    }
+
+    private KafkaStreams startTopology(final String namePrefix, final String inputTopic, final String outputTopic) {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> stream = builder.stream(inputTopic);
+        // The key-aware mapValues overload, so the probe can tell "two records of the same key at once"
+        // from "two different keys at once" - they are the two halves of the KEY-ordering claim, and the
+        // plain ValueMapper cannot distinguish them.
+        stream.mapValues((key, value) -> probe.processOneRecord(key, value)).to(outputTopic);
+
+        Properties props = baseStreamsProps(namePrefix + "-" + System.nanoTime());
+        // One StreamThread, so the only concurrency observed inside the chain is the one this unit
+        // introduced. With two threads a probe reading "2 at once" would prove nothing.
+        props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+        // __processing.threads.enabled__ is deliberately left UNSET (default false). It selects
+        // SynchronizedPartitionGroup inside StreamTask - a lock around a partition group that the PC path
+        // does not use at all - and it also puts Kafka Streams' own async task executor between the poll loop
+        // and process(), which is precisely the seam being measured. Leaving it off keeps the flag-off arm
+        // stock and the flag-on arm attributable.
+
+        return startAndAwaitRunning(builder, props, LOG_AND_SHUT_DOWN_CLIENT);
+    }
+
+    private void produce(final String inputTopic) {
+        try (KafkaProducer<String, String> producer = getKcu().createNewProducer(KafkaClientUtils.ProducerMode.NOT_TRANSACTIONAL)) {
+            for (int i = 0; i < RECORDS_PER_KEY; i++) {
+                for (int k = 0; k < KEYS; k++) {
+                    producer.send(new ProducerRecord<>(inputTopic, "key-" + k, "v" + i));
+                }
+            }
+            producer.flush();
+        }
+        log.info("Produced {} records across {} keys", TOTAL, KEYS);
+    }
+
+    private Map<String, List<String>> consumeByKey(final String outputTopic) {
+        Map<String, List<String>> byKey = new LinkedHashMap<>();
+        try (KafkaConsumer<String, String> consumer = getKcu().createNewConsumer(KafkaClientUtils.GroupOption.NEW_GROUP)) {
+            consumer.subscribe(UniLists.of(outputTopic));
+
+            await().atMost(Duration.ofSeconds(120)).until(() -> {
+                ConsumerRecords<String, String> polled = consumer.poll(Duration.ofMillis(500));
+                for (ConsumerRecord<String, String> record : polled) {
+                    byKey.computeIfAbsent(record.key(), k -> new ArrayList<>()).add(record.value());
+                }
+                int total = flatten(byKey).size();
+                log.debug("Consumed {}/{} so far", total, TOTAL);
+                return total >= TOTAL;
+            });
+        }
+        return byKey;
+    }
+
+    private static List<String> flatten(final Map<String, List<String>> byKey) {
+        List<String> all = new ArrayList<>();
+        byKey.values().forEach(all::addAll);
+        return all;
+    }
+
+    /**
+     * Sits inside the topology as the {@code mapValues} body, so what it measures is concurrency <em>within
+     * the processor chain</em> - not within the dispatcher. That distinction matters: the dispatcher could
+     * happily run four threads that all serialise on some lock inside Kafka Streams, and only a probe on this
+     * side of the seam would notice.
+     */
+    private static final class ChainConcurrencyProbe {
+
+        private final AtomicInteger inFlight = new AtomicInteger();
+        private final AtomicInteger peakConcurrency = new AtomicInteger();
+        private final Map<String, AtomicInteger> inFlightPerKey = new ConcurrentHashMap<>();
+        private final Map<String, Boolean> keysSeenConcurrentlyWithThemselves = new ConcurrentHashMap<>();
+
+        /** When set, records with this key throw - see the failure arm. */
+        private volatile String poisonKey;
+
+        private final AtomicInteger poisonAttempts = new AtomicInteger();
+
+        private void reset() {
+            inFlight.set(0);
+            peakConcurrency.set(0);
+            inFlightPerKey.clear();
+            keysSeenConcurrentlyWithThemselves.clear();
+            poisonKey = null;
+            poisonAttempts.set(0);
+        }
+
+        private String processOneRecord(final String key, final String value) {
+            if (key.equals(poisonKey)) {
+                poisonAttempts.incrementAndGet();
+                throw new IllegalStateException("processor blew up on " + key + "/" + value);
+            }
+            int concurrent = inFlight.incrementAndGet();
+            peakConcurrency.accumulateAndGet(concurrent, Math::max);
+
+            AtomicInteger perKey = inFlightPerKey.computeIfAbsent(key, ignored -> new AtomicInteger());
+            if (perKey.incrementAndGet() > 1) {
+                keysSeenConcurrentlyWithThemselves.put(key, Boolean.TRUE);
+            }
+            try {
+                Thread.sleep(PROCESSING_COST.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                perKey.decrementAndGet();
+                inFlight.decrementAndGet();
+            }
+            return value + SUFFIX;
+        }
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/integrationTests/WakeOnWorkShutdownTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/integrationTests/WakeOnWorkShutdownTest.java
@@ -1,0 +1,232 @@
+package bz.stub.parallelconsumer.streams.integrationTests;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.integrationTests.utils.KafkaClientUtils;
+import bz.stub.parallelconsumer.streams.PcDispatchCounters;
+import bz.stub.parallelconsumer.streams.PcDispatchSwitch;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Wake-on-work's shutdown proof (astubbs#255, item 3).
+ * <p>
+ * <b>Why this test exists at all.</b> The design note for wake-on-work names one trap explicitly: do not reach
+ * for {@code KafkaConsumer#wakeup()} as the wake signal, because Kafka Streams' vocabulary already gives
+ * {@code wakeup()} the meaning <em>shutdown</em>, and a wake delivered while the thread is not polling arms
+ * the <em>next</em> poll instead - so a stray completion signal could swallow a shutdown one. That is a
+ * failure that shows up once in a thousand shutdowns and never reproduces on demand. This module took the
+ * other road and built its own condition, which is precisely why the shutdown path is the one that has to be
+ * demonstrated rather than argued: the hazard being avoided is a shutdown-path hazard.
+ * <p>
+ * <b>The precondition is asserted, not assumed.</b> A close that happens to land while the StreamThread is
+ * somewhere else would pass this test while proving nothing. So the topology is held with records genuinely
+ * in flight, and {@link PcDispatchCounters#getSplitPollWaits()} - incremented only where the thread parks on
+ * our own condition - is required to <em>advance</em> immediately before the close is attempted, rather than
+ * merely to be non-zero. Non-zero is a historical fact that never becomes false again; an advancing count is
+ * the live one.
+ * <p>
+ * <b>What this test does not discriminate, and where that lives instead.</b> It cannot fail if
+ * {@code PcWorkSignal.wakeOwner} were made a no-op: at the default {@code poll.ms} of 100ms that regression
+ * costs at most ~100ms, and a broker-backed close of a draining topology is measured in seconds. Raising
+ * {@code poll.ms} to make the bill visible would not fix that, because it would make the control arm pay the
+ * same bill - stock {@code StreamThread.shutdown()} also only sets {@code PENDING_SHUTDOWN} and lets the loop
+ * notice - and both arms passing is the whole point of having a control here. The discriminating assertion on
+ * {@code wakeOwner} is {@code PcWorkSignalTest.wakeOwnerEndsTheWaitEvenWithNoWorkArriving}, which measures
+ * that wait directly against a budget three orders of magnitude wider than a correct wake. This test's claim
+ * is the narrower one, and the one only a broker can answer: closing <em>while parked on our own condition</em>
+ * still shuts down cleanly and completes rather than timing out.
+ *
+ * @author Antony Stubbs
+ * @see bz.stub.parallelconsumer.streams.PcWorkSignal
+ */
+@Slf4j
+// PcDispatchSwitch and PcDispatchCounters are process-wide: a concurrently running class would flip the arm
+// this test measured and write the counter it reads.
+@Isolated
+class WakeOnWorkShutdownTest extends BrokerStreamsIntegrationTest {
+
+    private static final int POOL_SIZE = 4;
+
+    /**
+     * Long enough that the records are unambiguously still in the chain when the close is called, and short
+     * enough that the teardown's own drain can finish inside {@link #CLOSE_TIMEOUT}.
+     * <p>
+     * That second half is not a detail. <b>Closing this module's task drains in-flight work on purpose</b> -
+     * the patched {@code suspend()} pumps to quiescence before the topology is torn down around it, so a
+     * worker still inside the chain would otherwise be forwarding into a record collector that is about to
+     * close. A first version of this test used a 30s record against a 20s close budget and both arms failed
+     * identically, which is the designed drain doing its job rather than a shutdown defect. The control arm
+     * is what said so.
+     */
+    private static final Duration RECORD_COST = Duration.ofSeconds(3);
+
+    private static final int RECORDS = 2;
+
+    /**
+     * Generous against the real cost of a broker-backed close plus the drain above, so that a close which
+     * merely ran out of patience is distinguishable from one that completed.
+     */
+    private static final Duration CLOSE_TIMEOUT = Duration.ofSeconds(60);
+
+    @BeforeEach
+    void resetCounters() {
+        PcDispatchCounters.reset();
+    }
+
+    @AfterEach
+    void restoreDefaultDispatch() {
+        PcDispatchSwitch.resetToDefault();
+    }
+
+    /**
+     * The proof: close a topology while workers are inside the chain and the StreamThread is parked on the
+     * wake-on-work condition, and it still shuts down cleanly and promptly.
+     */
+    @Test
+    void closingWhileParkedOnTheWakeConditionShutsDownCleanly() throws InterruptedException {
+        assertShutsDownCleanlyMidDispatch("wake-shutdown-on", true);
+    }
+
+    /**
+     * The control arm. The same close, with wake-on-work off, so the StreamThread is blocked in
+     * {@code Consumer#poll()} the way stock is.
+     * <p>
+     * Both arms are expected to pass - that is the point. The claim being defended is that owning the poll
+     * wait does not <em>change</em> the shutdown outcome, and a single green arm cannot say that: it would
+     * leave open whether this topology shuts down cleanly for reasons unrelated to the mechanism.
+     */
+    @Test
+    void theSameCloseWorksWithWakeOnWorkOff() throws InterruptedException {
+        assertShutsDownCleanlyMidDispatch("wake-shutdown-off", false);
+    }
+
+    private void assertShutsDownCleanlyMidDispatch(final String name, final boolean wakeOnWork)
+            throws InterruptedException {
+        PcDispatchSwitch.enable(POOL_SIZE);
+        PcDispatchSwitch.setWakeOnWork(wakeOnWork);
+        assertThat(PcDispatchSwitch.isWakeOnWorkEnabled())
+                .as("%s arm must run with wake-on-work %s", name, wakeOnWork ? "ON" : "OFF")
+                .isEqualTo(wakeOnWork);
+
+        String inputTopic = setupTopic(name + "-in");
+        String outputTopic = setupTopic(name + "-out");
+        ensureTopic(inputTopic, 1);
+        ensureTopic(outputTopic, 1);
+
+        CountDownLatch entered = new CountDownLatch(1);
+        AtomicInteger interrupted = new AtomicInteger();
+
+        produce(inputTopic);
+
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> stream = builder.stream(inputTopic);
+        stream.mapValues((key, value) -> {
+            entered.countDown();
+            try {
+                // Still in the chain when the close lands - which is the whole scenario. A block, not a spin,
+                // so the close is not competing with this thread for a core.
+                Thread.sleep(RECORD_COST.toMillis());
+            } catch (InterruptedException e) {
+                // Expected: the close interrupts the pool. Counted rather than swallowed silently, so the
+                // teardown path this test exercises is visible in the run's output.
+                Thread.currentThread().interrupt();
+                interrupted.incrementAndGet();
+            }
+            return value;
+        }).to(outputTopic);
+
+        Properties props = baseStreamsProps(name + "-" + System.nanoTime());
+        // One StreamThread, matching every other arm in this module: the only concurrency is the one under test.
+        props.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+
+        KafkaStreams streams = startAndAwaitRunning(builder, props);
+        boolean closedCleanly;
+        long closeMillis;
+        try {
+            assertThat(entered.await(120, TimeUnit.SECONDS))
+                    .as("a record must actually be inside the processor chain, or the close under test is not "
+                            + "happening mid-dispatch and this test proves nothing")
+                    .isTrue();
+
+            if (wakeOnWork) {
+                // THE PRECONDITION. Without this the close might land while the thread is anywhere at all, and
+                // a green result would say nothing about the wait this change introduced.
+                //
+                // Waited for a FRESH park, not for any park. The counter increments on ENTRY to the wait, so
+                // "> 0" says only that the thread parked at some point - which stays true forever afterwards,
+                // including long after the thread has moved on. Requiring the count to advance from a snapshot
+                // taken here proves it is still cycling into the wait as the close lands, which is the
+                // condition this test claims to be closing under.
+                long parkedBefore = PcDispatchCounters.getSplitPollWaits();
+                await().atMost(Duration.ofSeconds(60))
+                        .until(() -> PcDispatchCounters.getSplitPollWaits() > parkedBefore);
+                log.info("=== {} - StreamThread parked on the wake condition again ({} total) immediately "
+                        + "before close", name, PcDispatchCounters.getSplitPollWaits());
+            }
+        } finally {
+            long startNanos = System.nanoTime();
+            closedCleanly = streams.close(CLOSE_TIMEOUT);
+            closeMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+        }
+
+        log.info("=== {} - close returned {} in {}ms (wake-on-work {}), {} worker(s) interrupted",
+                name, closedCleanly, closeMillis, wakeOnWork ? "ON" : "OFF", interrupted.get());
+
+        assertThat(closedCleanly)
+                .as("%s: closing mid-dispatch must succeed within %s. A false here is the shutdown-path "
+                        + "hazard this design exists to avoid, arriving anyway.", name, CLOSE_TIMEOUT)
+                .isTrue();
+        assertThat(streams.state())
+                .as("%s: and the client must actually reach NOT_RUNNING rather than merely reporting success",
+                        name)
+                .isEqualTo(KafkaStreams.State.NOT_RUNNING);
+        assertThat(closeMillis)
+                .as("%s: the close must COMPLETE rather than run out the clock. Returning true only at the "
+                        + "%s mark would be a timeout wearing a success's clothes - and a StreamThread that "
+                        + "sat out its poll budget on our own condition is exactly how that would happen.",
+                        name, CLOSE_TIMEOUT)
+                .isLessThan(CLOSE_TIMEOUT.toMillis() / 2);
+
+        if (wakeOnWork) {
+            assertThat(PcDispatchCounters.getSplitPollWaits())
+                    .as("%s: and the mechanism must genuinely have been in play - a zero here means the "
+                            + "StreamThread never parked on our condition and this arm tested stock", name)
+                    .isPositive();
+        } else {
+            assertThat(PcDispatchCounters.getSplitPollWaits())
+                    .as("%s: the control arm must be genuinely inert. A non-zero here means the kill switch "
+                            + "did not reach the run and both arms measured the same thing.", name)
+                    .isZero();
+        }
+    }
+
+    private void produce(final String inputTopic) {
+        try (KafkaProducer<String, String> producer =
+                     getKcu().createNewProducer(KafkaClientUtils.ProducerMode.NOT_TRANSACTIONAL)) {
+            for (int i = 0; i < RECORDS; i++) {
+                producer.send(new ProducerRecord<>(inputTopic, "key-" + i, "value-" + i));
+            }
+            producer.flush();
+        }
+    }
+}


### PR DESCRIPTION
Serves astubbs/parallel-consumer#255.

depends on astubbs/parallel-consumer#379

## Description

**The claim this PR makes: a Kafka Streams topology's records can be selected by Parallel Consumer's
`WorkManager` and run on its worker pool instead of serially by `StreamTask`, and the seam can be
switched off so that the machinery rung's behaviour-preservation oracle is unchanged.**

Stock Kafka Streams parallelises across *partitions*. Inside one partition,
`PartitionGroup.nextRecord()` hands records over strictly one at a time, so one slow record delays
everything queued behind it whatever key it carries. That serialisation has no semantic justification
when the records are on different keys, and it is what this removes. A topology's own code does not
change.

The rung below this one, astubbs/parallel-consumer#379, established that Kafka Streams internals can
be patched at build time without vendoring them, and deliberately left `StreamTask` out of its patch
because it is the only class in the set that references Parallel Consumer. That separation held
exactly as predicted: this PR adds `StreamTask` and `StreamThread` to the patch and the Parallel
Consumer classes they call into, and changes nothing about how the machinery works.

### The switch: OFF by default, and this reverses an inherited decision

Turn it on for a JVM with `-Dpc.streams.dispatch.enabled=true`.

**The recommendation is off, and the reason is a missing refusal rather than caution.** Joins,
windows, suppression, exactly-once and stream-time punctuation are unsupported on the PC path *and
are not yet refused* - refusal is the next unit. A topology using one of them is dispatched anyway
and gets wrong behaviour with nothing in the log to say so. An opt-in preview is the honest default
until the refusal envelope exists.

**The argument being reversed is not the one that was made.** astubbs/parallel-consumer#271 defaulted
it on, reasoning that depending on a separate, loudly-labelled alpha artifact *is* the opt-in, so
demanding a system property as well is friction that buys nothing. That is a good argument and it
beat a real bad one - an earlier revision that defaulted off merely so a control-arm test would stay
stock without saying so, which was a test concern billed to every user. What it does not cover is a
user who opts in to *per-key concurrency* and gets *silently altered semantics* on a topology shape
nobody refused. `PcDispatchSwitch`'s javadoc states this where somebody would otherwise read the
default as timidity and revert it, and says to restore on-by-default the day refusal lands. No test
depends on which way the default points - each arm states its requirement at its own site.

**The per-instance switch is not here, and is recorded as debt rather than left implicit.** The
switch is process-wide, so two `KafkaStreams` instances in one JVM cannot differ; there is no seam
through `KafkaStreams` to inject a collaborator. An unfinished implementation exists on
`feats/streams-dispatch-streamsconfig-property` (`PcDispatchSettings`, precedence config > system
property > default) and is missing the one test that distinguishes it from the design it replaces -
two instances, two settings - which every single-instance test passes without. Judged out of scope
here: taking it meant reconciling three files and the patch against a branch cut from a base that
predates wake-on-work, and then either shipping the per-instance switch unproven or blocking this
seam on a test three previous attempts stopped at. The default being off makes waiting cheap. Written
up, with what it still needs, in
`docs/inflight/streams-dispatch-switch-is-jvm-wide-not-per-instance.md`.

### What is in the patch, and how it was produced

| Class | Change |
|---|---|
| `StreamTask` | `addRecords` registers into the dispatcher instead of the partition group; `process()` pumps instead of selecting; the commit gates ask the dispatcher rather than the raw `commitNeeded` field; `RecordInfo` becomes per-record, and the current record travels down the call stack as a parameter instead of being read out of task state - under PC there is no single "current record" for a task |
| `StreamThread` | the poll wait is split: a short poll, then a wait on our own condition that a worker completion ends |

Regenerated by the prescribed procedure - `process-sources`, edit under `target/kafka-patched`,
`bin/regen-patch.sh` with no maven run in between - **never hand-edited**, and **verified by content
rather than by hunk count**: the added and removed lines of the three inherited files are
byte-identical to what astubbs/parallel-consumer#379 tracked, and the two new files are byte-identical
to the forest branches they were cut from, modulo the `io.confluent` to `bz.stub` rename applied to
the PC-side import only. The patched Kafka sources stay in `org.apache.kafka`.

### Wake-on-work

`StreamThread` polls and processes on **one** thread, so blocking in `Consumer#poll()` for the full
`poll.ms` costs stock nothing - there is by definition no processing it could be doing instead. Hand
records to a worker pool and that inverts: records complete *during* the poll wait, and neither their
completions nor the records they unblock can move until poll returns. Worse, the inner work loop
breaks back out to poll whenever a pass dispatched nothing - which under an asynchronous dispatcher
also means "the pool is full" or "every available key is already in flight", states that resolve on a
worker completion and never on a broker fetch. The loop therefore blocks precisely when a completion
is imminent.

Deliberately **not** `KafkaConsumer#wakeup()`: that word already means *shutdown* to Kafka Streams,
and a wake delivered while the thread is not polling arms the *next* poll instead, so a stray
completion could swallow a shutdown - a failure that shows up once in a thousand shutdowns and never
reproduces on demand.

**The forest measured wake-on-work as roughly two thirds of the backlog benefit, by ablation, and
that figure is not repeated anywhere in this PR's code or docs.** It is owned by
`docs/solutions/best-practices/ablate-your-own-change-not-only-the-baseline.md`, already on master.
The benchmark that produces a number is a separate unit; a figure copied into a second document
drifts from the first silently. What this rung ships is the mechanism and the tests that show it is
load-bearing.

### Proven able to fail

Each claim was sabotaged with the predicted failure stated first, then reverted byte-identically.

- **`signalWorkAvailable()` made a no-op.** Predicted: the completion-wake cases fail, while
  `wakeOwnerEndsTheWaitEvenWithNoWorkArriving` stays green because it turns on a different counter.
  Four cases failed and that one stayed green - the asymmetry is what says the right thing broke.
- **The `StreamThread` hunks removed from the patch**, by the same regen procedure. Predicted:
  `WakeOnWorkShutdownTest` fails on its split-poll-wait precondition while the dispatch arm stays
  green. It timed out on exactly that precondition and `PcDrivenStreamsDispatchTest` stayed green -
  the loss localised to the poll wait alone.
- **`createIfEnabled` forced to return `null`.** Predicted: correct *output* but a failed *dispatch
  marker*, since stock Streams produces the same records. Exactly that, and the stock control arm
  stayed green - which is the whole reason the marker assertion sits beside the output assertion.

### The oracle, and the seam-on situation stated honestly

Kafka's own `StreamThreadTest` joins the upstream execution, because the rule is "the tests of the
classes we patch" and leaving it out would have made the widest-blast-radius class the one part of
the patch with no upstream suite behind it.

**Seam off, the control arm did not move**: the three classes astubbs/parallel-consumer#379 left
green are green at the same figures, run before and after this change. Re-derive rather than copy -
read them out of `target/surefire-reports-kafka-upstream/` after the module's whole `test` phase, and
never scope that run with `-Dtest=`.

Part of `StreamThreadTest` is skipped, by Kafka's **own** `assumeTrue`/`assumeFalse` on its
`stateUpdaterEnabled` x `processingThreadsEnabled` parameter matrix. Established by mechanism rather
than by a control run: those assumptions are the first statement of each method and are evaluated
from the test's own parameters before any patched code executes, so nothing in this patch can
influence them.

**Seam on, the upstream suite diverges, and this PR does not wire that up or hide it.** Measured once
locally by flipping the oracle's pin: `StreamTaskTest` and `StreamThreadTest` both go partly red.
Those cases assert on offset and commit-metadata *encodings* that this design deliberately diverges
from - PC's frontier is not Streams' `consumedOffsets` - so they are a statement about a different
design rather than a regression. Classifying them case by case and standing up a lane that can tell a
real regression from a designed divergence is the evidence unit's job. No count is written into the
code or the docs, because a number with no lane behind it gets quoted as a result.

The oracle's execution keeps its `pc.streams.dispatch.enabled=false` pin, written by the parent rung
ahead of any reader. It is **not** redundant now that the default agrees with it: the claim is about
the patch, not about a default, and deleting the pin would make the oracle silently follow the
default the day it moves.

### Deliberate, not oversights

- **`revive()` throws under PC dispatch.** `closeDirtyAndRevive` resurrects the same task instance,
  whose dispatcher is final and was closed on the way down, so a revived task would register records
  into a dispatcher that never hands them out again: no progress, no exception, nothing in the log.
  This is a loud-failure floor, **not** lifecycle support - recreating the dispatcher belongs to the
  rebalance unit.
- **Retries are disabled.** PC's answer to a failure is to re-dispatch, which here would re-run a
  processor chain whose `forward()` calls already emitted downstream - duplicates stock never
  produces. A failed record blocks its own KEY shard while every other key keeps flowing.
- **`forbiddenapis` fired on our own code and was fixed, not excluded.** A locale-dependent
  `String.format` in `PcTaskDispatcher`. The module's Kafka exclusion covers the generated
  `org.apache.kafka` tree only, so our code gets the same analysis as every other module - which is
  what astubbs/parallel-consumer#379 said would happen, and it did at the first opportunity.

### Static analysis on this diff, triaged

`bin/check-pr-analysis-surfaces.sh 388` reported six SpotBugs findings **on lines this PR wrote**
(and none inherited). The `static: spotbugs` gate passes; these are the advisory surface, and they
are answered rather than left.

- **Fixed** - `registerRecords` called `EpochAndRecordsMap.count()` four times for one answer.
  That method streams over every partition's record list and sums the sizes, so it is O(records)
  with an allocation, on the poll-batch hot path. Hoisted to two locals.
- **Not changed, verified sound** - two 64-bit non-atomic findings on `successesDrained` and
  `successesCollected`. Both are written and read only on the owner thread, and that is enforced
  rather than merely documented: `collectCommitData` and `onCommitSuccess` call `assertOwnerThread`,
  which throws. The one cross-thread publication goes through `successesCommitted`, which *is*
  `volatile`. Adding `volatile` to satisfy a detector that cannot see the contract would advertise a
  sharing that does not exist.
- **Not changed, cosmetic** - three findings in test scaffolding copied from the forest: an
  overloaded static/instance `startAndAwaitRunning` pair, and an unpresized collection in an
  assertion helper. Left as they were reviewed on astubbs/parallel-consumer#271.

**`PcTaskDispatcher` therefore differs from its forest original in exactly two places**, both forced
by gates that only fire on our side of the module (the Kafka exclusion covers the generated tree
alone): a `Locale.ROOT` on a `String.format`, and the hoist above. Everything else in the copied
classes is byte-identical modulo the package rename, which is what makes the forest's review of them
still worth something.

### Not in this PR

Named because the god PR's open review threads map onto them and a reader should not expect them
here: refusing unsupported surfaces; task lifecycle, rebalance and `revive()`; stream time and
punctuation; the seam-on upstream evidence lane and the benchmarks; the example module. Backpressure
and error surfacing are later still.

### Where this came from

Copied out of **astubbs/parallel-consumer#271**, the Kafka Streams feasibility study, which remains
the source god PR and keeps the semantic work, the measurements and the open review threads. The
dispatcher and switch come from `feats/ks-on-pc-spike`; the split poll wait and `PcWorkSignal` come
from `feats/ks-streams-wake-on-work`. Second rung of the reconstructed Wagon B stack: the branch
forest stays as the evidence record, and each rung is cut fresh so the PRs document what the design
*is* rather than how it was discovered.

## Checklist

- [x] Docs updated - the module README (the seam, the switch and why it is off, wake-on-work, the
      shadowing assertion that flipped), `NOTICE`'s Apache 2.0 changed-files list, `AGENTS.md`'s
      module row, and the two `docs/inflight/` notes
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - the module is
      still unpublished, so there is no artifact to depend on and nothing for the ladder to point a
      user at. The roadmap stage is unchanged for the same reason astubbs/parallel-consumer#379 gave`
- [x] Tests added/updated - `PcTaskDispatcherTest` and `PcWorkSignalTest` (unit), a broker-backed
      dispatch arm with its stock control and a shutdown-while-parked arm (failsafe), Kafka's own
      `StreamThreadTest` added to the upstream oracle, and `ShadowedClassLoadingTest` re-pointed at
      three new jar-resident neighbours
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - `N/A - asked for review on the PR instead. The
      diff is largely a copy from branches that were already reviewed on
      astubbs/parallel-consumer#271, and the parts that are new here - the default flip and its
      reasoning, the regenerated patch, the jar-resident set - are what a reviewer should spend
      attention on`
