### PR TITLE
refactor(core): confine the consumer to its owning thread, and make ownership a lifecycle

### DIFF
--- a/docs/inflight/static-archunit-main-code-rules.md
+++ b/docs/inflight/static-archunit-main-code-rules.md
@@ -50,6 +50,21 @@ code fixed or the rule narrowed, not a suppression. Read the granularity limits 
 costing any of them - one of them is not expressible in ArchUnit at all.
 
 <!-- post-merge: checked-begin -->
+- **Pin `ThreadConfinedConsumer`'s Lombok `@Delegate` excludes interface to its overrides**, so a
+  method the wrapper means to guard cannot silently become an unguarded passthrough. The wrapper
+  guards by *overriding* each `Consumer` method it cares about and listing that method on an
+  excludes interface, so `@Delegate` does not generate a competing passthrough. The two lists have
+  to agree, and nothing checks that they do: drop a signature from the excludes interface and the
+  generated delegate wins, reaching the consumer without the ownership check, with no compile error
+  and no test failure. A new Kafka `Consumer` method arriving in a client upgrade is the same hole
+  from the other direction - it is delegated by default, and defaults are how a guard acquires a
+  gap nobody chose.
+
+  Same shape as the two invariant rules already shipped, so it is the per-invariant exception below
+  rather than the post-v6 programme - but only once the guard is actually wired, since a rule
+  pinning an unenforced seam pins nothing. Suggested by the simplify pass on
+  astubbs/parallel-consumer#393, which is where the wrapper arrives; the claim call and the existing
+  `ArchitectureTest` live on astubbs/parallel-consumer#29.
 - **Dependency direction** between `internal`, `state`, `offsets` and the public API package - state
   should not reach back into the controller.
 - **No raw `Thread` / executor construction outside the places that own lifecycle**, so the

