### PR TITLE
fix(bin): close the last grep -c no-match fallback before a caller reaches it

### DIFF
--- a/bin/lib/quarantine-common.sh
+++ b/bin/lib/quarantine-common.sh
@@ -31,8 +31,20 @@ quarantined_files() {
 }
 
 # Count of annotation usages in one file.
+#
+# NOT `|| echo 0`: grep -c PRINTS 0 and EXITS 1 when nothing matches, so the fallback appends a
+# SECOND line and the caller captures "0\n0". check-quarantine-registry.sh then dies on
+# `[ "$entries" -ne "$count" ]` with "integer expression expected", and check-quarantine-owners.sh
+# silently compares a two-line string against "1" and never matches. Assign on failure instead.
+#
+# Unreachable from today's callers, which only pass files quarantined_files() already matched - so
+# this is a latent defect being closed, not an outage. bin/check-inflight-tags.sh carries the same
+# idiom and the same warning; that it was written there and reintroduced elsewhere is the argument
+# for fixing every instance rather than the one that bites.
 quarantined_occurrences() {
-    grep -cE "$QUARANTINE_ANNOTATION_ERE" "$1" 2>/dev/null || echo 0
+    local n
+    n=$(grep -cE "$QUARANTINE_ANNOTATION_ERE" "$1" 2>/dev/null) || n=0
+    printf '%s' "${n:-0}"
 }
 
 # The human-readable audit listing: every annotation usage with the following lines that carry its

--- a/bin/test-check-quarantine-registry.sh
+++ b/bin/test-check-quarantine-registry.sh
@@ -140,6 +140,32 @@ assert "the PREVIOUS implementation does leak the .git copy" YES \
 assert "the PREVIOUS implementation already excluded target" NO \
     "$(contains "$old" "target/generated-sources/Generated.java")"
 
+echo "--- quarantined_occurrences: a file with no match must count 0, on ONE line ---"
+
+# The bug this covers is invisible to a string comparison that happens to fail anyway, so assert the
+# exact bytes and then assert that a numeric test survives them - which is how the callers use it.
+no_match_file=$(mktemp)
+printf 'class NothingQuarantinedHere {}\n' > "$no_match_file"
+
+assert "no match counts exactly 0" "0" "$(quarantined_occurrences "$no_match_file")"
+
+numeric_ok=NO
+if [ "$(quarantined_occurrences "$no_match_file")" -eq 0 ] 2>/dev/null; then numeric_ok=YES; fi
+assert "the result survives a numeric test" YES "$numeric_ok"
+
+# Negative control, in this file's established style: the shipped-before implementation must fail
+# both, or the fixture has stopped reaching the defect and the two assertions above are vacuous.
+previous_occurrences() { grep -cE "$QUARANTINE_ANNOTATION_ERE" "$1" 2>/dev/null || echo 0; }
+
+assert "the PREVIOUS implementation returns two lines" "$(printf '0\n0')" \
+    "$(previous_occurrences "$no_match_file")"
+
+old_numeric_ok=NO
+if [ "$(previous_occurrences "$no_match_file")" -eq 0 ] 2>/dev/null; then old_numeric_ok=YES; fi
+assert "the PREVIOUS implementation breaks a numeric test" NO "$old_numeric_ok"
+
+rm -f "$no_match_file"
+
 echo
 if [ "$failures" -gt 0 ]; then
     printf '%d quarantine-scan self-test(s) failed\n' "$failures" >&2


### PR DESCRIPTION
No issue: this was found by a defect-class sweep rather than reported, and citing a loosely related
one would be a misdirection.

## Description

`quarantined_occurrences()` in `bin/lib/quarantine-common.sh` counted with
`grep -cE ... || echo 0`. `grep -c` **prints `0` and exits 1** when nothing matches, so the fallback
appends a second line and the caller captures `"0\n0"`.

**It is latent, and it is being fixed anyway.** Both callers only pass files that
`quarantined_files()` has already matched, so the no-match branch never runs today. "Unreachable" is
a property of today's callers, though, not of the function - the next caller will not know. Had it
been reached:

- `check-quarantine-registry.sh` would have died on `[ "$entries" -ne "$count" ]` with
  `integer expression expected`;
- `check-quarantine-owners.sh` compares the result against `"1"` as a string, so it would have
  quietly stopped matching - a gate that stops enforcing without going red.

### Why this one earns its own PR

It is the **last live instance of a class this repo has already learned twice**.
`bin/check-inflight-tags.sh` carries the correct idiom *with a comment naming this exact trap*, and
new scripts reintroduced it anyway - five times, fixed on
astubbs/parallel-consumer#381. Fixing the instances that bit and leaving this one sets up a third
round, so it is cut from master rather than carried on that branch.

The sweep also **ruled out** every `|| true` variant it found (`check-action-versions.sh`,
`check-ossindex-audit.sh`, `rename-packages.sh`, `test-check-copyright-headers.sh`,
`ci-mutation-test.sh`): `|| true` replaces the exit status without appending a line, so the capture
is the single `0` grep printed. Those are not instances and are deliberately untouched.

### The test

`bin/test-check-quarantine-registry.sh` gains the case in **that file's own negative-control style**:
the fixed function must count `0` on one line and survive a numeric test, and the implementation
shipped before this commit must fail both. Without that second half the assertions could pass against
a fixture that no longer reaches the defect - the failure mode `bin/AGENTS.md` names as "a regression
test that has never failed proves nothing". Both halves are asserted and pass.

### Verification

- `bin/check-all.sh`: 15 ran, 15 passed, 0 failed.
- `bin/test-check-quarantine-registry.sh` and `bin/test-check-quarantine-owners.sh`: both green,
  including the four new assertions.
- The defect was reproduced directly before fixing (the helper returned two lines and the numeric
  test errored), not inferred from reading.

## Checklist

- [x] Docs updated - the reasoning lives in the function's own header comment, which is where the
      next person to touch it will read it; no `docs/` page describes this helper
- [x] `N/A` - user-facing feature documentation: internal build tooling, nothing user-visible
- [x] Tests added/updated
- [x] Title & body reflect the final content of this PR
- [x] `N/A - this fix IS the output of a ce-simplify-code defect-class sweep` run on
      astubbs/parallel-consumer#381; no separate local review was run on this branch, and I would
      rather spend the review as `@claude review this` on the PR, which is the only route that can
      open inline threads
