### PR TITLE
feat(streams) astubbs#255: refuse the Kafka Streams surface PC dispatch cannot run safely

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -5,7 +5,8 @@ project-specific meaning. Seeded with core domain vocabulary, then accretes as c
 ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
 
 Seeded from the transactional-commit learning of 2026-08-07, so it covers the concurrency and
-transactional-commit area. Other areas of the project are not yet described here.
+transactional-commit area, and extended since with the vocabulary of running Kafka Streams on this
+project's dispatch. Other areas of the project are not yet described here.
 
 ## Relationships
 
@@ -86,6 +87,48 @@ only when something is dirty.
 
 The asymmetry is load-bearing: a partition whose records are all failing is never dirty, so no commit
 is attempted for it, and anything waiting on a commit-time behaviour will wait indefinitely.
+
+## Kafka Streams on this project's dispatch
+
+**Seam**
+The switch that decides whether a Kafka Streams topology runs on this project's concurrent dispatch or
+on stock Kafka Streams' single processing thread. It is the module's central device: with the seam off,
+behaviour must be identical to stock, which is what lets the module use Apache Kafka's own unmodified
+test suite as its behaviour-preservation evidence.
+
+Because that evidence depends on seam-off runs staying stock, every run-time refusal is conditional on
+the seam rather than unconditional. A check that fired with the seam off would refuse constructs Kafka's
+own suite builds, and would void the claim it exists to protect. The build-time half of a refusal is the
+exception, and cannot be otherwise - see **Refused construct**.
+
+**Supported envelope**
+The set of Kafka Streams constructs that stay correct when records are dispatched concurrently rather
+than one at a time. Membership is decided once, when a task is constructed, rather than per record, so a
+topology reaching outside the envelope fails at startup instead of quietly producing wrong answers.
+
+The boundary is currently drawn as a named set of refused constructs with everything else admitted, so
+an unrecognised construct is allowed by default. The stronger form, in which everything is refused until
+proven supported, is a known and deliberately deferred alternative: it needs the whole upstream suite
+running first, or the refused surface is defined by whatever nobody has looked at.
+
+**Refused construct**
+A Kafka Streams feature the module rejects outright rather than documenting as a caveat, because
+concurrent dispatch would make it answer wrongly rather than fail. Most of them are refused for one
+underlying reason: they gate on stream time, the clock Kafka Streams advances as records are read in
+order, and that clock does not advance on this project's dispatch path.
+
+A refusal names both the construct and the mechanism that breaks it, and says it will recur until the
+topology changes or the seam is turned off. That last part is load-bearing rather than padding: the
+condition is a property of the topology and the switch rather than a transient fault, so a handler that
+responds by replacing the failed thread will rebalance in a loop.
+
+A refusal is announced twice, and the two halves differ in an easily missed way. The build-time
+announcement is attached to the Kafka Streams method itself and cannot be conditional, because it is
+fixed at the point the method is compiled and nothing there can read a switch; the run-time refusal is
+conditional on the seam, and stays silent while the seam is off. Because the build-time half decorates a
+method Apache Kafka owns rather than anything this project wrote, it has to name this project as the
+party refusing and keep its objection distinct from any deprecation Apache Kafka has of its own - a
+marker on someone else's symbol is read as that symbol's owner speaking unless it says otherwise.
 
 ## Test reliability
 

--- a/NOTICE
+++ b/NOTICE
@@ -17,6 +17,14 @@ from Apache Kafka:
   org.apache.kafka.streams.processor.internals.RecordCollectorImpl
   org.apache.kafka.streams.processor.internals.StreamTask
   org.apache.kafka.streams.processor.internals.StreamThread
+  org.apache.kafka.streams.kstream.KStream
+  org.apache.kafka.streams.kstream.KTable
+  org.apache.kafka.streams.kstream.KGroupedStream
+  org.apache.kafka.streams.kstream.CogroupedKStream
+  org.apache.kafka.streams.kstream.internals.KStreamImpl
+  org.apache.kafka.streams.kstream.internals.KTableImpl
+  org.apache.kafka.streams.kstream.internals.KGroupedStreamImpl
+  org.apache.kafka.streams.kstream.internals.CogroupedKStreamImpl
 
 Apache Kafka
 Copyright 2024 The Apache Software Foundation
@@ -26,7 +34,10 @@ https://kafka.apache.org
 These files have been CHANGED by Antony Stubbs and contributors, to make Kafka Streams'
 processor context and record collector safe to drive from more than one thread, to let a
 task dispatch its records through Parallel Consumer instead of its own partition group,
-and to let a worker completion end the stream thread's poll wait. The changes are
+to let a worker completion end the stream thread's poll wait, and to refuse the
+constructs that do not work under that concurrency - windowed operators, joins,
+suppression, versioned and session stores, and exactly-once - rather than let them return
+silently wrong results. The changes are
 expressed as, and limited to, the patch tracked at
 parallel-consumer-streams/src/main/patch/pc-streams.patch; no Apache Kafka source is
 redistributed in this repository. See parallel-consumer-streams/README.md.

--- a/docs/inflight/streams-stream-time-punctuation-is-unsupported-and-not-refused.md
+++ b/docs/inflight/streams-stream-time-punctuation-is-unsupported-and-not-refused.md
@@ -1,0 +1,35 @@
+# Stream-time punctuation is unsupported on the PC dispatch path, and the refusal envelope does not catch it
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: config-lie -->
+
+A topology that calls `context.schedule(interval, PunctuationType.STREAM_TIME, callback)` registers
+the punctuator successfully and it never fires under PC dispatch. No exception, no warning, nothing
+in the log - just periodic output that does not arrive. `WALL_CLOCK_TIME` punctuation is unaffected.
+
+**Mechanism.** Stock Kafka Streams advances stream time inside `PartitionGroup.nextRecord()`. The PC
+dispatch path does not go through it - records go from the task's register call straight to a worker
+- so the clock the punctuator is scheduled against never moves.
+
+**Why the refusal envelope does not cover it, and this is a shape gap rather than an oversight.** All
+three refusal layers key on something structural: a DSL method call, a state store type reaching the
+task, or a config key. A punctuator is none of those. It is a call on the processor context, made
+from inside `init()` while the task is already running, long after the envelope check in
+`StreamTask`'s constructor has passed. Refusing it needs a different hook - either intercepting
+`schedule()` on the patched processor context, or walking the topology for processors that register
+one, which is not something the topology graph exposes.
+
+It is therefore the one item of the module's original unsupported list that is documented rather than
+refused, and the module README says so in its own words under "What is still unsupported and NOT
+refused". Anyone reading the refusal envelope and concluding the surface is now fully guarded is
+wrong by exactly this one construct.
+
+**Where it was raised.** As an open review thread on astubbs/parallel-consumer#271, the Kafka Streams
+feasibility study, alongside the other correctness threads that unit work has since taken over. That
+thread predicted the failure mode ("a common, non-windowed pattern ... silently never fires") before
+any of the refusal work existed, and it survived the refusal work intact.
+
+**Related but not the same thing:** the punctuators that *do* fire, on wall-clock time, set
+`commitNeeded` and the PC commit path discards it - so a punctuate-only interval does no flush and no
+checkpoint. That is a commit-cadence question owned by the task-lifecycle work, not a refusal
+question, and closing this note does not close that.