--- a/docs/inflight/test-untracked-ci-flakes.md
+++ b/docs/inflight/test-untracked-ci-flakes.md
@@ -19,7 +19,7 @@ Where their diagnoses generalised, the rule is in [`docs/solutions/`](../solutio
 | Test | Rate | Why it is worth attention |
 |---|---|---|
 | `ProducerManagerTest.producedRecordsCantBeInTransactionWithoutItsOffsetDirect` | 1 seen (2026-08-12) | Not from the original scan - found while babysitting astubbs#287. Mechanism known and owned (astubbs#262), quarantined - see below |
-| `simpleBatchTest` in **all three** of `ReactorBatchTest`, `MutinyBatchTest` and `VertxBatchTest` | 3 seen (2026-08-18, 2026-08-19, 2026-08-25) | Not from the original scan - each found while babysitting a branch carrying **no main Java**. Same Awaitility `ConditionTimeout`, same alias 'expected number of batches' (30s), same shared `BatchTestMethods` lambda. UNDIAGNOSED, but the third sighting carries the failing batch contents and they point at the test's own randomised input - see below, and classify (contention vs product vs expectation) before touching |
+| `simpleBatchTest` in **all three** of `ReactorBatchTest`, `MutinyBatchTest` and `VertxBatchTest` | 4 seen (2026-08-18, 2026-08-19, 2026-08-25, 2026-09-01) | Not from the original scan - each found while babysitting a branch. Same Awaitility `ConditionTimeout`, same alias 'expected number of batches' (30s), same shared `BatchTestMethods` lambda. UNDIAGNOSED, but the third and fourth sightings independently carry the **same three-way key collision** in the failing batch contents, which points at the test's own randomised input - see below, and classify (contention vs product vs expectation) before touching |
 
 **Classify before touching any of them** - the same rule that governs the load-tightness family next
 door, and for the same reason: two of that family turned out to be real product bugs, and the third
@@ -82,6 +82,46 @@ under KEY ordering, and predict a deterministic failure; then five distinct keys
 always passes. If both hold, this is
 the test's own input and neither the runner nor the batcher. If the collision case passes, the draw
 is a red herring and contention-versus-product stands as before.
+
+<!-- post-merge: checked-begin -->
+#### The 2026-09-01 sighting: the collision reproduces, in a second module, unprompted
+
+`ReactorBatchTest`, KEY ordering (`simpleBatchTest(ProcessingOrder)[3]` - `@EnumSource` orders the
+enum `UNORDERED, PARTITION, KEY`, so index 3 is KEY, the same parameter as 2026-08-25). Seen on the
+Unit Tests lane of astubbs/parallel-consumer#393, the thread-confinement extraction. Same
+`Expected size: 3 but was: 4`.
+
+**This is the first sighting whose branch carried main Java, so the master-state argument above is
+restated here rather than reused.** It still holds, for two reasons specific to
+astubbs/parallel-consumer#393. Relative to the head the failure was first seen on, the commit under
+test changed only comments and one core test fixture, and that fixture is loaded by two core
+ownership tests `ReactorBatchTest` never touches. That PR's one behavioural change to a poll path
+moves an existing `updateCache()` call from after `pollingBroker.set(true)` to before it - a
+reordering, not an addition, so the poll does no more work than master's does. Neither could reach a
+batch boundary in another module.
+
+**What makes the sighting worth recording is the payload, because it is the 2026-08-25 one again.**
+The five records carried keys `34, 62, 34, 34, 77` by offset - a **three-way collision on key 34** -
+and arrived as `{o0, o1}`, `{o4}`, `{o2}`, `{o3}`. 2026-08-25 saw keys `29, 36, 36, 36, 71`, a
+three-way collision on key 36, arriving as `{o0, o4}`, `{o1}`, `{o2}`, `{o3}`. Two independent
+draws, different modules, different collided key, **same shape**: one key drawn three times, two
+drawn once, and four batches where the expectation is `ceil(5 / 2) = 3`.
+
+That is what the expectation-versus-input reading predicts, and it is no longer resting on a single
+observation. Under KEY ordering the three colliding records share a shard and must be processed in
+order, so they cannot batch with each other however fast the runner is; only the two singletons are
+free to pair with anything. A three-way collision therefore forces at least four batches on
+arithmetic, while `expectedNumOfBatches` - grep `BatchTestMethods` for it - is computed from the
+record count alone and stays at three.
+
+**It still is not a diagnosis, and the experiment named above is still the thing that settles it**
+(pin `defaultKeys` through the Lombok setter on `KafkaTestUtils`, force the collision, predict a
+deterministic failure; then five distinct keys, predict it always passes). What has changed is the
+prior: the collision is now the leading reading rather than one of three equals, and a control arm
+that failed to reproduce under a forced collision would be a genuinely surprising result. Recorded
+while the CI log carrying the payload still existed - those logs expire, and the payload is the
+whole value of the sighting.
+<!-- post-merge: checked-end -->
 
 ### `ProducerManagerTest.producedRecordsCantBeInTransactionWithoutItsOffsetDirect` - a helper defect, not a test defect
 

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
+import java.util.regex.Pattern;
 
 import static bz.stub.parallelconsumer.internal.utils.StringUtils.msg;
 
@@ -88,21 +89,24 @@ public class ConsumerManager<K, V> {
     private int correctPollWakeups = 0;
     private int noWakeups = 0;
 
+    private boolean commitRequested;
+
     /**
      * Prime the metadata cache so that groupMetadata() returns a valid value before the poll
      * thread starts. Must be called after construction, before any thread claims ownership.
      * <p>
-     * Silently handles errors (e.g., missing group.id) — validation happens later in
-     * the PC constructor's checkGroupIdConfigured().
+     * Absorbs errors (e.g., missing group.id) — validation happens later in the PC constructor's
+     * checkGroupIdConfigured(), which calls groupMetadata() on the consumer directly and throws a
+     * message naming the missing config. Logs the exception itself rather than only its message, so
+     * a failure that is NOT the group-id case - which has no such backstop - is still diagnosable.
      */
     void init() {
         try {
             updateCache();
         } catch (Exception e) {
-            log.trace("Could not prime cache during init (will be validated later): {}", e.getMessage());
+            log.trace("Could not prime cache during init (will be validated later)", e);
         }
     }
-    private boolean commitRequested;
 
     ConsumerRecords<K, V> poll(Duration requestedLongPollTimeout) {
         Duration timeoutToUse = requestedLongPollTimeout;
@@ -128,7 +132,7 @@ public class ConsumerManager<K, V> {
             // property the exit refresh relies on (see the comment there).
             updateCache();
             pollingBroker.set(true);
-            log.trace("Poll starting with timeout: {}, assignment size: {}", timeoutToUse, assignmentSizeCache);
+            log.debug("Poll starting with timeout: {}", timeoutToUse);
             Instant pollStarted = Instant.now();
             long tryCount = 0;
             boolean polledSuccessfully = false;
@@ -177,25 +181,16 @@ public class ConsumerManager<K, V> {
         // Update the cache after pollingBroker is cleared, so wakeup() from another thread
         // won't call consumer.wakeup() while we're calling consumer.groupMetadata()/paused().
         // This fixes ConcurrentModificationException when close() races against poll().
-        // Always update (not just when records > 0) so assignment cache stays current after rebalances.
+        // Always update (not just when records > 0) so the caches stay current after a rebalance,
+        // which happens inside poll().
         // See https://github.com/confluentinc/parallel-consumer/issues/857
         updateCache();
         return records != null ? records : new ConsumerRecords<>(UniMaps.of());
     }
 
-    private volatile int assignmentSizeCache = 0;
-
     protected void updateCache() {
         metaCache = consumer.groupMetadata();
         pausedPartitionSizeCache = consumer.paused().size();
-        assignmentSizeCache = consumer.assignment().size();
-    }
-
-    /**
-     * Cached assignment size, safe to read from any thread. Updated during poll.
-     */
-    public int getAssignmentSize() {
-        return assignmentSizeCache;
     }
 
     /**
@@ -463,16 +458,8 @@ public class ConsumerManager<K, V> {
         consumer.subscribe(topics, listener);
     }
 
-    void subscribe(java.util.regex.Pattern pattern, ConsumerRebalanceListener listener) {
+    void subscribe(Pattern pattern, ConsumerRebalanceListener listener) {
         consumer.subscribe(pattern, listener);
-    }
-
-    /**
-     * Returns the raw consumer class type for reflection-based checks (e.g., auto-commit detection).
-     * Does not access the consumer's Kafka methods, just the class object.
-     */
-    Class<?> getConsumerClass() {
-        return consumer.getClass();
     }
 
     public void resume(final Set<TopicPartition> pausedTopics) {

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java
@@ -95,10 +95,17 @@ public class ConsumerManager<K, V> {
      * Prime the metadata cache so that groupMetadata() returns a valid value before the poll
      * thread starts. Must be called after construction, before any thread claims ownership.
      * <p>
-     * Absorbs errors (e.g., missing group.id) — validation happens later in the PC constructor's
-     * checkGroupIdConfigured(), which calls groupMetadata() on the consumer directly and throws a
-     * message naming the missing config. Logs the exception itself rather than only its message, so
-     * a failure that is NOT the group-id case - which has no such backstop - is still diagnosable.
+     * Absorbs whatever priming throws, and logs the exception itself rather than only its message,
+     * because nothing downstream re-reports it.
+     * <p>
+     * <b>A missing {@code group.id} is not what this catch is for</b>, though the shape invites that
+     * reading. The processor's constructor runs {@code validateConfiguration()} - and through it
+     * {@code checkGroupIdConfigured()} - before it asks the module for the broker poller, and the
+     * poller is what first constructs this manager and calls this method. On that path the
+     * missing-config error has already been thrown, naming the config, before priming is reached.
+     * The catch stays broad because the manager is built lazily, so nothing guarantees that ordering
+     * for a future caller, and because a genuine broker-side priming failure has no such backstop at
+     * all.
      */
     void init() {
         try {
@@ -454,10 +461,28 @@ public class ConsumerManager<K, V> {
         return pausedPartitionSizeCache;
     }
 
+    /**
+     * <b>These two have no caller yet, and that is deliberate - do not delete them as dead code.</b>
+     * {@code AbstractParallelEoSStreamProcessor.subscribe(...)} still subscribes through the
+     * <em>raw</em> consumer it holds from {@code options.getConsumer()}, so subscription is one of
+     * the paths that does not yet reach the thread-confinement guard. That is the same
+     * guard-installed-but-not-guarding state ownership itself is in on this branch: nothing calls
+     * {@code claimConsumerOwnership()}, so ownership never leaves
+     * {@link ConsumerOwnership.Phase#UNCLAIMED} and no call is refused at runtime.
+     * <p>
+     * They are the seam astubbs#29 wires, where the processor is changed to hold this manager rather
+     * than the raw consumer and the ArchUnit rule that pins the invariant lands with it. Kept here
+     * rather than re-added there because an unreachable-looking method carrying no note is exactly
+     * what a later reader removes as an oversight - which is the removal this paragraph exists to
+     * stop.
+     */
     void subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
         consumer.subscribe(topics, listener);
     }
 
+    /**
+     * @see #subscribe(Collection, ConsumerRebalanceListener) for why this has no caller yet
+     */
     void subscribe(Pattern pattern, ConsumerRebalanceListener listener) {
         consumer.subscribe(pattern, listener);
     }

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerManager.java
@@ -19,6 +19,7 @@ import pl.tlinkowski.unij.api.UniMaps;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -35,7 +36,7 @@ import static bz.stub.parallelconsumer.internal.utils.StringUtils.msg;
 @RequiredArgsConstructor
 public class ConsumerManager<K, V> {
 
-    private final Consumer<K, V> consumer;
+    private final ThreadConfinedConsumer<K, V> consumer;
 
     private final Duration offsetCommitTimeout;
 
@@ -66,15 +67,41 @@ public class ConsumerManager<K, V> {
      * Since Kakfa 2.7, multi-threaded access to consumer group metadata was blocked, so before and after polling, save
      * a copy of the metadata.
      *
+     * <p>
+     * <b>volatile</b> because it is written by the poll thread in {@code updateCache()} and read from
+     * other threads via {@code groupMetadata()}, with no other happens-before edge. It carries the
+     * generation and member IDs, which the control thread hands to
+     * {@code producer.sendOffsetsToTransaction(...)}, where the broker uses them to fence zombies - a
+     * stale read is the wrong answer to "is this member still legitimate?". Its two neighbours here
+     * were already volatile; this one was missed because the SpotBugs detector that found them,
+     * {@code AT_STALE_THREAD_WRITE_OF_PRIMITIVE}, cannot fire on an object reference and no
+     * {@code _OF_REFERENCE} variant exists. Safe as a plain reference publish because
+     * {@link ConsumerGroupMetadata} is immutable - all fields final, no setters.
+     *
      * @since 2.7.0
      */
-    private ConsumerGroupMetadata metaCache;
+    private volatile ConsumerGroupMetadata metaCache;
 
     private volatile int pausedPartitionSizeCache = 0;
 
     private int erroneousWakups = 0;
     private int correctPollWakeups = 0;
     private int noWakeups = 0;
+
+    /**
+     * Prime the metadata cache so that groupMetadata() returns a valid value before the poll
+     * thread starts. Must be called after construction, before any thread claims ownership.
+     * <p>
+     * Silently handles errors (e.g., missing group.id) — validation happens later in
+     * the PC constructor's checkGroupIdConfigured().
+     */
+    void init() {
+        try {
+            updateCache();
+        } catch (Exception e) {
+            log.trace("Could not prime cache during init (will be validated later): {}", e.getMessage());
+        }
+    }
     private boolean commitRequested;
 
     ConsumerRecords<K, V> poll(Duration requestedLongPollTimeout) {
@@ -86,9 +113,22 @@ public class ConsumerManager<K, V> {
                 timeoutToUse = Duration.ofMillis(1);// disable long poll, as commit needs performing
                 commitRequested = false;
             }
-            pollingBroker.set(true);
+            // Refresh the caches ON ENTRY, after the caller's pause/resume decision and BEFORE the
+            // long poll they describe. The control thread's back-pressure wakeup
+            // (maybeWakeupPoller -> BrokerPollSystem#isSubscriptionsPausedForBackPressure) reads
+            // pausedPartitionSizeCache precisely while this thread is asleep inside a PAUSED long
+            // poll - with only the exit refresh below, the cache reports every pause one poll late,
+            // reading "not paused" for the whole paused sleep, so the wakeup never fires and each
+            // pause costs the full long-poll timeout with the pipeline drained. That was the 4-10x
+            // transactional throughput regression on the confluentinc#857 branch
+            // (ConsumerManagerPauseCacheTest holds the contract).
+            //
+            // Deliberately BEFORE pollingBroker is set: wakeup() only forwards to consumer.wakeup()
+            // while pollingBroker is true, so these consumer calls cannot race a wakeup - the same
+            // property the exit refresh relies on (see the comment there).
             updateCache();
-            log.debug("Poll starting with timeout: {}", timeoutToUse);
+            pollingBroker.set(true);
+            log.trace("Poll starting with timeout: {}, assignment size: {}", timeoutToUse, assignmentSizeCache);
             Instant pollStarted = Instant.now();
             long tryCount = 0;
             boolean polledSuccessfully = false;
@@ -126,7 +166,6 @@ public class ConsumerManager<K, V> {
                 }
                 pendingRequests.addAndGet(-1L);
             }
-            updateCache();
         } catch (WakeupException w) {
             correctPollWakeups++;
             log.debug("Awoken from broker poll");
@@ -135,12 +174,28 @@ public class ConsumerManager<K, V> {
         } finally {
             pollingBroker.set(false);
         }
+        // Update the cache after pollingBroker is cleared, so wakeup() from another thread
+        // won't call consumer.wakeup() while we're calling consumer.groupMetadata()/paused().
+        // This fixes ConcurrentModificationException when close() races against poll().
+        // Always update (not just when records > 0) so assignment cache stays current after rebalances.
+        // See https://github.com/confluentinc/parallel-consumer/issues/857
+        updateCache();
         return records != null ? records : new ConsumerRecords<>(UniMaps.of());
     }
+
+    private volatile int assignmentSizeCache = 0;
 
     protected void updateCache() {
         metaCache = consumer.groupMetadata();
         pausedPartitionSizeCache = consumer.paused().size();
+        assignmentSizeCache = consumer.assignment().size();
+    }
+
+    /**
+     * Cached assignment size, safe to read from any thread. Updated during poll.
+     */
+    public int getAssignmentSize() {
+        return assignmentSizeCache;
     }
 
     /**
@@ -336,6 +391,23 @@ public class ConsumerManager<K, V> {
         return metaCache;
     }
 
+    /**
+     * Claim the underlying consumer for the current thread. After this, any consumer method
+     * (except wakeup) called from a different thread will throw immediately with a clear message.
+     */
+    void claimConsumerOwnership() {
+        consumer.claimOwnership();
+    }
+
+    /**
+     * Release the poll thread's claim on the underlying consumer. Called from the poll loop's
+     * finally block once that thread will never touch the consumer again, so the closing thread
+     * can take over. See {@link ThreadConfinedConsumer#releaseOwnership()}.
+     */
+    void releaseConsumerOwnership() {
+        consumer.releaseOwnership();
+    }
+
     public void close(final Duration defaultTimeout) {
         long deadline = System.currentTimeMillis() + defaultTimeout.toMillis();
         log.debug("Consumer Manager Closing...");
@@ -350,6 +422,23 @@ public class ConsumerManager<K, V> {
             }
         }
         log.debug("ConsumerManager close wait completed.");
+        // Take over ownership for the final close. Non-stealing: succeeds only if the poll loop
+        // has released (its loop exited - normally or by exception) or this IS the poll thread.
+        // If the poll loop is somehow still live (closeAndWait timed out and the close sequence
+        // proceeded anyway), the claim fails and the guarded close below throws - closing a
+        // consumer another thread is actively using must never be legalised.
+        boolean claimedForClose = consumer.tryClaimOwnership();
+        if (!claimedForClose) {
+            // Named and logged rather than branched on. Skipping the close here would swallow the
+            // report: the guarded close throws, doClose catches it, and THAT is where the user
+            // learns the consequence - no LeaveGroup, so the group's next rebalance waits out
+            // session.timeout.ms. This line only makes the cause legible first, so an expected
+            // shutdown race does not arrive as a bare guard exception that reads like a defect.
+            log.warn("Could not take consumer ownership for the final close - the broker-poll thread " +
+                    "is still alive and holds it, which means an earlier step in the close sequence " +
+                    "did not complete. The close below will refuse; the warning that follows explains " +
+                    "the cost.");
+        }
         consumer.close(defaultTimeout);
         log.debug("ConsumerManager closed");
     }
@@ -368,6 +457,22 @@ public class ConsumerManager<K, V> {
 
     public int getPausedPartitionSize() {
         return pausedPartitionSizeCache;
+    }
+
+    void subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
+        consumer.subscribe(topics, listener);
+    }
+
+    void subscribe(java.util.regex.Pattern pattern, ConsumerRebalanceListener listener) {
+        consumer.subscribe(pattern, listener);
+    }
+
+    /**
+     * Returns the raw consumer class type for reflection-based checks (e.g., auto-commit detection).
+     * Does not access the consumer's Kafka methods, just the class object.
+     */
+    Class<?> getConsumerClass() {
+        return consumer.getClass();
     }
 
     public void resume(final Set<TopicPartition> pausedTopics) {

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerOwnership.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ConsumerOwnership.java
@@ -1,0 +1,84 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+/**
+ * Who, if anyone, may currently call the Kafka consumer - the state {@link ThreadConfinedConsumer}
+ * guards.
+ * <p>
+ * Three states, and the third is the point:
+ * <ul>
+ *   <li>{@link Phase#UNCLAIMED} - before the poll loop starts. Every thread is allowed, because
+ *       init-time calls like {@code subscribe} happen on whatever thread builds PC.</li>
+ *   <li>{@link Phase#OWNED} - only {@link #owner} may call.</li>
+ *   <li>{@link Phase#RELEASED} - set by the poll loop as its last act. Admits <b>no direct use at
+ *       all</b>; the only legal move out of it is a claim.</li>
+ * </ul>
+ * Collapsing RELEASED into UNCLAIMED would reopen the window between the poll loop finishing and the
+ * closing thread taking over, during which a third thread's misuse would go undetected - the one
+ * hole a two-state guard cannot see.
+ * <p>
+ * A top-level type rather than nested inside {@link ThreadConfinedConsumer} for a build reason worth
+ * knowing: the ManagedTruth assertion generator treats that class as a
+ * {@code org.apache.kafka.clients.consumer.Consumer} implementation (it is in the plugin's
+ * {@code legacyClasses}) and emits a Truth Subject for each of its NESTED types into the parent
+ * package, where the package-private outer class is not visible - so any nested type there fails the
+ * build. Nothing reaches this class, because it is neither in the plugin's {@code classes} allow-list
+ * nor a Consumer implementation.
+ *
+ * @see <a href="https://github.com/confluentinc/parallel-consumer/issues/857">#857</a>
+ */
+public final class ConsumerOwnership {
+
+    public enum Phase {UNCLAIMED, OWNED, RELEASED}
+
+    static final ConsumerOwnership UNCLAIMED = new ConsumerOwnership(Phase.UNCLAIMED, null);
+    static final ConsumerOwnership RELEASED = new ConsumerOwnership(Phase.RELEASED, null);
+
+    private final Phase phase;
+    private final Thread owner;
+
+    private ConsumerOwnership(Phase phase, Thread owner) {
+        this.phase = phase;
+        this.owner = owner;
+    }
+
+    static ConsumerOwnership ownedBy(Thread owner) {
+        return new ConsumerOwnership(Phase.OWNED, owner);
+    }
+
+    boolean isOwnedBy(Thread thread) {
+        return phase == Phase.OWNED && owner == thread;
+    }
+
+    boolean isOwnedBySomeoneOtherThan(Thread thread) {
+        return phase == Phase.OWNED && owner != thread;
+    }
+
+    boolean isClaimable() {
+        return phase != Phase.OWNED;
+    }
+
+    boolean isReleased() {
+        return phase == Phase.RELEASED;
+    }
+
+    /** The owning thread, or null when not {@link Phase#OWNED}. */
+    Thread owner() {
+        return owner;
+    }
+
+    @Override
+    public String toString() {
+        switch (phase) {
+            case OWNED:
+                return "'" + owner.getName() + "' (id:" + owner.getId() + ", alive:" + owner.isAlive() + ")";
+            case RELEASED:
+                return "released-for-handoff";
+            default:
+                return "unclaimed";
+        }
+    }
+}

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/PCModule.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/PCModule.java
@@ -85,10 +85,16 @@ public class PCModule<K, V> {
 
     protected ConsumerManager<K, V> consumerManager() {
         if (consumerManager == null) {
-            consumerManager = new ConsumerManager<>(optionsInstance.getConsumer(),
+            // Wrap the user's consumer in a thread-confinement guard. Ownership is claimed
+            // by the poll thread when BrokerPollSystem.controlLoop starts. Before that,
+            // init-time calls (subscribe, groupMetadata) are allowed from any thread.
+            // See confluentinc#857.
+            var confinedConsumer = new ThreadConfinedConsumer<>(optionsInstance.getConsumer());
+            consumerManager = new ConsumerManager<>(confinedConsumer,
                     optionsInstance.getOffsetCommitTimeout(),
                     optionsInstance.getSaslAuthenticationRetryTimeout(),
                     optionsInstance.getSaslAuthenticationExceptionRetryBackoff());
+            consumerManager.init();
         }
         return consumerManager;
     }

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumer.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumer.java
@@ -60,11 +60,11 @@ class ThreadConfinedConsumer<K, V> implements Consumer<K, V> {
     void claimOwnership() {
         Thread current = Thread.currentThread();
         ConsumerOwnership previous = ownership.getAndSet(ConsumerOwnership.ownedBy(current));
-        Thread previousOwner = previous.isOwnedBySomeoneOtherThan(current) ? previous.owner() : null;
-        if (previousOwner != null && previousOwner != current) {
+        if (previous.isOwnedBySomeoneOtherThan(current)) {
             // claimOwnership is the poll thread's start-of-life claim; a live previous owner here
             // means two poll loops share one consumer, which the guard exists to catch. Log loudly
             // rather than throw: throwing here would kill the new loop, not the misuse.
+            Thread previousOwner = previous.owner();
             log.warn("Consumer ownership claimed by thread '{}' but was still held by thread '{}' (alive:{}) - " +
                             "two components polling one consumer? See confluentinc#857.",
                     current.getName(), previousOwner.getName(), previousOwner.isAlive());
@@ -85,8 +85,11 @@ class ThreadConfinedConsumer<K, V> implements Consumer<K, V> {
         if (witness.isOwnedBy(current) && ownership.compareAndSet(witness, ConsumerOwnership.RELEASED)) {
             log.debug("Consumer ownership released by thread: {}", current.getName());
         } else {
+            // Report the witness the branch above actually tested, not a fresh read: re-reading
+            // reports a state this call never saw, and when the CAS is what failed it contradicts
+            // the message by naming an owner that had already moved on.
             log.warn("Thread '{}' tried to release consumer ownership it does not hold (owner: {})",
-                    current.getName(), ownership.get());
+                    current.getName(), witness);
         }
     }
 
@@ -119,8 +122,6 @@ class ThreadConfinedConsumer<K, V> implements Consumer<K, V> {
             // lost a race against another claimer; re-read and decide again
         }
     }
-
-
 
     private void checkThread(String methodName) {
         Thread current = Thread.currentThread();
@@ -289,8 +290,8 @@ class ThreadConfinedConsumer<K, V> implements Consumer<K, V> {
         ConsumerGroupMetadata groupMetadata();
         void subscribe(Collection<String> topics, ConsumerRebalanceListener callback);
         void subscribe(Collection<String> topics);
-        void subscribe(java.util.regex.Pattern pattern, ConsumerRebalanceListener callback);
-        void subscribe(java.util.regex.Pattern pattern);
+        void subscribe(Pattern pattern, ConsumerRebalanceListener callback);
+        void subscribe(Pattern pattern);
         void close();
         void close(Duration timeout);
     }

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumer.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumer.java
@@ -1,0 +1,297 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.common.TopicPartition;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/**
+ * Delegating wrapper around {@link Consumer} that enforces thread confinement at runtime.
+ * All consumer methods (except {@link #wakeup()}) must be called from the owning thread.
+ * <p>
+ * Uses Lombok {@code @Delegate} to generate passthrough methods for all Consumer methods we
+ * don't explicitly override. We override all thread-unsafe methods with a {@link #checkThread}
+ * guard. {@link #wakeup()} is left to the delegate (thread-safe per Kafka API).
+ * <p>
+ * Ownership is a full lifecycle, not a one-shot: the poll thread calls {@link #claimOwnership()}
+ * before first use, and {@link #releaseOwnership()} when its loop exits and it will never touch
+ * the consumer again. A thread that closes the consumer afterwards (the control thread, in
+ * transactional mode) takes over with {@link #tryClaimOwnership()}, which never steals - it
+ * succeeds only when the consumer is unclaimed or already owned by the caller. The guard
+ * therefore asserts "no <i>other</i> thread currently owns this consumer", which is the property
+ * Kafka's single-threaded consumer contract actually requires; comparing raw thread identity
+ * forever would (and did) reject the legal sequential ownership handoff at close time, while a
+ * guard that let close bypass the check would legalise closing mid-poll. While unclaimed
+ * (before start, and between release and takeover during the strictly sequential close path),
+ * all methods are allowed - init-time calls like subscribe need this.
+ * <p>
+ * Pattern follows {@link ProducerWrapper} which uses the same Lombok delegate approach.
+ *
+ * @see <a href="https://github.com/confluentinc/parallel-consumer/issues/857">#857</a>
+ */
+@Slf4j
+@RequiredArgsConstructor
+class ThreadConfinedConsumer<K, V> implements Consumer<K, V> {
+
+    private final AtomicReference<ConsumerOwnership> ownership =
+            new AtomicReference<>(ConsumerOwnership.UNCLAIMED);
+
+    @NonNull
+    @Delegate(excludes = ThreadUnsafeMethods.class)
+    private final Consumer<K, V> delegate;
+
+    /**
+     * Claim this consumer for the current thread. After this call, any consumer method
+     * (except wakeup) called from a different thread will throw IllegalStateException.
+     */
+    void claimOwnership() {
+        Thread current = Thread.currentThread();
+        ConsumerOwnership previous = ownership.getAndSet(ConsumerOwnership.ownedBy(current));
+        Thread previousOwner = previous.isOwnedBySomeoneOtherThan(current) ? previous.owner() : null;
+        if (previousOwner != null && previousOwner != current) {
+            // claimOwnership is the poll thread's start-of-life claim; a live previous owner here
+            // means two poll loops share one consumer, which the guard exists to catch. Log loudly
+            // rather than throw: throwing here would kill the new loop, not the misuse.
+            log.warn("Consumer ownership claimed by thread '{}' but was still held by thread '{}' (alive:{}) - " +
+                            "two components polling one consumer? See confluentinc#857.",
+                    current.getName(), previousOwner.getName(), previousOwner.isAlive());
+        } else {
+            log.debug("Consumer ownership claimed by thread: {}", current.getName());
+        }
+    }
+
+    /**
+     * Release ownership. Called by the owning thread once it has permanently finished with the
+     * consumer (poll loop exit - normal or by exception), making the consumer claimable by the
+     * thread that performs the final {@link #close()}. No-op with a warning if the caller is not
+     * the owner: releasing on another thread's behalf would silently disarm the guard.
+     */
+    void releaseOwnership() {
+        Thread current = Thread.currentThread();
+        ConsumerOwnership witness = ownership.get();
+        if (witness.isOwnedBy(current) && ownership.compareAndSet(witness, ConsumerOwnership.RELEASED)) {
+            log.debug("Consumer ownership released by thread: {}", current.getName());
+        } else {
+            log.warn("Thread '{}' tried to release consumer ownership it does not hold (owner: {})",
+                    current.getName(), ownership.get());
+        }
+    }
+
+    /**
+     * Attempt to claim ownership for the current thread <b>without stealing</b>: succeeds only when
+     * the consumer is unclaimed, or the caller already owns it. Used by the closing thread after
+     * the poll loop has released - if the poll loop is still running (e.g. {@code closeAndWait}
+     * timed out and close proceeded anyway), the claim fails and the subsequent guarded call
+     * throws, exactly as before this method existed.
+     *
+     * @return true if the current thread owns the consumer after this call
+     */
+    boolean tryClaimOwnership() {
+        Thread current = Thread.currentThread();
+        while (true) {
+            ConsumerOwnership witness = ownership.get();
+            if (!witness.isClaimable()) {
+                if (witness.isOwnedBy(current)) {
+                    return true; // idempotent for the owner
+                }
+                log.debug("Thread '{}' could not take over consumer ownership - still held by {}",
+                        current.getName(), witness);
+                return false; // never steal from a live owner
+            }
+            // UNCLAIMED (never started) or RELEASED (poll loop finished) - both claimable
+            if (ownership.compareAndSet(witness, ConsumerOwnership.ownedBy(current))) {
+                log.debug("Consumer ownership taken over by thread: {}", current.getName());
+                return true;
+            }
+            // lost a race against another claimer; re-read and decide again
+        }
+    }
+
+
+
+    private void checkThread(String methodName) {
+        Thread current = Thread.currentThread();
+        ConsumerOwnership witness = this.ownership.get();
+        // RELEASED means the previous owner has finished but nobody has taken over yet. Direct use
+        // there is exactly the gap a two-state guard could not see.
+        boolean illegal = witness.isOwnedBySomeoneOtherThan(current) || witness.isReleased();
+        if (illegal) {
+            String msg = "Consumer." + methodName + "() called from thread '" +
+                    current.getName() + "' (id:" + current.getId() +
+                    ") but consumer ownership is " + witness +
+                    ". Only wakeup() is thread-safe. See confluentinc#857.";
+            log.error(msg);
+            throw new IllegalStateException(msg);
+        }
+        // Guarded because this runs on EVERY delegated consumer call, poll() included. Three
+        // arguments means SLF4J's varargs overload, which allocates an Object[] per call even with
+        // trace disabled - the one place this guard's "costs nothing when it never fires" is not
+        // literally true. The check itself is a currentThread(), an AtomicReference read and two
+        // comparisons, which is noise against any real consumer call.
+        if (log.isTraceEnabled()) {
+            log.trace("Consumer.{}() on thread '{}' (ownership: {})", methodName, current.getName(), witness);
+        }
+    }
+
+    // --- Thread-unsafe method overrides (all check thread before delegating) ---
+
+    @Override
+    public ConsumerRecords<K, V> poll(Duration timeout) {
+        checkThread("poll");
+        return delegate.poll(timeout);
+    }
+
+    @Override
+    public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+        checkThread("commitSync");
+        delegate.commitSync(offsets);
+    }
+
+    @Override
+    public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+        checkThread("commitSync");
+        delegate.commitSync(offsets, timeout);
+    }
+
+    @Override
+    public void commitSync() {
+        checkThread("commitSync");
+        delegate.commitSync();
+    }
+
+    @Override
+    public void commitSync(Duration timeout) {
+        checkThread("commitSync");
+        delegate.commitSync(timeout);
+    }
+
+    @Override
+    public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+        checkThread("commitAsync");
+        delegate.commitAsync(offsets, callback);
+    }
+
+    @Override
+    public void commitAsync(OffsetCommitCallback callback) {
+        checkThread("commitAsync");
+        delegate.commitAsync(callback);
+    }
+
+    @Override
+    public void commitAsync() {
+        checkThread("commitAsync");
+        delegate.commitAsync();
+    }
+
+    @Override
+    public Set<TopicPartition> assignment() {
+        checkThread("assignment");
+        return delegate.assignment();
+    }
+
+    @Override
+    public void pause(Collection<TopicPartition> partitions) {
+        checkThread("pause");
+        delegate.pause(partitions);
+    }
+
+    @Override
+    public Set<TopicPartition> paused() {
+        checkThread("paused");
+        return delegate.paused();
+    }
+
+    @Override
+    public void resume(Collection<TopicPartition> partitions) {
+        checkThread("resume");
+        delegate.resume(partitions);
+    }
+
+    @Override
+    public ConsumerGroupMetadata groupMetadata() {
+        checkThread("groupMetadata");
+        return delegate.groupMetadata();
+    }
+
+    @Override
+    public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
+        checkThread("subscribe");
+        delegate.subscribe(topics, callback);
+    }
+
+    @Override
+    public void subscribe(Collection<String> topics) {
+        checkThread("subscribe");
+        delegate.subscribe(topics);
+    }
+
+    @Override
+    public void subscribe(Pattern pattern, ConsumerRebalanceListener callback) {
+        checkThread("subscribe");
+        delegate.subscribe(pattern, callback);
+    }
+
+    @Override
+    public void subscribe(Pattern pattern) {
+        checkThread("subscribe");
+        delegate.subscribe(pattern);
+    }
+
+    @Override
+    public void close() {
+        checkThread("close");
+        delegate.close();
+    }
+
+    @Override
+    public void close(Duration timeout) {
+        checkThread("close");
+        delegate.close(timeout);
+    }
+
+    // --- wakeup() is intentionally NOT overridden ---
+    // Lombok @Delegate generates the passthrough: delegate.wakeup()
+    // This is correct — wakeup() is the one thread-safe Consumer method.
+
+    /**
+     * Excludes interface for Lombok @Delegate. Methods listed here are NOT auto-delegated;
+     * we override them above with thread-safety checks.
+     * <p>
+     * Note: method signatures must match the Consumer interface exactly for Lombok to exclude them.
+     */
+    @SuppressWarnings("unused")
+    private interface ThreadUnsafeMethods<K, V> {
+        ConsumerRecords<K, V> poll(Duration timeout);
+        void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets);
+        void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout);
+        void commitSync();
+        void commitSync(Duration timeout);
+        void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback);
+        void commitAsync(OffsetCommitCallback callback);
+        void commitAsync();
+        Set<TopicPartition> assignment();
+        void pause(Collection<TopicPartition> partitions);
+        Set<TopicPartition> paused();
+        void resume(Collection<TopicPartition> partitions);
+        ConsumerGroupMetadata groupMetadata();
+        void subscribe(Collection<String> topics, ConsumerRebalanceListener callback);
+        void subscribe(Collection<String> topics);
+        void subscribe(java.util.regex.Pattern pattern, ConsumerRebalanceListener callback);
+        void subscribe(java.util.regex.Pattern pattern);
+        void close();
+        void close(Duration timeout);
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerCloseOwnershipTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerCloseOwnershipTest.java
@@ -1,0 +1,121 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link ConsumerManager#close(Duration)} under a live consumer owner - the SHUTDOWN PATH, one level
+ * above {@link ThreadConfinedConsumerTest}.
+ * <p>
+ * That test covers the guard primitive: {@code tryClaimOwnership} refuses to steal, and a guarded
+ * {@code close()} then throws without closing the delegate. This one covers the caller that actually
+ * runs at shutdown, because the primitive being correct does not establish that the close SEQUENCE
+ * uses it correctly - {@code ConsumerManager.close} waits out pending requests, then claims, then
+ * closes, and the claim's result governs whether that last step can legally happen.
+ * <p>
+ * The case is not hypothetical. It is reached whenever {@code brokerPollSubsystem.closeAndWait()}
+ * times out or throws and the close sequence proceeds anyway: teardown runs in a {@code finally} that
+ * executes even though the poll thread was never joined.
+ * <p>
+ * The write-up naming this the two-threads-one-consumer commit seam arrives with the
+ * confluentinc#857 work rather than with this change - cited by topic rather than by path, because
+ * a path that does not resolve on the branch it is read from is worse than no citation.
+ * <p>
+ * <b>What must hold, and why each matters:</b>
+ * <ol>
+ *   <li><b>The delegate consumer is NOT closed</b> while another thread owns it. This is the safety
+ *   property; everything else is reporting. Closing a consumer another thread is polling is the data
+ *   race the ownership guard exists to prevent.</li>
+ *   <li><b>The refusal is loud.</b> It throws rather than returning quietly, because
+ *   {@code doClose} catches it and that catch is where the user is told the consequence - no
+ *   LeaveGroup, so the group's next rebalance waits out {@code session.timeout.ms}. A silent skip
+ *   would leave the member gone with nobody told why the group stalled.</li>
+ *   <li><b>An unowned consumer still closes normally</b> - the guard must not break the happy path,
+ *   which is the ordinary shutdown every user hits.</li>
+ * </ol>
+ */
+class ConsumerManagerCloseOwnershipTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(1);
+
+    private MockConsumer<String, String> delegate;
+    private ThreadConfinedConsumer<String, String> confined;
+    private ConsumerManager<String, String> manager;
+    private ExecutorService other;
+
+    @BeforeEach
+    void setup() {
+        delegate = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        confined = new ThreadConfinedConsumer<>(delegate);
+        manager = new ConsumerManager<>(confined, TIMEOUT, TIMEOUT, TIMEOUT);
+        other = Executors.newSingleThreadExecutor(r -> new Thread(r, "test-foreign-owner"));
+    }
+
+    @AfterEach
+    void teardown() throws InterruptedException {
+        other.shutdownNow();
+        other.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * The poll thread is still alive and owns the consumer - the closeAndWait-timed-out case. The
+     * manager must refuse, and above all must leave the delegate open.
+     */
+    @Test
+    void closeRefusesAndLeavesTheConsumerOpenWhenAnotherThreadStillOwnsIt() throws Exception {
+        onOtherThread(() -> confined.claimOwnership());
+
+        assertThrows(IllegalStateException.class, () -> manager.close(TIMEOUT));
+
+        // the property that matters: the live owner's consumer survived the attempt
+        assertThat(delegate.closed()).isFalse();
+    }
+
+    /**
+     * The ordinary shutdown: the poll loop has released (or never claimed), so the closing thread
+     * takes over and the consumer closes. Without this, the test above would pass just as well
+     * against a guard that refused everything.
+     */
+    @Test
+    void closeSucceedsWhenNobodyOwnsTheConsumer() {
+        assertDoesNotThrow(() -> manager.close(TIMEOUT));
+
+        assertThat(delegate.closed()).isTrue();
+    }
+
+    /**
+     * A released owner is the normal handoff at shutdown - the poll loop exited and released in its
+     * {@code finally}, and the closing thread claims what it left behind.
+     */
+    @Test
+    void closeSucceedsAfterTheOwnerReleases() throws Exception {
+        onOtherThread(() -> {
+            confined.claimOwnership();
+            confined.releaseOwnership();
+        });
+
+        assertDoesNotThrow(() -> manager.close(TIMEOUT));
+
+        assertThat(delegate.closed()).isTrue();
+    }
+
+    private void onOtherThread(Runnable work) throws Exception {
+        other.submit(work).get(5, TimeUnit.SECONDS);
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerCloseOwnershipTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerCloseOwnershipTest.java
@@ -4,16 +4,10 @@ package bz.stub.parallelconsumer.internal;
  * Copyright (C) 2026 Antony Stubbs and contributors
  */
 
-import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -50,27 +44,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *   which is the ordinary shutdown every user hits.</li>
  * </ol>
  */
-class ConsumerManagerCloseOwnershipTest {
+class ConsumerManagerCloseOwnershipTest extends ThreadConfinedConsumerTestBase {
 
     private static final Duration TIMEOUT = Duration.ofSeconds(1);
 
-    private MockConsumer<String, String> delegate;
-    private ThreadConfinedConsumer<String, String> confined;
     private ConsumerManager<String, String> manager;
-    private ExecutorService other;
 
     @BeforeEach
-    void setup() {
-        delegate = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-        confined = new ThreadConfinedConsumer<>(delegate);
+    void wrapTheConfinedConsumerInAManager() {
         manager = new ConsumerManager<>(confined, TIMEOUT, TIMEOUT, TIMEOUT);
-        other = Executors.newSingleThreadExecutor(r -> new Thread(r, "test-foreign-owner"));
-    }
-
-    @AfterEach
-    void teardown() throws InterruptedException {
-        other.shutdownNow();
-        other.awaitTermination(5, TimeUnit.SECONDS);
     }
 
     /**
@@ -113,9 +95,5 @@ class ConsumerManagerCloseOwnershipTest {
         assertDoesNotThrow(() -> manager.close(TIMEOUT));
 
         assertThat(delegate.closed()).isTrue();
-    }
-
-    private void onOtherThread(Runnable work) throws Exception {
-        other.submit(work).get(5, TimeUnit.SECONDS);
     }
 }

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerCommitRetryBudgetTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerCommitRetryBudgetTest.java
@@ -95,7 +95,7 @@ class ConsumerManagerCommitRetryBudgetTest {
             }
         };
 
-        var consumerManager = new ConsumerManager<>(mockConsumer,
+        var consumerManager = new ConsumerManager<>(new ThreadConfinedConsumer<>(mockConsumer),
                 COMMIT_BUDGET,
                 Duration.ofSeconds(30), // sasl budget - not under test, kept clear of the commit budget
                 Duration.ofMillis(10));
@@ -146,7 +146,7 @@ class ConsumerManagerCommitRetryBudgetTest {
             }
         };
 
-        var consumerManager = new ConsumerManager<>(mockConsumer, budget,
+        var consumerManager = new ConsumerManager<>(new ThreadConfinedConsumer<>(mockConsumer), budget,
                 Duration.ofSeconds(30), Duration.ofMillis(10));
 
         var thrown = assertThrows(OffsetCommitBudgetExceededException.class,
@@ -180,7 +180,7 @@ class ConsumerManagerCommitRetryBudgetTest {
             }
         };
 
-        var consumerManager = new ConsumerManager<>(mockConsumer,
+        var consumerManager = new ConsumerManager<>(new ThreadConfinedConsumer<>(mockConsumer),
                 Duration.ofMinutes(5), // commit budget, deliberately generous - it must NOT be what ends this
                 saslBudget,
                 Duration.ofMillis(10)); // backoff between SASL retries

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerPauseCacheTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerPauseCacheTest.java
@@ -10,14 +10,14 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import pl.tlinkowski.unij.api.UniLists;
+import pl.tlinkowski.unij.api.UniMaps;
+import pl.tlinkowski.unij.api.UniSets;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.truth.Truth.assertThat;
-import pl.tlinkowski.unij.api.UniLists;
-import pl.tlinkowski.unij.api.UniMaps;
-import pl.tlinkowski.unij.api.UniSets;
 
 /**
  * {@link ConsumerManager#getPausedPartitionSize()} must describe the pause state of the poll that is

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerPauseCacheTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ConsumerManagerPauseCacheTest.java
@@ -1,0 +1,77 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.truth.Truth.assertThat;
+import pl.tlinkowski.unij.api.UniLists;
+import pl.tlinkowski.unij.api.UniMaps;
+import pl.tlinkowski.unij.api.UniSets;
+
+/**
+ * {@link ConsumerManager#getPausedPartitionSize()} must describe the pause state of the poll that is
+ * <b>currently in flight</b>, because its one non-diagnostic reader acts during exactly that window:
+ * the control thread's back-pressure wakeup
+ * ({@code AbstractParallelEoSStreamProcessor#maybeWakeupPoller} via
+ * {@code BrokerPollSystem#isSubscriptionsPausedForBackPressure}) fires only while the poll thread is
+ * asleep inside a paused long poll, and only if the cache says "paused".
+ * <p>
+ * The poll loop pauses the subscription immediately BEFORE calling {@code poll()}
+ * ({@code BrokerPollSystem#checkStateForPausingSubscriptions}), so a cache refreshed only AFTER
+ * {@code poll()} returns always reports the pause one poll late: it reads "not paused" for the whole
+ * of the paused sleep. The control thread then never wakes the poller, the paused long poll runs its
+ * full timeout with the pipeline drained, and ingestion degrades to one burst per long-poll timeout -
+ * the 4-10x transactional throughput regression diagnosed on the confluentinc#857 branch
+ * (astubbs/parallel-consumer#29). The cache must therefore be refreshed on ENTRY to
+ * {@link ConsumerManager#poll(Duration)}, after the caller's pause/resume decision, as well as on
+ * exit (the exit refresh is what keeps assignment and group metadata current across a rebalance,
+ * which happens inside {@code poll()}).
+ */
+@Slf4j
+@Timeout(30)
+class ConsumerManagerPauseCacheTest {
+
+    private static final TopicPartition TP = new TopicPartition("ConsumerManagerPauseCacheTest", 0);
+    private static final Duration TIMEOUT = Duration.ofSeconds(1);
+
+    /**
+     * Pause the subscription after one completed poll (so the cache holds a stale "not paused"), then
+     * observe the cache from inside the next poll - the deterministic stand-in for the control
+     * thread's mid-poll read. {@link MockConsumer#schedulePollTask} runs the observation at the exact
+     * moment a paused long poll would be sleeping.
+     */
+    @Test
+    void pausedPartitionCacheIsFreshDuringThePollItDescribes() {
+        var mockConsumer = new MockConsumer<String, String>(OffsetResetStrategy.EARLIEST);
+        mockConsumer.updateBeginningOffsets(UniMaps.of(TP, 0L));
+        mockConsumer.assign(UniLists.of(TP));
+        var consumerManager = new ConsumerManager<>(new ThreadConfinedConsumer<>(mockConsumer),
+                TIMEOUT, TIMEOUT, TIMEOUT);
+
+        // a completed poll while unpaused - leaves the exit-refreshed cache reading "not paused"
+        consumerManager.poll(Duration.ofMillis(1));
+        assertThat(consumerManager.getPausedPartitionSize()).isEqualTo(0);
+
+        // the poll loop's pause decision, made between polls, exactly as managePauseOfSubscription does
+        consumerManager.pause(UniSets.of(TP));
+
+        // observed from within the following poll - the window in which maybeWakeupPoller decides
+        AtomicInteger pausedSizeSeenDuringPoll = new AtomicInteger(-1);
+        mockConsumer.schedulePollTask(() ->
+                pausedSizeSeenDuringPoll.set(consumerManager.getPausedPartitionSize()));
+        consumerManager.poll(Duration.ofMillis(1));
+
+        assertThat(pausedSizeSeenDuringPoll.get()).isEqualTo(1);
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumerTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumerTest.java
@@ -4,16 +4,9 @@ package bz.stub.parallelconsumer.internal;
  * Copyright (C) 2026 Antony Stubbs and contributors
  */
 
-import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -36,39 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *       would silently disarm the guard</li>
  * </ol>
  */
-class ThreadConfinedConsumerTest {
-
-    ThreadConfinedConsumer<String, String> confined;
-
-    MockConsumer<String, String> delegate;
-
-    ExecutorService otherThread;
-
-    @BeforeEach
-    void setup() {
-        delegate = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-        confined = new ThreadConfinedConsumer<>(delegate);
-        otherThread = Executors.newSingleThreadExecutor(runnable -> {
-            Thread thread = new Thread(runnable, "test-foreign-thread");
-            thread.setDaemon(true);
-            return thread;
-        });
-    }
-
-    @AfterEach
-    void teardown() {
-        otherThread.shutdownNow();
-    }
-
-    /** Runs the action on the foreign thread and rethrows anything it threw. */
-    private void onOtherThread(Runnable action) throws Exception {
-        try {
-            otherThread.submit(action).get(10, TimeUnit.SECONDS);
-        } catch (java.util.concurrent.ExecutionException e) {
-            if (e.getCause() instanceof Exception cause) throw cause;
-            throw e;
-        }
-    }
+class ThreadConfinedConsumerTest extends ThreadConfinedConsumerTestBase {
 
     @Test
     void unclaimedConsumerAllowsAnyThread() throws Exception {
@@ -84,7 +45,7 @@ class ThreadConfinedConsumerTest {
         onOtherThread(() -> {
             var thrown = assertThrows(IllegalStateException.class, () -> confined.close());
             assertThat(thrown).hasMessageThat().contains("close");
-            assertThat(thrown).hasMessageThat().contains("test-foreign-thread");
+            assertThat(thrown).hasMessageThat().contains(FOREIGN_THREAD_NAME);
         });
 
         // owner is unaffected

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumerTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumerTest.java
@@ -1,0 +1,180 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The ownership lifecycle of {@link ThreadConfinedConsumer}: claim, guarded use, release, and the
+ * non-stealing takeover the closing thread uses.
+ * <p>
+ * The load-bearing properties (see confluentinc#857 and the close-path incident this fixes -
+ * pc-control's {@code Consumer.close()} was rejected against a pc-broker-poll owner whose loop had
+ * already exited, so the consumer never closed and no LeaveGroup was sent):
+ * <ol>
+ *   <li>a foreign thread is rejected while the owner holds the claim - the guard's whole point</li>
+ *   <li>after the owner releases, another thread can take over and close - the sequential handoff
+ *       at shutdown is legal</li>
+ *   <li>{@link ThreadConfinedConsumer#tryClaimOwnership()} never steals from a live claim - a
+ *       close that races a still-running poll loop must still be rejected</li>
+ *   <li>a non-owner cannot release someone else's claim - releasing on another thread's behalf
+ *       would silently disarm the guard</li>
+ * </ol>
+ */
+class ThreadConfinedConsumerTest {
+
+    ThreadConfinedConsumer<String, String> confined;
+
+    MockConsumer<String, String> delegate;
+
+    ExecutorService otherThread;
+
+    @BeforeEach
+    void setup() {
+        delegate = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        confined = new ThreadConfinedConsumer<>(delegate);
+        otherThread = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "test-foreign-thread");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    @AfterEach
+    void teardown() {
+        otherThread.shutdownNow();
+    }
+
+    /** Runs the action on the foreign thread and rethrows anything it threw. */
+    private void onOtherThread(Runnable action) throws Exception {
+        try {
+            otherThread.submit(action).get(10, TimeUnit.SECONDS);
+        } catch (java.util.concurrent.ExecutionException e) {
+            if (e.getCause() instanceof Exception cause) throw cause;
+            throw e;
+        }
+    }
+
+    @Test
+    void unclaimedConsumerAllowsAnyThread() throws Exception {
+        // init-time calls (subscribe etc.) happen before any claim, from arbitrary threads
+        assertDoesNotThrow(() -> confined.assignment());
+        onOtherThread(() -> assertDoesNotThrow(() -> confined.assignment()));
+    }
+
+    @Test
+    void foreignThreadRejectedWhileClaimHeld() throws Exception {
+        confined.claimOwnership();
+
+        onOtherThread(() -> {
+            var thrown = assertThrows(IllegalStateException.class, () -> confined.close());
+            assertThat(thrown).hasMessageThat().contains("close");
+            assertThat(thrown).hasMessageThat().contains("test-foreign-thread");
+        });
+
+        // owner is unaffected
+        assertDoesNotThrow(() -> confined.assignment());
+    }
+
+    @Test
+    void closingThreadCanTakeOverAfterOwnerReleases() throws Exception {
+        // simulate the poll thread's life on the foreign thread: claim, use, release on loop exit
+        onOtherThread(() -> {
+            confined.claimOwnership();
+            confined.assignment();
+            confined.releaseOwnership();
+        });
+
+        // the closing thread takes over and closes - the shutdown handoff that was being rejected
+        assertThat(confined.tryClaimOwnership()).isTrue();
+        assertDoesNotThrow(() -> confined.close(Duration.ofSeconds(1)));
+        assertThat(delegate.closed()).isTrue();
+
+        // and the takeover re-arms the guard for the new owner
+        onOtherThread(() ->
+                assertThrows(IllegalStateException.class, () -> confined.assignment()));
+    }
+
+    @Test
+    void tryClaimNeverStealsFromLiveOwner() throws Exception {
+        onOtherThread(() -> confined.claimOwnership());
+
+        // the closeAndWait-timed-out case: poll loop still holds the claim - close must NOT proceed
+        assertThat(confined.tryClaimOwnership()).isFalse();
+        assertThrows(IllegalStateException.class, () -> confined.close());
+        assertThat(delegate.closed()).isFalse();
+    }
+
+    @Test
+    void tryClaimIsIdempotentForCurrentOwner() {
+        confined.claimOwnership();
+        assertThat(confined.tryClaimOwnership()).isTrue();
+        assertDoesNotThrow(() -> confined.assignment());
+    }
+
+    @Test
+    void nonOwnerCannotReleaseSomeoneElsesClaim() throws Exception {
+        confined.claimOwnership();
+
+        onOtherThread(() -> {
+            confined.releaseOwnership(); // must be a warning no-op, not a disarm
+            assertThrows(IllegalStateException.class, () -> confined.assignment());
+        });
+    }
+
+    /**
+     * The hole a two-state guard could not see: after the poll loop releases and before the closing
+     * thread takes over, ownership is RELEASED - not "unclaimed". Direct use in that window is
+     * illegal for <em>every</em> thread, including the thread that used to own it.
+     */
+    @Test
+    void releasedOwnershipDeniesDirectUseByEveryThread() throws Exception {
+        onOtherThread(() -> {
+            confined.claimOwnership();
+            confined.releaseOwnership();
+            // the previous owner has finished with it - it may not carry on using it either
+            assertThrows(IllegalStateException.class, () -> confined.assignment());
+        });
+
+        // ...and no other thread may simply pick it up by calling
+        assertThrows(IllegalStateException.class, () -> confined.assignment());
+    }
+
+    /**
+     * RELEASED admits exactly one move: a claim. This is what separates it from UNCLAIMED, where
+     * every call is allowed so that init-time work (subscribe, etc.) can run before the poll loop.
+     */
+    @Test
+    void releasedOwnershipAdmitsAClaimAndOnlyThenUse() throws Exception {
+        onOtherThread(() -> {
+            confined.claimOwnership();
+            confined.releaseOwnership();
+        });
+
+        assertThrows(IllegalStateException.class, () -> confined.assignment());
+        assertThat(confined.tryClaimOwnership()).isTrue();
+        assertDoesNotThrow(() -> confined.assignment());
+    }
+
+    @Test
+    void wakeupAllowedFromAnyThread() throws Exception {
+        confined.claimOwnership();
+        // the one documented thread-safe Consumer method must stay reachable cross-thread
+        onOtherThread(() -> assertDoesNotThrow(() -> confined.wakeup()));
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumerTestBase.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumerTestBase.java
@@ -1,0 +1,72 @@
+package bz.stub.parallelconsumer.internal;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The two-threads-one-consumer fixture every ownership test needs: a {@link MockConsumer} behind a
+ * {@link ThreadConfinedConsumer}, and one named foreign thread to play the other party.
+ * <p>
+ * Shared rather than repeated because the guard's whole subject is <em>which thread</em> called, so
+ * every test of it needs a second thread it can name - and two independent copies of that fixture had
+ * already drifted: only one of them unwrapped {@link ExecutionException}, so an assertion failing on
+ * the foreign thread surfaced in the other as a wrapper naming neither the assertion nor the thread.
+ *
+ * @see <a href="https://github.com/confluentinc/parallel-consumer/issues/857">#857</a>
+ */
+abstract class ThreadConfinedConsumerTestBase {
+
+    /**
+     * The foreign thread's name. A constant because the guard's rejection message must carry the
+     * offending thread's name, and a test asserting that should not restate the literal.
+     */
+    static final String FOREIGN_THREAD_NAME = "test-foreign-thread";
+
+    MockConsumer<String, String> delegate;
+
+    ThreadConfinedConsumer<String, String> confined;
+
+    private ExecutorService foreignThread;
+
+    @BeforeEach
+    void setUpConfinedConsumerFixture() {
+        delegate = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+        confined = new ThreadConfinedConsumer<>(delegate);
+        foreignThread = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, FOREIGN_THREAD_NAME);
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    @AfterEach
+    void tearDownConfinedConsumerFixture() throws InterruptedException {
+        foreignThread.shutdownNow();
+        foreignThread.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Runs {@code action} on the foreign thread and waits for it, rethrowing whatever it threw rather
+     * than the {@link ExecutionException} wrapper - an assertion that fails over there has to fail the
+     * test over here, naming its own cause.
+     */
+    void onOtherThread(Runnable action) throws Exception {
+        try {
+            foreignThread.submit(action).get(10, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof Exception cause) throw cause;
+            throw e;
+        }
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumerTestBase.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/ThreadConfinedConsumerTestBase.java
@@ -40,9 +40,20 @@ abstract class ThreadConfinedConsumerTestBase {
     private ExecutorService foreignThread;
 
     @BeforeEach
-    void setUpConfinedConsumerFixture() {
+    void setUpConfinedConsumerFixture() throws InterruptedException {
         delegate = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
         confined = new ThreadConfinedConsumer<>(delegate);
+        // Stop whatever is already here before the field stops pointing at it. JUnit runs the
+        // teardown below between tests so this cannot fire today, and the threads are daemons so a
+        // leaked pool could not hold a JVM open either - but overwriting a live ExecutorService
+        // field is a leak shape regardless of who currently guarantees it cannot happen, and
+        // fb-contrib reports it here (HES_EXECUTOR_OVERWRITTEN_WITHOUT_SHUTDOWN). Not having the
+        // shape costs three lines; the only sanctioned alternative is switching the rule off for the
+        // whole repository, which docs/inflight/static-spotbugs-rule-registry.md prices far higher.
+        if (foreignThread != null) {
+            foreignThread.shutdownNow();
+            foreignThread.awaitTermination(5, TimeUnit.SECONDS);
+        }
         foreignThread = Executors.newSingleThreadExecutor(runnable -> {
             Thread thread = new Thread(runnable, FOREIGN_THREAD_NAME);
             thread.setDaemon(true);


### PR DESCRIPTION
Extracted from astubbs/parallel-consumer#29 and cut fresh from master, where it compiles and passes
on its own. That PR's own decomposition plan called for this split and said why: this is the largest
piece of it by main-code volume, and its shape is a design decision about consumer ownership rather
than a patch, so it earns review separate from the lock fix it has been travelling with.

## Description

**`KafkaConsumer` is not thread safe, and this codebase runs two long-lived threads near it.**
`ThreadConfinedConsumer` wraps the consumer and refuses any call from a thread that does not own it.
`ConsumerOwnership` makes that a **lifecycle** rather than a one-shot flag: the poll thread claims at
start of life, releases when the poll loop exits, and a closing thread may claim only what is
unclaimed or already its own.

**Never stealing is the point.** A guard that let close bypass the check would legalise closing
mid-poll, which is the failure it exists to prevent.

### What ships here is the guard INSTALLED, not the guard GUARDING

Say this plainly, because the paragraphs above read as though the wrapper is already refusing calls,
and on this branch it is not.

`AbstractParallelEoSStreamProcessor` still holds and calls the **raw** consumer from
`options.getConsumer()`, and nothing calls `claimConsumerOwnership()`. Ownership therefore never
leaves `UNCLAIMED`, whose documented meaning is that **every thread is allowed** - so no call is
refused at runtime, on any path, today. What this PR delivers is the wrapper, the ownership
lifecycle, their tests, and a seam that is correct and ready.

That is deliberate and it matches where the enforcement lives: the `ArchitectureTest` rule that
pins the invariant stays on astubbs/parallel-consumer#29, and the claim call is wired there. It is
recorded here so a reviewer does not approve this as a shipped protection, and so nobody later reads
the unwired seam as an oversight and removes it.

### Why this is separate from the deadlock fix

The measured claim on astubbs/parallel-consumer#29 is about roughly twenty lines of lock change - a
revoke path that declines with `tryLock()` instead of blocking - verified by a four-cell control
across both rebalance assignors. **That control never measured this code.** Reviewed together, the
verification of one invites being read as evidence for the other. They are independent in fact: the
deadlock fix references this wrapper only in comments and compiles without it.

### It carries a regression it caused, and the test that proves it

Restructuring `ConsumerManager` for thread confinement replaced a per-poll `updateCache()` at poll
**entry** with one-time priming in `init()`. That left the pause cache written only when a poll
*ended* - so during every paused long poll, the control thread's back-pressure wakeup read the
previous poll's "not paused" value, never fired, and each pause cost a full long-poll timeout with
the pipeline drained. Measured as a four- to tenfold transactional throughput collapse that read as a
flaky CI lane for weeks.

The entry refresh is restored here, deliberately **before** `pollingBroker.set(true)` rather than
after it as on master, so `wakeup()` cannot reach the consumer while those calls run - preserving the
thread-confinement property this change exists for.

**`ConsumerManagerPauseCacheTest` is red-proven on this branch, not assumed.** Removing the entry
refresh fails it with `expected: 1`; restoring it passes. `MockConsumer.schedulePollTask` observes
the cache from *inside* the poll it describes, so the test is deterministic - no timeouts, no
concurrency.

That the fix ships beside the code that caused it is the argument for this split rather than an
awkwardness of it.

### Verification

- All 16 tests across the four suites pass on master with only these files added
- `main` and `test-compile` clean
- `bin/check-all.sh` - every gate passes
- The regression test demonstrated failing before it was trusted passing

### What deliberately did not come with it

- **`ArchitectureTest` stays on astubbs/parallel-consumer#29.** It holds this work's
  consumer-holder allowlist *and* that branch's rebalance-blocking rule; splitting a shared file
  drags unrelated work whichever way it is cut.
- **The docs stayed too, and the reason is worth stating.** One test cited a solution write-up on
  that branch; following the citation pulled in a plan, then two inflight notes, then `bin/` scripts.
  A cascade that does not terminate is the tell that those documents are that PR's interconnected
  research trail rather than this change's rationale. The citation now names the topic instead of a
  path, because a path that does not resolve on the branch it is read from is worse than no citation.
  The gate's escape hatch was not used.

### Two things arrived after review, and one of them is unrelated to the subject

**Answering the review at the code.** The automated review read the two `ConsumerManager.subscribe`
overloads as dead code. It was right that nothing calls them and right that nothing *at the code*
said so - the "guard INSTALLED" section above is where that fact lived, and a PR body is not where
the next reader of `ConsumerManager` looks. The review reaching exactly the conclusion that section
exists to prevent is the evidence a body-only note was not enough, so the reasoning now sits on the
methods. The review's second finding, that `init()`'s javadoc offered an example its catch cannot
actually see, was a real inaccuracy and is corrected. Both are comments only.

**A SpotBugs finding on a line this branch wrote**, which the review did not reach:
`bin/check-pr-analysis-surfaces.sh` reported `HES_EXECUTOR_OVERWRITTEN_WITHOUT_SHUTDOWN` on the
`foreignThread` assignment in `ThreadConfinedConsumerTestBase`. The static lane is non-gating, so it
was green and silent. The fixture now shuts down what it is about to drop, chosen over the
rule-registry route because suppressing by rule would switch `HES` off repo-wide. That section of
the report now reads `none`.

**Unrelated to this change, and deliberately here anyway:** the Unit Tests lane went red once on
`ReactorBatchTest.simpleBatchTest` under KEY ordering - a known, already-tracked, still-undiagnosed
flake, green on re-run. It is recorded as a fourth sighting in
`docs/inflight/test-untracked-ci-flakes.md`, which is the one file in this diff that has nothing to
do with consumer ownership. It is here because that ledger's rule is to record a sighting before the
CI log carrying its evidence expires, and this one's evidence is worth keeping: the failing batch
payload shows the same three-way key collision as the 2026-08-25 sighting, in a different module,
which promotes the ledger's untested expectation-versus-input reading to the leading one.

## Checklist

- [x] Docs updated - the ownership lifecycle, the never-steal rule and the cache-refresh placement
      all carry their reasoning in javadoc at the point of use
- [x] N/A - internal thread-safety enforcement; no user-facing feature to document under
      `docs/features/`
- [x] Tests added/updated - `ThreadConfinedConsumerTest`, `ConsumerManagerCloseOwnershipTest`,
      `ConsumerManagerPauseCacheTest` (red-proven), and `ConsumerManagerCommitRetryBudgetTest`
      updated for the wrapped constructor
- [x] Title & body reflect the final content of this PR
- [x] N/A - asking for `@claude review this` on the PR instead, which is the route that can open
      inline review threads


