### PR TITLE
docs(inflight): rank the decisions the mirror triage left, and retire two that settled

### DIFF
--- a/docs/inflight/pr-mirror-fixes-and-what-they-close.md
+++ b/docs/inflight/pr-mirror-fixes-and-what-they-close.md
@@ -5,33 +5,15 @@
 
 Four of the mirrors swept in the 2026-08-20 triage already had a fix, so they were checked for a
 different thing than the other ten: does the PR actually close the issue, and if it deliberately does
-not, is that reasoning anywhere a reader will find it? Two need an edit. The companion note for the
-ten without fixes is [`upstream-mirror-bodies-are-stale.md`](upstream-mirror-bodies-are-stale.md).
+not, is that reasoning anywhere a reader will find it? The companion note for the ten without fixes is
+[`upstream-mirror-bodies-are-stale.md`](upstream-mirror-bodies-are-stale.md).
 
-## astubbs#201 should close astubbs#155, and does not say so
-
-The PR carries no closing reference, and its body describes itself as fixing "the log-noise half" of
-astubbs#155. That framing implies a remainder, and there is not one.
-
-Both the issue's own `## Fork status` and this PR's body say the other half - the stall - was already
-fixed by confluentinc#547 and confluentinc#606, and further by the confluentinc#857 family here
-(astubbs#119), with "nothing in this PR touches it". So once astubbs#201 lands, astubbs#155 has
-nothing open left in it.
-
-**Add `Fixes astubbs/parallel-consumer#155` to the body before merge.** Without it the issue outlives
-its own fix, and the next person to read it inherits the "half" framing and goes looking for the
-missing half.
-
-## astubbs#203 closes astubbs#169 and astubbs#170, in a form the convention forbids
-
-The links resolve, so GitHub will close both. But the body writes `Closes #169. Closes #170.` -
-bare - and [`docs/issue-references.md`](../issue-references.md) requires the fully qualified
-`owner/parallel-consumer#NN` for anything posted to GitHub, because that is the only form that both
-names the repo and auto-links. confluentinc#169 and confluentinc#170 both exist and mean other
-things, so a reader of that body is guessing.
-
-Cosmetic against the gate, which passes, and not cosmetic against a human. Worth correcting while the
-PR is open.
+Three of the four are settled. astubbs#201 now carries `Fixes astubbs/parallel-consumer#155`, and
+astubbs#203 carries `Closes astubbs/parallel-consumer#169. Closes astubbs/parallel-consumer#170.` in
+the qualified form the convention requires - both verified against GitHub's own resolved links, not
+the PR bodies alone. Confirm with `gh pr view <n> -R astubbs/parallel-consumer --json
+closingIssuesReferences` rather than trusting this sentence; the point of recording it is that the
+question was asked and answered, not the answer itself.
 
 ## astubbs#204 deliberately does not close astubbs#177, and that is right
 
@@ -41,13 +23,13 @@ astubbs#100 and astubbs#80 landed, astubbs#204 took the reporting and the retry 
 - an AB-BA deadlock between the poll and control threads on the commit path - is astubbs#29, still a
 draft whose fix has never been observed working.
 
-No change needed to the PR. **The gap is on the issue**, which has no comments at all, so the
-reasoning for why it survived its own fix exists only inside a merged PR body. Anyone scanning the
-tracker sees an open issue whose fix merged and draws the obvious wrong conclusion. The remaining
-scope is recorded here and in [`core-commit-failure-seam.md`](core-commit-failure-seam.md); it is
-not recorded where a reader of the issue will meet it.
+No change needed to the PR. **The gap is on the issue**, whose only comment is a heads-up about the
+`InternalRuntimeException` rename, so the reasoning for why it survived its own fix exists only inside
+a merged PR body. Anyone scanning the tracker sees an open issue whose fix merged and draws the
+obvious wrong conclusion. The remaining scope is recorded here and in
+[`core-commit-failure-seam.md`](core-commit-failure-seam.md); it is not recorded where a reader of the
+issue will meet it.
 
 ## Delete when
 
-astubbs#201 carries its closing reference, astubbs#203's is qualified, and astubbs#177 says on its
-own face what is left in it.
+astubbs#177 says on its own face what is left in it.

--- a/docs/inflight/process-candidate-ranking.md
+++ b/docs/inflight/process-candidate-ranking.md
@@ -3,6 +3,61 @@
 <!-- inflight-type: register -->
 
 
+## Decisions waiting on the maintainer, ranked
+
+**These outrank everything below, and the reason is cost rather than importance.** Each is a note
+whose engineering is already done or already unnecessary - what is left is one reply, and until it
+arrives the note cannot close and the work behind it cannot be scheduled. Ranked by how little input
+each needs, not by the size of what it unblocks: an item needing a yes/no beats one needing a policy,
+and a policy beats a bound that has to be argued for.
+
+They came out of the 2026-08-20 mirror triage, which produced one note per issue - each carrying the
+verification, the draft answer, and the collision list. **Do not re-derive any of it here**; the note
+named on each line owns it.
+
+1. **astubbs#161** (confluentinc#543), `upstream-161-reactor-scheduler-rationale.md` - the reply is
+   written and postable as-is, so the only decision is to post it and close. Two code findings ride
+   along that nothing else records: the scheduler supplier is resolved per wrapped invocation rather
+   than once, so a factory-shaped supplier leaks a `Scheduler` and its threads every batch, and the
+   two-argument `ReactorProcessor` constructor has no test.
+2. **astubbs#181** (confluentinc#862), `deps-181-java-24-compatibility.md` - close it on the
+   kafka-clients 3.9.2 rationale and let astubbs#128 carry the CI proof, or hold it open until that
+   lane exists. The note has the evidence and states the one caveat (`MockConsumer` cannot exercise
+   SASL, which is the path that broke).
+3. **astubbs#163** (confluentinc#550), `core-163-poll-path-has-no-error-seam.md` - post the drafted
+   answer, then close as a duplicate of astubbs#153 with astubbs#148 as the contained step. **This
+   one has a deadline the others do not**: it corrects open question 6 of the DLQ prior-art report on
+   astubbs#313, which currently assumes deserialization failures can ride along with the DLQ work.
+   They cannot, on the mechanism. Deciding DLQ requirements before this is answered settles them on a
+   false premise.
+4. **astubbs#189** (confluentinc#887), `core-189-batch-failure-granularity.md` - go/no-go on jitter in
+   the default retry delay. A small change, but it moves retry timing for every existing deployment,
+   which is why it is a call rather than a commit. Nothing else in the poison-isolation ladder waits
+   on the answer.
+5. **astubbs#162** (confluentinc#546), `bug-162-offset-state-truncation.md` - should absent commit
+   data warn at all? It is the normal state of a new group or an expired offset, so the honest
+   handling is a quieter distinct message and no truncation branch - against which operators alert on
+   the current line.
+6. **astubbs#241** (confluentinc#144), `core-241-tx-commit-failure-taxonomy.md` - agree the issue's
+   stated premise died in confluentinc#355, then keep it open with a rewritten `## Fork status` and
+   relabel `bug` to `feature`. No defect is demonstrated; what survives is a policy design.
+7. **astubbs#173** (confluentinc#777), `upstream-173-revocation-duplicate-processing.md` - should PC
+   offer a revocation grace period at all? Upstream declined it. **If the answer is no, confluentinc#777
+   is a documentation obligation rather than a defect** and the close is unblocked - at the cost of a
+   README section and one chaos cell that must be run rather than predicted.
+8. **astubbs#178** (confluentinc#843), `core-178-key-order-across-a-rebalance.md` - is an undrained
+   old-epoch delivery a violation of the README's "strong ordering by key", or legitimate
+   at-least-once? Last because it is the only one that needs a *bound* argued for rather than a
+   yes/no, and `KeyOrderLedger`'s javadoc already says picking that number is the whole job.
+
+**What is NOT on this list, from the same triage, and why:** astubbs#139 is a 1.0 blocker with a
+four-step definition of done in `core-139-public-api-thread-safety-contract.md` - real work, not a
+call. astubbs#175 has no decision left in it; its one live strand is the AB-BA wedge owned by
+astubbs#29. astubbs#155, astubbs#169 and astubbs#170 have their fixes written and correctly linked -
+what they need is the three draft PRs de-conflicted and merged, which is scheduling.
+
+## Ready picks
+
 Collisions are in `pr-blockers-and-collisions.md`. The ranked backlog and full verdicts live in
 `src/docs/development/upstream-pr-analysis.adoc`; these are the ready picks:
 

--- a/docs/inflight/release-0.6.0.0.md
+++ b/docs/inflight/release-0.6.0.0.md
@@ -8,6 +8,13 @@
 comments. This file is the detail behind it. Keep them in step: if a blocker is resolved here, tick it
 there.
 
+**Six mirrors carrying the `0.6.0.0` label came out of the 2026-08-20 triage with no engineering
+left in them.** astubbs#155, astubbs#169 and astubbs#170 need their written fixes de-conflicted and
+merged; astubbs#161 and astubbs#181 need a maintainer decision; astubbs#177 needs a comment saying
+what survived its own merged fix. [`process-candidate-ranking.md`](process-candidate-ranking.md) owns
+the ranking and says what each one needs - this file does not repeat it, because a second ordering
+here is how the two drift.
+
 Not yet released: the pom is `0.6.0.0-SNAPSHOT`, there is no `v0.6.0.0` tag, and the changelog section
 is written. Release = strip `-SNAPSHOT` and merge to `master`; `publish.yml` runs after CI succeeds,
 deploys via the `maven-central` profile, tags `v<version>` and cuts a GitHub release


### PR DESCRIPTION
## Description

The 2026-08-20 mirror triage produced one note per issue, and most of them end in something only
the maintainer can answer. `process-candidate-ranking.md` listed none of them, on the implicit
reasoning that a decision is not a work item. That is backwards - a decision costs one reply and
unblocks a note whose engineering is already done or already unnecessary, so it outranks every
candidate that still needs building.

**`docs/inflight/process-candidate-ranking.md`** gains a ranked *Decisions waiting on the maintainer*
section above the ready picks, ordered by how little input each needs rather than by what it unblocks:
astubbs/parallel-consumer#161 (the reply is written - post it) through
astubbs/parallel-consumer#178 (argue a bound for how long an old-epoch delivery may run before it
counts as a key-ordering violation). Each line names the note that owns the verification and the
draft answer; none of it is re-derived. The section also says which of the thirteen triaged issues
are *not* decisions and why, so the next reader does not re-triage
astubbs/parallel-consumer#139, astubbs/parallel-consumer#175, or the three whose fixes are already
written.