--- a/docs/inflight/test-streamthreadtest-invalid-timestamps-flake.md
+++ b/docs/inflight/test-streamthreadtest-invalid-timestamps-flake.md
@@ -1,0 +1,60 @@
+# `StreamThreadTest` invalid-timestamps case is flaky, and it breaks the gate this module rests on
+
+<!-- inflight-type: bug -->
+<!-- inflight-impact: misdirection -->
+
+`StreamThreadTest.shouldLogAndRecordSkippedRecordsForInvalidTimestamps[3]` fails intermittently in the
+upstream-Kafka suite that `parallel-consumer-streams` runs against its patched classes. Diagnosed
+2026-08-11 with a control arm; carried onto the reconstructed stack when it was sighted again on the
+refusal-envelope branch.
+
+**Mechanism.** The test embeds `Thread.currentThread().getName()` in an expected log line, while with
+`processingThreadsEnabled=true` the line is logged from Kafka's own processing thread. The names do not
+match, so the assertion depends on which thread got there. It is Kafka's test, on Kafka's code, and no
+patch in this module touches either side of that race.
+
+**Established pre-existing, with a control arm.** Two failures in five runs at the then-HEAD *without*
+the investigating agent's changes, against three in seven with them. The control arm itself needed a
+second attempt: the first re-ran already-built binaries and would have "proved" the flake pre-existing
+on no evidence at all. What made it real was asserting the changed symbol was absent from the compiled
+class before trusting the run.
+
+<!-- post-merge: checked-begin -->
+<!-- Reads the same after the merge: the PR is cited as the landed change that recorded this sighting,
+     which is a permanent link, and no live branch is named. -->
+**Sighted again while the refusal envelope was being verified** (astubbs/parallel-consumer#389),
+seam off: once in seven consecutive runs of the module's whole `test` phase on one machine - green on
+the immediate re-run, and green in every other run, including both arms of that work's before/after
+control. Lower than the original rate, on one machine, which is a data point rather than a new
+measurement.
+<!-- post-merge: checked-end -->
+
+## Why this matters more than one flaky test
+
+**Every agent working on this module is told that "Kafka's own suites, zero failures with the seam
+off" is a non-negotiable gate.** That instruction is not satisfiable as stated: it will go red some of
+the time on any branch in this chain, through no fault of the change under test. An unsatisfiable gate
+is worse than no gate - it teaches people to re-run until green, which is exactly the habit that lets a
+real regression through.
+
+So the gate needs restating rather than repeating. Options, in rough order of preference:
+
+- **Quarantine it** through the repo's `@Quarantined` mechanism with this diagnosis attached, so the
+  count becomes deterministic and the exclusion is visible. It is not obvious this is even reachable -
+  the case is in Apache Kafka's own compiled test class, which this module runs unmodified and does not
+  recompile, so the annotation has nowhere to go without an exclude in the surefire execution. That is
+  the first thing to establish. Note also that the release gate forbids shipping while the quarantine
+  registry is non-empty, which is a real cost to weigh.
+- **Fix it upstream-style** by not asserting on a thread name, and carry that in the test-fixtures
+  patch - which is where a change to a Kafka test class can actually live.
+- **State the gate as "zero failures other than this named case"**, which is honest but relies on every
+  future agent knowing the exception.
+
+Until then, when this case fails: **do not chase it, and do not "fix" the code under test.** Confirm it
+is this test and this parameterisation, then re-run. Anything else that fails is real.
+
+## Delete when
+
+The outcome is deterministic - the test is fixed, excluded with this diagnosis attached, or the gate is
+restated in the places agents actually read (the module README's verification section, and the surefire
+execution's own comment).

--- a/docs/inflight/test-streamthreadtest-invalid-timestamps-flake.md
+++ b/docs/inflight/test-streamthreadtest-invalid-timestamps-flake.md
@@ -27,6 +27,13 @@ seam off: once in seven consecutive runs of the module's whole `test` phase on o
 the immediate re-run, and green in every other run, including both arms of that work's before/after
 control. Lower than the original rate, on one machine, which is a data point rather than a new
 measurement.
+
+**And then on CI, on the very next run** - the `Unit Tests` lane of the same PR, failing on
+parameterisation `[3]` with the whole upstream execution otherwise clean. That is worth more than
+another tally mark: every sighting until now had been on a developer machine, so "a loaded laptop"
+was still available as an explanation. It is not any more. This flake reaches the shared lane, where
+it costs every branch in the chain a red build and a re-run, and where the temptation to re-run until
+green is strongest.
 <!-- post-merge: checked-end -->
 
 ## Why this matters more than one flaky test

--- a/docs/inflight/test-untracked-ci-flakes.md
+++ b/docs/inflight/test-untracked-ci-flakes.md
@@ -19,7 +19,7 @@ Where their diagnoses generalised, the rule is in [`docs/solutions/`](../solutio
 | Test | Rate | Why it is worth attention |
 |---|---|---|
 | `ProducerManagerTest.producedRecordsCantBeInTransactionWithoutItsOffsetDirect` | 1 seen (2026-08-12) | Not from the original scan - found while babysitting astubbs#287. Mechanism known and owned (astubbs#262), quarantined - see below |
-| `simpleBatchTest` in **all three** of `ReactorBatchTest`, `MutinyBatchTest` and `VertxBatchTest` | 3 seen (2026-08-18, 2026-08-19, 2026-08-25) | Not from the original scan - each found while babysitting a branch carrying **no main Java**. Same Awaitility `ConditionTimeout`, same alias 'expected number of batches' (30s), same shared `BatchTestMethods` lambda. UNDIAGNOSED, but the third sighting carries the failing batch contents and they point at the test's own randomised input - see below, and classify (contention vs product vs expectation) before touching |
+| `simpleBatchTest` in **all three** of `ReactorBatchTest`, `MutinyBatchTest` and `VertxBatchTest` | 4 seen (2026-08-18, 2026-08-19, 2026-08-25, 2026-08-31) | Not from the original scan - each found while babysitting a branch carrying **no main Java** in the failing module. Same Awaitility `ConditionTimeout`, same alias 'expected number of batches' (30s), same shared `BatchTestMethods` lambda. UNDIAGNOSED, but the third and fourth sightings carry the failing batch contents and both point at the test's own randomised input - see below, and classify (contention vs product vs expectation) before touching |
 
 **Classify before touching any of them** - the same rule that governs the load-tightness family next
 door, and for the same reason: two of that family turned out to be real product bugs, and the third
@@ -82,6 +82,33 @@ under KEY ordering, and predict a deterministic failure; then five distinct keys
 always passes. If both hold, this is
 the test's own input and neither the runner nor the batcher. If the collision case passes, the draw
 is a red herring and contention-versus-product stands as before.
+
+#### The 2026-08-31 sighting: the key-collision reading survives its second independent test
+
+<!-- post-merge: checked-begin -->
+<!-- Reads the same after the merge: it cites the landed PR whose CI produced the sighting, which is a
+     permanent link, and names no live branch. -->
+`ReactorBatchTest`, on the CI Unit lane of astubbs/parallel-consumer#389 - a branch whose diff is a
+leaf module plus documentation and contains **no Reactor code at all**. Same
+`Expected size: 3 but was: 4`. Passed on the previous push of the same branch and is the only
+sighting so far to appear twice in one lane's history without a code change between.
+<!-- post-merge: checked-end -->
+
+**The payload matches the 2026-08-25 reading rather than merely being consistent with it.** Keys drawn
+were `80, 51, 80, 80, 89` - a three-way collision on key 80, exactly the shape the previous sighting
+had on key 36 - and the batches came out `{o0(k80), o1(k51)}`, `{o4(k89)}`, `{o2(k80)}`, `{o3(k80)}`.
+Under KEY ordering only one key-80 record can be in flight at a time, so its three records cannot
+share a batch however fast the runner is, and four batches is the *only* achievable answer for that
+draw. The expectation of three is computed from the record count alone.
+
+So two independent sightings, in two modules, on two machines, both show a three-way key collision and
+both show the extra batch falling exactly where that collision forces it. That is not proof - the
+prediction still has to be run - but it moves the expectation-versus-input reading from "a third
+reading to separate" to the one to test first, and it makes the contention reading harder to hold:
+contention would have to reproduce the same collision shape twice by coincidence.
+
+**The experiment named above is still the one to run, and still nobody has run it.** Its value has
+gone up: it now has a prediction with two prior observations behind it rather than one.
 
 ### `ProducerManagerTest.producedRecordsCantBeInTransactionWithoutItsOffsetDirect` - a helper defect, not a test defect
 

--- a/parallel-consumer-streams/README.md
+++ b/parallel-consumer-streams/README.md
@@ -25,11 +25,28 @@ time rather than at runtime when the change stops applying.
 -Dpc.streams.dispatch.enabled=true
 ```
 
-**The seam is OFF by default. This is an opt-in preview, and the reason is a missing refusal rather
-than caution.** Joins, windows, suppression, exactly-once and stream-time punctuation are unsupported
-on the PC path *and are not yet refused* - a topology using one of them is dispatched anyway and gets
-wrong behaviour, with nothing in the log to say so. Until that refusal envelope exists, the only
-honest default is one that cannot silently mis-run a topology nobody checked.
+**The seam is OFF by default. This is an opt-in preview** - but the reason has changed, and the
+change is worth reading rather than skipping.
+
+The original reason was a missing refusal: joins, windows, suppression and exactly-once were
+unsupported *and not refused*, so a topology using one was dispatched anyway and got wrong behaviour
+with nothing in the log to say so. That gap is closed - see
+[What is refused, and how you find out](#what-is-refused-and-how-you-find-out). The commitment made
+at the time was to restore on-by-default the day refusal landed.
+
+**It is not being restored, and the replacement reason was found by measuring rather than by
+worrying.** Run Apache Kafka's own suite against the patched classes with the seam *on* and
+`StreamThreadTest` reaches `StreamTask.revive()` through Kafka's ordinary task-corruption recovery: a
+`TaskCorruptedException` closes the task dirty and revives the same instance, whose PC dispatcher is
+final and was closed on the way down. `revive()` throws the loud-failure `IllegalStateException` that
+exists to stop that becoming a silent stall, nothing catches it, and it leaves the run loop uncaught
+on the StreamThread. `TaskCorruptedException` is not exotic - it is what Kafka raises when a
+consumer's offset falls outside the topic's retained range.
+
+So: a refused surface is safe to have switched on; a thrown lifecycle event mid-recovery is not. The
+default now waits on task lifecycle and rebalance - the work that gives the dispatcher a life beyond
+the task instance it was built with - and whoever moves it should re-run that seam-on measurement
+first rather than trusting this paragraph.
 
 Two further switches, both process-wide for the reason given in
 [`PcDispatchSwitch`](src/main/java/bz/stub/parallelconsumer/streams/PcDispatchSwitch.java) (there is
@@ -83,10 +100,14 @@ through a second, smaller patch, for the reason given below.
 | `RecordCollectorImpl` | two `HashMap`s become `ConcurrentHashMap`s | written from the producer's I/O thread for every in-flight send; the compiler would never have demanded this class, so it is named rather than discovered |
 | `StreamTask` | record selection and the commit gates ask the dispatcher instead of the partition group; the processor chain runs on a worker | **the seam itself**, and the only class here that references Parallel Consumer - which is what let the machinery rung land the three above without it |
 | `StreamThread` | the poll wait is split: a short poll, then a wait on our own condition that a worker completion ends | it owns the only blocking wait in the run loop, and nothing else can split it - see [wake-on-work](#wake-on-work-why-the-poll-wait-is-split) |
+| `KStream`, `KTable`, `KGroupedStream`, `CogroupedKStream` | the refused overloads gain `@DoNotCall`, `@Deprecated` and a javadoc `@deprecated` tag naming this module | a call site resolves to the symbol its receiver's **static type** declares, so the compile-time half of a refusal has to sit on the interface - an annotation on the impl would never be consulted |
+| `KStreamImpl`, `KTableImpl`, `KGroupedStreamImpl`, `CogroupedKStreamImpl` | the same operators throw `UnsupportedOperationException` naming the construct, when the seam is on | an interface method has no body to throw from; this is the run-time half, and it is what refuses a topology built reflectively or from a language the annotations do not reach |
 
 That is the whole patch. The set is **named in the pom, not discovered**
 (`patched.classes`), and the stop-threshold is stated there: if it has to grow much past a dozen, the
-sprawl is itself the answer to "how little had to change", and this is a fork by instalments.
+sprawl is itself the answer to "how little had to change", and this is a fork by instalments. It is
+now thirteen - past that line rather than at it, which the pom says out loud along with the smaller
+alternative that was weighed and its cost.
 
 Kafka's `InternalMockProcessorContext` needs the second patch because it *also* reads those fields
 directly. Un-patched, every `RecordCollectorTest` case dies at construction with a
@@ -110,13 +131,22 @@ than a fork; and every generated class shares both a package name and a **classl
 because different classloaders split the package and break package-private access while the names
 still match.
 
-The jar-resident three are chosen for adjacency, not convenience: `PartitionGroup` is the buffer the
-seam bypasses, `RecordQueue` is reached into by the seam's own record preparation, and `TaskManager`
+Those three are chosen for adjacency, not convenience: `PartitionGroup` is the buffer the seam
+bypasses, `RecordQueue` is reached into by the seam's own record preparation, and `TaskManager`
 constructs `StreamTask`. If generation ever sprawled past the declared set, those are the first three
 it would reach.
 
 `StreamTask` and `StreamThread` used to be that list, on the machinery rung, precisely so the
-assertion would have to flip *visibly* on the day the generated set grew. It flipped here.
+assertion would have to flip *visibly* on the day the generated set grew. It flipped on the execution
+seam.
+
+**"Same runtime package" is a per-package property**, and the refusal envelope took the generated set
+into two more packages - so the jar-resident list gained `Materialized` and `ConsumedInternal`, one
+neighbour for each. Without them the coexistence claim about those packages would have been checked
+against nothing while still passing. The test fails loudly on a generated class in a package with no
+declared neighbour rather than skipping it, and a further test reads `patched.classes` out of the pom
+through surefire and asserts the two lists are the same set - because "keep this in sync" is a comment,
+not a check.
 
 ### An empty patch is a no-op, and that is checked by the tooling
 
@@ -131,8 +161,13 @@ between the technique and the change.
 Kafka publishes its **compiled** tests to Maven Central. This module takes them as a `test`-classifier
 dependency and points a dedicated surefire execution at them, so Kafka's own `StreamTaskTest`,
 `StreamThreadTest`, `RecordCollectorTest` and `ProcessorContextImplTest` exercise **our** copies of
-the five patched classes. Nothing is excluded, rewritten, recompiled or relaxed. It runs in the
+the patched classes. Nothing is excluded, rewritten, recompiled or relaxed. It runs in the
 module's normal `test` phase, on every build, with no profile and no flag.
+
+This is also the reason **no refused signature was deleted**. Those tests are Kafka's own *compiled*
+classes, never recompiled here, so a deleted method would link-fail against classes this project does
+not own - and the behaviour-preservation evidence would be forfeited by the very change meant to make
+the module honest. Refusal is therefore additive: annotations, and a throw guarded on the seam.
 
 That is the behaviour-preservation claim, and it is the strongest one available: **anything the patch
 broke that Kafka tested, fails here.**
@@ -181,6 +216,89 @@ split wait idle. That measurement, its refuted prediction and its arms are owned
 **this rung does not re-derive it and no figure is repeated here**, because the benchmark that
 produces one is a separate unit and a number copied out of its write-up drifts silently from it. What
 this rung ships is the mechanism and the tests that show it is load-bearing.
+
+---
+
+## What is refused, and how you find out
+
+Everything currently known to be broken on this path is **physically refused**. You do not get a
+plausible wrong answer.
+
+That matters more than it sounds. None of these constructs throws in stock Kafka Streams, and none of
+them would have thrown here either. They read a stream-time counter that never advances on the PC
+path - `PartitionGroup.nextRecord()` is where stock Streams advances it, and the PC path does not go
+through it - and several of them read-modify-write a **non-volatile `long`** from every worker, so
+under concurrent dispatch the value is corrupted rather than merely stale. Left reachable, the
+topology runs to completion and emits the wrong numbers, silently. Refusing is the only honest
+behaviour available until the semantics are fixed.
+
+### Three layers, because no one of them covers the surface
+
+| You get | When |
+|---|---|
+| A **compile error** - `@DoNotCall` under Error Prone, a deprecation warning without it | you write `join`, `leftJoin`, `outerJoin`, `windowedBy` or `suppress` against `KStream`, `KTable`, `KGroupedStream` or `CogroupedKStream` |
+| An `UnsupportedOperationException` naming the construct, at topology construction | you build that topology with the seam on |
+| An `UnsupportedOperationException` naming the construct, at task construction | your topology reaches a `WindowStore`, `SessionStore`, versioned key-value store or suppression buffer **through the Processor API**, or sets `processing.guarantee` to exactly-once |
+
+The DSL layer only fires for someone who called a refused method. The Processor API reaches the same
+machinery without touching `KStream` at all - `topology.addStateStore(Stores.windowStoreBuilder(...))`
+connects a window store to a plain `Processor` - and exactly-once is not a topology shape at all, it
+is one configuration key. The third layer is what covers both, and it lives in `StreamTask`'s
+constructor because that is the one place holding both the topology and the task config, so it costs
+no additional patched class.
+
+The store check is by **interface, never by class name**: the stores that reach the task are wrapped
+several layers deep, and every wrapper implements the interface it wraps. `instanceof` sees through
+the whole stack; a name match sees the outermost wrapper and breaks the first time Kafka adds one.
+The versioned key-value store is the trap in that design and is worth knowing about - it extends
+`StateStore` directly rather than `WindowStore`, so it looks ordinary, and it is reachable with **no
+refused DSL call anywhere** via `Materialized.as(Stores.persistentVersionedKeyValueStore(...))`. The
+general rule that came out of that is written up in
+[`a-type-gate-is-a-claim-about-a-hierarchy-you-did-not-write.md`](../docs/solutions/architecture-patterns/a-type-gate-is-a-claim-about-a-hierarchy-you-did-not-write.md).
+
+### The two run-time layers are conditional on the seam; the compile-time one cannot be
+
+With `-Dpc.streams.dispatch.enabled=false` the whole of the refusal's run-time half is inert and every
+one of these topologies builds and runs exactly as stock Kafka Streams does. That is both the escape
+hatch and the reason Kafka's own suite still passes: several of those tests build precisely the
+constructs listed here, and an unconditional check would refuse them and void the
+behaviour-preservation claim.
+
+**The compile-time layer is not conditional and cannot be** - an annotation in a class file cannot
+read a system property. If you have deliberately turned the seam off and want the call anyway,
+suppress `DoNotCall` at that call site. This repository does compile under Error Prone, so that is a
+hard error here rather than a theoretical one, and the module's own refusal test carries exactly that
+suppression: deleting it fails the build with one error per refused call site, which is the cheapest
+available falsification of the compile-time layer.
+
+Every refused method also carries a javadoc `@deprecated` tag naming **this module** as the thing
+refusing it. Without that, an IDE strikes `stream.join(...)` through with no reason attached, and the
+obvious inference - that Apache Kafka deprecated `join` - is false and alarming. The general shape of
+that mistake is written up in
+[`a-deprecation-without-an-explanation-misattributes-itself-to-the-wrong-party.md`](../docs/solutions/architecture-patterns/a-deprecation-without-an-explanation-misattributes-itself-to-the-wrong-party.md).
+
+### If you hit the task-construction refusal, it will not stop on its own
+
+That throw leaves `StreamTask`'s constructor, is caught by nothing on the way out, and reaches
+`KafkaStreams`' uncaught-exception handler. Under `StreamsUncaughtExceptionHandlerResponse.REPLACE_THREAD`
+the thread is replaced with no backoff and no attempt limit - and the replacement is refused for the
+same reason, so the application rebalances in a loop. The refusal is a property of the topology and
+the switch, not a transient failure. **Do not pair `REPLACE_THREAD` with a topology this module can
+refuse.** Moving the check ahead of `KafkaStreams.start()` is the structural fix and is not done here.
+
+### Reinstatement is evidence-gated, not judgement-gated
+
+A construct comes off the refused list when Kafka's own suite exercises it with the seam **on** and
+passes - not when someone reads the code and concludes it looks fine.
+
+### What is still unsupported and NOT refused
+
+**Stream-time punctuation.** A topology that calls
+`context.schedule(interval, PunctuationType.STREAM_TIME, ...)` is a common, non-windowed pattern, and
+under PC dispatch stream time never advances, so the punctuator simply never fires: no exception, no
+warning, no output. It is the one item of the original unsupported list this envelope does not cover,
+because it is a call on the processor context rather than a topology shape or a store type. Wall-clock
+punctuation does fire.
 
 ---
 

--- a/parallel-consumer-streams/README.md
+++ b/parallel-consumer-streams/README.md
@@ -190,6 +190,12 @@ is stated here without a number.
 > **Do not scope the run with `-Dtest=`.** It silently overrides that execution's `<includes>`, so
 > Kafka's suite does not run at all - and the build still goes green, with the number you were
 > checking never computed. It has cost several people a whole run.
+>
+> **"Zero failures" has one known exception**, and it is Kafka's own flake rather than this patch's:
+> `StreamThreadTest.shouldLogAndRecordSkippedRecordsForInvalidTimestamps` asserts on a thread name
+> that depends on which thread logged. Diagnosed, with its control arm and what to do about it, in
+> [`docs/inflight/test-streamthreadtest-invalid-timestamps-flake.md`](../docs/inflight/test-streamthreadtest-invalid-timestamps-flake.md).
+> If that exact case fails, re-run. **Anything else that fails is real.**
 
 ### Wake-on-work: why the poll wait is split
 

--- a/parallel-consumer-streams/pom.xml
+++ b/parallel-consumer-streams/pom.xml
@@ -24,10 +24,12 @@
         topology's own code does not change.
 
         THE SEAM IS OFF BY DEFAULT - this is an opt-in preview. Turn it on for a JVM with
-        -Dpc.streams.dispatch.enabled=true. It is off because the refusal envelope that would make it
-        safe for an arbitrary topology does not exist yet: joins, windows, suppression, EOS and
-        stream-time punctuation are NOT supported and are NOT yet refused, so a topology using one
-        gets wrong behaviour rather than an error. PcDispatchSwitch's javadoc owns that reasoning.
+        -Dpc.streams.dispatch.enabled=true. Joins, windows, suppression, versioned and session stores
+        and EOS are unsupported and are now REFUSED by name, at build time and at task construction,
+        rather than allowed to return silently wrong answers. What the default is waiting on now is
+        task lifecycle: with the seam on, Kafka's own task-corruption recovery revives a task whose
+        dispatcher was closed with it, and the loud-failure floor there leaves the StreamThread.
+        PcDispatchSwitch's javadoc owns that decision and the measurement behind it.
 
         Build machinery: the named classes are unpacked from the published kafka-streams sources jar,
         a tracked patch is applied, and the result is compiled into this module's own target/classes,

--- a/parallel-consumer-streams/pom.xml
+++ b/parallel-consumer-streams/pom.xml
@@ -88,8 +88,22 @@
              kill switch and why StreamThreadTest joins the upstream oracle below.
 
              If this list has to grow much past a dozen, that sprawl is itself the answer to "how little had
-             to change" - see the "Do not apply when" section of the technique write-up. -->
-        <patched.classes>org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java,org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java,org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java,org/apache/kafka/streams/processor/internals/StreamTask.java,org/apache/kafka/streams/processor/internals/StreamThread.java</patched.classes>
+             to change" - see the "Do not apply when" section of the technique write-up.
+
+             The eight kstream entries are the refusal envelope (astubbs#255), and they come in matched pairs
+             for a reason the compiler enforces. A call site resolves to the symbol its receiver's STATIC TYPE
+             declares, so `stream.join(...)` against a KStream variable resolves to KStream#join - an
+             annotation on KStreamImpl is invisible there. That is why the four public INTERFACES carry
+             @DoNotCall/@Deprecated. Conversely an interface method has no body to throw from, which is why
+             the four IMPLS carry the runtime refusal. Neither half substitutes for the other.
+
+             This list is now thirteen, which is past the point the sentence above sets rather than at it.
+             Stated rather than absorbed: the smaller alternative is a single check in InternalStreamsBuilder
+             keyed on the DSL's graph-node types, at the cost of a message one step removed from the method
+             the user actually called. It reaches ten, not five - the four IMPLS go away and
+             InternalStreamsBuilder arrives, but the four INTERFACES stay patched, because the compile-time
+             refusal is the half that has to sit on the symbol a call site resolves to. -->
+        <patched.classes>org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java,org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java,org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java,org/apache/kafka/streams/processor/internals/StreamTask.java,org/apache/kafka/streams/processor/internals/StreamThread.java,org/apache/kafka/streams/kstream/KStream.java,org/apache/kafka/streams/kstream/KTable.java,org/apache/kafka/streams/kstream/KGroupedStream.java,org/apache/kafka/streams/kstream/CogroupedKStream.java,org/apache/kafka/streams/kstream/internals/KStreamImpl.java,org/apache/kafka/streams/kstream/internals/KTableImpl.java,org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java,org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java</patched.classes>
 
         <!-- Module-local and explicitly versioned on purpose: pinning jackson-databind in root
              dependencyManagement forces WireMock (parallel-consumer-vertx) onto an incompatible Jackson and
@@ -181,6 +195,18 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- TopologyTestDriver, which the refusal envelope's Processor API backstop arms build a real
+             topology against. It runs the topology on the calling thread, which is exactly right here and
+             exactly wrong for the dispatch arms below: a refusal is thrown while the task is CONSTRUCTED, so
+             no worker pool and no broker are needed to observe it, and the driver is several orders of
+             magnitude cheaper than a container per case. -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams-test-utils</artifactId>
+            <version>${kafka.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -453,6 +479,13 @@
                     <classpathDependencyExcludes>
                         <classpathDependencyExclude>org.slf4j:slf4j-reload4j</classpathDependencyExclude>
                     </classpathDependencyExcludes>
+                    <!-- Handed to ShadowedClassLoadingTest so it can assert its own list against the real
+                         property rather than against a "keep in sync" comment. A class added here and not
+                         there would otherwise be silently unproven - which is precisely the false positive
+                         that test exists to prevent. -->
+                    <systemPropertyVariables>
+                        <patched.classes>${patched.classes}</patched.classes>
+                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcDispatchSwitch.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcDispatchSwitch.java
@@ -17,11 +17,31 @@ package bz.stub.parallelconsumer.streams;
  * Turn it on for a whole JVM with {@code -Dpc.streams.dispatch.enabled=true}, or per test with
  * {@link #enable(int)}.
  * <p>
- * <b>The reason is a missing refusal, not caution.</b> Joins, windows, suppression, exactly-once and
- * stream-time punctuation are unsupported on the PC path <em>and are not yet refused</em> - a topology using
- * one of them is dispatched anyway and gets wrong behaviour with nothing in the log to say so. Until the
- * refusal envelope exists, the only honest default is one that cannot silently mis-run a topology nobody
- * checked. When it lands, the default becomes a real choice again rather than a hedge.
+ * <b>The reason WAS a missing refusal. That gap is now closed, and the default still does not move -
+ * because measuring it turned up a second reason the first one was hiding.</b> Joins, windows, suppression,
+ * versioned and session stores and exactly-once are now refused, loudly and by name, at build time and at
+ * task construction ({@link PcUnsupportedConstruct}, {@link PcSupportedEnvelope}); stream-time punctuation is
+ * not yet, and is the one item of the original list still outstanding. The promise written here was to
+ * restore the on-by-default the day refusal landed. <b>That promise is superseded rather than forgotten,
+ * and the new trigger is task lifecycle and rebalance</b> - the unit that gives {@link PcTaskDispatcher} a
+ * life beyond the task instance it was constructed with.
+ * <p>
+ * <b>The evidence, because "it felt risky" is not a reason.</b> Run Apache Kafka's own suite against the
+ * patched classes with the seam <em>on</em>, and {@code StreamThreadTest} reaches
+ * {@code StreamTask.revive()} through Kafka's ordinary task-corruption recovery: a
+ * {@code TaskCorruptedException} closes the task dirty and then revives the same instance, whose dispatcher
+ * is final and was closed on the way down. {@code revive()} throws its loud-failure {@code
+ * IllegalStateException}, nothing catches it, and it leaves the run loop as an uncaught exception on the
+ * StreamThread. That is not an exotic path: {@code TaskCorruptedException} is what Kafka raises when a
+ * consumer's offset falls outside the topic's retained range, which happens to ordinary applications.
+ * The same run on the rung below this one produces the identical revival failures and zero refusals, so
+ * the two things are independent: this unit changed what a refused construct does and changed nothing at
+ * all about revival.
+ * <p>
+ * So a refused surface is safe to have on; a thrown lifecycle event mid-recovery is not, and the second is
+ * what the default is now waiting on. When the dispatcher can be recreated on revival, this becomes a real
+ * choice again rather than a hedge - and whoever makes it should re-run that seam-on measurement first,
+ * rather than trusting this paragraph.
  * <p>
  * <b>This reverses an inherited decision, and the argument it reverses was a different one.</b> The seam
  * defaulted <em>on</em> in the feasibility study (astubbs#271) on the grounds that depending on a separate,
@@ -32,8 +52,9 @@ package bz.stub.parallelconsumer.streams;
  * every user of the artifact, and it is not being paid for here - the arms below still state their
  * requirement at each site. What the artifact-is-the-opt-in argument does not cover is a user who opts in
  * to <em>per-key concurrency</em> and gets <em>silently altered semantics</em> on a topology shape nobody
- * refused. Restore the on-by-default the moment that gap closes; do not restore it merely because this
- * paragraph looks like timidity.
+ * refused. That objection is now answered by the refusal envelope above; the revival one is not, which is
+ * why the default is where it is. Do not restore on-by-default merely because these paragraphs look like
+ * timidity - restore it when revival works, and say so with a measurement.
  * <p>
  * Tests that want the stock path still say so explicitly with {@link #disable()} rather than leaning on the
  * default, because a control arm that is only a control by default stops being one the moment the default

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcRefusalMessage.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcRefusalMessage.java
@@ -1,0 +1,85 @@
+package bz.stub.parallelconsumer.streams;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import java.util.List;
+
+/**
+ * The one shape every refusal message takes.
+ * <p>
+ * There are two refusal sites - {@link PcUnsupportedConstruct#refuse()} at the DSL call, and
+ * {@link PcSupportedEnvelope} at task construction - and a user who hits both should not have to work out
+ * that they are the same rule. Both come through here, so both name the construct, say why it is refused,
+ * and end with the exact property that turns the seam off.
+ * <p>
+ * Whoever hits one of these messages is, by definition, surprised: they wrote ordinary Kafka Streams and it
+ * refused. So the message has to carry the whole answer - not a code, not a doc link on its own.
+ *
+ * @author Antony Stubbs
+ */
+final class PcRefusalMessage {
+
+    /**
+     * The tracking issue, named once. Every refusal message carries it twice - as the prefix that says which
+     * subsystem is talking, and in the closing pointer - and the refusal tests assert on it, so a literal
+     * would have to be kept in step across four files by hand. Same treatment, for the same reason, as
+     * {@link PcDispatchSwitch#ENABLED_PROPERTY}.
+     */
+    static final String ISSUE = "astubbs#255";
+
+    /**
+     * Where a reader goes for the full list and its rationale. The plan is the living document; the README
+     * points at it rather than duplicating it.
+     */
+    private static final String REFERENCE = "See parallel-consumer-streams/README.md and " + ISSUE + ".";
+
+    private PcRefusalMessage() {
+    }
+
+    /**
+     * @param constructs every unsupported construct found, never just the first. Someone who removes their
+     *                   windowed aggregation only to be refused again for a join has been made to pay twice for
+     *                   one diagnosis.
+     */
+    static String forConstructs(final List<PcUnsupportedConstruct> constructs) {
+        if (constructs.isEmpty()) {
+            throw new IllegalArgumentException("Refusing nothing is not a refusal - this is a bug in "
+                    + PcRefusalMessage.class.getName());
+        }
+
+        final StringBuilder message = new StringBuilder("PC dispatch (" + ISSUE + "): ");
+        final String supported;
+        if (constructs.size() == 1) {
+            message.append(constructs.get(0).getDisplayName())
+                    .append(" is not supported on the Parallel Consumer dispatch path, because ")
+                    .append(constructs.get(0).getReason())
+                    .append('.');
+            supported = "which supports it";
+        } else {
+            // "in this topology or its configuration", not "in this topology": exactly-once comes off the task
+            // config and is not a topology shape at all, so it can be one of the entries listed below.
+            message.append(constructs.size())
+                    .append(" constructs in this topology or its configuration are not supported on the "
+                            + "Parallel Consumer dispatch path:");
+            for (final PcUnsupportedConstruct construct : constructs) {
+                message.append("\n  - ")
+                        .append(construct.getDisplayName())
+                        .append(" - ")
+                        .append(construct.getReason())
+                        .append('.');
+            }
+            supported = "which supports all of the above";
+        }
+
+        return message.append("\n\nThis is refused rather than allowed to produce silently wrong results. "
+                        + "Run with -D")
+                .append(PcDispatchSwitch.ENABLED_PROPERTY)
+                .append("=false for stock Kafka Streams dispatch, ")
+                .append(supported)
+                .append(". ")
+                .append(REFERENCE)
+                .toString();
+    }
+}

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcSupportedEnvelope.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcSupportedEnvelope.java
@@ -1,0 +1,151 @@
+package bz.stub.parallelconsumer.streams;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.VersionedKeyValueStore;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.internals.TimeOrderedKeyValueBuffer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The backstop: what this module supports, checked once, at task construction.
+ * <p>
+ * <b>Why a second line of defence exists at all.</b> The DSL refusals in
+ * {@link PcUnsupportedConstruct#refuse()} only fire for someone who called {@code windowedBy}, {@code join}
+ * or {@code suppress}. The Processor API reaches the same machinery without touching {@code KStream} at
+ * all - {@code topology.addStateStore(Stores.windowStoreBuilder(...))} builds a window store and connects
+ * it to a plain {@code Processor}, and no DSL method is ever called. That route would sail straight past
+ * layers 1 and 2. And exactly-once is not a topology shape at all: it is one configuration key.
+ * <p>
+ * <b>Why here.</b> {@code StreamTask}'s constructor holds both the {@code ProcessorTopology} and the task
+ * config, and {@code StreamTask} is already patched - so this check costs no additional patched class,
+ * which is the objection that sinks most "just add a check" proposals in this module.
+ * <p>
+ * <b>Classification is by interface, never by class name.</b> The stores that reach
+ * {@code ProcessorTopology.stateStores()} are wrapped several layers deep - {@code MeteredWindowStore} over
+ * {@code ChangeLoggingWindowBytesStore} over the bytes store - and every wrapper implements the interface it
+ * wraps. {@code instanceof} sees through the whole stack; a name match sees only the outermost wrapper and
+ * breaks the first time Kafka adds one.
+ *
+ * @author Antony Stubbs
+ * @see PcUnsupportedConstruct
+ */
+public final class PcSupportedEnvelope {
+
+    private PcSupportedEnvelope() {
+    }
+
+    /**
+     * Refuse a task whose topology or configuration reaches outside the supported envelope.
+     * <p>
+     * A no-op when the seam is off, for the same reason {@link PcUnsupportedConstruct#refuse()} is: Apache
+     * Kafka's own {@code StreamTaskTest} builds EOS-enabled tasks and window stores, and this module runs that
+     * suite unmodified with the seam off as its behaviour-preservation evidence. An unguarded check here turns
+     * those cases into constructor errors and voids the claim.
+     * <p>
+     * Called <b>before</b> the task's PC dispatcher is created, so a refused task never allocates a worker pool
+     * that nothing will shut down.
+     *
+     * <b>Global stores are deliberately out of scope.</b> {@code ProcessorTopology.globalStateStores()} is not
+     * inspected, because a global store is read and written by {@code GlobalStreamThread} - one thread, its own
+     * task type, never the PC dispatch path. Refusing one here would refuse a construct this module does not
+     * actually break.
+     *
+     * @param taskId      named in the message, because a user with several tasks needs to know which topology
+     *                    is at fault
+     * @param stateStores the task topology's state stores, already constructed
+     * @param eosEnabled  the task config's exactly-once flag - configuration, not topology shape, which is why
+     *                    it cannot be inferred from the stores
+     * @throws UnsupportedOperationException if the seam is on and anything here is outside the envelope
+     */
+    public static void checkTask(final String taskId,
+                                 final Collection<StateStore> stateStores,
+                                 final boolean eosEnabled) {
+        if (!PcDispatchSwitch.isEnabled()) {
+            return;
+        }
+
+        final List<PcUnsupportedConstruct> found = findUnsupported(stateStores, eosEnabled);
+        if (found.isEmpty()) {
+            return;
+        }
+
+        // The recurrence sentence is not padding. This throw leaves StreamTask's constructor, is caught by
+        // nothing on the way out, and reaches KafkaStreams' uncaught-exception handler - which under
+        // StreamsUncaughtExceptionHandlerResponse.REPLACE_THREAD replaces the thread unconditionally, with no
+        // backoff and no attempt counter. The refusal is a property of the topology and the switch, so the
+        // replacement thread is refused too, and the application rebalances in a loop. Whoever reads this
+        // message is looking at that loop; the message has to tell them it will not stop on its own.
+        throw new UnsupportedOperationException("Task " + taskId + ": " + PcRefusalMessage.forConstructs(found)
+                + " This is a property of the topology and the switch, not a transient failure, so every task "
+                + "creation refuses again: a REPLACE_THREAD uncaught-exception handler will rebalance in a loop "
+                + "until the topology changes or the seam is turned off.");
+    }
+
+    /**
+     * Every unsupported construct in one pass, de-duplicated and in a stable order.
+     * <p>
+     * Package-private rather than private so the unit tests can assert the classification directly, without
+     * standing up a {@code StreamTask} to observe it through a thrown message.
+     */
+    static List<PcUnsupportedConstruct> findUnsupported(final Collection<StateStore> stateStores,
+                                                        final boolean eosEnabled) {
+        // A LinkedHashSet because both properties are load-bearing: de-duplicated, because three window stores
+        // in one topology is one problem rather than three lines of message; insertion-ordered, because the
+        // message should read in the order the constructs were found. An EnumSet would silently reorder them
+        // into declaration order.
+        final Set<PcUnsupportedConstruct> found = new LinkedHashSet<>();
+
+        if (eosEnabled) {
+            found.add(PcUnsupportedConstruct.EXACTLY_ONCE);
+        }
+
+        if (stateStores != null) {
+            for (final StateStore store : stateStores) {
+                final PcUnsupportedConstruct construct = classify(store);
+                if (construct != null) {
+                    found.add(construct);
+                }
+            }
+        }
+
+        return new ArrayList<>(found);
+    }
+
+    /**
+     * @return the construct this store implies, or {@code null} when the store is inside the envelope. A plain
+     *         key-value store is the supported stateful case (KTD3 - stateless first, then one non-windowed
+     *         aggregation) and must not be refused, or the module's own stateful proof stops running.
+     */
+    private static PcUnsupportedConstruct classify(final StateStore store) {
+        // The four store interfaces are disjoint in Kafka 3.9.2, so this order does not currently disambiguate
+        // anything. It is written most-specific-first anyway, so that a future Kafka in which one of them
+        // starts extending another reports the narrower construct rather than the vaguer one.
+        if (store instanceof TimeOrderedKeyValueBuffer) {
+            return PcUnsupportedConstruct.SUPPRESSION_BUFFER;
+        }
+        if (store instanceof SessionStore) {
+            return PcUnsupportedConstruct.SESSION_STORE;
+        }
+        if (store instanceof WindowStore) {
+            return PcUnsupportedConstruct.WINDOW_STORE;
+        }
+        // Easy to miss, and the most dangerous of the four: VersionedKeyValueStore extends StateStore directly
+        // rather than WindowStore, so it looks like an ordinary key-value store and is reachable with no refused
+        // DSL call anywhere - Materialized.as(Stores.persistentVersionedKeyValueStore(...)) is enough. Its
+        // observedStreamTime does not merely mis-order under concurrency, it silently discards puts.
+        if (store instanceof VersionedKeyValueStore) {
+            return PcUnsupportedConstruct.VERSIONED_KEY_VALUE_STORE;
+        }
+        return null;
+    }
+}

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcTaskDispatcher.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcTaskDispatcher.java
@@ -697,6 +697,18 @@ public class PcTaskDispatcher implements Closeable {
      */
     private static final Set<PcTaskDispatcher> ACTIVE = ConcurrentHashMap.newKeySet();
 
+    /**
+     * How many dispatchers are live in this JVM right now.
+     * <p>
+     * Exists so a test can prove a <b>negative</b>: that a task refused by {@link PcSupportedEnvelope} built no
+     * dispatcher. That ordering - the envelope check before this constructor - is the difference between a
+     * refused task and a leaked worker pool, and it is otherwise asserted only by a comment in the patched
+     * {@code StreamTask}, which nothing enforces.
+     */
+    public static int activeCount() {
+        return ACTIVE.size();
+    }
+
     /** Crash-injection for tests: {@link #abortClose()} every live dispatcher in the JVM. */
     public static void abortAllActive() {
         for (PcTaskDispatcher dispatcher : ACTIVE) {

--- a/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcUnsupportedConstruct.java
+++ b/parallel-consumer-streams/src/main/java/bz/stub/parallelconsumer/streams/PcUnsupportedConstruct.java
@@ -1,0 +1,144 @@
+package bz.stub.parallelconsumer.streams;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collections;
+
+/**
+ * The Kafka Streams constructs that do not work on the Parallel Consumer dispatch path, and the one place
+ * that says so.
+ * <p>
+ * <b>These are not merely unimplemented - they produce silently wrong answers.</b> Stream time advances in
+ * {@code PartitionGroup.nextRecord()}, which the PC path bypasses entirely (KTD8 - one record path,
+ * switched, never both), so it never moves. Window close, join emission and suppression emission are all
+ * gated on it. Worse, the {@code observedStreamTime} fields those operators keep are plain non-volatile
+ * {@code long}s doing read-modify-write: under concurrent dispatch they are corrupted, not merely
+ * reordered. Nothing throws and nothing logs - the topology runs and the numbers are wrong. Refusing the
+ * construct is the only honest behaviour available until the semantics are fixed.
+ * <p>
+ * <b>Refusal is conditional on the seam.</b> {@link #refuse()} is a no-op when
+ * {@link PcDispatchSwitch#isEnabled()} is false, so a seam-off run stays behaviourally identical to stock
+ * Kafka Streams - which is what makes the module's behaviour-preservation claim (Apache Kafka's own 419
+ * tests, unmodified, zero failures) still true after this class exists.
+ * <p>
+ * <b>Reinstatement is evidence-gated, not judgement-gated.</b> A construct comes back off this list when
+ * Kafka's own test suite exercises it with the seam <b>on</b> and passes - not when someone reads the code
+ * and concludes it looks fine.
+ *
+ * @author Antony Stubbs
+ * @see PcSupportedEnvelope
+ * @see PcDispatchSwitch
+ */
+@RequiredArgsConstructor
+public enum PcUnsupportedConstruct {
+
+    KSTREAM_KSTREAM_JOIN(
+            "KStream-KStream join",
+            "join emission is gated on stream time, which never advances on the PC path, and "
+                    + "KStreamKStreamJoin.sharedTimeTracker is mutated from both join sides without synchronisation"),
+
+    KSTREAM_KTABLE_JOIN(
+            "KStream-KTable join",
+            "the table side is read at the record's stream time, which never advances on the PC path"),
+
+    KSTREAM_GLOBALKTABLE_JOIN(
+            "KStream-GlobalKTable join",
+            "the global table is read at the record's stream time, which never advances on the PC path"),
+
+    KTABLE_KTABLE_JOIN(
+            "KTable-KTable join",
+            "join results are emitted per update in arrival order, which concurrent dispatch does not preserve"),
+
+    KTABLE_KTABLE_FOREIGN_KEY_JOIN(
+            "KTable-KTable foreign-key join",
+            "the subscription store is updated and read across the join's two halves without ordering guarantees "
+                    + "that concurrent dispatch can honour"),
+
+    WINDOWED_AGGREGATION(
+            "windowed aggregation (windowedBy)",
+            "windowCloseTime is derived from observedStreamTime, which never advances on the PC path, so which "
+                    + "records count as late changes with dispatch order - and observedStreamTime is a non-volatile "
+                    + "long updated read-modify-write from every worker"),
+
+    WINDOWED_COGROUPED_AGGREGATION(
+            "windowed cogrouped aggregation (windowedBy)",
+            "same as windowed aggregation - window close is stream-time driven and stream time does not advance "
+                    + "on the PC path"),
+
+    SUPPRESSION(
+            "suppression (suppress)",
+            "\"only the final result per window\" is a statement about stream time, which never advances on the "
+                    + "PC path, so suppressed updates would never be emitted"),
+
+    WINDOW_STORE(
+            "a WindowStore",
+            "the store keeps its own non-volatile observedStreamTime and uses it to decide which records are too "
+                    + "late to retain - so under concurrent dispatch it drops records based on a value that is being "
+                    + "corrupted by read-modify-write from several workers at once"),
+
+    SESSION_STORE(
+            "a SessionStore",
+            "session merging is driven by stream time and by record arrival order, neither of which the PC path "
+                    + "preserves"),
+
+    SUPPRESSION_BUFFER(
+            "a suppression buffer",
+            "the buffer emits on stream time, which never advances on the PC path"),
+
+    VERSIONED_KEY_VALUE_STORE(
+            "a versioned key-value store",
+            "the store keeps a non-volatile observedStreamTime and silently DROPS any put older than "
+                    + "observedStreamTime minus the grace period, so concurrent dispatch loses writes rather than "
+                    + "merely reordering them - and reads outside history retention are rejected off the same field"),
+
+    EXACTLY_ONCE(
+            "exactly-once processing (processing.guarantee)",
+            "under exactly_once_v2 the Kafka Streams transaction is per-StreamThread rather than per-task, so a "
+                    + "worker's send joins a transaction covering every task on that thread and one task's work "
+                    + "cannot be committed without committing every other worker's in-flight work; the older "
+                    + "per-task exactly_once is no better placed, because StreamsProducer.transactionInFlight is a "
+                    + "non-volatile check-then-act (KTD7: this module is at-least-once)");
+
+    /**
+     * How this construct is named back to the user. Deliberately the name they would recognise from their own
+     * topology, not the internal class that implements it.
+     */
+    @Getter
+    private final String displayName;
+
+    /**
+     * Why it is refused. Carried with the construct rather than written at the throw site, so the twelve
+     * {@link #refuse()} call sites in the generated Kafka sources stay one line each and cannot drift apart.
+     */
+    @Getter
+    private final String reason;
+
+    /**
+     * Refuse this construct if - and only if - the PC dispatch seam is on.
+     * <p>
+     * The guard is the whole point. Unconditional refusal would break Apache Kafka's own test suite, which this
+     * module runs unmodified with the seam <b>off</b> as its behaviour-preservation evidence, and several of
+     * those tests build exactly the constructs listed here.
+     *
+     * @throws UnsupportedOperationException if the seam is on
+     */
+    public void refuse() {
+        if (!PcDispatchSwitch.isEnabled()) {
+            return;
+        }
+        throw new UnsupportedOperationException(describe());
+    }
+
+    /**
+     * The refusal message for this construct on its own: what was refused, why, and how to get stock Kafka
+     * Streams dispatch back.
+     */
+    public String describe() {
+        return PcRefusalMessage.forConstructs(Collections.singletonList(this));
+    }
+}

--- a/parallel-consumer-streams/src/main/patch/pc-streams.patch
+++ b/parallel-consumer-streams/src/main/patch/pc-streams.patch
@@ -1317,7 +1317,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/RecordColl
      @Override
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask.java kafka-patched/org/apache/kafka/streams/processor/internals/StreamTask.java
 --- a/org/apache/kafka/streams/processor/internals/StreamTask.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/StreamTask.java	2026-09-01 00:52:51.879525818 +1200
++++ b/org/apache/kafka/streams/processor/internals/StreamTask.java	2026-09-01 00:54:42.376360802 +1200
 @@ -16,6 +16,8 @@
   */
  package org.apache.kafka.streams.processor.internals;
@@ -1430,7 +1430,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
      }
  
      // create queues for each assigned partition and associate them
-@@ -314,8 +359,45 @@
+@@ -314,8 +359,53 @@
          }
      }
  
@@ -1445,6 +1445,14 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
 +     * <p>
 +     * Recreating the dispatcher instead is the real fix and belongs with the rebalance work; this is the
 +     * loud-failure floor until then.
++     * <p>
++     * <b>This throw is also what keeps the seam off by default</b>, which is not obvious from here. Run
++     * Apache Kafka's own {@code StreamThreadTest} with the seam on and this path is reached through ordinary
++     * task-corruption recovery - a {@code TaskCorruptedException}, which is what Kafka raises when a
++     * consumer's offset falls outside the topic's retained range - and the exception leaves the run loop
++     * uncaught on the StreamThread. The refusal envelope closed the gap the default was originally waiting
++     * on; this is the gap it is waiting on now. {@code PcDispatchSwitch}'s javadoc owns that decision and
++     * the measurement behind it.
 +     */
 +    @Override
 +    public void revive() {
@@ -1476,7 +1484,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          switch (state()) {
              case CREATED:
                  transitToSuspend();
-@@ -437,7 +519,23 @@
+@@ -437,7 +527,23 @@
                  // the commitNeeded flag just indicates whether we have reached RUNNING and processed any new data,
                  // so it only indicates whether the record collector should be flushed or not, whereas the state
                  // manager should always be flushed; either there is newly restored data or the flush will be a no-op
@@ -1501,7 +1509,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
                      // we need to flush the store caches before flushing the record collector since it may cause some
                      // cached records to be processed and hence generate more records to be sent out
                      //
-@@ -645,7 +743,9 @@
+@@ -645,7 +751,9 @@
      public void maybeCheckpoint(final boolean enforceCheckpoint) {
          // commitNeeded indicates we may have processed some records since last commit
          // and hence we need to refresh checkpointable offsets regardless whether we should checkpoint or not
@@ -1512,7 +1520,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
              stateMgr.updateChangelogOffsets(checkpointableOffsets());
          }
  
-@@ -655,7 +755,9 @@
+@@ -655,7 +763,9 @@
      private void validateClean() {
          // It may be that we failed to commit a task during handleRevocation, but "forgot" this and tried to
          // closeClean in handleAssignment. We should throw if we detect this to force the TaskManager to closeDirty
@@ -1523,7 +1531,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
              log.debug("Tried to close clean but there was pending uncommitted data, this means we failed to"
                            + " commit and should close as dirty instead");
              throw new TaskMigratedException("Tried to close dirty task as clean");
-@@ -673,6 +775,12 @@
+@@ -673,6 +783,12 @@
       * You must commit a task and checkpoint the state manager before closing as this will release the state dir lock
       */
      private void close(final boolean clean) {
@@ -1536,7 +1544,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          switch (state()) {
              case SUSPENDED:
                  TaskManager.executeAndMaybeSwallow(
-@@ -765,12 +873,20 @@
+@@ -765,12 +881,20 @@
       */
      @SuppressWarnings("unchecked")
      public boolean process(final long wallClockTime) {
@@ -1557,7 +1565,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
              record = partitionGroup.nextRecord(recordInfo, wallClockTime);
  
              // if there is no record to process, return immediately
-@@ -780,10 +896,13 @@
+@@ -780,10 +904,13 @@
          }
  
          try {
@@ -1573,7 +1581,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
              }
  
              // update the consumed offset map after processing is done
-@@ -792,7 +911,7 @@
+@@ -792,7 +919,7 @@
  
              // after processing this record, if its partition queue's buffered size has been
              // decreased to the threshold, we can then resume the consumption on this partition
@@ -1582,7 +1590,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
                  partitionsToResume.add(partition);
              }
  
-@@ -843,8 +962,15 @@
+@@ -843,8 +970,15 @@
          throw error;
      }
  
@@ -1599,7 +1607,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          // process the record by passing to the source node of the topology
          final ProcessorNode<Object, Object, Object, Object> currNode = (ProcessorNode<Object, Object, Object, Object>) recordInfo.node();
          log.trace("Start processing one record [{}]", record);
-@@ -870,16 +996,108 @@
+@@ -870,16 +1004,108 @@
          log.trace("Completed processing one record [{}]", record);
      }
  
@@ -1711,7 +1719,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
      }
  
      /**
-@@ -1102,6 +1320,15 @@
+@@ -1102,6 +1328,15 @@
       */
      @Override
      public void addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
@@ -1727,7 +1735,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          final int newQueueSize = partitionGroup.addRawRecords(partition, records);
  
          if (log.isTraceEnabled()) {
-@@ -1288,8 +1515,28 @@
+@@ -1288,8 +1523,28 @@
          return sb.toString();
      }
  
@@ -1756,7 +1764,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          // we need to do an extra check if the flag was false, that
          // if the consumer position has been updated; this is because
          // there may be non data records such as control markers bypassed
-@@ -1357,6 +1604,16 @@
+@@ -1357,6 +1612,16 @@
  
      public void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset) {
          committedOffsets.put(topicPartition, offset);

--- a/parallel-consumer-streams/src/main/patch/pc-streams.patch
+++ b/parallel-consumer-streams/src/main/patch/pc-streams.patch
@@ -1,6 +1,1114 @@
+diff -ruN kafka-pristine/org/apache/kafka/streams/kstream/CogroupedKStream.java kafka-patched/org/apache/kafka/streams/kstream/CogroupedKStream.java
+--- a/org/apache/kafka/streams/kstream/CogroupedKStream.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/kstream/CogroupedKStream.java	2026-09-01 00:51:01.604813959 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.kstream;
+ 
++import com.google.errorprone.annotations.DoNotCall;
+ import org.apache.kafka.common.utils.Bytes;
+ import org.apache.kafka.streams.KafkaStreams;
+ import org.apache.kafka.streams.KeyValue;
+@@ -295,7 +296,13 @@
+      * @param <W>     the window type
+      *
+      * @return an instance of {@link TimeWindowedCogroupedKStream}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because window close is driven by {@code observedStreamTime},
++     *             which does not advance there and is corrupted under concurrent read-modify-write. Turn that dispatch
++     *             off ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("windowedBy is not supported on the Parallel Consumer dispatch path (astubbs#255): window close is driven by observedStreamTime, which does not advance there and is corrupted under concurrent read-modify-write")
+     <W extends Window> TimeWindowedCogroupedKStream<K, VAgg> windowedBy(final Windows<W> windows);
+ 
+     /**
+@@ -306,7 +313,13 @@
+      *        the specification of the aggregation {@link SlidingWindows}
+      *
+      * @return an instance of {@link TimeWindowedCogroupedKStream}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because window close is driven by {@code observedStreamTime},
++     *             which does not advance there and is corrupted under concurrent read-modify-write. Turn that dispatch
++     *             off ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("windowedBy is not supported on the Parallel Consumer dispatch path (astubbs#255): window close is driven by observedStreamTime, which does not advance there and is corrupted under concurrent read-modify-write")
+     TimeWindowedCogroupedKStream<K, VAgg> windowedBy(final SlidingWindows windows);
+ 
+     /**
+@@ -317,7 +330,13 @@
+      *        the specification of the aggregation {@link SessionWindows}
+      *
+      * @return an instance of {@link SessionWindowedCogroupedKStream}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because window close is driven by {@code observedStreamTime},
++     *             which does not advance there and is corrupted under concurrent read-modify-write. Turn that dispatch
++     *             off ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("windowedBy is not supported on the Parallel Consumer dispatch path (astubbs#255): window close is driven by observedStreamTime, which does not advance there and is corrupted under concurrent read-modify-write")
+     SessionWindowedCogroupedKStream<K, VAgg> windowedBy(final SessionWindows windows);
+ 
+ }
+diff -ruN kafka-pristine/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java kafka-patched/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+--- a/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java	2026-09-01 00:51:01.606461884 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.kstream.internals;
+ 
++import bz.stub.parallelconsumer.streams.PcUnsupportedConstruct;
+ import org.apache.kafka.common.utils.Bytes;
+ import org.apache.kafka.streams.kstream.Aggregator;
+ import org.apache.kafka.streams.kstream.CogroupedKStream;
+@@ -39,6 +40,15 @@
+ import java.util.Objects;
+ import java.util.Set;
+ 
++// PC dispatch (astubbs#255): the refusal envelope annotates the four DSL INTERFACES with @DoNotCall,
++// because a call site resolves to the symbol its receiver's static type declares. Error Prone then asks
++// every override of such a method to carry the annotation too, which is 118 findings across the four impl
++// classes in this tree. Suppressed rather than propagated, for two reasons that hold together: the impls
++// carry the RUNTIME half of the same refusal - reaching one of these bodies by its internal type still
++// throws, so there is no unrefused path, only one refused a call later than the interface - and every one
++// of these findings is on an override declaration rather than a call site, so nothing that could reach a
++// refused construct is being silenced.
++@SuppressWarnings("DoNotCall")
+ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> implements CogroupedKStream<K, VOut> {
+ 
+     static final String AGGREGATE_NAME = "COGROUPKSTREAM-AGGREGATE-";
+@@ -98,6 +108,10 @@
+ 
+     @Override
+     public <W extends Window> TimeWindowedCogroupedKStream<K, VOut> windowedBy(final Windows<W> windows) {
++        // PC dispatch (astubbs#255): refused on the PC path - time windows over a cogroup. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.WINDOWED_COGROUPED_AGGREGATION.refuse();
++
+         Objects.requireNonNull(windows, "windows can't be null");
+         return new TimeWindowedCogroupedKStreamImpl<>(
+             windows,
+@@ -111,6 +125,10 @@
+ 
+     @Override
+     public TimeWindowedCogroupedKStream<K, VOut> windowedBy(final SlidingWindows slidingWindows) {
++        // PC dispatch (astubbs#255): refused on the PC path - sliding windows over a cogroup. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.WINDOWED_COGROUPED_AGGREGATION.refuse();
++
+         Objects.requireNonNull(slidingWindows, "slidingWindows can't be null");
+         return new SlidingWindowedCogroupedKStreamImpl<>(
+             slidingWindows,
+@@ -124,6 +142,10 @@
+ 
+     @Override
+     public SessionWindowedCogroupedKStream<K, VOut> windowedBy(final SessionWindows sessionWindows) {
++        // PC dispatch (astubbs#255): refused on the PC path - session windows over a cogroup. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.WINDOWED_COGROUPED_AGGREGATION.refuse();
++
+         Objects.requireNonNull(sessionWindows, "sessionWindows can't be null");
+         return new SessionWindowedCogroupedKStreamImpl<>(sessionWindows,
+             builder,
+diff -ruN kafka-pristine/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java kafka-patched/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+--- a/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java	2026-09-01 00:51:01.607072928 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.kstream.internals;
+ 
++import bz.stub.parallelconsumer.streams.PcUnsupportedConstruct;
+ import org.apache.kafka.common.serialization.Serdes;
+ import org.apache.kafka.common.utils.Bytes;
+ import org.apache.kafka.streams.kstream.Aggregator;
+@@ -39,6 +40,15 @@
+ import java.util.Objects;
+ import java.util.Set;
+ 
++// PC dispatch (astubbs#255): the refusal envelope annotates the four DSL INTERFACES with @DoNotCall,
++// because a call site resolves to the symbol its receiver's static type declares. Error Prone then asks
++// every override of such a method to carry the annotation too, which is 118 findings across the four impl
++// classes in this tree. Suppressed rather than propagated, for two reasons that hold together: the impls
++// carry the RUNTIME half of the same refusal - reaching one of these bodies by its internal type still
++// throws, so there is no unrefused path, only one refused a call later than the interface - and every one
++// of these findings is on an override declaration rather than a call site, so nothing that could reach a
++// refused construct is being silenced.
++@SuppressWarnings("DoNotCall")
+ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedStream<K, V> {
+ 
+     static final String REDUCE_NAME = "KSTREAM-REDUCE-";
+@@ -191,6 +201,10 @@
+ 
+     @Override
+     public <W extends Window> TimeWindowedKStream<K, V> windowedBy(final Windows<W> windows) {
++        // PC dispatch (astubbs#255): refused on the PC path - time windows. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.WINDOWED_AGGREGATION.refuse();
++
+ 
+         return new TimeWindowedKStreamImpl<>(
+             windows,
+@@ -206,6 +220,10 @@
+ 
+     @Override
+     public TimeWindowedKStream<K, V> windowedBy(final SlidingWindows windows) {
++        // PC dispatch (astubbs#255): refused on the PC path - sliding windows. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.WINDOWED_AGGREGATION.refuse();
++
+ 
+         return new SlidingWindowedKStreamImpl<>(
+                 windows,
+@@ -221,6 +239,10 @@
+ 
+     @Override
+     public SessionWindowedKStream<K, V> windowedBy(final SessionWindows windows) {
++        // PC dispatch (astubbs#255): refused on the PC path - session windows. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.WINDOWED_AGGREGATION.refuse();
++
+ 
+         return new SessionWindowedKStreamImpl<>(
+             windows,
+diff -ruN kafka-pristine/org/apache/kafka/streams/kstream/internals/KStreamImpl.java kafka-patched/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+--- a/org/apache/kafka/streams/kstream/internals/KStreamImpl.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/kstream/internals/KStreamImpl.java	2026-09-01 00:51:01.609076855 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.kstream.internals;
+ 
++import bz.stub.parallelconsumer.streams.PcUnsupportedConstruct;
+ import org.apache.kafka.common.serialization.Serde;
+ import org.apache.kafka.common.utils.Bytes;
+ import org.apache.kafka.streams.KeyValue;
+@@ -80,6 +81,15 @@
+ 
+ import static org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNode.optimizableRepartitionNodeBuilder;
+ 
++// PC dispatch (astubbs#255): the refusal envelope annotates the four DSL INTERFACES with @DoNotCall,
++// because a call site resolves to the symbol its receiver's static type declares. Error Prone then asks
++// every override of such a method to carry the annotation too, which is 118 findings across the four impl
++// classes in this tree. Suppressed rather than propagated, for two reasons that hold together: the impls
++// carry the RUNTIME half of the same refusal - reaching one of these bodies by its internal type still
++// throws, so there is no unrefused path, only one refused a call later than the interface - and every one
++// of these findings is on an override declaration rather than a call site, so nothing that could reach a
++// refused construct is being silenced.
++@SuppressWarnings("DoNotCall")
+ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K, V> {
+ 
+     static final String JOINTHIS_NAME = "KSTREAM-JOINTHIS-";
+@@ -943,6 +953,10 @@
+                                            final JoinWindows windows,
+                                            final StreamJoined<K, V, VO> streamJoined,
+                                            final KStreamImplJoin join) {
++        // PC dispatch (astubbs#255): refused on the PC path - every stream-stream join overload funnels through here. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.KSTREAM_KSTREAM_JOIN.refuse();
++
+         Objects.requireNonNull(otherStream, "otherStream can't be null");
+         Objects.requireNonNull(joiner, "joiner can't be null");
+         Objects.requireNonNull(windows, "windows can't be null");
+@@ -1214,6 +1228,10 @@
+                                                         final ValueJoinerWithKey<? super K, ? super V, ? super VG, ? extends VR> joiner,
+                                                         final boolean leftJoin,
+                                                         final Named named) {
++        // PC dispatch (astubbs#255): refused on the PC path - every global-table join overload funnels through here. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.KSTREAM_GLOBALKTABLE_JOIN.refuse();
++
+         Objects.requireNonNull(globalTable, "globalTable can't be null");
+         Objects.requireNonNull(keySelector, "keySelector can't be null");
+         Objects.requireNonNull(joiner, "joiner can't be null");
+@@ -1252,6 +1270,10 @@
+                                                       final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                                       final Joined<K, V, VO> joined,
+                                                       final boolean leftJoin) {
++        // PC dispatch (astubbs#255): refused on the PC path - every stream-table join overload funnels through here. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.KSTREAM_KTABLE_JOIN.refuse();
++
+         Objects.requireNonNull(table, "table can't be null");
+         Objects.requireNonNull(joiner, "joiner can't be null");
+ 
+diff -ruN kafka-pristine/org/apache/kafka/streams/kstream/internals/KTableImpl.java kafka-patched/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+--- a/org/apache/kafka/streams/kstream/internals/KTableImpl.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/kstream/internals/KTableImpl.java	2026-09-01 00:51:01.611116781 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.kstream.internals;
+ 
++import bz.stub.parallelconsumer.streams.PcUnsupportedConstruct;
+ import org.apache.kafka.common.serialization.Serde;
+ import org.apache.kafka.common.utils.Bytes;
+ import org.apache.kafka.streams.KeyValue;
+@@ -98,6 +99,15 @@
+  * @param <S> the source's (parent's) value type
+  * @param <V> the value type
+  */
++// PC dispatch (astubbs#255): the refusal envelope annotates the four DSL INTERFACES with @DoNotCall,
++// because a call site resolves to the symbol its receiver's static type declares. Error Prone then asks
++// every override of such a method to carry the annotation too, which is 118 findings across the four impl
++// classes in this tree. Suppressed rather than propagated, for two reasons that hold together: the impls
++// carry the RUNTIME half of the same refusal - reaching one of these bodies by its internal type still
++// throws, so there is no unrefused path, only one refused a call later than the interface - and every one
++// of these findings is on an override declaration rather than a call site, so nothing that could reach a
++// refused construct is being silenced.
++@SuppressWarnings("DoNotCall")
+ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<K, V> {
+     private static final Logger LOG = LoggerFactory.getLogger(KTableImpl.class);
+ 
+@@ -543,6 +553,10 @@
+ 
+     @Override
+     public KTable<K, V> suppress(final Suppressed<? super K> suppressed) {
++        // PC dispatch (astubbs#255): refused on the PC path - the only entry point to suppression. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.SUPPRESSION.refuse();
++
+         // this is an eager, but insufficient check
+         // the check only works if the direct parent is materialized
+         // the actual check for "version inheritance" can only be done in the build-phase later
+@@ -731,6 +745,10 @@
+                                           final MaterializedInternal<K, VR, KeyValueStore<Bytes, byte[]>> materializedInternal,
+                                           final boolean leftOuter,
+                                           final boolean rightOuter) {
++        // PC dispatch (astubbs#255): refused on the PC path - every table-table join overload funnels through here. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.KTABLE_KTABLE_JOIN.refuse();
++
+         Objects.requireNonNull(other, "other can't be null");
+         Objects.requireNonNull(joiner, "joiner can't be null");
+         Objects.requireNonNull(joinName, "joinName can't be null");
+@@ -1090,6 +1108,10 @@
+                                                           final TableJoined<K, KO> tableJoined,
+                                                           final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized,
+                                                           final boolean leftJoin) {
++        // PC dispatch (astubbs#255): refused on the PC path - every foreign-key join overload funnels through here. No-op with the seam off, so
++        // this stays behaviourally identical to stock Kafka Streams and Kafka's own suite is unaffected.
++        PcUnsupportedConstruct.KTABLE_KTABLE_FOREIGN_KEY_JOIN.refuse();
++
+         Objects.requireNonNull(foreignKeyTable, "foreignKeyTable can't be null");
+         Objects.requireNonNull(foreignKeyExtractor, "foreignKeyExtractor can't be null");
+         Objects.requireNonNull(joiner, "joiner can't be null");
+diff -ruN kafka-pristine/org/apache/kafka/streams/kstream/KGroupedStream.java kafka-patched/org/apache/kafka/streams/kstream/KGroupedStream.java
+--- a/org/apache/kafka/streams/kstream/KGroupedStream.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/kstream/KGroupedStream.java	2026-09-01 00:51:01.612337245 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.kstream;
+ 
++import com.google.errorprone.annotations.DoNotCall;
+ import org.apache.kafka.common.utils.Bytes;
+ import org.apache.kafka.streams.KafkaStreams;
+ import org.apache.kafka.streams.KeyValue;
+@@ -543,21 +544,39 @@
+      * @param windows the specification of the aggregation {@link Windows}
+      * @param <W>     the window type
+      * @return an instance of {@link TimeWindowedKStream}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because window close is driven by {@code observedStreamTime},
++     *             which does not advance there and is corrupted under concurrent read-modify-write. Turn that dispatch
++     *             off ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("windowedBy is not supported on the Parallel Consumer dispatch path (astubbs#255): window close is driven by observedStreamTime, which does not advance there and is corrupted under concurrent read-modify-write")
+     <W extends Window> TimeWindowedKStream<K, V> windowedBy(final Windows<W> windows);
+ 
+     /**
+      * Create a new {@link TimeWindowedKStream} instance that can be used to perform sliding windowed aggregations.
+      * @param windows the specification of the aggregation {@link SlidingWindows}
+      * @return an instance of {@link TimeWindowedKStream}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because window close is driven by {@code observedStreamTime},
++     *             which does not advance there and is corrupted under concurrent read-modify-write. Turn that dispatch
++     *             off ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("windowedBy is not supported on the Parallel Consumer dispatch path (astubbs#255): window close is driven by observedStreamTime, which does not advance there and is corrupted under concurrent read-modify-write")
+     TimeWindowedKStream<K, V> windowedBy(final SlidingWindows windows);
+ 
+     /**
+      * Create a new {@link SessionWindowedKStream} instance that can be used to perform session windowed aggregations.
+      * @param windows the specification of the aggregation {@link SessionWindows}
+      * @return an instance of {@link TimeWindowedKStream}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because window close is driven by {@code observedStreamTime},
++     *             which does not advance there and is corrupted under concurrent read-modify-write. Turn that dispatch
++     *             off ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("windowedBy is not supported on the Parallel Consumer dispatch path (astubbs#255): window close is driven by observedStreamTime, which does not advance there and is corrupted under concurrent read-modify-write")
+     SessionWindowedKStream<K, V> windowedBy(final SessionWindows windows);
+ 
+     /**
+diff -ruN kafka-pristine/org/apache/kafka/streams/kstream/KStream.java kafka-patched/org/apache/kafka/streams/kstream/KStream.java
+--- a/org/apache/kafka/streams/kstream/KStream.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/kstream/KStream.java	2026-09-01 00:51:01.619068443 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.kstream;
+ 
++import com.google.errorprone.annotations.DoNotCall;
+ import org.apache.kafka.common.serialization.Serde;
+ import org.apache.kafka.common.serialization.Serdes;
+ import org.apache.kafka.common.utils.Bytes;
+@@ -1254,7 +1255,13 @@
+      * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
+      * @see #leftJoin(KStream, ValueJoiner, JoinWindows)
+      * @see #outerJoin(KStream, ValueJoiner, JoinWindows)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
+                                  final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                  final JoinWindows windows);
+@@ -1331,7 +1338,13 @@
+      * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key and within the joining window intervals
+      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
+      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
+                                  final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                  final JoinWindows windows);
+@@ -1410,7 +1423,13 @@
+      * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
+      * @see #leftJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
+      * @see #outerJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
+                                  final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                  final JoinWindows windows,
+@@ -1491,7 +1510,13 @@
+      * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key and within the joining window intervals
+      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
+                                  final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                  final JoinWindows windows,
+@@ -1571,7 +1596,13 @@
+      * this {@code KStream} and within the joining window intervals
+      * @see #join(KStream, ValueJoiner, JoinWindows)
+      * @see #outerJoin(KStream, ValueJoiner, JoinWindows)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                      final JoinWindows windows);
+@@ -1651,7 +1682,13 @@
+      * this {@code KStream} and within the joining window intervals
+      * @see #join(KStream, ValueJoinerWithKey, JoinWindows)
+      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                      final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                      final JoinWindows windows);
+@@ -1734,7 +1771,13 @@
+      * this {@code KStream} and within the joining window intervals
+      * @see #join(KStream, ValueJoiner, JoinWindows, StreamJoined)
+      * @see #outerJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                      final JoinWindows windows,
+@@ -1819,7 +1862,13 @@
+      * this {@code KStream} and within the joining window intervals
+      * @see #join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                      final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                      final JoinWindows windows,
+@@ -1900,7 +1949,13 @@
+      * both {@code KStream} and within the joining window intervals
+      * @see #join(KStream, ValueJoiner, JoinWindows)
+      * @see #leftJoin(KStream, ValueJoiner, JoinWindows)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                       final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                       final JoinWindows windows);
+@@ -1981,7 +2036,13 @@
+      * both {@code KStream} and within the joining window intervals
+      * @see #join(KStream, ValueJoinerWithKey, JoinWindows)
+      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                       final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                       final JoinWindows windows);
+@@ -2065,7 +2126,13 @@
+      * both {@code KStream} and within the joining window intervals
+      * @see #join(KStream, ValueJoiner, JoinWindows, StreamJoined)
+      * @see #leftJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                       final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                       final JoinWindows windows,
+@@ -2151,7 +2218,13 @@
+      * both {@code KStream} and within the joining window intervals
+      * @see #join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because join emission is stream-time gated and stream time does
++     *             not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as
++     *             stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KStream join is not supported on the Parallel Consumer dispatch path (astubbs#255): join emission is stream-time gated and stream time does not advance there")
+     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                       final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                       final JoinWindows windows,
+@@ -2228,7 +2301,13 @@
+      * {@link ValueJoiner}, one for each matched record-pair with the same key
+      * @see #leftJoin(KTable, ValueJoiner)
+      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the table side is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the table side is read at a stream time that does not advance there")
+     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
+                                  final ValueJoiner<? super V, ? super VT, ? extends VR> joiner);
+ 
+@@ -2306,7 +2385,13 @@
+      * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key
+      * @see #leftJoin(KTable, ValueJoinerWithKey)
+      * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the table side is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the table side is read at a stream time that does not advance there")
+     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
+                                  final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
+ 
+@@ -2384,7 +2469,13 @@
+      * {@link ValueJoiner}, one for each matched record-pair with the same key
+      * @see #leftJoin(KTable, ValueJoiner, Joined)
+      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the table side is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the table side is read at a stream time that does not advance there")
+     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
+                                  final ValueJoiner<? super V, ? super VT, ? extends VR> joiner,
+                                  final Joined<K, V, VT> joined);
+@@ -2465,7 +2556,13 @@
+      * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key
+      * @see #leftJoin(KTable, ValueJoinerWithKey, Joined)
+      * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the table side is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the table side is read at a stream time that does not advance there")
+     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
+                                  final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
+                                  final Joined<K, V, VT> joined);
+@@ -2545,7 +2642,13 @@
+      * {@link ValueJoiner}, one output for each input {@code KStream} record
+      * @see #join(KTable, ValueJoiner)
+      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the table side is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the table side is read at a stream time that does not advance there")
+     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
+                                      final ValueJoiner<? super V, ? super VT, ? extends VR> joiner);
+ 
+@@ -2625,7 +2728,13 @@
+      * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+      * @see #join(KTable, ValueJoinerWithKey)
+      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the table side is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the table side is read at a stream time that does not advance there")
+     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
+                                      final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
+ 
+@@ -2706,7 +2815,13 @@
+      * {@link ValueJoiner}, one output for each input {@code KStream} record
+      * @see #join(KTable, ValueJoiner, Joined)
+      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the table side is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the table side is read at a stream time that does not advance there")
+     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
+                                      final ValueJoiner<? super V, ? super VT, ? extends VR> joiner,
+                                      final Joined<K, V, VT> joined);
+@@ -2789,7 +2904,13 @@
+      * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+      * @see #join(KTable, ValueJoinerWithKey, Joined)
+      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the table side is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the table side is read at a stream time that does not advance there")
+     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
+                                      final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
+                                      final Joined<K, V, VT> joined);
+@@ -2820,7 +2941,13 @@
+      * @return a {@code KStream} that contains join-records for each key and values computed by the given
+      * {@link ValueJoiner}, one output for each input {@code KStream} record
+      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the global table is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-GlobalKTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the global table is read at a stream time that does not advance there")
+     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
+                                      final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                      final ValueJoiner<? super V, ? super GV, ? extends RV> joiner);
+@@ -2852,7 +2979,13 @@
+      * @return a {@code KStream} that contains join-records for each key and values computed by the given
+      * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the global table is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-GlobalKTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the global table is read at a stream time that does not advance there")
+     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
+                                      final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                      final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner);
+@@ -2884,7 +3017,13 @@
+      * @return a {@code KStream} that contains join-records for each key and values computed by the given
+      * {@link ValueJoiner}, one output for each input {@code KStream} record
+      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the global table is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-GlobalKTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the global table is read at a stream time that does not advance there")
+     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
+                                      final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                      final ValueJoiner<? super V, ? super GV, ? extends RV> joiner,
+@@ -2918,7 +3057,13 @@
+      * @return a {@code KStream} that contains join-records for each key and values computed by the given
+      * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the global table is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-GlobalKTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the global table is read at a stream time that does not advance there")
+     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
+                                      final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                      final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner,
+@@ -2954,7 +3099,13 @@
+      * @return a {@code KStream} that contains join-records for each key and values computed by the given
+      * {@link ValueJoiner}, one output for each input {@code KStream} record
+      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the global table is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-GlobalKTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the global table is read at a stream time that does not advance there")
+     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
+                                          final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                          final ValueJoiner<? super V, ? super GV, ? extends RV> valueJoiner);
+@@ -2990,7 +3141,13 @@
+      * @return a {@code KStream} that contains join-records for each key and values computed by the given
+      * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+      * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the global table is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-GlobalKTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the global table is read at a stream time that does not advance there")
+     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
+                                          final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                          final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoiner);
+@@ -3026,7 +3183,13 @@
+      * @return a {@code KStream} that contains join-records for each key and values computed by the given
+      * {@link ValueJoiner}, one output for each input {@code KStream} record
+      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the global table is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-GlobalKTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the global table is read at a stream time that does not advance there")
+     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
+                                          final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                          final ValueJoiner<? super V, ? super GV, ? extends RV> valueJoiner,
+@@ -3063,7 +3226,13 @@
+      * @return a {@code KStream} that contains join-records for each key and values computed by the given
+      * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+      * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the global table is read at a stream time that does not
++     *             advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this behaves exactly as stock
++     *             Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KStream-GlobalKTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): the global table is read at a stream time that does not advance there")
+     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
+                                          final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                          final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoiner,
+diff -ruN kafka-pristine/org/apache/kafka/streams/kstream/KTable.java kafka-patched/org/apache/kafka/streams/kstream/KTable.java
+--- a/org/apache/kafka/streams/kstream/KTable.java	2026-02-07 12:00:08.000000000 +1300
++++ b/org/apache/kafka/streams/kstream/KTable.java	2026-09-01 00:51:01.622718919 +1200
+@@ -16,6 +16,7 @@
+  */
+ package org.apache.kafka.streams.kstream;
+ 
++import com.google.errorprone.annotations.DoNotCall;
+ import org.apache.kafka.common.serialization.Serde;
+ import org.apache.kafka.common.utils.Bytes;
+ import org.apache.kafka.streams.KafkaStreams;
+@@ -727,7 +728,13 @@
+      *
+      * @param suppressed Configuration object determining what, if any, updates to suppress
+      * @return A new KTable with the desired suppression characteristics.
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because "only the final result per window" is a statement about
++     *             stream time, which does not advance there. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("suppress is not supported on the Parallel Consumer dispatch path (astubbs#255): \"only the final result per window\" is a statement about stream time, which does not advance there")
+     KTable<K, V> suppress(final Suppressed<? super K> suppressed);
+ 
+     /**
+@@ -1174,7 +1181,13 @@
+      * {@link ValueJoiner}, one for each matched record-pair with the same key
+      * @see #leftJoin(KTable, ValueJoiner)
+      * @see #outerJoin(KTable, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> join(final KTable<K, VO> other,
+                                 final ValueJoiner<? super V, ? super VO, ? extends VR> joiner);
+ 
+@@ -1250,7 +1263,13 @@
+      * {@link ValueJoiner}, one for each matched record-pair with the same key
+      * @see #leftJoin(KTable, ValueJoiner)
+      * @see #outerJoin(KTable, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> join(final KTable<K, VO> other,
+                                 final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                 final Named named);
+@@ -1329,7 +1348,13 @@
+      * {@link ValueJoiner}, one for each matched record-pair with the same key
+      * @see #leftJoin(KTable, ValueJoiner, Materialized)
+      * @see #outerJoin(KTable, ValueJoiner, Materialized)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> join(final KTable<K, VO> other,
+                                 final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                 final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+@@ -1409,7 +1434,13 @@
+      * {@link ValueJoiner}, one for each matched record-pair with the same key
+      * @see #leftJoin(KTable, ValueJoiner, Materialized)
+      * @see #outerJoin(KTable, ValueJoiner, Materialized)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> join(final KTable<K, VO> other,
+                                 final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                 final Named named,
+@@ -1493,7 +1524,13 @@
+      * left {@code KTable}
+      * @see #join(KTable, ValueJoiner)
+      * @see #outerJoin(KTable, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> leftJoin(final KTable<K, VO> other,
+                                     final ValueJoiner<? super V, ? super VO, ? extends VR> joiner);
+ 
+@@ -1576,7 +1613,13 @@
+      * left {@code KTable}
+      * @see #join(KTable, ValueJoiner)
+      * @see #outerJoin(KTable, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> leftJoin(final KTable<K, VO> other,
+                                     final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                     final Named named);
+@@ -1662,7 +1705,13 @@
+      * left {@code KTable}
+      * @see #join(KTable, ValueJoiner, Materialized)
+      * @see #outerJoin(KTable, ValueJoiner, Materialized)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> leftJoin(final KTable<K, VO> other,
+                                     final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                     final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+@@ -1749,7 +1798,13 @@
+      * left {@code KTable}
+      * @see #join(KTable, ValueJoiner, Materialized)
+      * @see #outerJoin(KTable, ValueJoiner, Materialized)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> leftJoin(final KTable<K, VO> other,
+                                     final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                     final Named named,
+@@ -1832,7 +1887,13 @@
+      * both {@code KTable}s
+      * @see #join(KTable, ValueJoiner)
+      * @see #leftJoin(KTable, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> outerJoin(final KTable<K, VO> other,
+                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner);
+ 
+@@ -1915,7 +1976,13 @@
+      * both {@code KTable}s
+      * @see #join(KTable, ValueJoiner)
+      * @see #leftJoin(KTable, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> outerJoin(final KTable<K, VO> other,
+                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                      final Named named);
+@@ -2000,7 +2067,13 @@
+      * both {@code KTable}s
+      * @see #join(KTable, ValueJoiner)
+      * @see #leftJoin(KTable, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> outerJoin(final KTable<K, VO> other,
+                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                      final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+@@ -2087,7 +2160,13 @@
+      * both {@code KTable}s
+      * @see #join(KTable, ValueJoiner)
+      * @see #leftJoin(KTable, ValueJoiner)
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because results are emitted per update in arrival order, which
++     *             concurrent dispatch does not preserve. Turn that dispatch off ({@code PcDispatchSwitch}) and this
++     *             behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable join is not supported on the Parallel Consumer dispatch path (astubbs#255): results are emitted per update in arrival order, which concurrent dispatch does not preserve")
+     <VO, VR> KTable<K, VR> outerJoin(final KTable<K, VO> other,
+                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                      final Named named,
+@@ -2106,7 +2185,13 @@
+      * @param <KO>                the key type of the other {@code KTable}
+      * @param <VO>                the value type of the other {@code KTable}
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the subscription store is updated and read across both
++     *             halves without ordering concurrent dispatch can honour. Turn that dispatch off
++     *             ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> join(final KTable<KO, VO> other,
+                                     final Function<V, KO> foreignKeyExtractor,
+                                     final ValueJoiner<V, VO, VR> joiner);
+@@ -2127,8 +2212,13 @@
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
+      *
+      * @deprecated since 3.1, removal planned for 4.0. Use {@link #join(KTable, Function, ValueJoiner, TableJoined)} instead.
++     *             Separately, {@code parallel-consumer-streams} also refuses this on the Parallel Consumer dispatch
++     *             path (astubbs#255), because the subscription store is updated and read across both halves without
++     *             ordering concurrent dispatch can honour; turn that dispatch off ({@code PcDispatchSwitch}) and it
++     *             behaves exactly as stock Kafka Streams.
+      */
+     @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> join(final KTable<KO, VO> other,
+                                     final Function<V, KO> foreignKeyExtractor,
+                                     final ValueJoiner<V, VO, VR> joiner,
+@@ -2151,7 +2241,13 @@
+      * @param <KO>                the key type of the other {@code KTable}
+      * @param <VO>                the value type of the other {@code KTable}
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the subscription store is updated and read across both
++     *             halves without ordering concurrent dispatch can honour. Turn that dispatch off
++     *             ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> join(final KTable<KO, VO> other,
+                                     final Function<V, KO> foreignKeyExtractor,
+                                     final ValueJoiner<V, VO, VR> joiner,
+@@ -2172,7 +2268,13 @@
+      * @param <KO>                the key type of the other {@code KTable}
+      * @param <VO>                the value type of the other {@code KTable}
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the subscription store is updated and read across both
++     *             halves without ordering concurrent dispatch can honour. Turn that dispatch off
++     *             ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> join(final KTable<KO, VO> other,
+                                     final Function<V, KO> foreignKeyExtractor,
+                                     final ValueJoiner<V, VO, VR> joiner,
+@@ -2196,8 +2298,13 @@
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
+      *
+      * @deprecated since 3.1, removal planned for 4.0. Use {@link #join(KTable, Function, ValueJoiner, TableJoined, Materialized)} instead.
++     *             Separately, {@code parallel-consumer-streams} also refuses this on the Parallel Consumer dispatch
++     *             path (astubbs#255), because the subscription store is updated and read across both halves without
++     *             ordering concurrent dispatch can honour; turn that dispatch off ({@code PcDispatchSwitch}) and it
++     *             behaves exactly as stock Kafka Streams.
+      */
+     @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> join(final KTable<KO, VO> other,
+                                     final Function<V, KO> foreignKeyExtractor,
+                                     final ValueJoiner<V, VO, VR> joiner,
+@@ -2223,7 +2330,13 @@
+      * @param <KO>                the key type of the other {@code KTable}
+      * @param <VO>                the value type of the other {@code KTable}
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the subscription store is updated and read across both
++     *             halves without ordering concurrent dispatch can honour. Turn that dispatch off
++     *             ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> join(final KTable<KO, VO> other,
+                                     final Function<V, KO> foreignKeyExtractor,
+                                     final ValueJoiner<V, VO, VR> joiner,
+@@ -2243,7 +2356,13 @@
+      * @param <KO>                the key type of the other {@code KTable}
+      * @param <VO>                the value type of the other {@code KTable}
+      * @return a {@code KTable} that contains only those records that satisfy the given predicate
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the subscription store is updated and read across both
++     *             halves without ordering concurrent dispatch can honour. Turn that dispatch off
++     *             ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> leftJoin(final KTable<KO, VO> other,
+                                         final Function<V, KO> foreignKeyExtractor,
+                                         final ValueJoiner<V, VO, VR> joiner);
+@@ -2264,8 +2383,13 @@
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
+      *
+      * @deprecated since 3.1, removal planned for 4.0. Use {@link #leftJoin(KTable, Function, ValueJoiner, TableJoined)} instead.
++     *             Separately, {@code parallel-consumer-streams} also refuses this on the Parallel Consumer dispatch
++     *             path (astubbs#255), because the subscription store is updated and read across both halves without
++     *             ordering concurrent dispatch can honour; turn that dispatch off ({@code PcDispatchSwitch}) and it
++     *             behaves exactly as stock Kafka Streams.
+      */
+     @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> leftJoin(final KTable<KO, VO> other,
+                                         final Function<V, KO> foreignKeyExtractor,
+                                         final ValueJoiner<V, VO, VR> joiner,
+@@ -2287,7 +2411,13 @@
+      * @param <KO>                the key type of the other {@code KTable}
+      * @param <VO>                the value type of the other {@code KTable}
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the subscription store is updated and read across both
++     *             halves without ordering concurrent dispatch can honour. Turn that dispatch off
++     *             ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> leftJoin(final KTable<KO, VO> other,
+                                         final Function<V, KO> foreignKeyExtractor,
+                                         final ValueJoiner<V, VO, VR> joiner,
+@@ -2308,7 +2438,13 @@
+      * @param <KO>                the key type of the other {@code KTable}
+      * @param <VO>                the value type of the other {@code KTable}
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the subscription store is updated and read across both
++     *             halves without ordering concurrent dispatch can honour. Turn that dispatch off
++     *             ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> leftJoin(final KTable<KO, VO> other,
+                                         final Function<V, KO> foreignKeyExtractor,
+                                         final ValueJoiner<V, VO, VR> joiner,
+@@ -2332,8 +2468,13 @@
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
+      *
+      * @deprecated since 3.1, removal planned for 4.0. Use {@link #leftJoin(KTable, Function, ValueJoiner, TableJoined, Materialized)} instead.
++     *             Separately, {@code parallel-consumer-streams} also refuses this on the Parallel Consumer dispatch
++     *             path (astubbs#255), because the subscription store is updated and read across both halves without
++     *             ordering concurrent dispatch can honour; turn that dispatch off ({@code PcDispatchSwitch}) and it
++     *             behaves exactly as stock Kafka Streams.
+      */
+     @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> leftJoin(final KTable<KO, VO> other,
+                                         final Function<V, KO> foreignKeyExtractor,
+                                         final ValueJoiner<V, VO, VR> joiner,
+@@ -2359,7 +2500,13 @@
+      * @param <KO>                the key type of the other {@code KTable}
+      * @param <VO>                the value type of the other {@code KTable}
+      * @return a {@code KTable} that contains the result of joining this table with {@code other}
++     * @deprecated Not deprecated by Apache Kafka: {@code parallel-consumer-streams} refuses this on the Parallel
++     *             Consumer dispatch path (astubbs#255), because the subscription store is updated and read across both
++     *             halves without ordering concurrent dispatch can honour. Turn that dispatch off
++     *             ({@code PcDispatchSwitch}) and this behaves exactly as stock Kafka Streams.
+      */
++    @Deprecated
++    @DoNotCall("KTable-KTable foreign-key join is not supported on the Parallel Consumer dispatch path (astubbs#255): the subscription store is updated and read across both halves without ordering concurrent dispatch can honour")
+     <VR, KO, VO> KTable<K, VR> leftJoin(final KTable<KO, VO> other,
+                                         final Function<V, KO> foreignKeyExtractor,
+                                         final ValueJoiner<V, VO, VR> joiner,
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java kafka-patched/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
 --- a/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java	2026-08-31 23:37:36.155425717 +1200
++++ b/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java	2026-09-01 00:51:01.623563548 +1200
 @@ -44,8 +44,13 @@
      private final Serde<?> keySerde;
      private final Serde<?> valueSerde;
@@ -129,7 +1237,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/AbstractPr
      @Override
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java kafka-patched/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
 --- a/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java	2026-08-31 23:37:36.156122264 +1200
++++ b/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java	2026-09-01 00:51:01.624223676 +1200
 @@ -243,7 +243,11 @@
                      "multiple times.");
          }
@@ -175,7 +1283,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/ProcessorC
      }
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java kafka-patched/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
 --- a/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java	2026-08-31 23:37:36.157220189 +1200
++++ b/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java	2026-09-01 00:51:01.625122180 +1200
 @@ -64,6 +64,7 @@
  import java.util.Objects;
  import java.util.Optional;
@@ -209,16 +1317,17 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/RecordColl
      @Override
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask.java kafka-patched/org/apache/kafka/streams/processor/internals/StreamTask.java
 --- a/org/apache/kafka/streams/processor/internals/StreamTask.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/StreamTask.java	2026-08-31 23:37:36.158979953 +1200
-@@ -16,6 +16,7 @@
++++ b/org/apache/kafka/streams/processor/internals/StreamTask.java	2026-09-01 00:52:51.879525818 +1200
+@@ -16,6 +16,8 @@
   */
  package org.apache.kafka.streams.processor.internals;
  
++import bz.stub.parallelconsumer.streams.PcSupportedEnvelope;
 +import bz.stub.parallelconsumer.streams.PcTaskDispatcher;
  import org.apache.kafka.clients.consumer.Consumer;
  import org.apache.kafka.clients.consumer.ConsumerConfig;
  import org.apache.kafka.clients.consumer.ConsumerRecord;
-@@ -52,6 +53,7 @@
+@@ -52,6 +54,7 @@
  import org.apache.kafka.streams.state.internals.ThreadCache;
  
  import java.io.IOException;
@@ -226,7 +1335,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
  import java.util.Collections;
  import java.util.HashMap;
  import java.util.HashSet;
-@@ -60,6 +62,7 @@
+@@ -60,6 +63,7 @@
  import java.util.Objects;
  import java.util.Optional;
  import java.util.Set;
@@ -234,7 +1343,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
  import java.util.function.Function;
  import java.util.stream.Collectors;
  
-@@ -84,7 +87,12 @@
+@@ -84,7 +88,12 @@
      private final int maxBufferedSize;
      private final AbstractPartitionGroup partitionGroup;
      private final RecordCollector recordCollector;
@@ -248,7 +1357,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
      private final Map<TopicPartition, Long> consumedOffsets;
      private final Map<TopicPartition, Long> committedOffsets;
      private final Map<TopicPartition, Long> highWatermark;
-@@ -94,7 +102,8 @@
+@@ -94,7 +103,8 @@
      private final PunctuationQueue systemTimePunctuationQueue;
      private final StreamsMetricsImpl streamsMetrics;
  
@@ -258,7 +1367,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
  
      private final Sensor closeTaskSensor;
      private final Sensor processRatioSensor;
-@@ -113,8 +122,32 @@
+@@ -113,8 +123,32 @@
      private final ProcessingExceptionHandler processingExceptionHandler;
  
      private StampedRecord record;
@@ -292,7 +1401,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
      private boolean hasPendingTxCommit = false;
      private Optional<Long> timeCurrentIdlingStarted;
  
-@@ -191,8 +224,6 @@
+@@ -191,8 +225,6 @@
  
          recordQueueCreator = new RecordQueueCreator(this.logContext, config.timestampExtractor, config.deserializationExceptionHandler);
  
@@ -301,10 +1410,19 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          final Sensor enforcedProcessingSensor;
          enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics);
          final long maxTaskIdleMs = config.maxTaskIdleMs;
-@@ -225,6 +256,10 @@
+@@ -225,6 +257,19 @@
          }
          timeCurrentIdlingStarted = Optional.empty();
          processingExceptionHandler = config.processingExceptionHandler;
++
++        // PC dispatch (astubbs#255): the backstop for the unsupported surface. The DSL refusals only fire for
++        // someone who called windowedBy/join/suppress; the Processor API reaches a WindowStore through
++        // addStateStore without touching KStream at all, and exactly-once is a config key rather than a
++        // topology shape. This constructor is the one place holding both the topology and the config, so the
++        // check costs no additional patched class. It is a no-op with the seam off - Kafka's own StreamTaskTest
++        // builds EOS-enabled tasks, and the behaviour-preservation claim is a seam-off claim.
++        // Deliberately BEFORE the dispatcher below: a refused task must not leave a worker pool behind.
++        PcSupportedEnvelope.checkTask(id.toString(), topology.stateStores(), config.eosEnabled);
 +
 +        // PC dispatch (astubbs#255): the switch. Off by default, so the stock path above stays the one that
 +        // runs unless a test or a system property says otherwise.
@@ -312,7 +1430,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
      }
  
      // create queues for each assigned partition and associate them
-@@ -314,8 +349,45 @@
+@@ -314,8 +359,45 @@
          }
      }
  
@@ -358,7 +1476,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          switch (state()) {
              case CREATED:
                  transitToSuspend();
-@@ -437,7 +509,23 @@
+@@ -437,7 +519,23 @@
                  // the commitNeeded flag just indicates whether we have reached RUNNING and processed any new data,
                  // so it only indicates whether the record collector should be flushed or not, whereas the state
                  // manager should always be flushed; either there is newly restored data or the flush will be a no-op
@@ -383,7 +1501,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
                      // we need to flush the store caches before flushing the record collector since it may cause some
                      // cached records to be processed and hence generate more records to be sent out
                      //
-@@ -645,7 +733,9 @@
+@@ -645,7 +743,9 @@
      public void maybeCheckpoint(final boolean enforceCheckpoint) {
          // commitNeeded indicates we may have processed some records since last commit
          // and hence we need to refresh checkpointable offsets regardless whether we should checkpoint or not
@@ -394,7 +1512,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
              stateMgr.updateChangelogOffsets(checkpointableOffsets());
          }
  
-@@ -655,7 +745,9 @@
+@@ -655,7 +755,9 @@
      private void validateClean() {
          // It may be that we failed to commit a task during handleRevocation, but "forgot" this and tried to
          // closeClean in handleAssignment. We should throw if we detect this to force the TaskManager to closeDirty
@@ -405,7 +1523,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
              log.debug("Tried to close clean but there was pending uncommitted data, this means we failed to"
                            + " commit and should close as dirty instead");
              throw new TaskMigratedException("Tried to close dirty task as clean");
-@@ -673,6 +765,12 @@
+@@ -673,6 +775,12 @@
       * You must commit a task and checkpoint the state manager before closing as this will release the state dir lock
       */
      private void close(final boolean clean) {
@@ -418,7 +1536,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          switch (state()) {
              case SUSPENDED:
                  TaskManager.executeAndMaybeSwallow(
-@@ -765,12 +863,20 @@
+@@ -765,12 +873,20 @@
       */
      @SuppressWarnings("unchecked")
      public boolean process(final long wallClockTime) {
@@ -439,7 +1557,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
              record = partitionGroup.nextRecord(recordInfo, wallClockTime);
  
              // if there is no record to process, return immediately
-@@ -780,10 +886,13 @@
+@@ -780,10 +896,13 @@
          }
  
          try {
@@ -455,7 +1573,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
              }
  
              // update the consumed offset map after processing is done
-@@ -792,7 +901,7 @@
+@@ -792,7 +911,7 @@
  
              // after processing this record, if its partition queue's buffered size has been
              // decreased to the threshold, we can then resume the consumption on this partition
@@ -464,7 +1582,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
                  partitionsToResume.add(partition);
              }
  
-@@ -843,8 +952,15 @@
+@@ -843,8 +962,15 @@
          throw error;
      }
  
@@ -481,7 +1599,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          // process the record by passing to the source node of the topology
          final ProcessorNode<Object, Object, Object, Object> currNode = (ProcessorNode<Object, Object, Object, Object>) recordInfo.node();
          log.trace("Start processing one record [{}]", record);
-@@ -870,16 +986,108 @@
+@@ -870,16 +996,108 @@
          log.trace("Completed processing one record [{}]", record);
      }
  
@@ -593,7 +1711,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
      }
  
      /**
-@@ -1102,6 +1310,15 @@
+@@ -1102,6 +1320,15 @@
       */
      @Override
      public void addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
@@ -609,7 +1727,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          final int newQueueSize = partitionGroup.addRawRecords(partition, records);
  
          if (log.isTraceEnabled()) {
-@@ -1288,8 +1505,28 @@
+@@ -1288,8 +1515,28 @@
          return sb.toString();
      }
  
@@ -638,7 +1756,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
          // we need to do an extra check if the flag was false, that
          // if the consumer position has been updated; this is because
          // there may be non data records such as control markers bypassed
-@@ -1357,6 +1594,16 @@
+@@ -1357,6 +1604,16 @@
  
      public void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset) {
          committedOffsets.put(topicPartition, offset);
@@ -657,7 +1775,7 @@ diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamTask
      public void updateEndOffsets(final TopicPartition topicPartition, final Long offset) {
 diff -ruN kafka-pristine/org/apache/kafka/streams/processor/internals/StreamThread.java kafka-patched/org/apache/kafka/streams/processor/internals/StreamThread.java
 --- a/org/apache/kafka/streams/processor/internals/StreamThread.java	2026-02-07 12:00:08.000000000 +1300
-+++ b/org/apache/kafka/streams/processor/internals/StreamThread.java	2026-08-31 23:37:36.280299670 +1200
++++ b/org/apache/kafka/streams/processor/internals/StreamThread.java	2026-09-01 00:51:01.630408413 +1200
 @@ -16,6 +16,7 @@
   */
  package org.apache.kafka.streams.processor.internals;

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/PcSupportedEnvelopeTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/PcSupportedEnvelopeTest.java
@@ -1,0 +1,240 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.streams.processor.StateStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The refusal logic on its own - no topology, no {@code StreamTask}, no broker.
+ * <p>
+ * Two things are being separated here on purpose. This class proves that the <em>classification and the
+ * message</em> are right; {@link ProcessorApiBackstopTest} proves that {@code StreamTask}'s constructor
+ * actually calls it. A single end-to-end test would conflate "we do not detect a session store" with "we
+ * never got asked", and those have different fixes.
+ * <p>
+ * The stores come from {@link RefusedStoreFixtures}, and they are real Kafka stores rather than stubs - see
+ * that class for why that matters to the {@code instanceof} chain being exercised here.
+ *
+ * @author Antony Stubbs
+ */
+// The switch is process-wide static state - there is no seam through KafkaStreams to inject a collaborator -
+// and this module inherits concurrent JUnit execution from core's junit-platform.properties. Left concurrent,
+// these methods would toggle each other's switch and each other's verdicts.
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated
+class PcSupportedEnvelopeTest {
+
+    private static final String TASK_ID = "0_0";
+
+    private static final boolean AT_LEAST_ONCE = false;
+    private static final boolean EXACTLY_ONCE = true;
+
+    @AfterEach
+    void restoreSwitch() {
+        // Hand the JVM back at the artifact's default rather than parking it wherever this class left it.
+        PcDispatchSwitch.resetToDefault();
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The seam guard. Without this, layers 2 and 3 would break Apache Kafka's own suite, which this module
+    // runs unmodified with the seam OFF as its behaviour-preservation evidence.
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void seamOffRefusesNothingEvenWhenEverythingUnsupportedIsPresent() {
+        PcDispatchSwitch.disable();
+
+        assertThatCode(() -> PcSupportedEnvelope.checkTask(TASK_ID, allUnsupportedStores(), EXACTLY_ONCE))
+                .as("a seam-off run must be behaviourally identical to stock Kafka Streams, whose own tests "
+                        + "build exactly these constructs")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void seamOffRefusesNothingAtTheDslCallEither() {
+        PcDispatchSwitch.disable();
+
+        for (final PcUnsupportedConstruct construct : PcUnsupportedConstruct.values()) {
+            assertThatCode(construct::refuse)
+                    .as("%s must be a no-op with the seam off", construct)
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    void seamOnRefusesEveryConstructAndNamesItInTheMessage() {
+        PcDispatchSwitch.enable(2);
+
+        for (final PcUnsupportedConstruct construct : PcUnsupportedConstruct.values()) {
+            assertThatThrownBy(construct::refuse)
+                    .as("%s must refuse with the seam on", construct)
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining(construct.getDisplayName())
+                    .hasMessageContaining(construct.getReason())
+                    .hasMessageContaining(PcRefusalMessage.ISSUE)
+                    // The property is the whole escape hatch. A refusal that does not carry it is a dead end
+                    // for whoever hits it.
+                    .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY + "=false");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Classification: what the backstop sees in a topology.
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void aWindowStoreIsClassifiedAsWindowing() {
+        assertThat(PcSupportedEnvelope.findUnsupported(Collections.singletonList(windowStore()), AT_LEAST_ONCE))
+                .containsExactly(PcUnsupportedConstruct.WINDOW_STORE);
+    }
+
+    @Test
+    void aSessionStoreIsClassifiedAsSessionWindowing() {
+        assertThat(PcSupportedEnvelope.findUnsupported(Collections.singletonList(sessionStore()), AT_LEAST_ONCE))
+                .containsExactly(PcUnsupportedConstruct.SESSION_STORE);
+    }
+
+    @Test
+    void aSuppressionBufferIsClassifiedAsSuppression() {
+        assertThat(PcSupportedEnvelope.findUnsupported(Collections.singletonList(suppressionBuffer()), AT_LEAST_ONCE))
+                .containsExactly(PcUnsupportedConstruct.SUPPRESSION_BUFFER);
+    }
+
+    @Test
+    void aVersionedKeyValueStoreIsRefusedEvenThoughItIsNotAWindowStore() {
+        // The one that gets missed. VersionedKeyValueStore extends StateStore directly, so it satisfies none of
+        // the window/session/buffer checks and looks like an ordinary key-value store - yet RocksDBVersionedStore
+        // silently DROPS puts older than its non-volatile observedStreamTime. Reachable with no refused DSL call
+        // anywhere: Materialized.as(Stores.persistentVersionedKeyValueStore(...)) is enough.
+        assertThat(PcSupportedEnvelope.findUnsupported(
+                Collections.singletonList(versionedKeyValueStore()), AT_LEAST_ONCE))
+                .containsExactly(PcUnsupportedConstruct.VERSIONED_KEY_VALUE_STORE);
+    }
+
+    @Test
+    void exactlyOnceIsFoundFromConfigurationWithNoStoresAtAll() {
+        // EOS is not a topology shape, which is why it cannot be inferred from the store list.
+        assertThat(PcSupportedEnvelope.findUnsupported(Collections.<StateStore>emptyList(), EXACTLY_ONCE))
+                .containsExactly(PcUnsupportedConstruct.EXACTLY_ONCE);
+    }
+
+    @Test
+    void everyUnsupportedConstructInOneTopologyIsReportedTogether() {
+        // Someone who removes their windowed aggregation only to be refused again for the session store has
+        // been made to pay twice for one diagnosis.
+        assertThat(PcSupportedEnvelope.findUnsupported(allUnsupportedStores(), EXACTLY_ONCE))
+                .containsExactlyInAnyOrder(
+                        PcUnsupportedConstruct.EXACTLY_ONCE,
+                        PcUnsupportedConstruct.WINDOW_STORE,
+                        PcUnsupportedConstruct.SESSION_STORE,
+                        PcUnsupportedConstruct.SUPPRESSION_BUFFER,
+                        PcUnsupportedConstruct.VERSIONED_KEY_VALUE_STORE);
+    }
+
+    @Test
+    void repeatedStoresOfOneKindAreOneProblemNotThree() {
+        assertThat(PcSupportedEnvelope.findUnsupported(
+                Arrays.asList(windowStore(), windowStore(), windowStore()), AT_LEAST_ONCE))
+                .containsExactly(PcUnsupportedConstruct.WINDOW_STORE);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Positive controls. Without these the guard could refuse everything and every test above would still
+    // pass.
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void aPlainKeyValueStoreStaysSupported() {
+        PcDispatchSwitch.enable(2);
+
+        // Non-windowed stateful aggregation is the supported stateful case (KTD3), and it is what
+        // PcDrivenStatefulProofTest exercises. Refusing it here would silently delete that proof.
+        assertThatCode(() -> PcSupportedEnvelope.checkTask(
+                TASK_ID, Collections.singletonList(keyValueStore()), AT_LEAST_ONCE))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aStatelessAtLeastOnceTaskStaysSupported() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatCode(() -> PcSupportedEnvelope.checkTask(
+                TASK_ID, Collections.<StateStore>emptyList(), AT_LEAST_ONCE))
+                .doesNotThrowAnyException();
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The message a user actually reads.
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void theTaskRefusalNamesTheTaskAndEveryConstruct() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatThrownBy(() -> PcSupportedEnvelope.checkTask(TASK_ID, allUnsupportedStores(), EXACTLY_ONCE))
+                .isInstanceOf(UnsupportedOperationException.class)
+                // Which topology is at fault, for someone running several tasks.
+                .hasMessageContaining("Task " + TASK_ID)
+                .hasMessageContaining(PcUnsupportedConstruct.WINDOW_STORE.getDisplayName())
+                .hasMessageContaining(PcUnsupportedConstruct.SESSION_STORE.getDisplayName())
+                .hasMessageContaining(PcUnsupportedConstruct.SUPPRESSION_BUFFER.getDisplayName())
+                .hasMessageContaining(PcUnsupportedConstruct.VERSIONED_KEY_VALUE_STORE.getDisplayName())
+                .hasMessageContaining(PcUnsupportedConstruct.EXACTLY_ONCE.getDisplayName())
+                .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY + "=false");
+    }
+
+    @Test
+    void everyConstructCarriesBothANameAndAReason() {
+        for (final PcUnsupportedConstruct construct : PcUnsupportedConstruct.values()) {
+            assertThat(construct.getDisplayName()).as("%s display name", construct).isNotBlank();
+            assertThat(construct.getReason()).as("%s reason", construct).isNotBlank();
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+
+    private static List<StateStore> allUnsupportedStores() {
+        final List<StateStore> stores = new ArrayList<>();
+        stores.add(windowStore());
+        stores.add(sessionStore());
+        stores.add(suppressionBuffer());
+        stores.add(versionedKeyValueStore());
+        stores.add(keyValueStore());
+        return stores;
+    }
+
+    private static StateStore windowStore() {
+        return RefusedStoreFixtures.build(RefusedStoreFixtures.windowStoreBuilder());
+    }
+
+    private static StateStore sessionStore() {
+        return RefusedStoreFixtures.build(RefusedStoreFixtures.sessionStoreBuilder());
+    }
+
+    private static StateStore suppressionBuffer() {
+        return RefusedStoreFixtures.build(RefusedStoreFixtures.suppressionBufferBuilder());
+    }
+
+    private static StateStore versionedKeyValueStore() {
+        return RefusedStoreFixtures.build(RefusedStoreFixtures.versionedKeyValueStoreBuilder());
+    }
+
+    private static StateStore keyValueStore() {
+        return RefusedStoreFixtures.build(RefusedStoreFixtures.keyValueStoreBuilder());
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ProcessorApiBackstopTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ProcessorApiBackstopTest.java
@@ -1,0 +1,261 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.Arrays;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Layer 3: the backstop in {@code StreamTask}'s constructor, reached the way the DSL refusals cannot be.
+ * <p>
+ * <b>This is the case that justifies layer 3 existing at all.</b> Every topology here is built with the
+ * Processor API: {@code addStateStore} with a window-store builder, connected to a plain
+ * {@code Processor}. No {@code KStream} is created, no {@code windowedBy} is called, so
+ * {@link RefusedDslConstructsTest}'s guards are never consulted - and without this layer the topology would
+ * run and quietly produce wrong window contents.
+ * <p>
+ * <b>{@code TopologyTestDriver} is the vehicle because it constructs a real {@code StreamTask}</b> (verified
+ * against the Kafka 3.9.2 bytecode) with no broker. That makes it a genuine test of the patched constructor
+ * rather than of a helper, which is the distinction {@link PcSupportedEnvelopeTest} deliberately cannot
+ * make.
+ * <p>
+ * The seam-on cases only <em>construct</em> the driver and never pipe a record. Construction is the whole
+ * claim - the refusal happens there - and driving records through {@code TopologyTestDriver} on the PC
+ * dispatch path is a different subject with a different test.
+ *
+ * @author Antony Stubbs
+ */
+// PcDispatchSwitch is process-wide static state; concurrent execution would have these methods toggling
+// each other's switch, and a seam-off control arm that is only a control by accident is not one.
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated
+class ProcessorApiBackstopTest {
+
+    private static final String INPUT_TOPIC = "backstop-in";
+    private static final String SOURCE = "source";
+    private static final String PROCESSOR = "processor";
+
+    @AfterEach
+    void restoreSwitch() {
+        PcDispatchSwitch.resetToDefault();
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The Processor API route - unreachable from the DSL guards.
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void aWindowStoreBuiltThroughTheProcessorApiIsRefused() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatThrownBy(() -> openAndClose(topologyWith(RefusedStoreFixtures.windowStoreBuilder()), atLeastOnce()))
+                .as("a window store reached without ever touching KStream must still be refused - this is the "
+                        + "hole layer 3 exists to close")
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(PcUnsupportedConstruct.WINDOW_STORE.getDisplayName())
+                .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY + "=false");
+    }
+
+    @Test
+    void aSessionStoreBuiltThroughTheProcessorApiIsRefused() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatThrownBy(() -> openAndClose(topologyWith(RefusedStoreFixtures.sessionStoreBuilder()), atLeastOnce()))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(PcUnsupportedConstruct.SESSION_STORE.getDisplayName())
+                .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY + "=false");
+    }
+
+    @Test
+    void aVersionedKeyValueStoreBuiltThroughTheProcessorApiIsRefused() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatThrownBy(() -> openAndClose(
+                topologyWith(RefusedStoreFixtures.versionedKeyValueStoreBuilder()), atLeastOnce()))
+                .as("a versioned store is not a WindowStore and so is the easiest of these to leave unguarded - "
+                        + "and it is the one that drops writes rather than merely reordering them")
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(PcUnsupportedConstruct.VERSIONED_KEY_VALUE_STORE.getDisplayName())
+                .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY + "=false");
+    }
+
+    @Test
+    void aSuppressionBufferBuiltThroughTheProcessorApiIsRefused() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatThrownBy(() -> openAndClose(
+                topologyWith(RefusedStoreFixtures.suppressionBufferBuilder()), atLeastOnce()))
+                .as("the suppression buffer is a state store like the other three, so it has to be proven "
+                        + "through a real StreamTask too - classifying it correctly in a unit test says nothing "
+                        + "about whether the backstop sees it")
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(PcUnsupportedConstruct.SUPPRESSION_BUFFER.getDisplayName())
+                .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY + "=false");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // EOS - configuration, not topology shape.
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void exactlyOnceIsRefusedOnAnOtherwiseSupportedTopology() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatThrownBy(() -> openAndClose(topologyWith(RefusedStoreFixtures.keyValueStoreBuilder()), exactlyOnce()))
+                .as("EOS cannot be inferred from the topology - it has to come off the task config, and this "
+                        + "is the only test that proves that wiring")
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(PcUnsupportedConstruct.EXACTLY_ONCE.getDisplayName())
+                .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY + "=false");
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The ordering the refusal depends on.
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * A refused task must build no dispatcher, which is why {@code PcSupportedEnvelope.checkTask} is called
+     * before {@code PcTaskDispatcher.createIfEnabled} in {@code StreamTask}'s constructor and not after.
+     * <p>
+     * Without this, that ordering is asserted only by a comment. Swapping the two lines would leave every
+     * other assertion in this class green while orphaning a worker pool, a {@code WorkManager} and a
+     * {@code PcWorkSignal} registration per refused task - and a refused task is one a rebalance will try to
+     * create again.
+     */
+    @Test
+    void aRefusedTaskBuildsNoDispatcher() {
+        PcDispatchSwitch.enable(2);
+
+        final int before = PcTaskDispatcher.activeCount();
+
+        for (final StoreBuilder<?> refused : Arrays.asList(
+                RefusedStoreFixtures.windowStoreBuilder(),
+                RefusedStoreFixtures.sessionStoreBuilder(),
+                RefusedStoreFixtures.suppressionBufferBuilder(),
+                RefusedStoreFixtures.versionedKeyValueStoreBuilder())) {
+            assertThatThrownBy(() -> openAndClose(topologyWith(refused), atLeastOnce()))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+        assertThatThrownBy(() -> openAndClose(topologyWith(RefusedStoreFixtures.keyValueStoreBuilder()),
+                exactlyOnce()))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThat(PcTaskDispatcher.activeCount())
+                .as("every refusal above must happen before the dispatcher is constructed; a live dispatcher "
+                        + "here is a worker pool nothing will ever shut down")
+                .isEqualTo(before);
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Control arms. The seam-off pair is what distinguishes a conditional guard from an unconditional one.
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void everythingRefusedAboveConstructsNormallyWithTheSeamOff() {
+        PcDispatchSwitch.disable();
+
+        assertThatCode(() -> {
+            openAndClose(topologyWith(RefusedStoreFixtures.windowStoreBuilder()), atLeastOnce());
+            openAndClose(topologyWith(RefusedStoreFixtures.sessionStoreBuilder()), atLeastOnce());
+            openAndClose(topologyWith(RefusedStoreFixtures.suppressionBufferBuilder()), atLeastOnce());
+            openAndClose(topologyWith(RefusedStoreFixtures.versionedKeyValueStoreBuilder()), atLeastOnce());
+            openAndClose(topologyWith(RefusedStoreFixtures.keyValueStoreBuilder()), exactlyOnce());
+        }).as("with the seam off the patched StreamTask must construct exactly as stock does - this is the "
+                + "assertion that would fail if the backstop were unconditional, and Apache Kafka's own "
+                + "StreamTaskTest would fail with it")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aPlainKeyValueStoreTopologyStillConstructsWithTheSeamOn() {
+        PcDispatchSwitch.enable(2);
+
+        // Non-windowed stateful work is inside the supported envelope (KTD3). Without this, a backstop that
+        // refused every state store would satisfy every other assertion in this class.
+        assertThatCode(() -> openAndClose(topologyWith(RefusedStoreFixtures.keyValueStoreBuilder()), atLeastOnce()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aStatelessTopologyStillConstructsWithTheSeamOn() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatCode(() -> openAndClose(topologyWith(null), atLeastOnce()))
+                .doesNotThrowAnyException();
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * A source plus one Processor API node, optionally with a state store attached. No DSL anywhere, which is
+     * the point.
+     */
+    private static Topology topologyWith(final StoreBuilder<?> store) {
+        final Topology topology = new Topology();
+        topology.addSource(SOURCE, Serdes.String().deserializer(), Serdes.String().deserializer(), INPUT_TOPIC);
+        topology.addProcessor(PROCESSOR, DoNothingProcessor::new, SOURCE);
+        if (store != null) {
+            topology.addStateStore(store, PROCESSOR);
+        }
+        return topology;
+    }
+
+    /**
+     * Construct the driver and close it again. Construction is the whole claim - the refusal happens in
+     * {@code StreamTask}'s constructor - and closing on the way out matters most in the cases that are
+     * <em>expected</em> to throw: if the refusal ever stops happening, a leaked driver would turn one clean
+     * failure into a cascade of state-directory-lock noise from every test after it.
+     */
+    private static void openAndClose(final Topology topology, final Properties config) {
+        final TopologyTestDriver driver = new TopologyTestDriver(topology, config);
+        driver.close();
+    }
+
+    private static Properties baseConfig() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "pc-streams-backstop");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        return config;
+    }
+
+    private static Properties atLeastOnce() {
+        return baseConfig();
+    }
+
+    private static Properties exactlyOnce() {
+        final Properties config = baseConfig();
+        config.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2);
+        return config;
+    }
+
+    /**
+     * The topology has to have a processor for the store to attach to; what it does is irrelevant, because
+     * every assertion here is about construction.
+     */
+    private static final class DoNothingProcessor implements Processor<String, String, Void, Void> {
+        @Override
+        public void process(final Record<String, String> record) {
+            // Deliberately empty - no record is ever piped in.
+        }
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/RefusedDslAnnotationsTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/RefusedDslAnnotationsTest.java
@@ -1,0 +1,347 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.streams.kstream.CogroupedKStream;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Layer 1: the refused DSL methods carry {@code @Deprecated} and {@code @DoNotCall}, so a call site is a
+ * compile <b>error</b> under ErrorProne and a warning without it.
+ * <p>
+ * <b>And a javadoc {@code @deprecated} tag, which is the half a human actually reads.</b> An IDE renders
+ * {@code @Deprecated} as a strikethrough and shows that tag as the reason. {@code @DoNotCall}'s message is not
+ * a substitute: only ErrorProne reads it, and an ErrorProne build already fails hard - so without the tag, the
+ * explanation reaches exactly the audience that needs it least, and everyone else sees {@code stream.join(...)}
+ * struck through and reasonably concludes Apache Kafka deprecated {@code join}. It did not; this module refuses
+ * it, and only while the dispatch seam is on.
+ * <p>
+ * <b>Why the two halves are asserted differently.</b> {@code java.lang.Deprecated} is {@code RUNTIME}-
+ * retained, so reflection can enumerate every overload and check each one - which makes that half
+ * exhaustive by construction, and it is the half that catches a missed overload after a Kafka upgrade adds
+ * one. {@code @DoNotCall} is {@code CLASS}-retained: it is in the class file but invisible to reflection.
+ * So it is asserted per class, by looking for its descriptor in the compiled constant pool. Weaker, and
+ * stated here rather than quietly skipped.
+ * <p>
+ * <b>Why the compile error itself is not asserted here - and where it IS observed.</b> This repository does
+ * compile under Error Prone, so a call to a refused overload is a hard compile error in this very build. That
+ * is not something a JUnit assertion can reach, because a compile error stops the build long before any test
+ * runs. It is instead demonstrated by the one place that has to make those calls on purpose:
+ * {@link RefusedDslConstructsTest} carries a class-level {@code @SuppressWarnings("DoNotCall")}, and deleting
+ * it fails the module's compilation with one error per refused call site. What this test can prove is the
+ * other half - that the annotation is present on the symbol the compiler resolves, for every refused overload
+ * rather than the one that happened to be checked.
+ * <p>
+ * The annotations go on the <b>interfaces</b> rather than the impls because a call site resolves to the
+ * symbol its receiver's static type declares - {@code stream.join(...)} against a {@code KStream} variable
+ * resolves to {@code KStream#join}, and an annotation on {@code KStreamImpl} would never be consulted.
+ *
+ * @author Antony Stubbs
+ * @see PcUnsupportedConstruct
+ */
+class RefusedDslAnnotationsTest {
+
+    private static final String DO_NOT_CALL_DESCRIPTOR = "Lcom/google/errorprone/annotations/DoNotCall;";
+
+    /**
+     * The refused method names, per interface. Deliberately name-based and coarse: every overload of these
+     * names on these types is refused, so a Kafka upgrade that adds a twenty-ninth {@code join} overload
+     * fails this test instead of shipping an unguarded hole.
+     */
+    private static final List<String> KSTREAM_REFUSED = Arrays.asList("join", "leftJoin", "outerJoin");
+    private static final List<String> KTABLE_REFUSED = Arrays.asList("join", "leftJoin", "outerJoin", "suppress");
+    private static final List<String> WINDOWED_BY = Arrays.asList("windowedBy");
+
+    private static final int KSTREAM_OVERLOADS = 28;
+    private static final int KTABLE_OVERLOADS = 25;
+    private static final int KGROUPED_STREAM_OVERLOADS = 3;
+    private static final int COGROUPED_KSTREAM_OVERLOADS = 3;
+
+    private static final int TOTAL_REFUSED_OVERLOADS =
+            KSTREAM_OVERLOADS + KTABLE_OVERLOADS + KGROUPED_STREAM_OVERLOADS + COGROUPED_KSTREAM_OVERLOADS;
+
+    /**
+     * The four {@code KTable} foreign-key overloads taking a {@link org.apache.kafka.streams.kstream.Named} that
+     * Kafka had already deprecated itself. The patch gives them {@code @DoNotCall} but cannot give them a second
+     * {@code @Deprecated}, and cannot give them a second javadoc {@code @deprecated} either - two of those in one
+     * block is malformed - so its refusal is appended to Kafka's existing tag instead.
+     */
+    private static final int ALREADY_DEPRECATED_BY_KAFKA = 4;
+
+    private static final int DEPRECATED_ADDED_BY_THE_PATCH =
+            TOTAL_REFUSED_OVERLOADS - ALREADY_DEPRECATED_BY_KAFKA;
+
+    /**
+     * The tracked patch, read once for the whole class. Two tests below walk it with different parsers, and
+     * both want the same bytes; re-reading a 1774-line file per test buys nothing.
+     */
+    private static List<String> patchLines;
+
+    @BeforeAll
+    static void readThePatch() throws IOException {
+        patchLines = Files.readAllLines(Paths.get("src/main/patch/pc-streams.patch"), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void everyRefusedKStreamMethodIsDeprecated() {
+        assertEveryOverloadDeprecated(KStream.class, KSTREAM_REFUSED, KSTREAM_OVERLOADS);
+    }
+
+    @Test
+    void everyRefusedKTableMethodIsDeprecated() {
+        assertEveryOverloadDeprecated(KTable.class, KTABLE_REFUSED, KTABLE_OVERLOADS);
+    }
+
+    @Test
+    void everyKGroupedStreamWindowedByIsDeprecated() {
+        assertEveryOverloadDeprecated(KGroupedStream.class, WINDOWED_BY, KGROUPED_STREAM_OVERLOADS);
+    }
+
+    @Test
+    void everyCogroupedKStreamWindowedByIsDeprecated() {
+        assertEveryOverloadDeprecated(CogroupedKStream.class, WINDOWED_BY, COGROUPED_KSTREAM_OVERLOADS);
+    }
+
+    @Test
+    void everyRefusedInterfaceCarriesDoNotCall() throws IOException {
+        for (final Class<?> refused : Arrays.asList(
+                KStream.class, KTable.class, KGroupedStream.class, CogroupedKStream.class)) {
+            assertThat(classFileOf(refused))
+                    .as("%s must reference %s, or a call site is only a warning rather than a compile error",
+                            refused.getSimpleName(), DO_NOT_CALL_DESCRIPTOR)
+                    .contains(DO_NOT_CALL_DESCRIPTOR);
+        }
+    }
+
+    /**
+     * The per-method half of layer 1, which the class-file scan above cannot give: the constant pool holds one
+     * UTF8 entry for the descriptor however many methods use it, so that assertion would pass with 1 of 59
+     * annotated. Counting the annotations in the tracked patch is exhaustive, and it is the only check that
+     * covers the four {@code KTable} foreign-key overloads Kafka had <em>already</em> deprecated itself - for
+     * those, {@link #everyRefusedKTableMethodIsDeprecated()} passes whether or not the patch touched them.
+     */
+    @Test
+    void thePatchAnnotatesEveryRefusedOverloadIndividually() {
+        int doNotCallAdded = 0;
+        for (final String line : patchLines) {
+            // An added line in a unified diff is "+" then the source line, so the "+" has to come off before
+            // trimming - trim() alone leaves it in front of the indentation and matches nothing.
+            if (line.startsWith("+") && line.substring(1).trim().startsWith("@DoNotCall(")) {
+                doNotCallAdded++;
+            }
+        }
+
+        assertThat(doNotCallAdded)
+                .as("the patch must add one @DoNotCall per refused overload: 28 on KStream, 25 on KTable, 3 on "
+                        + "KGroupedStream, 3 on CogroupedKStream. A lower number means an overload is reachable "
+                        + "without a compile error; a higher one means something is annotated that should not be.")
+                .isEqualTo(TOTAL_REFUSED_OVERLOADS);
+    }
+
+    /**
+     * The strikethrough has to come with its reason attached, or it misinforms - see this class's header. Two
+     * assertions, because neither covers the whole surface on its own.
+     * <p>
+     * The <b>structural</b> one walks the patch's post-image and requires that every {@code @Deprecated} the patch
+     * adds sits behind a javadoc block carrying a {@code @deprecated} tag. It says nothing about wording, so
+     * rephrasing a tag does not fail it, while forgetting one on a Kafka overload added by a future upgrade does.
+     * It cannot see the four Kafka had already deprecated, because for those the patch adds no {@code @Deprecated}.
+     * <p>
+     * The <b>count</b> one closes that gap from the other end: each tag names this module once, as the thing doing
+     * the refusing, so one such line per refused overload means all 59 carry an explanation - including the four
+     * where it was appended to Kafka's own text. It is deliberately coupled to that one phrase; a reword has to
+     * come here and say so, which is the cheapest available guard on the sentence the reader is going to see.
+     */
+    @Test
+    void everyRefusedOverloadExplainsTheRefusalInJavadoc() {
+        // The post-image of one hunk: the lines a reader of the patched file would see, and whether the patch
+        // added each. Reset per hunk, because line adjacency does not survive a hunk boundary.
+        final List<String> postImage = new ArrayList<>();
+        final List<Boolean> addedByPatch = new ArrayList<>();
+        int deprecatedAdded = 0;
+        int explainedByJavadoc = 0;
+        int namesThisModule = 0;
+
+        for (final String line : patchLines) {
+            if (line.startsWith("@@") || line.startsWith("--- ") || line.startsWith("+++ ")
+                    || line.startsWith("diff ")) {
+                explainedByJavadoc += countExplained(postImage, addedByPatch);
+                deprecatedAdded += countAddedDeprecated(postImage, addedByPatch);
+                postImage.clear();
+                addedByPatch.clear();
+            } else if (line.startsWith("+")) {
+                postImage.add(line.substring(1));
+                addedByPatch.add(true);
+                if (line.contains("{@code parallel-consumer-streams}")) {
+                    namesThisModule++;
+                }
+            } else if (line.startsWith(" ")) {
+                // A context line: unchanged, but present in the patched file and so part of the post-image.
+                postImage.add(line.substring(1));
+                addedByPatch.add(false);
+            }
+            // A "-" line is pre-image only and is deliberately not part of what the reader ends up with.
+        }
+        explainedByJavadoc += countExplained(postImage, addedByPatch);
+        deprecatedAdded += countAddedDeprecated(postImage, addedByPatch);
+
+        assertThat(deprecatedAdded)
+                .as("the patch must add one @Deprecated per refused overload Kafka had not already deprecated. "
+                        + "If this moved, the two halves of layer 1 have drifted apart")
+                .isEqualTo(DEPRECATED_ADDED_BY_THE_PATCH);
+
+        assertThat(explainedByJavadoc)
+                .as("every @Deprecated the patch adds must sit behind a javadoc @deprecated tag. Without it an IDE "
+                        + "strikes the call through with no reason given, and the reader concludes Apache Kafka "
+                        + "deprecated the method - which is false, and is the defect this assertion exists to stop")
+                .isEqualTo(deprecatedAdded);
+
+        assertThat(namesThisModule)
+                .as("each refused overload's javadoc must name parallel-consumer-streams as the thing refusing it, "
+                        + "once: 55 new tags plus 4 appended to tags Kafka already had. A lower number means an "
+                        + "overload is struck through without saying who struck it")
+                .isEqualTo(TOTAL_REFUSED_OVERLOADS);
+    }
+
+    private static int countAddedDeprecated(final List<String> postImage, final List<Boolean> addedByPatch) {
+        int count = 0;
+        for (int i = 0; i < postImage.size(); i++) {
+            if (addedByPatch.get(i) && postImage.get(i).trim().equals("@Deprecated")) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * How many of the {@code @Deprecated} annotations this hunk adds are preceded by a javadoc block that carries a
+     * {@code @deprecated} tag. The tag can be a context line rather than an added one - that is the appended-to-
+     * Kafka's-own case - so the post-image is what gets walked, not the additions alone.
+     */
+    private static int countExplained(final List<String> postImage, final List<Boolean> addedByPatch) {
+        int explained = 0;
+        for (int i = 0; i < postImage.size(); i++) {
+            if (!addedByPatch.get(i) || !postImage.get(i).trim().equals("@Deprecated")) {
+                continue;
+            }
+
+            // Other annotations may sit between the javadoc and this one - @DoNotCall does, and so does
+            // @SuppressWarnings on a couple of Kafka's own methods.
+            int close = i - 1;
+            while (close >= 0
+                    && (postImage.get(close).trim().startsWith("@") || postImage.get(close).trim().isEmpty())) {
+                close--;
+            }
+            if (close < 0 || !postImage.get(close).trim().endsWith("*/")) {
+                continue;
+            }
+
+            for (int k = close - 1; k >= 0; k--) {
+                final String text = postImage.get(k).trim();
+                if (text.startsWith("/**")) {
+                    break;
+                }
+                if (text.startsWith("* @deprecated")) {
+                    explained++;
+                    break;
+                }
+            }
+        }
+        return explained;
+    }
+
+    @Test
+    void supportedMethodsOnTheSameInterfacesAreNotDeprecated() {
+        // The control. Without it, an indiscriminate pass that deprecated the entire interface would satisfy
+        // every assertion above - and would have refused the operators this module exists to support.
+        assertNotDeprecated(KStream.class, "mapValues");
+        assertNotDeprecated(KStream.class, "filter");
+        assertNotDeprecated(KStream.class, "groupByKey");
+        assertNotDeprecated(KGroupedStream.class, "count");
+        assertNotDeprecated(KGroupedStream.class, "reduce");
+        assertNotDeprecated(KTable.class, "toStream");
+    }
+
+    private static void assertEveryOverloadDeprecated(final Class<?> type,
+                                                      final List<String> refusedNames,
+                                                      final int expectedCount) {
+        final List<Method> refused = new ArrayList<>();
+        for (final Method method : type.getMethods()) {
+            if (refusedNames.contains(method.getName())) {
+                refused.add(method);
+            }
+        }
+
+        // A count assertion, so that a rename upstream fails loudly rather than making the loop below vacuous.
+        assertThat(refused)
+                .as("%s: refused overloads found. If Kafka changed this surface, the patch needs revisiting "
+                        + "before this number is edited", type.getSimpleName())
+                .hasSize(expectedCount);
+
+        for (final Method method : refused) {
+            assertThat(method.isAnnotationPresent(Deprecated.class))
+                    .as("%s#%s%s must be @Deprecated", type.getSimpleName(), method.getName(),
+                            Arrays.toString(method.getParameterTypes()))
+                    .isTrue();
+        }
+    }
+
+    private static void assertNotDeprecated(final Class<?> type, final String methodName) {
+        final List<Method> found = new ArrayList<>();
+        for (final Method method : type.getMethods()) {
+            if (method.getName().equals(methodName)) {
+                found.add(method);
+            }
+        }
+
+        // Without this, a typo - or Kafka renaming the method - turns the control silently into a no-op, and
+        // the control is the only thing stopping "deprecate the whole interface" from passing every test here.
+        assertThat(found)
+                .as("%s#%s does not exist, so this control proves nothing", type.getSimpleName(), methodName)
+                .isNotEmpty();
+
+        for (final Method method : found) {
+            assertThat(method.isAnnotationPresent(Deprecated.class))
+                    .as("%s#%s is a supported operator and must not be refused", type.getSimpleName(), methodName)
+                    .isFalse();
+        }
+    }
+
+    /**
+     * The compiled class file as text. Crude, and enough: the descriptor is a UTF8 constant-pool entry, and it
+     * can only be there if something in the file references the annotation.
+     */
+    private static String classFileOf(final Class<?> type) throws IOException {
+        final String resource = type.getName().replace('.', '/') + ".class";
+        try (InputStream in = type.getClassLoader().getResourceAsStream(resource)) {
+            assertThat(in).as("%s must be loadable as a resource", resource).isNotNull();
+            final ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+            // ISO_8859_1 keeps every byte addressable rather than collapsing invalid UTF-8
+            // sequences, and the descriptor is pure ASCII, so contains() over it is reliable.
+            return new String(out.toByteArray(), StandardCharsets.ISO_8859_1);
+        }
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/RefusedDslConstructsTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/RefusedDslConstructsTest.java
@@ -1,0 +1,251 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.SlidingWindows;
+import org.apache.kafka.streams.kstream.Suppressed;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Layer 2: the DSL refuses at topology construction, seam on - and is completely inert, seam off.
+ * <p>
+ * <b>The seam-off arm is not padding.</b> Every refusal test here would pass just as well against an
+ * unconditional guard, and an unconditional guard would break Apache Kafka's own suite - the 419-test
+ * behaviour-preservation claim this whole module rests on. So each refusal is paired with the same topology
+ * built with the seam off, which is the only assertion that can tell those two implementations apart.
+ * <p>
+ * Only the topology is built; no {@code KafkaStreams} is started and no broker is involved, because layer 2
+ * fires at the DSL call. That the same constructs are also caught later, at task construction, is
+ * {@link ProcessorApiBackstopTest}'s subject.
+ * <p>
+ * Every method calls methods this module has deliberately deprecated, hence the class-level suppression -
+ * the deprecation is the product, and warning about it here would be warning about the feature working.
+ * <p>
+ * <b>{@code "DoNotCall"} is suppressed for a stronger reason, and deleting it is the red-proof of layer 1.</b>
+ * This repository compiles under Error Prone, so {@code @DoNotCall} on the refused interface overloads is a
+ * hard compile ERROR here rather than the theoretical one it is in a build that does not run Error Prone.
+ * Every call below is exactly the call a user must not make, so without this suppression the module does not
+ * compile at all - which is layer 1 firing, observed rather than argued. Remove it and watch the build fail
+ * on one error per refused call site; that is the cheapest falsification available for the compile-time half
+ * of the refusal, and it needs no test of its own.
+ *
+ * @author Antony Stubbs
+ * @see PcUnsupportedConstruct
+ */
+@SuppressWarnings({"deprecation", "DoNotCall"})
+// PcDispatchSwitch is process-wide static state and this module inherits concurrent JUnit execution from
+// core's junit-platform.properties; left concurrent these methods would toggle each other's switch.
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated
+class RefusedDslConstructsTest {
+
+    private static final String LEFT_TOPIC = "left";
+    private static final String RIGHT_TOPIC = "right";
+
+    private static final Consumed<String, String> STRINGS = Consumed.with(Serdes.String(), Serdes.String());
+
+    @AfterEach
+    void restoreSwitch() {
+        PcDispatchSwitch.resetToDefault();
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Joins
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void streamStreamJoinRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.KSTREAM_KSTREAM_JOIN, builder -> {
+            final KStream<String, String> left = builder.stream(LEFT_TOPIC, STRINGS);
+            final KStream<String, String> right = builder.stream(RIGHT_TOPIC, STRINGS);
+            left.join(right, (a, b) -> a + b, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMinutes(1)));
+        });
+    }
+
+    @Test
+    void streamStreamLeftJoinRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.KSTREAM_KSTREAM_JOIN, builder -> {
+            final KStream<String, String> left = builder.stream(LEFT_TOPIC, STRINGS);
+            final KStream<String, String> right = builder.stream(RIGHT_TOPIC, STRINGS);
+            left.leftJoin(right, (a, b) -> a + b, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMinutes(1)));
+        });
+    }
+
+    @Test
+    void streamStreamOuterJoinRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.KSTREAM_KSTREAM_JOIN, builder -> {
+            final KStream<String, String> left = builder.stream(LEFT_TOPIC, STRINGS);
+            final KStream<String, String> right = builder.stream(RIGHT_TOPIC, STRINGS);
+            left.outerJoin(right, (a, b) -> a + b, JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMinutes(1)));
+        });
+    }
+
+    @Test
+    void streamTableJoinRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.KSTREAM_KTABLE_JOIN, builder -> {
+            final KStream<String, String> stream = builder.stream(LEFT_TOPIC, STRINGS);
+            final KTable<String, String> table = builder.table(RIGHT_TOPIC, STRINGS);
+            stream.join(table, (a, b) -> a + b);
+        });
+    }
+
+    @Test
+    void streamGlobalTableJoinRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.KSTREAM_GLOBALKTABLE_JOIN, builder ->
+                builder.stream(LEFT_TOPIC, STRINGS)
+                        .join(builder.globalTable(RIGHT_TOPIC, STRINGS), (k, v) -> k, (a, b) -> a + b));
+    }
+
+    @Test
+    void tableTableJoinRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.KTABLE_KTABLE_JOIN, builder -> {
+            final KTable<String, String> left = builder.table(LEFT_TOPIC, STRINGS);
+            final KTable<String, String> right = builder.table(RIGHT_TOPIC, STRINGS);
+            left.join(right, (a, b) -> a + b);
+        });
+    }
+
+    @Test
+    void tableTableForeignKeyJoinRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.KTABLE_KTABLE_FOREIGN_KEY_JOIN, builder -> {
+            final KTable<String, String> left = builder.table(LEFT_TOPIC, STRINGS);
+            final KTable<String, String> right = builder.table(RIGHT_TOPIC, STRINGS);
+            left.join(right, value -> value, (a, b) -> a + b,
+                    Materialized.with(Serdes.String(), Serdes.String()));
+        });
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Windowing
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void timeWindowedAggregationRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.WINDOWED_AGGREGATION, builder ->
+                builder.stream(LEFT_TOPIC, STRINGS)
+                        .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                        .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMinutes(1))));
+    }
+
+    @Test
+    void slidingWindowedAggregationRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.WINDOWED_AGGREGATION, builder ->
+                builder.stream(LEFT_TOPIC, STRINGS)
+                        .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                        .windowedBy(SlidingWindows.ofTimeDifferenceWithNoGrace(Duration.ofMinutes(1))));
+    }
+
+    @Test
+    void sessionWindowedAggregationRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.WINDOWED_AGGREGATION, builder ->
+                builder.stream(LEFT_TOPIC, STRINGS)
+                        .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                        .windowedBy(SessionWindows.ofInactivityGapWithNoGrace(Duration.ofMinutes(1))));
+    }
+
+    @Test
+    void windowedCogroupedAggregationRefusesWithTheSeamOnAndBuildsWithItOff() {
+        // The cogroup route reaches windowing through a different interface, so it needs its own guard and
+        // its own proof - CogroupedKStream is not a KGroupedStream.
+        assertRefusedThenAllowed(PcUnsupportedConstruct.WINDOWED_COGROUPED_AGGREGATION, builder ->
+                builder.stream(LEFT_TOPIC, STRINGS)
+                        .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                        .cogroup((key, value, aggregate) -> aggregate + value)
+                        .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMinutes(1))));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Suppression
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void suppressionRefusesWithTheSeamOnAndBuildsWithItOff() {
+        assertRefusedThenAllowed(PcUnsupportedConstruct.SUPPRESSION, builder ->
+                builder.table(LEFT_TOPIC, STRINGS)
+                        .suppress(Suppressed.untilTimeLimit(Duration.ofMinutes(1),
+                                Suppressed.BufferConfig.unbounded())));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // The positive control. Without it, refusing absolutely everything would pass every test above.
+    // ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void aSupportedTopologyStillBuildsWithTheSeamOn() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatCode(() -> {
+            final StreamsBuilder builder = new StreamsBuilder();
+            builder.stream(LEFT_TOPIC, STRINGS)
+                    .filter((k, v) -> v != null)
+                    // A one-argument lambda rather than a method reference: String::toUpperCase matches both
+                    // ValueMapper and ValueMapperWithKey, and the arity here picks ValueMapper unambiguously.
+                    .mapValues(value -> value.toUpperCase())
+                    .to("out");
+            builder.build();
+        }).as("stateless stream -> mapValues -> to is the module's proven envelope and must not be refused")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aNonWindowedAggregationStillBuildsWithTheSeamOn() {
+        PcDispatchSwitch.enable(2);
+
+        assertThatCode(() -> {
+            final StreamsBuilder builder = new StreamsBuilder();
+            builder.stream(LEFT_TOPIC, STRINGS)
+                    .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                    .count();
+            builder.build();
+        }).as("non-windowed stateful aggregation is supported (KTD3) and is what PcDrivenStatefulProofTest "
+                + "exercises - refusing it here would delete that proof")
+                .doesNotThrowAnyException();
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * Build the same topology twice: once with the seam on, expecting refusal that names the construct, and
+     * once with it off, expecting silence.
+     */
+    private static void assertRefusedThenAllowed(final PcUnsupportedConstruct expected,
+                                                 final TopologyFragment fragment) {
+        PcDispatchSwitch.enable(2);
+        assertThatThrownBy(() -> fragment.applyTo(new StreamsBuilder()))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(expected.getDisplayName())
+                .hasMessageContaining(PcRefusalMessage.ISSUE)
+                .hasMessageContaining(PcDispatchSwitch.ENABLED_PROPERTY + "=false");
+
+        PcDispatchSwitch.disable();
+        assertThatCode(() -> fragment.applyTo(new StreamsBuilder()))
+                .as("with the seam off this module must behave exactly like stock Kafka Streams, which is what "
+                        + "lets Apache Kafka's own suite keep passing unmodified")
+                .doesNotThrowAnyException();
+    }
+
+    @FunctionalInterface
+    private interface TopologyFragment {
+        void applyTo(StreamsBuilder builder);
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/RefusedStoreFixtures.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/RefusedStoreFixtures.java
@@ -1,0 +1,80 @@
+package bz.stub.parallelconsumer.streams;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.internals.InMemoryTimeOrderedKeyValueChangeBuffer;
+
+import java.time.Duration;
+
+/**
+ * The state stores the refusal tests are built on, in one place.
+ * <p>
+ * {@link PcSupportedEnvelopeTest} classifies the built stores directly; {@link ProcessorApiBackstopTest}
+ * attaches the builders to a Processor API topology. Same stores, two levels - so they belong here rather
+ * than cloned into both, which is exactly the shape the repo's duplicate-code check flags.
+ * <p>
+ * <b>These are real Kafka stores, deliberately.</b> A hand-rolled stub implementing {@code WindowStore}
+ * would satisfy the {@code instanceof} chain while telling us nothing about the
+ * {@code MeteredWindowStore}-over-{@code ChangeLogging...}-over-bytes-store stack that
+ * {@code ProcessorTopology.stateStores()} actually hands the backstop.
+ * <p>
+ * In-memory wherever Kafka offers it, so the unit suite never opens RocksDB. Versioned stores have no
+ * in-memory variant in Kafka 3.9, but building a store is not opening one - RocksDB is touched at
+ * {@code init}, and nothing here initialises.
+ *
+ * @author Antony Stubbs
+ */
+final class RefusedStoreFixtures {
+
+    private static final Duration RETENTION = Duration.ofMinutes(10);
+    private static final Duration WINDOW_SIZE = Duration.ofMinutes(1);
+
+    private RefusedStoreFixtures() {
+    }
+
+    static StoreBuilder<?> windowStoreBuilder() {
+        return Stores.windowStoreBuilder(
+                Stores.inMemoryWindowStore("windows", RETENTION, WINDOW_SIZE, false),
+                Serdes.String(), Serdes.String());
+    }
+
+    static StoreBuilder<?> sessionStoreBuilder() {
+        return Stores.sessionStoreBuilder(
+                Stores.inMemorySessionStore("sessions", RETENTION),
+                Serdes.String(), Serdes.String());
+    }
+
+    static StoreBuilder<?> suppressionBufferBuilder() {
+        return new InMemoryTimeOrderedKeyValueChangeBuffer.Builder<>(
+                "suppression", Serdes.String(), Serdes.String());
+    }
+
+    /**
+     * The one that looks harmless. {@code VersionedKeyValueStore} extends {@code StateStore} directly rather
+     * than {@code WindowStore}, so it is reachable through {@code Materialized} with no refused DSL call
+     * anywhere - and it silently drops puts older than its observed stream time.
+     */
+    static StoreBuilder<?> versionedKeyValueStoreBuilder() {
+        return Stores.versionedKeyValueStoreBuilder(
+                Stores.persistentVersionedKeyValueStore("versioned", Duration.ofDays(1)),
+                Serdes.String(), Serdes.String());
+    }
+
+    /**
+     * The supported one. Non-windowed stateful aggregation is inside the envelope (KTD3), and every refusal
+     * test needs it as the positive control.
+     */
+    static StoreBuilder<?> keyValueStoreBuilder() {
+        return Stores.keyValueStoreBuilder(
+                Stores.inMemoryKeyValueStore("counts"), Serdes.String(), Serdes.String());
+    }
+
+    static StateStore build(final StoreBuilder<?> builder) {
+        return (StateStore) builder.build();
+    }
+}

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java
@@ -4,14 +4,14 @@ package bz.stub.parallelconsumer.streams;
  */
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.streams.processor.internals.AbstractProcessorContext;
-import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
-import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
-import org.apache.kafka.streams.processor.internals.StreamTask;
-import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.junit.jupiter.api.Test;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,19 +28,35 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ShadowedClassLoadingTest {
 
     /**
-     * The classes listed in {@code patched.classes} in this module's pom. Keep in sync: a class that is
-     * generated but missing here is unguarded, and one listed here but not generated fails loudly below.
+     * The classes listed in {@code patched.classes} in this module's pom, asserted to be exactly that list by
+     * {@link #theGeneratedListMatchesThePomProperty()} rather than by a comment asking for care.
+     * <p>
+     * Named as strings rather than as class literals because two of them - {@code KGroupedStreamImpl} and
+     * {@code CogroupedKStreamImpl} - are package-private and cannot be referenced from here at all. Strings
+     * also make this a direct transcription of the pom property it has to match, which is the thing that
+     * actually has to stay in step.
      */
-    private static final Class<?>[] GENERATED = {
-            AbstractProcessorContext.class,
-            ProcessorContextImpl.class,
-            RecordCollectorImpl.class,
-            // Moved up from JAR_RESIDENT by the execution seam. The rung below this one (astubbs#379) put
-            // them in the jar-resident set precisely so that this assertion would have to flip, visibly, on
-            // the day the generated set grew - which is today. StreamTask is the seam; StreamThread is the
-            // poll wait wake-on-work splits.
-            StreamTask.class,
-            StreamThread.class,
+    private static final String[] GENERATED = {
+            "org.apache.kafka.streams.processor.internals.AbstractProcessorContext",
+            "org.apache.kafka.streams.processor.internals.ProcessorContextImpl",
+            "org.apache.kafka.streams.processor.internals.RecordCollectorImpl",
+            // Moved up from JAR_RESIDENT_NAMES by the execution seam. The rung below that one (astubbs#379)
+            // put them in the jar-resident set precisely so that this assertion would have to flip, visibly,
+            // on the day the generated set grew. StreamTask is the seam; StreamThread is the poll wait
+            // wake-on-work splits.
+            "org.apache.kafka.streams.processor.internals.StreamTask",
+            "org.apache.kafka.streams.processor.internals.StreamThread",
+            // The refusal envelope (astubbs#255). The interfaces carry @DoNotCall/@Deprecated and the impls
+            // carry the runtime throw - and these sit in two packages of their own, so the
+            // same-runtime-package assertion below is doing new work rather than repeating itself.
+            "org.apache.kafka.streams.kstream.KStream",
+            "org.apache.kafka.streams.kstream.KTable",
+            "org.apache.kafka.streams.kstream.KGroupedStream",
+            "org.apache.kafka.streams.kstream.CogroupedKStream",
+            "org.apache.kafka.streams.kstream.internals.KStreamImpl",
+            "org.apache.kafka.streams.kstream.internals.KTableImpl",
+            "org.apache.kafka.streams.kstream.internals.KGroupedStreamImpl",
+            "org.apache.kafka.streams.kstream.internals.CogroupedKStreamImpl",
     };
 
     /**
@@ -52,6 +68,12 @@ class ShadowedClassLoadingTest {
      * constructs {@code StreamTask} on the StreamThread. If generation were ever to sprawl past the declared
      * set, these are the first three it would reach.
      * <p>
+     * <b>At least one per package we generate into</b>, because "same runtime package" is a per-package
+     * property and the refusal envelope took the generated set into two more packages. {@code Materialized}
+     * and {@code ConsumedInternal} are the {@code kstream} and {@code kstream.internals} entries: both are
+     * used by the classes we patch there without ever being generated themselves, which is what makes the
+     * coexistence claim about those packages a real one rather than a vacuous one.
+     * <p>
      * Named as strings rather than imported because two of the sharpest neighbours are package-private, and
      * a check that can only name public classes cannot pick its own subjects.
      */
@@ -59,11 +81,14 @@ class ShadowedClassLoadingTest {
             "org.apache.kafka.streams.processor.internals.PartitionGroup",
             "org.apache.kafka.streams.processor.internals.RecordQueue",
             "org.apache.kafka.streams.processor.internals.TaskManager",
+            "org.apache.kafka.streams.kstream.Materialized",
+            "org.apache.kafka.streams.kstream.internals.ConsumedInternal",
     };
 
     @Test
     void generatedClassesWinOverTheJar() {
-        for (Class<?> generated : GENERATED) {
+        for (String name : GENERATED) {
+            Class<?> generated = load(name);
             URL location = codeSourceOf(generated);
             log.info("{} loaded from {}", generated.getSimpleName(), location);
 
@@ -80,7 +105,8 @@ class ShadowedClassLoadingTest {
 
     @Test
     void unGeneratedSiblingsStillComeFromTheJar() {
-        for (Class<?> resident : jarResidentClasses()) {
+        for (String name : JAR_RESIDENT_NAMES) {
+            Class<?> resident = load(name);
             URL location = codeSourceOf(resident);
             log.info("{} loaded from {}", resident.getSimpleName(), location);
 
@@ -100,12 +126,21 @@ class ShadowedClassLoadingTest {
      */
     @Test
     void generatedAndJarClassesShareOneRuntimePackage() {
-        for (Class<?> generated : GENERATED) {
-            for (Class<?> resident : jarResidentClasses()) {
-                assertThat(generated.getPackage().getName())
-                        .as("%s must sit in the same package as the jar-resident classes it reaches into", generated.getName())
-                        .isEqualTo(resident.getPackage().getName());
+        Set<String> coveredPackages = jarResidentPackages();
 
+        for (String name : GENERATED) {
+            Class<?> generated = load(name);
+
+            // Asserted against the declared set rather than against the siblings looked up below: those are
+            // selected BY package name, so comparing the two afterwards could never fail. What can fail, and
+            // is worth failing on, is generating into a package with no declared neighbour at all.
+            assertThat(generated.getPackage().getName())
+                    .as("%s is generated into a package this test does not know about. Every generated package "
+                                    + "needs a declared jar-resident sibling, or its coexistence is unproven.",
+                            generated.getName())
+                    .isIn(coveredPackages);
+
+            for (Class<?> resident : jarResidentSiblingsOf(generated)) {
                 assertThat(generated.getClassLoader())
                         .as("%s must share a classloader with %s, or they are in different runtime packages and "
                                         + "package-private access fails despite the matching package name",
@@ -116,23 +151,74 @@ class ShadowedClassLoadingTest {
     }
 
     /**
-     * Loads {@link #JAR_RESIDENT_NAMES} through the same classloader that loaded this test, which is the one
-     * whose classpath ordering the whole module depends on. A name that does not resolve fails here rather
-     * than silently shrinking the check to whatever still exists after a Kafka upgrade.
+     * {@link #GENERATED} has to match {@code patched.classes} in this module's pom, and a comment saying so is
+     * not a check. Surefire passes the property through so that this can be one.
      */
-    private static Class<?>[] jarResidentClasses() {
-        Class<?>[] resolved = new Class<?>[JAR_RESIDENT_NAMES.length];
-        for (int i = 0; i < JAR_RESIDENT_NAMES.length; i++) {
-            try {
-                resolved[i] = Class.forName(JAR_RESIDENT_NAMES[i], false,
-                        ShadowedClassLoadingTest.class.getClassLoader());
-            } catch (ClassNotFoundException e) {
-                throw new AssertionError(JAR_RESIDENT_NAMES[i] + " is named as a jar-resident neighbour but "
-                        + "does not exist - Kafka has moved or renamed it, and this check is now guarding "
-                        + "nothing. Pick another adjacent class rather than deleting the entry.", e);
+    @Test
+    void theGeneratedListMatchesThePomProperty() {
+        String property = System.getProperty("patched.classes");
+        assertThat(property)
+                .as("patched.classes was not passed through by surefire, so this test cannot tell whether the "
+                        + "list above is still complete - fix the pom rather than deleting this test")
+                .isNotBlank();
+
+        List<String> fromPom = new ArrayList<>();
+        for (String path : property.split(",")) {
+            fromPom.add(path.trim().replace(".java", "").replace('/', '.'));
+        }
+
+        assertThat(Arrays.asList(GENERATED))
+                .as("GENERATED and patched.classes have drifted apart. A class in the pom but not here is "
+                        + "generated and unproven; one here but not in the pom is loaded from the jar and every "
+                        + "assertion about it is a lie.")
+                .containsExactlyInAnyOrderElementsOf(fromPom);
+    }
+
+    /**
+     * The jar-resident classes that have to coexist with this generated one, i.e. those in its own package.
+     * Fails rather than returning empty: a generated class in a package with no declared jar sibling would
+     * otherwise be checked against nothing, and the loop over the result would pass while proving nothing.
+     */
+    private static List<Class<?>> jarResidentSiblingsOf(Class<?> generated) {
+        List<Class<?>> siblings = new ArrayList<>();
+        for (String name : JAR_RESIDENT_NAMES) {
+            Class<?> candidate = load(name);
+            if (candidate.getPackage().getName().equals(generated.getPackage().getName())) {
+                siblings.add(candidate);
             }
         }
-        return resolved;
+        if (siblings.isEmpty()) {
+            throw new AssertionError("No jar-resident sibling declared for package "
+                    + generated.getPackage().getName() + " (needed by " + generated.getName() + "). Add one to "
+                    + "JAR_RESIDENT_NAMES - without it the same-runtime-package assertion for that package is "
+                    + "vacuous.");
+        }
+        return siblings;
+    }
+
+    private static Set<String> jarResidentPackages() {
+        Set<String> packages = new LinkedHashSet<>();
+        for (String name : JAR_RESIDENT_NAMES) {
+            packages.add(load(name).getPackage().getName());
+        }
+        return packages;
+    }
+
+    /**
+     * Loads a class through the same classloader that loaded this test, which is the one whose classpath
+     * ordering the whole module depends on. A name that does not resolve fails here rather than silently
+     * shrinking the check to whatever still exists after a Kafka upgrade - or, for a {@link #GENERATED} entry,
+     * after {@code patched.classes} and this list have drifted apart.
+     */
+    private static Class<?> load(String name) {
+        try {
+            return Class.forName(name, false, ShadowedClassLoadingTest.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError(name + " is named here but does not exist on the classpath - either Kafka "
+                    + "has moved or renamed it and this check is now guarding nothing, or patched.classes and "
+                    + "this list have drifted apart. Pick another adjacent class rather than deleting the "
+                    + "entry.", e);
+        }
     }
 
     private static URL codeSourceOf(Class<?> type) {

--- a/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java
+++ b/parallel-consumer-streams/src/test/java/bz/stub/parallelconsumer/streams/ShadowedClassLoadingTest.java
@@ -162,8 +162,9 @@ class ShadowedClassLoadingTest {
                         + "list above is still complete - fix the pom rather than deleting this test")
                 .isNotBlank();
 
-        List<String> fromPom = new ArrayList<>();
-        for (String path : property.split(",")) {
+        String[] paths = property.split(",");
+        List<String> fromPom = new ArrayList<>(paths.length);
+        for (String path : paths) {
             fromPom.add(path.trim().replace(".java", "").replace('/', '.'));
         }
 
@@ -180,7 +181,7 @@ class ShadowedClassLoadingTest {
      * otherwise be checked against nothing, and the loop over the result would pass while proving nothing.
      */
     private static List<Class<?>> jarResidentSiblingsOf(Class<?> generated) {
-        List<Class<?>> siblings = new ArrayList<>();
+        List<Class<?>> siblings = new ArrayList<>(JAR_RESIDENT_NAMES.length);
         for (String name : JAR_RESIDENT_NAMES) {
             Class<?> candidate = load(name);
             if (candidate.getPackage().getName().equals(generated.getPackage().getName())) {
@@ -197,7 +198,7 @@ class ShadowedClassLoadingTest {
     }
 
     private static Set<String> jarResidentPackages() {
-        Set<String> packages = new LinkedHashSet<>();
+        Set<String> packages = new LinkedHashSet<>(JAR_RESIDENT_NAMES.length);
         for (String name : JAR_RESIDENT_NAMES) {
             packages.add(load(name).getPackage().getName());
         }


### PR DESCRIPTION
Serves astubbs/parallel-consumer#255.

depends on astubbs/parallel-consumer#388

## Description

**The claim this PR makes: every Kafka Streams construct known to answer wrongly under concurrent
dispatch now refuses, by name and with its reason, at build time or at startup - and the seam-off
behaviour-preservation oracle the rung below this one established is unchanged.**

Windowed operators, joins, suppression, versioned and session stores and exactly-once all gate on
stream time. Stock Kafka Streams advances stream time inside `PartitionGroup.nextRecord()`, and the
PC dispatch path does not go through it, so that clock never moves. Several of these constructs
additionally read-modify-write a **non-volatile `long`** from every worker, so under concurrent
dispatch the value is corrupted rather than merely stale. None of them throws in stock Kafka
Streams, and none of them would have thrown here either: the topology runs to completion and emits
the wrong numbers, with nothing in the log. Refusal is the only honest behaviour available until the
semantics are fixed.

### Three layers, because no one of them reaches the whole surface

| Layer | What a user gets | The route only it covers |
|---|---|---|
| `@DoNotCall` + `@Deprecated` + a javadoc `@deprecated` tag on the refused overloads of `KStream`, `KTable`, `KGroupedStream`, `CogroupedKStream` | a compile **error** under Error Prone, a deprecation warning without it | the call before it is ever run |
| `UnsupportedOperationException` from the DSL impl funnels | the whole topology refuses at construction, with the construct named | a topology built where the annotations do not reach the call site |
| A `ProcessorTopology` + `eosEnabled` check in `StreamTask`'s constructor | the same exception at task construction | the **Processor API**, which reaches a `WindowStore` via `addStateStore` without touching `KStream` at all; and **exactly-once**, which is a config key rather than a topology shape |

The annotations go on the **interfaces** because a call site resolves to the symbol its receiver's
static type declares - one on `KStreamImpl` would never be consulted. The throw goes in the
**impls** because an interface method has no body. Neither half substitutes for the other, which is
why `patched.classes` grows by eight rather than four.

The javadoc tag is not decoration. Without it an IDE strikes `stream.join(...)` through with no
reason attached, and the obvious inference - that Apache Kafka deprecated `join` - is false and
alarming.

Layer 3 runs **before** `PcTaskDispatcher.createIfEnabled`, so a refused task never leaves a worker
pool behind. That ordering was asserted only by a comment; `PcTaskDispatcher.activeCount()` exists
so a test can prove the negative.

Store classification is by **interface, never by class name** - the stores reaching a task are
wrapped several layers deep and every wrapper implements what it wraps. `VersionedKeyValueStore` is
the trap in that design: it extends `StateStore` directly rather than `WindowStore`, so it looks
ordinary, and it is reachable with **no refused DSL call anywhere** via
`Materialized.as(persistentVersionedKeyValueStore(...))`.

### No signature was deleted, and the reason is the evidence

The oracle runs Apache Kafka's own **compiled** test classes, never recompiled here, so a deleted
method would link-fail against classes this project does not own - and the change meant to make the
module honest would have destroyed the proof that it is. Refusal is therefore additive: annotations,
plus a throw guarded on the seam.

Every run-time layer is guarded on `PcDispatchSwitch.isEnabled()`, and **every refusal test is
paired with a seam-off control arm**. Without that pairing an unconditional guard would pass the
refusal half of each test while voiding the behaviour-preservation claim, since Kafka's own suite
builds EOS-enabled tasks and window stores.

### The default-on question, which this rung owns - and it stays off

astubbs/parallel-consumer#388's `PcDispatchSwitch` javadoc promised: restore on-by-default the day
refusal lands. **It landed, and the default is not being restored** - not from caution, but because
measuring it found a second reason the first one was hiding. That is recorded in the same javadoc
chain, so the unkept promise cannot read as an oversight.

Run Kafka's own suite against the patched classes with the seam **on** and `StreamThreadTest`
reaches `StreamTask.revive()` through Kafka's ordinary task-corruption recovery: a
`TaskCorruptedException` closes the task dirty and revives that same instance, whose PC dispatcher
is final and was closed on the way down. The loud-failure `IllegalStateException` there is caught by
nothing and leaves the run loop **uncaught on the StreamThread**. `TaskCorruptedException` is what
Kafka raises when a consumer's offset falls outside the topic's retained range - an ordinary event
on an ordinary topic.

**Control arm**, because a failure seen on one branch says nothing about that branch. The same
experiment on astubbs/parallel-consumer#388 - one term changed, the refusal envelope absent -
produces the identical revival failures and **zero** refusals. The two are independent: this unit
changed what a refused construct does and changed nothing about revival, and the gap was already
there, unmeasured, when the promise was written. Both arms also confirm the refusal firing where it
should: seam on, every added failure against that control is a refusal, and every one of them is an
EOS test - the mechanism working rather than a regression.

So a refused surface is safe to switch on; a thrown lifecycle event mid-recovery is not. **The
trigger moves rather than the default**: task lifecycle and rebalance, the unit that gives the
dispatcher a life beyond the task instance it was built with. The javadoc says so at three sites -
`PcDispatchSwitch` owns the decision, `revive()`'s javadoc says its own throw is what holds it
(because a reader arrives there from a stack trace), and the pom's module description carries the
one-line version.

### Proven able to fail

Both sabotages had the prediction stated first and were reverted byte-identically, verified by
checksum against the source branch's originals.

- **`refuse()` made a no-op.** Predicted: layer 2 goes red, layer 3 stays green, because the
  backstop throws directly rather than through `refuse()`. Exactly that - every DSL refusal case
  failed plus the one unit test that calls `refuse()` directly, and the entire Processor API
  backstop stayed green. The asymmetry is what says the right thing broke.
- **The `WindowStore` branch removed from `classify()`.** Predicted: only the window-store cases go
  red; session, versioned and suppression stay green and layer 2 is untouched. Exactly that.

The seam-off oracle was run on this branch and on astubbs/parallel-consumer#388, before and after,
same machine: **identical, unchanged**. Re-derive rather than copy - read the per-class numbers out
of `target/surefire-reports-kafka-upstream/` after the module's whole `test` phase, and never scope
that run with `-Dtest=`.

One caveat that turned out to matter, and it is Kafka's flake rather than this patch's.
`StreamThreadTest.shouldLogAndRecordSkippedRecordsForInvalidTimestamps` failed once in seven
consecutive seam-off runs here, green on the immediate re-run and green in every other run including
both control arms. It asserts on a thread name that depends on which thread logged. It was already
diagnosed with a control arm on the branch forest this work is cut from - **and that diagnosis had
reached neither master nor either rung below this one**, so every rung has been making a "zero
failures" claim against a gate that is not satisfiable as stated. The note is carried onto the stack
here, re-tagged for the tag gate that postdates it, with this sighting added and one open question
sharpened: whether `@Quarantined` can even reach a case that lives in Apache Kafka's own compiled
test class. The README's verification section now names the exception where a reader meets the claim.

### Static analysis on this diff, triaged

`bin/check-pr-analysis-surfaces.sh 389` reported six SpotBugs findings **on lines this PR wrote**.

- **Fixed** - three unpresized collections in `ShadowedClassLoadingTest`, which is code this rung
  authored rather than copied. The sizes are known constants at each site, so there was nothing to
  weigh.
- **Not changed, it is the design** - `classify()` "uses instanceof on multiple types to arbitrate
  logic". That is the point: the stores reaching a task are wrapped several layers deep and every
  wrapper implements what it wraps, so `instanceof` sees through the stack where anything keyed on a
  concrete type sees only the outermost wrapper. The versioned-store case is the worked example of
  what a weaker gate misses.
- **Not changed, cosmetic** - two findings in `RefusedDslAnnotationsTest` scaffolding copied verbatim
  from astubbs/parallel-consumer#271, where it was reviewed. Same treatment the rung below gave the
  equivalent findings.

The two inherited findings on `PcTaskDispatcher` are astubbs/parallel-consumer#388's, answered in its
body.

**One CI flake was met and recorded rather than re-run past.**
`ReactorBatchTest.simpleBatchTest` timed out on the Unit lane - a module this diff does not touch. It
is already in `docs/inflight/test-untracked-ci-flakes.md` with three prior sightings, every one of
them on a branch carrying no main Java in the failing module. This is the fourth, and it is worth
more than a tally row: the batch payload repeats the *same shape* the 2026-08-25 sighting found - a
three-way key collision, with the extra batch falling exactly where KEY ordering forces it, since
three records on one key cannot share a batch however fast the runner is. That moves the note's
expectation-versus-input reading from third of three to the one to test first. The experiment the
note already specifies still has to be run; this branch has no business fixing a Reactor test.

**`dups: similarity` is red and no duplication is being introduced.** Both token-based engines - PMD
CPD and jscpd - report **zero** new clones. The similarity tool is lexical, and its own output gives
it away: it scores a streams refusal test against core's `WorkClaimStateMachineTest`, two files with
nothing whatever in common, at 88%. What it is measuring is shared JUnit and AssertJ vocabulary. The
one pair worth a real look, `PcSupportedEnvelopeTest` against `ProcessorApiBackstopTest`, tests two
different levels - direct classification versus a real topology through `TopologyTestDriver` - and
already shares its store construction through `RefusedStoreFixtures`, which was extracted on
astubbs/parallel-consumer#271 for exactly that reason.

### Two things master changed under this work

Both because Error Prone is now on repo-wide, which it was not when this was first written on
astubbs/parallel-consumer#271.

- **The compile-time layer is real here rather than theoretical.** The first evidence was this
  module's own refusal test failing to compile - it exists to make exactly the calls a user must not
  make. It now carries a class-level `@SuppressWarnings("DoNotCall")`, and **deleting that is the
  cheapest available falsification of layer 1**: the build fails with one error per refused call
  site.
- **Error Prone also asks every override of a `@DoNotCall` method to carry the annotation**, which
  fires on the four patched impl classes. Suppressed at class level with the reason at the site
  rather than propagated, on two grounds together: the impls carry the **run-time** half of the same
  refusal, so reaching one of those bodies by its internal type still throws and there is no
  unrefused path - only one refused a call later; and every one of those findings is on an override
  declaration rather than a call site, so nothing that could reach a refused construct is silenced.
  Propagating would also contradict the interfaces-only placement rule that the module's own guard
  test and the learning write-up already on master both state.

The module-local `error_prone_annotations` declaration the original work needed is **not** carried
across: master's root pom now supplies it to every module at `provided` scope, which is the right
scope for a `CLASS`-retention annotation and the one this module would otherwise have leaked to
consumers at compile scope.

### What is still unsupported and NOT refused

**Stream-time punctuation.** `context.schedule(interval, PunctuationType.STREAM_TIME, ...)`
registers successfully and the punctuator never fires - no exception, no warning, no output. It
escapes all three layers for a structural reason: it is a call on the processor context made from
inside `init()`, long after the task-construction check has passed, and it is neither a DSL method,
a store type, nor a config key. It was predicted as a review thread on
astubbs/parallel-consumer#271 before any of this existed, and survived it intact. Recorded in
`docs/inflight/streams-stream-time-punctuation-is-unsupported-and-not-refused.md` and stated in the
README rather than left for a reader to discover.

### The README, and what was deliberately not taken

The source branch carries a 460-line README of its own, and it is **not** adopted wholesale. It
leads with benchmark figures that astubbs/parallel-consumer#388 excluded on purpose - the benchmark
that produces a number is a separate unit, and a figure copied into a second document drifts from
the first silently. What lock-step actually demands is that this rung's code and this rung's
documentation land together, which they do: the refusal section, the patched-class table, the
`ShadowedClassLoadingTest` change, and the default's new reason are all here.

`CONCEPTS.md` gains the module's vocabulary - **seam**, **supported envelope**, **refused
construct** - because those three words now appear across a pom description, a README, four javadocs
and the patch, and nothing said what they mean.

### Where this came from

Copied out of **astubbs/parallel-consumer#271**, the Kafka Streams feasibility study, which remains
the source god PR and keeps the semantic work, the measurements and the open review threads. The
PC-side classes are renamed `io.confluent` to `bz.stub`; the patched Kafka sources stay in
`org.apache.kafka`. The patch was regenerated by the prescribed procedure - `process-sources`, edit
under `target/kafka-patched`, `bin/regen-patch.sh` with no maven run in between - **never
hand-edited**, and **verified by content rather than by hunk count**: every added and removed line
of astubbs/parallel-consumer#388's patch survives unchanged, and every added line of the source
branch's patch survives modulo the rename, with one deliberate exception noted in the commit body.

Third rung of the reconstructed Wagon B stack. Not here, and named so a reader does not expect them:
task lifecycle, rebalance and `revive()`; stream time and punctuation; the seam-on upstream evidence
lane; the benchmarks; the example module.

## Checklist

- [x] Docs updated - the module README (the refused surface, the three layers, the
      `REPLACE_THREAD` warning, the new reason the default is off, the patched-class table, the
      per-package shadowing check), `CONCEPTS.md`'s module vocabulary, `NOTICE`'s Apache 2.0
      changed-files list, the pom's module description, and one `docs/inflight/` note for the
      construct the envelope does not cover, plus the oracle-flake note carried onto the stack
- [x] User-facing feature documentation data added under `docs/features/` - `N/A - the module is
      still unpublished, so there is no artifact to depend on and nothing for the ladder to point a
      user at. The roadmap stage is unchanged, for the same reason the two rungs below gave`
- [x] Tests added/updated - `PcSupportedEnvelopeTest` and `RefusedDslAnnotationsTest` (unit),
      `RefusedDslConstructsTest` and `ProcessorApiBackstopTest` (each refusal paired with a seam-off
      control arm), shared `RefusedStoreFixtures`, and `ShadowedClassLoadingTest` extended to the
      two new generated packages plus a new test asserting its own list against `patched.classes`
      from the pom
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - `N/A - asked for review on the PR instead.
      Most of the diff is a copy from a branch already reviewed on astubbs/parallel-consumer#271;
      what is new here - the default-off decision and its measurement, the two Error Prone
      suppressions, the regenerated patch and the merged shadowing test - is what a reviewer should
      spend attention on`