One item in there carries a deadline the others do not: astubbs/parallel-consumer#163's note corrects
open question 6 of the DLQ prior-art report on astubbs/parallel-consumer#313, which assumes
deserialization failures can ride along with the DLQ work. On the mechanism they cannot - such a
record never becomes a `WorkContainer`. Settling DLQ requirements before that is answered settles them
on a false premise.

**`docs/inflight/pr-mirror-fixes-and-what-they-close.md`** was reporting finished work as
outstanding. It flagged two edits needed before merge - astubbs/parallel-consumer#201 carrying no
closing reference, and astubbs/parallel-consumer#203 carrying the bare `Closes #169` form the
convention forbids. Both were fixed on the PRs after the note was written, and GitHub resolves the
links on all three issues. Shrunk to the one item still live: astubbs/parallel-consumer#204
deliberately does not close astubbs/parallel-consumer#177, which is right, and that issue still
carries no comment saying so.

**`docs/inflight/release-0.6.0.0.md`** gets a pointer, not a copy. Six mirrors labelled `0.6.0.0`
have no engineering left in them and they split three ways - merge, decide, comment. Naming the split
there and the ordering in the ranking register gives each one owner, which is what stops the two
drifting. The same split was added to astubbs/parallel-consumer#197's body.

Gates run locally, all green: `bin/check-inflight-tags.sh`, `bin/check-issue-refs.sh`,
`bin/check-file-refs.sh`, `bin/check-copyright-headers.sh`, `bin/check-branch-self-reference.sh`.

## Checklist

- [x] Docs updated - this PR is docs only
- [ ] User-facing feature documentation data added under `docs/features/` - N/A - no user-facing feature; these are in-flight tracking notes
- [ ] Tests added/updated - N/A - no code changes; the four relevant gates were run locally instead
- [x] Title & body reflect the final content of this PR
- [ ] Ran `ce-simplify` and `ce-code-review` locally - N/A - docs only, so `ce-simplify` has no code to work on
