### PR TITLE
test(chaos) confluentinc#857: the overnight torture harness, extracted from the 857 PR

### DIFF
--- a/bin/soak-deadlock-probe.sh
+++ b/bin/soak-deadlock-probe.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# shell-justified: a loop around mvn invocations whose entire content is the exact flag set - no
+# -Pci, no forking - that keeps the probe's window open. The value is in those flags being visible
+# and copy-pasteable next to the note that explains them; wrapping them in Node would put a layer
+# between the reader and the command line they need to reproduce by hand.
+#
+# Overnight A/B soak on the DETERMINISTIC deadlock probe (not chaos seeds - those never open the
+# window). Each invocation is @RepeatedTest(20); one tally row per invocation per arm.
+# docs/inflight/test-857-deadlock-ab-soak-harness.md owns the method and the results.
+#
+# TWO SETTINGS SILENTLY DESTROY THIS EXPERIMENT, which is why the mvn line is spelled out here
+# rather than left to a wrapper:
+#   * -Pci sets surefire.forkCount=1C, and forking removes the window the probe exists to open.
+#   * A JDK other than 17 fails in a module this does not touch.
+#
+# THE WINDOW GATE IS PER ARM, and getting it uniform is the defect this script carried until
+# 2026-09-02. "Zero declines means the window never opened" is right for the FIXED arm and exactly
+# WRONG for the CONTROL arm: a blocking revoke never reaches the decline, it deadlocks, so on that
+# arm zero declines with a FAILURE is the window opening, and zero declines with a PASS is the run
+# that proves nothing. Scoring both arms by declines alone throws away every real control
+# observation and keeps the empty ones - the inversion this whole probe exists to avoid.
+#
+# `set -e` is deliberately omitted: a failing iteration is the data.
+set -u
+# shellcheck source=bin/lib/chaos-experiment-common.sh
+source "${BASH_SOURCE[0]%/*}/lib/chaos-experiment-common.sh"
+
+usage() {
+    cat >&2 <<USAGE
+usage: ${0##*/} FIXED_TREE CONTROL_TREE [INVOCATIONS]
+
+  FIXED_TREE     worktree carrying the fix
+  CONTROL_TREE   worktree with the fix reverted - the arm that must deadlock
+  INVOCATIONS    A/B pairs to run (default 12)
+
+Both trees are required and are NOT defaulted: this script used to hardcode two absolute paths on
+one machine, one of them a throwaway experiment worktree, so it silently measured nothing anywhere
+else. JAVA_HOME must point at a JDK 17.
+USAGE
+    exit 2
+}
+
+[ $# -ge 2 ] || usage
+FIXED=$1
+CONTROL=$2
+ROUNDS=${3:-12}
+TALLY=${PC_SOAK_TALLY:-/tmp/probe-soak.tsv}
+
+for d in "$FIXED" "$CONTROL"; do
+    [ -x "$d/mvnw" ] || { echo "not a usable tree (no mvnw): $d" >&2; exit 2; }
+done
+[ -n "${JAVA_HOME:-}" ] || { echo "JAVA_HOME must be set to a JDK 17" >&2; exit 2; }
+
+printf '# probe soak start %s  fixed=%s control=%s rounds=%s\n' \
+    "$(pc_now)" "$FIXED" "$CONTROL" "$ROUNDS" >> "$TALLY"
+
+for i in $(seq 1 "$ROUNDS"); do
+    for arm in FIXED CONTROL; do
+        [ "$arm" = FIXED ] && dir=$FIXED || dir=$CONTROL
+        log=$(mktemp)
+        "$dir/mvnw" -f "$dir/pom.xml" -q -pl parallel-consumer-core -am \
+            -DskipUTs=true -Dit.test=Rebalance857CommitSyncDeadlockProbeIT \
+            -DfailIfNoTests=false -Dfailsafe.failIfNoSpecifiedTests=false verify > "$log" 2>&1
+        rc=$?
+
+        stats=$(pc_failsafe_stats "$dir" Rebalance857)
+        outcome=$(pc_classify_failsafe_stats "$stats")
+        declines=$(pc_count_matches 'Skipping offset commit during partition revocation' "$log")
+        timeouts=$(pc_count_matches 'Timeout waiting for commit response' "$log")
+
+        # Per-arm window gate - see the header. USABLE means the run is evidence either way; EMPTY
+        # means the window never opened and the row must not be counted in a rate.
+        if [ "$outcome" = DID-NOT-RUN ]; then
+            window=DID-NOT-RUN
+        elif [ "$arm" = FIXED ]; then
+            [ "$declines" -gt 0 ] && window=USABLE || window=EMPTY
+        else
+            { [ "$outcome" = FAILED ] || [ "$timeouts" -gt 0 ]; } && window=USABLE || window=EMPTY
+        fi
+
+        printf '%s\tinv=%s\tarm=%-7s\trc=%s\t%s\toutcome=%s\twindow=%s\tdeclines=%s\ttimeouts=%s\n' \
+            "$(pc_now)" "$i" "$arm" "$rc" "$stats" "$outcome" "$window" "$declines" "$timeouts" \
+            >> "$TALLY"
+        rm -f "$log"
+    done
+done
+printf '# probe soak done %s\n' "$(pc_now)" >> "$TALLY"

--- a/bin/test-torture-overnight.sh
+++ b/bin/test-torture-overnight.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# shell-justified: it sources bin/torture-overnight.sh to call its functions directly, which is the
+# only way to test the verdict logic without running an eight-hour build. A Node test cannot source
+# bash functions; it could only shell out to the whole script, which is the thing being avoided.
+# Self-test for the parts of bin/torture-overnight.sh that decide what a run MEANT, plus the
+# argument parsing that decides whether it runs at all - which is where this harness has been wrong
+# three times. Nothing here needs Docker, a JDK or a broker: the reporting cases run against
+# synthetic logs, and the parsing cases exit before any build starts.
+#
+# WHY THIS EXISTS, and why these cases. The drain verdict decides whether a detector firing is a
+# harmless timing proxy (backlog CLIMBED after the violation) or the wedge the whole confluentinc#857
+# investigation is hunting (FLAT). Getting it backwards reports the most interesting result in the
+# family as the boring one, and nothing downstream would ever question it.
+#
+# The first implementation compared the FIRST diagnostic sample to the LAST. That reads "CLIMBED" for
+# a run that raced to 97386, tripped the detector, and then never moved again - because it climbed to
+# 97386 first. The `wedge` case below is exactly that shape and it is the regression this file
+# guards: it FAILS against the first-to-last implementation and passes against the current one, which
+# is the only thing that makes it evidence rather than decoration.
+#
+# Usage:  bin/test-torture-overnight.sh
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$HERE/torture-overnight.sh"
+[ -f "$TARGET" ] || { echo "cannot find $TARGET" >&2; exit 2; }
+# The harness losing its executable bit is a silent CI failure - check-all.sh invokes gates through
+# `bash`, so nothing else would notice until an unattended run did not start.
+[ -x "$TARGET" ] || { echo "$TARGET is not executable - chmod +x it" >&2; exit 2; }
+
+# Pull each function under test out of the script rather than copying it, so the two cannot drift.
+# Sourcing the script itself would run it - it launches maven.
+#
+# THE EXTRACTION MUST BE CHECKED, not just non-empty. `sed` runs to the next line that is exactly
+# `}`, so indenting a closing brace by two spaces - an ordinary reformat - silently captures the
+# NEXT function too, `eval` defines both, and the suite reports all green having tested something
+# else. A target with no `^}$` after the marker captures hundreds of lines and starts executing the
+# harness body. So: the capture must start with the function, end with a bare `}`, and contain
+# exactly one top-level opener.
+extract_fn() {   # extract_fn <name>
+    local name="$1" body
+    body="$(sed -n "/^$name() {/,/^}\$/p" "$TARGET")"
+    [ -n "$body" ] || { echo "extract: $name() not found in $TARGET - renamed?" >&2; exit 2; }
+    case "$(printf '%s\n' "$body" | head -1)" in "$name() {"*) ;; *) false ;; esac \
+        || { echo "extract: $name() capture does not start at its definition" >&2; exit 2; }
+    [ "$(printf '%s\n' "$body" | tail -1)" = "}" ] \
+        || { echo "extract: $name() capture is not brace-terminated - is its closing } indented?" >&2; exit 2; }
+    local openers; openers="$(printf '%s\n' "$body" | grep -c '^[a-z_][a-z_]*() {')"
+    [ "$openers" -eq 1 ] \
+        || { echo "extract: $name() capture spans $openers functions - a reformat has broken the range" >&2; exit 2; }
+    printf '%s\n' "$body"
+}
+
+eval "$(extract_fn drain_verdict)"
+eval "$(extract_fn verdict_for)"
+eval "$(extract_fn field_of)"
+eval "$(extract_fn aggregate_stats)"
+eval "$(extract_fn fresh_reports)"
+# drain_verdict reads this; the script defaults it at its own definition site, which the
+# extraction above does not carry. Pinned here so the expectations are against a KNOWN
+# calibration rather than whatever the environment happens to hold.
+# shellcheck disable=SC2034  # consumed by the extracted drain_verdict, not by this file
+DRAIN_MIN_RECOVERY_PCT=10
+
+TMP="$(mktemp -d)" || { echo "cannot create a temp dir" >&2; exit 2; }
+trap 'rm -rf "$TMP"' EXIT
+pass=0; fail=0
+
+# Build a log of [diagnose] samples: each argument is consumed:violations:inFlight
+mklog() {
+    local f="$TMP/$1.log"; shift
+    : > "$f"
+    local row c v i
+    for row in "$@"; do
+        c="${row%%:*}"; v="${row#*:}"; v="${v%%:*}"; i="${row##*:}"
+        printf '[diagnose] run: consumed=%s/100000 started=1 inFlight=%s violations=%s observations=0 done=false\n' \
+            "$c" "$i" "$v" >> "$f"
+    done
+    printf '%s' "$f"
+}
+
+# WHOLE-STRING, not a prefix. The numbers in the parentheses are not decoration: they are what a
+# morning reviewer reads to decide whether a FLAT line is a wedge or a fleet in the heavy tail, and
+# summarise()'s `drain=[A-Za-z/-]+` grep depends on the verdict word ending where it does. A prefix
+# match would pass a verdict that had kept the right word and lost the evidence behind it.
+expect() {   # expect <name> <expected-verdict> <logfile>
+    local got; got="$(drain_verdict "$3")"
+    if [ "$got" = "$2" ]; then pass=$((pass+1)); printf '  ok    %-14s -> %s\n' "$1" "$got"
+    else fail=$((fail+1)); printf '  FAIL  %-14s -> got %s, wanted %s\n' "$1" "$got" "$2"; fi
+}
+
+echo "test-torture-overnight: drain_verdict"
+
+# THE REGRESSION CASE. Climbs, trips the detector, then dead flat with work still in flight.
+# First-to-last comparison calls this CLIMBED. It is the wedge.
+expect wedge 'FLAT(+0-of-2614,97386-to-97386,inFlight-80-to-80,n=3)' \
+    "$(mklog wedge 12000:0:50 97386:0:80 97386:1:80 97386:1:80 97386:1:80)"
+
+# The drain shape from the 2026-08-28 answer: flat across the violation, then recovers past target.
+expect drain 'CLIMBED(+5260-of-5122,94878-to-100138,inFlight-114-to-67,n=4)' \
+    "$(mklog drain 12000:0:50 94878:1:114 94878:1:100 99665:1:80 100138:1:67)"
+
+# A clean run samples throughout and never violates - there is nothing to judge, and saying
+# CLIMBED here would launder a passing run into evidence about stalls.
+expect clean no-violation "$(mklog clean 12000:0:50 100000:0:0)"
+
+# One post-violation sample cannot show a trend. Distinct from FLAT, which claims evidence.
+expect single 'insufficient(n=1)' "$(mklog single 12000:0:50 97386:1:80)"
+
+# The diagnostic never engaged. Must never be reported as either outcome.
+printf 'no diagnostic samples here\n' > "$TMP/none.log"
+expect no-samples n/a "$TMP/none.log"
+
+# THE MAGNITUDE REGRESSION. One record recovered across the whole post-violation window. Direction
+# alone calls this CLIMBED - "the backlog recovered" - for a fleet that moved a single record in half
+# an hour. It is a wedge, and CREEPING is the word that claims neither recovery nor a dead stop.
+expect creeping 'CREEPING(+1-of-2614,97386-to-97387,inFlight-80-to-79,n=4)' \
+    "$(mklog creeping 12000:0:50 97386:1:80 97386:1:80 97386:1:80 97387:1:79)"
+
+# Backwards. FLAT would have printed a verdict contradicted by its own numbers.
+expect receded 'RECEDED(-1386-of-2614,97386-to-96000,inFlight-80-to-80,n=2)' \
+    "$(mklog receded 97386:1:80 96000:1:80)"
+
+# A line the parser cannot read is its own answer - folding it into the pre-violation case would let
+# a log truncated by interleaved writers report as "nothing fired, nothing to judge".
+printf '[diagnose] run: consumed=97386/100000 started=1 inFli\n' > "$TMP/torn.log"
+expect torn 'unparseable(1)' "$TMP/torn.log"
+
+# ---- The verdict ladder -----------------------------------------------------------------------
+#
+# It publishes the run's headline number and had no test at all until now. `aggregate_stats` exists
+# because `tail -1` let directory order decide: with two fresh reports, one carrying failures="1",
+# the cycle scored `passed` and the failing report was copied into the cycle directory unread.
+echo "test-torture-overnight: verdict ladder"
+
+vexpect() {   # vexpect <name> <expected> <hung> <dumps> <stats>
+    local got; got="$(verdict_for "$3" "$4" "$5")"
+    if [ "$got" = "$2" ]; then pass=$((pass+1)); printf '  ok    %-14s -> %s\n' "$1" "$got"
+    else fail=$((fail+1)); printf '  FAIL  %-14s -> got %s, wanted %s\n' "$1" "$got" "$2"; fi
+}
+
+vexpect hung-dumped   HUNG-DUMP-CAPTURED yes 2 'tests=1 errors=0 skipped=0 failures=0'
+vexpect hung-nodump   HUNG-NO-DUMP       yes 0 'tests=1 errors=0 skipped=0 failures=0'
+vexpect stale-report  DID-NOT-RUN        no  0 ''
+vexpect zero-tests    DID-NOT-RUN        no  0 'tests=0 errors=0 skipped=0 failures=0'
+vexpect failure       FAILED             no  0 'tests=2 errors=0 skipped=0 failures=1'
+vexpect error         FAILED             no  0 'tests=2 errors=1 skipped=0 failures=0'
+vexpect all-skipped   ALL-SKIPPED        no  0 'tests=2 errors=0 skipped=2 failures=0'
+vexpect green         passed             no  0 'tests=2 errors=0 skipped=1 failures=0'
+
+# aggregate_stats must SUM, so a failure in any report survives. Directory order decided this before.
+mkrpt() { printf '<testsuite tests="%s" errors="%s" skipped="%s" failures="%s">\n' "$2" "$3" "$4" "$5" > "$TMP/$1"; }
+# The FAILING report goes FIRST, deliberately. With it last, `tail -1` happens to pick it and the
+# case passes against the very bug it guards - which is what the first draft of this case did.
+mkrpt a.xml 1 0 0 1
+mkrpt b.xml 1 0 0 0
+agg="$(aggregate_stats "$TMP/a.xml" "$TMP/b.xml")"
+if [ "$(verdict_for no 0 "$agg")" = FAILED ]; then
+    pass=$((pass+1)); printf '  ok    %-14s -> %s -> FAILED\n' aggregate "$agg"
+else
+    fail=$((fail+1)); printf '  FAIL  %-14s -> %s did not reach FAILED\n' aggregate "$agg"
+fi
+
+# ---- Freshness selection ----------------------------------------------------------------------
+#
+# The calibration list carries "a stale failsafe XML scored a cycle that never ran as passed" with no
+# case. This is it: an old report for the same class must not be selected by a newer marker.
+echo "test-torture-overnight: freshness"
+mkdir -p "$TMP/rpt"
+: > "$TMP/rpt/TEST-x.ChaosChurnStormIT.xml"
+sleep 1
+: > "$TMP/marker"
+stale="$(fresh_reports "$TMP/rpt" ChaosChurnStormIT "$TMP/marker")"
+if [ -z "$stale" ]; then pass=$((pass+1)); printf '  ok    %-14s -> stale report not selected\n' stale-excluded
+else fail=$((fail+1)); printf '  FAIL  %-14s -> selected %s\n' stale-excluded "$stale"; fi
+
+sleep 1
+: > "$TMP/rpt/TEST-x.ChaosChurnStormIT.xml"
+if [ -n "$(fresh_reports "$TMP/rpt" ChaosChurnStormIT "$TMP/marker")" ]; then
+    pass=$((pass+1)); printf '  ok    %-14s -> fresh report selected\n' fresh-included
+else fail=$((fail+1)); printf '  FAIL  %-14s -> fresh report missed\n' fresh-included; fi
+
+# ---- The fixture must match the Java that produces the real thing ------------------------------
+#
+# Every [diagnose] case above is a HAND COPY of a format string in ChaosScenarioBase. They agree
+# today, and nothing pins them. Rename a field there and the harness reports `no-violation` -
+# rendered in SUMMARY.md as "nothing fired, nothing to judge" - while this suite stays green and
+# diag=ACTIVE still says the diagnostic ran. A dead-wedged run laundered into a passing one, with
+# every instrument agreeing. So assert the real format string still contains the fields parsed here.
+echo "test-torture-overnight: fixture pinning"
+JAVA_SRC="$HERE/../parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosScenarioBase.java"
+if [ ! -f "$JAVA_SRC" ]; then
+    fail=$((fail+1)); printf '  FAIL  %-14s -> cannot find ChaosScenarioBase.java\n' diagnose-format
+else
+    missing=""
+    for token in '\[diagnose\]' 'consumed=\{\}/\{\}' 'inFlight=\{\}' 'violations=\{\}'; do
+        grep -qE "$token" "$JAVA_SRC" || missing="$missing $token"
+    done
+    if [ -z "$missing" ]; then pass=$((pass+1)); printf '  ok    %-14s -> Java format string still carries every parsed field\n' diagnose-format
+    else fail=$((fail+1)); printf '  FAIL  %-14s -> ChaosScenarioBase no longer emits:%s (drain_verdict parses fields that are gone)\n' diagnose-format "$missing"; fi
+fi
+
+# ---- Argument parsing -----------------------------------------------------------------------
+#
+# A DEADLINE, because the bug this guards is a HANG. A trailing `--groups` with no value left
+# `shift 2` failing with $1 unchanged, and the parser span forever - so a plain invocation here
+# would hang the self-test rather than fail it, which is the one outcome CI cannot act on.
+# `--groups` cannot use the `${2:?...}` guard the other options use, because `--groups ''` is a
+# real value: the empty tag selects untagged tests, which is how the transactional vehicles run.
+echo "test-torture-overnight: argument parsing"
+
+exits_within() {   # exits_within <name> <seconds> <expected-rc> <arg...>
+    local name="$1" limit="$2" want="$3"; shift 3
+    bash "$TARGET" "$@" >/dev/null 2>&1 &
+    local p=$! waited=0 rc
+    while [ "$waited" -lt "$limit" ]; do
+        kill -0 "$p" 2>/dev/null || break
+        sleep 1; waited=$((waited+1))
+    done
+    if kill -0 "$p" 2>/dev/null; then
+        kill -9 "$p" 2>/dev/null; wait "$p" 2>/dev/null
+        fail=$((fail+1)); printf '  FAIL  %-14s -> still running after %ss (it should have exited %s)\n' \
+            "$name" "$limit" "$want"
+        return
+    fi
+    wait "$p" 2>/dev/null; rc=$?
+    if [ "$rc" -eq "$want" ]; then pass=$((pass+1)); printf '  ok    %-14s -> exit %s\n' "$name" "$rc"
+    else fail=$((fail+1)); printf '  FAIL  %-14s -> exit %s, wanted %s\n' "$name" "$rc" "$want"; fi
+}
+
+# Assert the MESSAGE, not just the code. Exit 2 is this harness's universal cannot-run code, so
+# `ok exit 2` is also what you get when the script never reached the option loop at all - running
+# from outside a git repo, for instance. Only this path emits this sentence.
+exits_within groups-novalue 10 2 --groups
+msg="$(bash "$TARGET" --groups 2>&1 >/dev/null | head -1)"
+case "$msg" in
+    *"--groups needs a value"*) pass=$((pass+1)); printf '  ok    %-14s -> %s\n' groups-message "$msg" ;;
+    *) fail=$((fail+1)); printf '  FAIL  %-14s -> got %s\n' groups-message "$msg" ;;
+esac
+
+# --list must describe what would ACTUALLY run. It used to print and exit from inside the option
+# loop, before --scenario replaced the rotation, so it answered with the built-in five either way.
+# The absent name must be one the DEFAULT rotation contains, or the assertion passes for the wrong
+# reason: with ChaosChurnStormIT dropped from ROTATION, the old inline --list printed four scenarios
+# and this case still said ok. So the contaminant is verified present in the target first.
+if grep -qE '^ *"ChaosChurnStormIT"' "$TARGET"; then
+    pass=$((pass+1)); printf '  ok    %-14s -> contaminant is in the default rotation\n' list-premise
+else
+    fail=$((fail+1)); printf '  FAIL  %-14s -> ChaosChurnStormIT is not in ROTATION, so list-scenario proves nothing\n' list-premise
+fi
+
+# Bounded, because this drives the same parser the deadline above exists for; and the exit code is
+# checked rather than discarded, so printing the right text and then failing is not a pass.
+listed=""; lrc=0
+bash "$TARGET" --scenario ChaosKeyOrderIT --list > "$TMP/list.out" 2>"$TMP/list.err" &
+lp=$!; n=0
+while [ "$n" -lt 10 ] && kill -0 "$lp" 2>/dev/null; do sleep 1; n=$((n+1)); done
+if kill -0 "$lp" 2>/dev/null; then
+    kill -9 "$lp" 2>/dev/null; wait "$lp" 2>/dev/null; lrc=124
+else
+    wait "$lp" 2>/dev/null; lrc=$?; listed="$(cat "$TMP/list.out")"
+fi
+case "$lrc:$listed" in
+    124:*) fail=$((fail+1)); printf '  FAIL  %-14s -> --list did not exit within 10s\n' list-scenario ;;
+    0:*ChaosChurnStormIT*) fail=$((fail+1)); printf '  FAIL  %-14s -> --list ignored --scenario\n' list-scenario ;;
+    0:*ChaosKeyOrderIT*)   pass=$((pass+1)); printf '  ok    %-14s -> --list honours --scenario\n' list-scenario ;;
+    *) fail=$((fail+1)); printf '  FAIL  %-14s -> exit %s, output: %s\n' list-scenario "$lrc" "$listed" ;;
+esac
+
+# --list exists to print the scenario AND the commit mode its source hardcodes. The mode half was
+# unasserted, so reintroducing the exact bug its own comment names - reading the base class's mode
+# for every scenario - printed both modes for ChaosKeyOrderIT with this suite green. That is the
+# manufactured-label class the whole script is about, one screen from where it is described.
+case "$listed" in
+    *"PERIODIC_CONSUMER_ASYNCHRONOUS,PERIODIC_CONSUMER_SYNC"*|*"PERIODIC_CONSUMER_SYNC,PERIODIC_CONSUMER_ASYNCHRONOUS"*)
+        fail=$((fail+1)); printf '  FAIL  %-14s -> ChaosKeyOrderIT credited with BOTH modes\n' list-mode ;;
+    *"ChaosKeyOrderIT"*"PERIODIC_CONSUMER_ASYNCHRONOUS"*)
+        pass=$((pass+1)); printf '  ok    %-14s -> mode column names one mode, and the right one\n' list-mode ;;
+    *)  fail=$((fail+1)); printf '  FAIL  %-14s -> unexpected mode column: %s\n' list-mode "$listed" ;;
+esac
+
+echo "test-torture-overnight: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/bin/torture-overnight.sh
+++ b/bin/torture-overnight.sh
@@ -1,0 +1,654 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Antony Stubbs and contributors
+#
+# shell-justified: process orchestration is the core of this harness, not incidental to it - watchdog
+# timers, jstack against a live PID, killing a wedged JVM, traps and wall-clock budgets across an
+# eight-hour run. That is bash's domain and Node would wrap it rather than replace it. The part the
+# Node-default rule is actually aimed at - the verdict logic that decides what a run MEANT - is the
+# part of this file that HAS been wrong three times, and it is covered by bin/test-torture-overnight.sh
+# for that exact reason. Stating the weakness rather than claiming there isn't one: if the verdict
+# logic grows further, it should move out of here into .mjs, not be defended by this comment.
+# OVERNIGHT TORTURE HARNESS - MVP spike. Runs for hours in short cycles, hunting the lock-ups and
+# data-skips confluentinc#857's family has not yet accounted for, and packages everything an agent
+# needs to review it in the morning without asking anyone a question.
+#
+# WHY CYCLES. A live-locked run tells you nothing while it hangs and everything the moment you look
+# at it. Rather than teach the harness to detect every way PC can wedge, each cycle gets a hard
+# wall-clock budget; when it expires the WATCHDOG TAKES A THREAD DUMP AND THEN KILLS IT. Restarting
+# every 30 minutes costs almost nothing against an 8-hour run, and the dump is the artefact that
+# turns a hang into a diagnosis - the six captures that identified the revoke deadlock exist only
+# because something dumped the stack while it was still stuck. A cycle that finishes early does not
+# burn its slot; the watchdog returns the moment the build exits and the next cycle starts.
+#
+# WHAT IT HUNTS, and why these first. The AB-BA revoke deadlock is fixed and verified. What remains
+# unaccounted for in that family is:
+#   * COMMIT-RESPONSE TIMEOUTS reported in the field twice and never reproduced (astubbs#175, astubbs#177).
+#   * DATA SKIP - confluentinc#875 describes an offset silently never delivered, lag growing, and a
+#     restart making it reappear. That is not a liveness failure and no liveness detector will see
+#     it. The end-of-run LEDGER_LOSS check is what would catch it (see COMPLETENESS below).
+#   * the UNBOUNDED REVOKE WAIT in transactional mode - astubbs#44 / confluentinc#803, which
+#     carries upstream's `verified bug` label (one of a couple of dozen that do; this file
+#     previously called it the only one, which was false). THIS RUN DOES NOT HUNT IT. See below.
+#
+# ############################################################################################
+# THE TRANSACTIONAL HUNT IS NOT HAPPENING, AND THIS HARNESS WILL NOT PRETEND OTHERWISE.
+#
+# An earlier revision of this script passed `-Dchaos.commitMode=PERIODIC_TRANSACTIONAL_PRODUCER`
+# on three of its six rotation entries. NO SUCH PROPERTY EXISTS. Nothing in the tree reads it;
+# every chaos scenario hardcodes its commit mode in its own source:
+#
+#     ChaosChurnStormIT ................... PERIODIC_CONSUMER_ASYNCHRONOUS
+#     ChaosKeyOrderIT ..................... PERIODIC_CONSUMER_ASYNCHRONOUS
+#     AbstractRevokeUnderWorkScenario ..... PERIODIC_CONSUMER_SYNC
+#         (and so ChaosRevokeUnderWorkIT, ...CooperativeIT, ...DrainIT)
+#
+# The flag was accepted and silently ignored, so every cycle ran the hardcoded mode while the
+# cycle directory name, the tally and the summary all said TRANSACTIONAL. That is worse than not
+# running the hunt: it manufactures an eight-hour artefact asserting the transactional mode was
+# tortured clean, which is the exact class of measurement error this whole investigation keeps
+# tripping over. The mode labels are gone; each cycle now RECORDS THE MODE IT OBSERVED in the log
+# rather than the mode somebody hoped for.
+#
+# Plumbing a real property is NOT a one-line change, which is why it is not done here.
+# AbstractRevokeUnderWorkScenario's SYNC value is load-bearing and says so in a comment - sync
+# commits sharpen the revoke-vs-commit lock contention that IS the confluentinc#857 recipe. Making
+# that scenario transactional changes what the experiment is, per scenario, and that decision is
+# adjacent to the one docs/inflight/bug-857-transactional-revoke-wait.md says not to settle alone.
+#
+# WHY THE ROTATION STILL DOES NOT HUNT IT - and this reason CHANGED on 2026-09-01, so read it
+# rather than the version you may remember. It used to be that no chaos scenario existed for that
+# mode at all: `grep -rl PERIODIC_TRANSACTIONAL_PRODUCER` over the chaostests package returned
+# NOTHING, so no flag or rotation entry could have reached it, and the 214-cycle run of 2026-08-29
+# confirmed it from the other side - 129 SYNC, 85 ASYNC, zero transactional.
+#
+# A VEHICLE NOW EXISTS: ChaosRevokeUnderWorkTransactionalIT overrides commitMode() to return
+# PERIODIC_TRANSACTIONAL_PRODUCER, and it is reachable by name:
+#
+#     bin/torture-overnight.sh --scenario ChaosRevokeUnderWorkTransactionalIT
+#
+# What is still true is the sentence at the top of this block: the DEFAULT ROTATION does not run
+# it, so an ordinary overnight run is not a transactional hunt and must not be reported as one.
+# What is also still true is the harder half - that scenario's first green run established only
+# that it RUNS. Whether repeating it hunts the unbounded revoke wait is an OPEN QUESTION, not
+# something this script asserts by being able to select it.
+#
+# The vehicles that DO exist are outside the chaos group, which is why --groups exists:
+#   RebalanceEoSDeadlockTest   untagged; its javadoc keeps the mode deliberately, because the
+#                              producer transaction lock exists ONLY in that mode. This is the
+#                              closest thing to a transactional revoke-wait reproducer in the tree.
+#   TransactionTimeoutsTest    @Tag("transactions")
+# So:  bin/torture-overnight.sh --groups '' --scenario RebalanceEoSDeadlockTest --cycles 20
+# Whether repeating either of those actually hunts the unbounded revoke wait is an open question,
+# NOT something this script asserts by being able to run them.
+# ############################################################################################
+#
+# COMPLETENESS, and what it does and does not catch. ChaosScenarioBase.assertScenarioSlos calls
+# ProgressProbe.ledger, which compares the producer-side expectedKeys against what the user
+# function actually saw and emits `LEDGER_LOSS: N produced records never consumed`. That IS
+# independent of PC's own offset accounting - it is the application's observation - so a record
+# never delivered fails the run. What it does NOT catch is confluentinc#875's exact shape: the
+# ledger asks "was it ever delivered" once, at the end, so a skip that self-heals inside the cycle
+# is invisible to it. Catching that needs a TIME-BOUNDED claim (delivered within N seconds of
+# production), which does not exist yet and is real design work, not a grep.
+#
+# WHY EVERY CHECK BELOW IS A COMPARISON, NOT A JUDGEMENT. Five times in one week a measurement
+# error, not the system, was the answer: an inverted reproducer, a probe whose window never opened,
+# a grep narrower than the question. So this script refuses to infer. It fails at startup if jstack
+# is missing rather than writing empty dumps; it reads only failsafe reports NEWER than the cycle
+# that produced them rather than trusting whatever is on disk; it reports the commit mode it saw in
+# the log rather than the one it asked for; and it flags an empty siloed-log directory rather than
+# packaging a tarball of nothing.
+#
+# NOT DOCKER YET. Deliberately: containers are the right long-term shape
+# (docs/inflight/test-pc-soak-harness-architecture.md) but a script runs tonight.
+#
+# Usage:
+#   bin/torture-overnight.sh                        # 8 hours, 30-minute cycles (the overnight run)
+#   bin/torture-overnight.sh 8 30                   # same, positional (hours, cycle-minutes)
+#   bin/torture-overnight.sh --cycles 1             # ONE cycle, then stop - the smoke test
+#   bin/torture-overnight.sh --hours 0 --minutes 30 # a SHORT run - --minutes ADDS to --hours,
+#                                                   # which defaults to 8, so bare --minutes 30 is 8h30m
+#   bin/torture-overnight.sh --cycles 1 --scenario ChaosChurnStormIT --cycle-minutes 20
+#
+# Options:
+#   --hours N           total wall-clock budget in hours (default 8)
+#   --minutes N         total wall-clock budget in minutes, ADDED to --hours (default 0)
+#   --cycle-minutes N   per-cycle budget before the watchdog dumps and kills (default 30)
+#   --cycles N          stop after N cycles, whichever limit is reached first (0 = no limit,
+#                       which is the default)
+#   --scenario CLASS    run only this scenario instead of rotating (repeatable)
+#   --groups G          JUnit tag filter (default "chaos"); "" selects untagged tests, which is how
+#                       the transactional vehicles above are reached
+#   --out DIR           output directory (default /tmp/torture-<stamp>, or $TORTURE_OUT)
+#   --list              print what WOULD run - each scenario and the commit mode its source
+#                       hardcodes - then exit. Honours --scenario, in either order.
+#   -h, --help          this text
+#
+# Exit codes:  0 ran to completion   1 a cycle FAILED or HUNG   2 could not run (preflight)
+set -u
+
+D="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "not in a git repo" >&2; exit 2; }
+CHAOS_SRC="$D/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests"
+# Search the whole integration tree, not just the chaos package: --groups lets a non-chaos vehicle
+# be driven (the transactional ones are not chaos scenarios - see the header). Defined here rather
+# than in preflight because --list resolves scenarios too, and runs earlier.
+IT_SRC="$D/parallel-consumer-core/src/test-integration/java"
+
+# The rotation. Scenario classes only - a commit mode here would be a wish, not an instruction.
+# The trailing comment is the mode the class HARDCODES, kept for the reader; the run reports the
+# mode it actually observed, so this comment going stale cannot corrupt a result.
+ROTATION=(
+  "ChaosChurnStormIT"                 # ASYNC
+  "ChaosRevokeUnderWorkIT"            # SYNC
+  "ChaosRevokeUnderWorkCooperativeIT" # SYNC
+  "ChaosRevokeUnderWorkDrainIT"       # SYNC
+  "ChaosKeyOrderIT"                   # ASYNC
+)
+
+usage() { sed -n '/^# Usage:/,/^# Exit codes:/p' "$0" | sed 's/^# \{0,1\}//'; }
+
+# Collapse a stream of matches to one deduplicated comma-joined line. Used wherever a cycle reports
+# a SET of observed values, so "two modes were seen" and "one mode was seen" read differently.
+join_unique() { sort -u | tr '\n' ',' | sed 's/,$//'; }
+
+list_rotation() {
+    echo "rotation (scenario -> the commit mode its source hardcodes):"
+    for s in "${ROTATION[@]}"; do
+        # A scenario that extends the shared base inherits the base's hardcoded mode; one that does
+        # not must not be credited with it. Reading both files unconditionally reported every class
+        # as running BOTH modes, which is the kind of tidy-looking wrong answer this script exists
+        # to stop producing.
+        # --list runs BEFORE preflight, so a class that does not exist must say so rather than
+        # share the `unknown` word with a class whose mode simply could not be parsed. Those are
+        # different answers and only one of them is a typo.
+        src="$(find "$IT_SRC" -name "$s.java" -print -quit 2>/dev/null)"
+        if [ -z "$src" ]; then printf '  %-36s %s\n' "$s" "NO SUCH CLASS"; continue; fi
+        srcs=("$src")
+        if grep -q 'extends AbstractRevokeUnderWorkScenario' "$src" 2>/dev/null; then
+            srcs+=("$CHAOS_SRC/AbstractRevokeUnderWorkScenario.java")
+        fi
+        m=$(grep -ohE '\.commitMode\(CommitMode\.[A-Z_]+' "${srcs[@]}" 2>/dev/null \
+              | sed 's/.*CommitMode\.//' | join_unique)
+        # `unknown` means the mode could not be read from source - which is the honest answer for a
+        # non-chaos vehicle, and the same reason those cycles report modes=UNOBSERVED unless a PC
+        # actually starts and logs one.
+        printf '  %-36s %s\n' "$s" "${m:-unknown}"
+    done
+}
+
+# EVERY missing-value case exits 2, not 1. `${2:?...}` exits 1, and 1 is documented as "a cycle
+# FAILED or HUNG" - so a typo in an unattended `nohup ... &` invocation was indistinguishable from a
+# night that found a real defect. 2 is this script's cannot-run code and the only honest answer.
+need_value() { echo "$1 needs a value${2:+ - $2}" >&2; exit 2; }
+
+ONLY=()
+HOURS=8; MINUTES=0; CYCLE_MIN=30; MAX_CYCLES=0; OUT_OVERRIDE=""; TEST_GROUPS=chaos
+DO_LIST=no
+positional=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --hours)         [ $# -ge 2 ] || need_value --hours; HOURS="$2"; shift 2 ;;
+        --minutes)       [ $# -ge 2 ] || need_value --minutes; MINUTES="$2"; shift 2 ;;
+        --cycle-minutes) [ $# -ge 2 ] || need_value --cycle-minutes; CYCLE_MIN="$2"; shift 2 ;;
+        --cycles)        [ $# -ge 2 ] || need_value --cycles; MAX_CYCLES="$2"; shift 2 ;;
+        --scenario)      [ $# -ge 2 ] || need_value --scenario; ONLY+=("$2"); shift 2 ;;
+        # `${2:?}` cannot guard this one: `--groups ''` is a REAL value - it selects untagged tests,
+        # which is how the transactional vehicles are reached - so the missing-value case has to be
+        # caught by counting arguments instead. Without this, a trailing bare `--groups` left
+        # `shift 2` failing with $1 unchanged, and the parser span forever instead of erroring.
+        --groups)        [ $# -ge 2 ] || need_value --groups "'' selects untagged tests, and is a real value"
+                         TEST_GROUPS="$2"; shift 2 ;;
+        --out)           [ $# -ge 2 ] || need_value --out; OUT_OVERRIDE="$2"; shift 2 ;;
+        # Deferred, not printed here: --scenario replaces the rotation AFTER this loop, so listing
+        # inline answered "what will run" with the built-in rotation even when --scenario was given.
+        --list)          DO_LIST=yes; shift ;;
+        -h|--help)       usage; exit 0 ;;
+        -*)              echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)
+            positional=$((positional+1))
+            case "$positional" in
+                1) HOURS="$1" ;;
+                2) CYCLE_MIN="$1" ;;
+                *) echo "unexpected argument: $1" >&2; usage >&2; exit 2 ;;
+            esac
+            shift ;;
+    esac
+done
+
+for n in "$HOURS" "$MINUTES" "$CYCLE_MIN" "$MAX_CYCLES"; do
+    case "$n" in ''|*[!0-9]*) echo "expected a whole number, got: $n" >&2; exit 2 ;; esac
+done
+[ "$CYCLE_MIN" -gt 0 ] || { echo "--cycle-minutes must be at least 1" >&2; exit 2; }
+
+if [ "${#ONLY[@]}" -gt 0 ]; then ROTATION=("${ONLY[@]}"); fi
+[ "$DO_LIST" = no ] || { list_rotation; exit 0; }
+
+# MAX_CYCLES is the string "0" when unset, never empty, so `${MAX_CYCLES:-unlimited}` never fired -
+# every unlimited run announced itself and headed its SUMMARY.md with `cycles=0`, which reads as the
+# opposite of what it means. The label is derived once and printed from one place.
+cycles_label=unlimited
+[ "$MAX_CYCLES" -eq 0 ] || cycles_label="$MAX_CYCLES"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="${OUT_OVERRIDE:-${TORTURE_OUT:-/tmp/torture-$STAMP}}"
+J="${JAVA_HOME:-/Users/astubbs/.sdkman/candidates/java/17.0.18-tem}"
+BUDGET=$(( CYCLE_MIN*60 ))
+TOTAL=$(( HOURS*3600 + MINUTES*60 ))
+[ "$TOTAL" -gt 0 ] || { echo "total budget is zero - set --hours or --minutes" >&2; exit 2; }
+
+# ---- Preflight. Every one of these is a silent failure if left to be discovered mid-run. --------
+fail=0
+note() { echo "PREFLIGHT: $*" >&2; }
+[ -x "$J/bin/jstack" ] || { note "no jstack at $J/bin/jstack - the dump-before-kill IS the design, so this is fatal. Set JAVA_HOME to a full JDK."; fail=1; }
+[ -x "$J/bin/java" ]   || { note "no java at $J/bin/java"; fail=1; }
+[ -x "$D/mvnw" ]       || { note "no maven wrapper at $D/mvnw"; fail=1; }
+for s in "${ROTATION[@]}"; do
+    [ -n "$(find "$IT_SRC" -name "$s.java" -print -quit 2>/dev/null)" ] \
+        || { note "no such scenario: $s (searched $IT_SRC)"; fail=1; }
+done
+[ "$fail" -eq 0 ] || { echo "preflight failed - nothing ran" >&2; exit 2; }
+# Only after everything else passes, so a rejected run leaves no empty output directory behind.
+mkdir -p "$OUT/cycles" "$OUT/dumps" 2>/dev/null || { note "cannot create $OUT"; exit 2; }
+[ -w "$OUT" ] || { note "$OUT is not writable"; exit 2; }
+
+TALLY="$OUT/tally.tsv"
+: > "$TALLY"
+START_TS=$(date +%s)
+END=$(( START_TS + TOTAL ))
+RPT="$D/parallel-consumer-core/target/failsafe-reports"
+worst=0
+
+# say() goes to BOTH the tally and the terminal. A harness that prints nothing for eight hours is
+# indistinguishable from one that died in the first minute.
+say() { printf '%s\t%s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$TALLY" >&2; }
+
+# Every "how many cycles said X" question is this one line. It is a function because the verdict
+# histogram is needed twice - in SUMMARY.md and on the terminal at the end - and two copies of the
+# regex would let the two disagree about the same run.
+tally_field() { grep -oE "$1" "$TALLY" | sort | uniq -c; }
+
+# grep -c prints "0" AND exits 1 when there is no match, so the obvious `|| echo 0` appends a
+# SECOND zero and the tally line splits in two. Ask once, default only when the file is absent.
+count() { local n; n="$(grep -cE "$1" "$2" 2>/dev/null)"; printf '%s' "${n:-0}"; }
+
+# ABSENT IS NOT ZERO. The correctness ledger runs inside assertScenarioSlos, which a probe violation
+# throws before reaching - so on exactly the runs where a skipped offset would matter, the ledger
+# never ran and `loss=0` meant "not measured". It read as clean. Anything that cannot tell absent
+# from zero eventually reports the wrong one, so a counter whose source did not run says so.
+counted() {   # counted <regex> <logfile> <ran-marker-regex>
+    if grep -qE "$3" "$2" 2>/dev/null; then count "$1" "$2"; else printf 'unmeasured'; fi
+}
+
+# RECORDS, not lines. `LEDGER_LOSS: 37 produced records never consumed` is ONE line, so counting
+# lines reported loss=1 for a 37-record loss - the number a reader would act on, off by the entire
+# magnitude of the finding. Sums the captured figure instead, and keeps counted()'s absent-is-not-
+# zero contract.
+#
+# The ran-marker is `[chaos-ledger] expected=`, not a bare `[chaos-ledger]`: TWO classes emit that
+# prefix, and this is sound only because ProgressProbe.ledger happens to be called before
+# KeyOrderLedger.checkIfRecording. Swap those two calls and `loss=0` silently means unmeasured
+# again - sound by call order is not sound by construction, so the marker names the emitter.
+sum_of() {   # sum_of <regex-with-one-capture-group> <logfile> <ran-marker-regex>
+    grep -qE "$3" "$2" 2>/dev/null || { printf 'unmeasured'; return; }
+    sed -nE "s/.*$1.*/\1/p" "$2" 2>/dev/null | awk '{ s += $1 } END { printf "%d", s+0 }'
+}
+
+# Did the backlog drain, or stay flat? THE one judgement this investigation keeps getting wrong, so
+# the script makes it as a comparison and prints both numbers. -Dchaos.diagnoseStallRecovery keeps
+# the run watching past a violation and logs `[diagnose] consumed=N/TARGET` samples; climbing means
+# it drained (a timing proxy), flat means a genuine wedge. n/a means the diagnostic produced no
+# samples, which is a third answer and never to be read as either of the first two.
+# MEASURE ONLY THE SAMPLES AFTER THE VIOLATION FIRED. The diagnostic samples the ENTIRE wait, not
+# just the tail, so comparing the first sample to the last says "CLIMBED" for every run that got
+# anywhere - including one that stalled dead at 97386 and never moved again, because it climbed to
+# 97386 first. That would report the one signature worth finding as the harmless one. The sample
+# line carries `violations=N`, so the post-violation window is selectable without guessing.
+# inFlight is reported alongside because a flat consumed line with work in flight is a fleet dwelling
+# in the heavy tail, not a wedged one - that pair is what makes a flat line interpretable at all.
+# MAGNITUDE, NOT JUST DIRECTION. `last > first` made ANY forward movement CLIMBED, so a wedge that
+# completed ONE record in half an hour - 97386 to 97387 - filed as "the backlog recovered". Same
+# inversion as the window bug, reached the other way: the first fix asked the right question of the
+# wrong samples, this one asked a question too weak to separate the answers. Recovery is judged
+# against the backlog that was actually outstanding when the detector fired, because "+400 records"
+# means recovery with 500 left and means nothing with 50,000 left.
+#
+# DRAIN_MIN_RECOVERY_PCT is a CALIBRATION, not a truth, which is why the numbers behind it are
+# printed on every verdict: `+2752of2614` is the recovery and the outstanding backlog it is measured
+# against, so a reader can overrule the word without rerunning anything. A run that moves but not
+# enough is CREEPING - its own word, because calling it FLAT would claim evidence of a wedge and
+# calling it CLIMBED would claim evidence of recovery, and it is neither.
+DRAIN_MIN_RECOVERY_PCT="${DRAIN_MIN_RECOVERY_PCT:-10}"
+drain_verdict() {
+    awk -v minpct="$DRAIN_MIN_RECOVERY_PCT" '
+      /\[diagnose\]/ {
+        c=""; v=""; f=""; t="";
+        # consumed=N/TARGET - the target is what makes "outstanding" computable, so it is parsed
+        # rather than assumed. Without it there is no denominator and no magnitude test.
+        if (match($0, /consumed=[0-9]+\/[0-9]+/)) {
+          split(substr($0, RSTART+9, RLENGTH-9), pair, "/"); c = pair[1]; t = pair[2];
+        }
+        if (match($0, /violations=[0-9]+/)) v = substr($0, RSTART+11, RLENGTH-11);
+        if (match($0, /inFlight=[0-9]+/))   f = substr($0, RSTART+9,  RLENGTH-9);
+        seen++;
+        # A line the parse could not read is its own answer. Folding it into the pre-violation case
+        # would let a log truncated by interleaved writers read as "nothing fired".
+        if (c == "" || v == "") { malformed++; next }
+        if (v+0 == 0) next;
+        if (n == 0) { first = c; firstF = f; target = t }
+        last = c; lastF = f; n++;
+      }
+      END {
+        if (seen == 0)              { printf "n/a"; exit }               # diagnostic never sampled
+        if (n == 0 && malformed)    { printf "unparseable(%d)", malformed; exit }
+        if (n == 0)                 { printf "no-violation"; exit }      # nothing fired to judge
+        if (n == 1)                 { printf "insufficient(n=1)"; exit } # one sample shows no trend
+        delta = last - first;
+        outstanding = target - first;
+        detail = sprintf("%+d-of-%d,%s-to-%s,inFlight-%s-to-%s,n=%d", \
+                         delta, outstanding, first, last, firstF, lastF, n);
+        if (delta < 0)  { printf "RECEDED(%s)", detail; exit }   # backwards: the word must not say FLAT
+        if (delta == 0) { printf "FLAT(%s)", detail; exit }
+        if (outstanding > 0 && delta * 100 < outstanding * minpct) { printf "CREEPING(%s)", detail; exit }
+        printf "CLIMBED(%s)", detail;
+      }' "$1" 2>/dev/null
+}
+
+# Dump only OUR OWN process tree. `pgrep -f surefire|failsafe` is machine-wide, and this repo runs
+# dozens of worktrees at once - it would file a stranger's stacks under this cycle.
+descendants() {
+    local kid
+    for kid in $(pgrep -P "$1" 2>/dev/null); do printf '%s\n' "$kid"; descendants "$kid"; done
+}
+
+# SIGKILL, and children before the parent. This only ever runs on a build already judged wedged - the
+# jstack dump has been taken by the time we get here, so there is nothing left to lose by killing
+# hard. `pkill -P` sent SIGTERM, which is the signal LEAST likely to work on the process we suspect:
+# a JVM deadlocked inside a shutdown hook never returns from it, and killing the parent first would
+# reparent it onto init to survive the rest of the night. Re-derived rather than snapshotted, so a
+# child spawned during the dump is still caught.
+kill_tree() {
+    local p
+    for p in $(descendants "$1"); do kill -9 "$p" 2>/dev/null; done
+    kill -9 "$1" 2>/dev/null
+}
+
+# jstack ON A DEADLINE. Attaching to a JVM that cannot reach a safepoint does not fail - it BLOCKS,
+# and the call sits synchronously inside the watchdog. So the one input most likely to hang it is
+# the exact input this harness exists to collect: a wedged JVM. Unbounded, one such process at hour
+# one consumes the remaining seven hours and yields no dump, no verdict, no SUMMARY.md, no tarball
+# and no DONE marker - a night's run destroyed by the thing it was hunting, silently.
+#
+# `timeout(1)` is not on macOS, so the deadline is background-poll-kill, the same shape as the
+# cycle watchdog above. 0 = captured, 1 = failed, 2 = timed out (its own outcome: it means the JVM
+# was too wedged even to be inspected, which is a finding, not an absence).
+JSTACK_TIMEOUT_SECS="${JSTACK_TIMEOUT_SECS:-60}"
+jstack_with_deadline() {   # jstack_with_deadline <pid> <outfile>
+    local jp="$1" out="$2" jsp waited=0
+    "$J/bin/jstack" -l "$jp" > "$out" 2>"$out.err" &
+    jsp=$!
+    while kill -0 "$jsp" 2>/dev/null; do
+        if [ "$waited" -ge "$JSTACK_TIMEOUT_SECS" ]; then
+            kill -9 "$jsp" 2>/dev/null; wait "$jsp" 2>/dev/null
+            return 2
+        fi
+        sleep 1; waited=$((waited+1))
+    done
+    wait "$jsp" 2>/dev/null || return 1
+    [ -s "$out" ] || return 1
+    return 0
+}
+
+# Reports THIS cycle wrote. `find -newer <file>` is POSIX; -newermt is not portable to macOS.
+# Lifted out of the cycle loop so it can be fixtured: the bug it exists for - a stale XML from an
+# earlier cycle scoring a cycle that never ran as `passed` - is on the calibration list with no
+# case, and bin/AGENTS.md asks a fixed bug for a test that goes red against the old code.
+fresh_reports() {   # fresh_reports <reports-dir> <scenario> <marker-file>
+    find "$1" -name "TEST-*$2*.xml" -newer "$3" 2>/dev/null | sort
+}
+
+# SUM ACROSS EVERY FRESH REPORT, never `tail -1`. Taking the last match let directory order decide
+# the verdict: with two fresh reports, one carrying failures="1", the cycle scored `passed` and the
+# failing report was copied into the cycle directory to be read by nobody. A cycle is FAILED if
+# ANY of its reports failed, which is the only aggregation that cannot hide one.
+aggregate_stats() {   # aggregate_stats <report-file>...
+    [ "$#" -gt 0 ] || return 0
+    grep -ohE 'tests="[0-9]+" errors="[0-9]+" skipped="[0-9]+" failures="[0-9]+"' "$@" 2>/dev/null | awk '
+      { for (i = 1; i <= NF; i++) if (match($i, /"[0-9]+"/)) {
+            k = substr($i, 1, index($i, "=") - 1);
+            sum[k] += substr($i, RSTART+1, RLENGTH-2);
+        } }
+      END { if (NR) printf "tests=%d errors=%d skipped=%d failures=%d",
+                          sum["tests"], sum["errors"], sum["skipped"], sum["failures"] }'
+}
+
+# The verdict ladder, lifted for the same reason as the two above: it publishes the run's headline
+# number and had no test at all. Order matters - a hung cycle is hung whatever its reports say,
+# because they may be from before the wedge.
+verdict_for() {   # verdict_for <hung:yes|no> <dumps> <stats-string>
+    local hung="$1" dumps="$2" stats="$3" t e s f
+    if [ "$hung" = yes ] && [ "$dumps" -gt 0 ]; then printf 'HUNG-DUMP-CAPTURED'; return; fi
+    if [ "$hung" = yes ]; then printf 'HUNG-NO-DUMP'; return; fi
+    t="$(field_of tests "$stats")"; e="$(field_of errors "$stats")"
+    s="$(field_of skipped "$stats")"; f="$(field_of failures "$stats")"
+    if [ "$t" -eq 0 ]; then printf 'DID-NOT-RUN'; return; fi
+    if [ "$e" -gt 0 ] || [ "$f" -gt 0 ]; then printf 'FAILED'; return; fi
+    # An all-skipped cycle executed nothing and must not read as a pass. Not reachable today, but
+    # this harness passes BOTH -Dfailsafe.failIfNoSpecifiedTests=false and -Dexcluded.groups= - the
+    # two settings whose job is to make non-execution non-fatal - so the gap is one flag away.
+    if [ "$s" -ge "$t" ]; then printf 'ALL-SKIPPED'; return; fi
+    printf 'passed'
+}
+
+field_of() {   # field_of <name> <"tests=N errors=N ..."> - 0 when absent, so callers can do arithmetic
+    local v; v="$(printf '%s' "$2" | sed -n "s/.*$1=\([0-9]\{1,\}\).*/\1/p")"
+    printf '%s' "${v:-0}"
+}
+
+summarise() {
+    local dumped
+    dumped="$(find "$OUT/dumps" -type f -name "*.txt" 2>/dev/null | sort)"
+    {   echo "# Torture run $STAMP"
+        echo
+        echo "Budget: ${HOURS}h${MINUTES}m total, ${CYCLE_MIN}m per cycle, cycles limit $cycles_label"
+        echo "Rotation: ${ROTATION[*]}"
+        echo
+        echo "## Verdicts"
+        tally_field 'END [A-Z-]+|END passed'
+        echo
+        echo "## Commit modes actually observed (NOT requested - see the header)"
+        tally_field 'modes=[A-Z_,-]+'
+        echo
+        echo "## Did the stall-recovery diagnostic engage? (NOT-ENGAGED invalidates every drain= below)"
+        tally_field 'diag=[A-Z-]+'
+        echo
+        echo "## Drain verdicts - did the backlog recover AFTER the detector fired?"
+        echo "   CLIMBED recovered materially (a timing proxy) · CREEPING moved but negligibly ·"
+        echo "   FLAT did not move · RECEDED went backwards - the last three are all wedge-shaped."
+        echo "   n/a, no-violation, insufficient and unparseable are NOT verdicts: they each mean"
+        echo "   the question could not be asked, and must never be read as a quiet CLIMBED."
+        tally_field 'drain=[A-Za-z/-]+'
+        echo
+        echo "## The hunted signals"
+        echo "   unmeasured is NOT zero - it means the source of that count never ran in that cycle."
+        for f in timeouts loss dupes blocked silo; do
+            printf '  %s:\n' "$f"
+            tally_field "$f=[A-Za-z0-9-]+" | sed 's/^/   /'
+        done
+        echo
+        echo "## Failing cycles, in full - the seeds here are the asset, copy them somewhere durable"
+        # Every non-passing verdict, derived from the ladder rather than a second list of names that
+        # could fall out of step with it - ALL-SKIPPED was added to verdict_for and would have been
+        # missing from a hand-maintained alternation here.
+        grep -E 'END ' "$TALLY" | grep -vE 'END (passed|ABANDONED)' || echo "   none"
+        echo
+        echo "## Cycles with a thread dump (look here first)"
+        # One question, asked once. This used to `find` the dumps and then ask `ls -A` whether the
+        # directory was empty - two different questions, so a cycle whose jstack FAILED left only a
+        # .err file behind, printed no dump, and had its explanatory line suppressed by the .err.
+        # The HUNG verdicts are what say whether a cycle overran; this section only says what was
+        # captured, and must not answer the other question by implication.
+        if [ -n "$dumped" ]; then printf '%s\n' "$dumped"
+        else echo "   none captured - check the Verdicts section above for HUNG cycles"; fi
+        echo
+        echo "## Full tally"
+        cat "$TALLY"
+    } > "$OUT/SUMMARY.md"
+    # Announced by the caller as `packaged:`, so a silent failure here would advertise a tarball that
+    # is not there - and the artefacts are the whole point of an unattended run.
+    tar -czf "$OUT.tar.gz" -C "$(dirname "$OUT")" "$(basename "$OUT")" \
+        || say "PACKAGING FAILED - $OUT.tar.gz was not written; the cycle directories are still in $OUT"
+}
+
+# Ctrl-C still gets you a summary and a tarball - an interrupted eight-hour run has results in it.
+interrupted=no
+# shellcheck disable=SC2329  # invoked by the trap below, not by name
+on_signal() { interrupted=yes; say "INTERRUPTED - summarising what ran"; }
+trap on_signal INT TERM
+
+say "TORTURE START budget=${HOURS}h${MINUTES}m cycle=${CYCLE_MIN}m cycles=$cycles_label out=$OUT"
+say "hunting: commit-response timeouts, silent data skip. NOT transactional - see the script header."
+
+cycle=0
+while [ "$interrupted" = no ] && [ "$(date +%s)" -lt "$END" ]; do
+    [ "$MAX_CYCLES" -eq 0 ] || [ "$cycle" -lt "$MAX_CYCLES" ] || break
+    cycle=$((cycle+1))
+    scenario="${ROTATION[$(( (cycle-1) % ${#ROTATION[@]} ))]}"
+    seed=$(( (RANDOM<<15 | RANDOM) * 100003 + cycle ))
+    cdir="$OUT/cycles/$cycle-$scenario"; mkdir -p "$cdir"
+    log="$cdir/run.log"
+    remaining=$(( END - $(date +%s) ))
+    say "cycle=$cycle START scenario=$scenario seed=$seed budget=${CYCLE_MIN}m remaining=$((remaining/60))m"
+
+    # The freshness marker. Failsafe writes into a shared target/ directory that is never cleaned
+    # between cycles, and each scenario recurs every few cycles - so a cycle that never ran would
+    # otherwise read the PREVIOUS cycle's XML for the same class and score itself `passed`. Reports
+    # older than this marker are, by construction, not this cycle's.
+    marker="$cdir/.cycle-start"; : > "$marker"
+
+    JAVA_HOME="$J" "$D/mvnw" -f "$D/pom.xml" -Pci -pl parallel-consumer-core -am verify \
+        -DskipUTs=true -Dincluded.groups="$TEST_GROUPS" -Dexcluded.groups= \
+        -Dchaos.seed="$seed" -Dit.test="$scenario" \
+        -Dpc.log.dir="$cdir/pc-logs" \
+        -Dchaos.diagnoseStallRecovery=true \
+        -Dfailsafe.failIfNoSpecifiedTests=false -Dcopyright.skip=true -Djacoco.skip=true \
+        > "$log" 2>&1 &
+    mvn_pid=$!
+
+    # WATCHDOG. Dump before killing - a hang with no stack is a rumour, a hang with a stack is a bug.
+    # Test liveness IMMEDIATELY BEFORE judging the budget, never before the sleep that precedes it.
+    # Checking first and sleeping second means a build that exits during that 15s window is still
+    # declared hung: a clean 1m48s pass was reported HUNG-NO-DUMP because it finished 9 seconds
+    # before a 2-minute budget expired. The watchdog was manufacturing the failure it watches for.
+    waited=0; hung=no; dumps=0; abandoned=no
+    while :; do
+        kill -0 "$mvn_pid" 2>/dev/null || break   # finished on its own - not hung, whatever the clock says
+        if [ "$waited" -ge "$BUDGET" ]; then
+            hung=yes
+            say "cycle=$cycle BUDGET EXCEEDED after ${waited}s - dumping our JVMs before kill"
+            # The maven launcher itself is included, not just its descendants: it is a JVM, it is
+            # the parent of the forked test JVM, and a wedge in the fork's parent is exactly the
+            # kind of thing a dump is for. Excluding it left the root of the tree uninspected.
+            for jp in "$mvn_pid" $(descendants "$mvn_pid"); do
+                dumpfile="$OUT/dumps/cycle-$cycle-pid-$jp.txt"
+                jstack_with_deadline "$jp" "$dumpfile"
+                case $? in
+                    0) dumps=$((dumps+1)); rm -f "$dumpfile.err" ;;
+                    2) say "cycle=$cycle jstack TIMED OUT after ${JSTACK_TIMEOUT_SECS}s on pid $jp - that JVM is too wedged to inspect, which is itself a finding"
+                       rm -f "$dumpfile" "$dumpfile.err" ;;
+                    *) say "cycle=$cycle jstack FAILED on pid $jp - see $dumpfile.err"
+                       rm -f "$dumpfile" ;;
+                esac
+            done
+            kill_tree "$mvn_pid"
+            break
+        fi
+        # The interrupt check goes AFTER the sleep, deliberately: the liveness test above must stay
+        # immediately before the budget judgement, and anything inserted between them reopens the
+        # HUNG-NO-DUMP bug. Killing the build before breaking is what makes the trap's "summarising
+        # what ran" true - without it the `wait` below blocks until this cycle ends on its own.
+        sleep 15; waited=$((waited+15))
+        if [ "$interrupted" != no ]; then
+            abandoned=yes
+            kill_tree "$mvn_pid"
+            break
+        fi
+    done
+    wait "$mvn_pid" 2>/dev/null; rc=$?
+
+    fresh=()
+    while IFS= read -r f; do [ -n "$f" ] && fresh+=("$f"); done \
+        < <(fresh_reports "$RPT" "$scenario" "$marker")
+    stats=""
+    if [ "${#fresh[@]}" -gt 0 ]; then
+        stats="$(aggregate_stats "${fresh[@]}")"
+        mkdir -p "$cdir/failsafe-reports"
+        cp "${fresh[@]}" "$cdir/failsafe-reports/" 2>/dev/null
+    fi
+
+    # An abandoned cycle gets no verdict - the interrupt killed the build, so its reports describe
+    # a run that was stopped, not one that failed. Scoring it manufactured `DID-NOT-RUN rc=137`,
+    # set the exit code to 1, and listed a fictitious failing cycle with a seed under "the seeds
+    # here are the asset" - so Ctrl-C at hour seven of a clean run invented work for the morning.
+    if [ "$abandoned" = yes ]; then
+        say "cycle=$cycle END ABANDONED rc=$rc seed=$seed - interrupted mid-cycle, no verdict"
+        break
+    fi
+
+    verdict="$(verdict_for "$hung" "$dumps" "$stats")"
+    [ "$verdict" = passed ] || worst=1
+
+    # What commit mode did PC actually boot with? Read it out of the run rather than asserting it.
+    # ManagedPCInstance logs it on every instance start, at info on the integrationTests logger -
+    # PC's own boot line is on bz.stub.parallelconsumer, pinned to warn, and never appears.
+    # Both the console capture and the siloed harness stream are searched, so losing one still
+    # answers the question. UNOBSERVED is a real verdict: it means the run died before any PC
+    # started, and it must never be quietly read as "the mode I asked for".
+    modeSrc=("$log")
+    [ -f "$cdir/pc-logs/harness.log" ] && modeSrc+=("$cdir/pc-logs/harness.log")
+    modes="$(grep -ohE 'commitMode=[A-Z_]+' "${modeSrc[@]}" 2>/dev/null | sed 's/commitMode=//' | join_unique)"
+    [ -n "$modes" ] || modes=UNOBSERVED
+
+    # The siloed streams are half the point of the tarball. An empty directory here means
+    # -Dpc.log.dir did nothing, and a morning review would open a tarball of nothing.
+    silo=ok
+    if [ ! -d "$cdir/pc-logs" ] || [ -z "$(ls -A "$cdir/pc-logs" 2>/dev/null)" ]; then silo=EMPTY; fi
+
+    # Did the diagnostic actually engage? A flag that is accepted and ignored is this project's
+    # signature failure - `-Dchaos.commitMode` was one, and `-Dchaos.diagnoseStallRecovery` itself
+    # was another until it was lifted to ChaosScenarioBase. So the run is asked, not assumed.
+    if grep -q 'chaos.diagnoseStallRecovery ACTIVE' "$log" 2>/dev/null; then diag=ACTIVE; else diag=NOT-ENGAGED; fi
+
+    # `blocked=` reads THE DUMPS, not the build log. It greps jstack's own header line, and jstack
+    # writes to $OUT/dumps/*.txt - that string has never appeared in run.log and never will, so a
+    # HUNG cycle whose dump contained a Java-level deadlock reported blocked=0. The harness was not
+    # reading the one artefact it exists to produce.
+    blocked=unmeasured
+    if [ "$dumps" -gt 0 ]; then
+        blocked="$(grep -lE 'Found one Java-level deadlock' "$OUT"/dumps/cycle-"$cycle"-pid-*.txt 2>/dev/null | wc -l | tr -d ' ')"
+    fi
+
+    say "cycle=$cycle END $verdict rc=$rc seed=$seed modes=$modes silo=$silo dumps=$dumps diag=$diag $(
+        printf 'drain=%s timeouts=%s loss=%s dupes=%s blocked=%s' \
+          "$(drain_verdict "$log")" \
+          "$(counted 'Timeout waiting for commit response' "$log" 'commitMode=')" \
+          "$(sum_of 'LEDGER_LOSS: ([0-9]+)' "$log" '\[chaos-ledger\] expected=')" \
+          "$(sum_of 'LEDGER_DUPLICATES: ([0-9]+)' "$log" '\[chaos-ledger\] expected=')" \
+          "$blocked")"
+done
+
+say "TORTURE COMPLETE cycles=$cycle"
+summarise
+[ -f "$OUT.tar.gz" ] && say "packaged: $OUT.tar.gz"
+: > "$OUT/DONE"   # completion marker, so anything polling this run can tell finished from wedged
+
+echo >&2
+echo "=========================================================================" >&2
+echo " TORTURE RUN COMPLETE - $cycle cycle(s), $(( ( $(date +%s) - START_TS ) / 60 )) minutes" >&2
+tally_field 'END [A-Z-]+|END passed' >&2
+echo " summary:  $OUT/SUMMARY.md" >&2
+if [ -f "$OUT.tar.gz" ]; then echo " tarball:  $OUT.tar.gz" >&2
+else echo " tarball:  NOT WRITTEN - packaging failed; the cycle directories are still in $OUT" >&2; fi
+echo " dumps:    $OUT/dumps" >&2
+echo "=========================================================================" >&2
+exit "$worst"

--- a/docs/inflight/branch-overnight-torture-harness.md
+++ b/docs/inflight/branch-overnight-torture-harness.md
@@ -1,0 +1,158 @@
+# Handoff: the overnight torture harness, and the state of the confluentinc#857 work behind it
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: coordination -->
+
+For an agent picking this up with no context. Written 2026-08-28 at the end of a long session; the
+detail behind every claim is in the notes cited, not repeated here.
+
+## What you are inheriting
+
+`bin/torture-overnight.sh`. An MVP spike, not finished work. Run it overnight on the highcpu rig:
+
+    bin/torture-overnight.sh                  # 8 hours, 30-minute cycles
+    bin/torture-overnight.sh --cycles 1       # one cycle, then stop - the smoke test
+    bin/torture-overnight.sh --minutes 30     # a short run
+    bin/torture-overnight.sh --list           # the rotation, and the mode each scenario hardcodes
+
+It rotates chaos scenarios - scenarios only, never commit modes, and below is why that distinction
+is load-bearing - gives each cycle a hard wall-clock budget, **takes a thread dump before killing
+anything that overruns**, and packages every cycle's logs, failsafe reports and siloed log streams
+into a tarball with a `SUMMARY.md`. The morning review should need the summary and the `dumps/`
+directory, nothing else.
+
+**The dump-before-kill is the point of the whole design.** A hang with no stack is a rumour; the six
+thread dumps that identified the revoke deadlock are the only reason it stopped being a signature and
+became a mechanism.
+
+## What it is hunting, and why those
+
+The AB-BA revoke deadlock is **fixed and verified** - see below. What remains unaccounted for:
+
+- **The unbounded revoke wait in transactional mode.** Carries astubbs#44 / confluentinc#803, the
+  an issue carrying upstream's verified-bug label (one of a couple of dozen, not the only one). **This harness does not hunt it** - no chaos
+  scenario is built for `PERIODIC_TRANSACTIONAL_PRODUCER`, so no rotation can reach it; see "Known
+  gaps that remain" below.
+  See `bug-857-transactional-revoke-wait.md` - its design decision is explicitly unsettled, so **do
+  not write a fix before settling it with Antony**.
+- **Commit-response timeouts**, reported in the field twice and never reproduced -
+  `bug-177-commit-response-timeout-unreproduced.md`.
+- **Silent data skip.** confluentinc#875 describes an offset never delivered, lag growing, and a
+  restart making it reappear. That is not a liveness failure and no liveness detector will see it.
+  Completeness is asserted, but only end-of-cycle - what is still missing is below.
+
+## State of the investigation - what is settled, so you do not redo it
+
+- **The deadlock is verified.** A/B on `Rebalance857CommitSyncDeadlockProbeIT`, one term changed:
+  control failed every repetition, the fix failed none and logged the contended decline throughout.
+  ~240 repetitions per arm. `test-857-deadlock-ab-soak-harness.md`.
+- **The async `NO_PROGRESS` line is a TIMING PROXY, not a defect.** Six firings, six drains.
+  `test-857-churn-storm-async-stalls.md`.
+- **The `CLASS2_STALL` line was demoted the same way** on 2026-08-25. Roughly half the family ledger
+  is superseded; every sighting now carries a STATUS line saying which.
+- **Six more family defects landed than astubbs#119's status counts** - astubbs#346, astubbs#345,
+  astubbs#373, astubbs#336, astubbs#344 and astubbs#349. The issue's `## Fork status` needs rewriting, not appending to.
+- **`largeNumberOfInstances` does not reproduce here** - 19 green across three scales. But that is
+  evidence about an M2 desktop, not about the code.
+
+## The one habit that mattered most
+
+**Five times this week a measurement error, not the system, was the answer.** The reproducer was
+inverted; a probe's window never opened; a test was reshaped between the claim and the measurement; a
+grep was narrower than the question; a classifier labelled drained runs flat. Every one produced a
+confident wrong answer and every one cost a single command to catch.
+
+So: **before believing any result, check what actually ran.** Did the test execute? Did the code path
+fire? Is the file you grepped the file that holds the answer? A green run is evidence only about the
+thing that ran.
+
+## Gaps that were checked, and what checking them found
+
+**`-Dchaos.commitMode` was NOT honoured. No such property has ever existed** - it appeared only in
+this script and in this note, so every cycle ran the mode its scenario hardcodes while the directory
+names, the tally and the summary all said `PERIODIC_TRANSACTIONAL_PRODUCER`. The labels are gone and
+each cycle now reports the mode it OBSERVED. **`bin/torture-overnight.sh`'s header owns the detail** -
+which class hardcodes which mode, why plumbing a real property is not a one-liner, and why the
+decision belongs with the one `bug-857-transactional-revoke-wait.md` says not to settle alone.
+
+The part worth carrying beyond that script is **the tell**: `-Dchaos.seed` and `-Dpc.log.dir`, on
+adjacent lines, are real and used by several other scripts in `bin/` (`grep -rl chaos.seed bin/`).
+The pattern was copied and the third member of it was never confirmed. A flag sitting among working
+flags looks like one.
+
+**The completeness gap is real but narrower than this note used to claim.** An independent
+delivery check already exists - `ChaosScenarioBase.assertScenarioSlos` runs one, and the script
+header's `COMPLETENESS` block owns what it does and does not reach. So **the missing thing is a
+TIME-BOUNDED claim** (delivered within N seconds of production), not an independent one, and that
+is a different and larger piece of work. `kafka-verifiable-producer` is still the cheap way in.
+
+**The cycle-budget worry was wrong**: the watchdog returns as soon as the build exits, so a fast
+cycle never burnt its slot. A real defect was hiding next to it and is fixed - liveness was tested
+*before* the sleep rather than after, so a clean 1m48s pass was reported `HUNG-NO-DUMP` because it
+finished nine seconds inside a two-minute budget.
+
+## The first real run, 2026-08-29
+
+An overnight rotation of the five chaos scenarios, **no hangs and a handful of failures, every one
+of them `ChaosChurnStormIT`** - the other four scenarios were clean all night. The correctness
+ledger balanced on every completed run: no data loss anywhere. The rates and per-scenario tallies
+belong to the notes below and to the run's own `SUMMARY.md`.
+The sightings themselves stayed with the investigation rather than travelling with this harness:
+`docs/inflight/test-857-churn-storm-async-stalls.md` owns the four, their three distinct signatures
+and their seeds, and the two `NO_PROGRESS` ones are also in
+`docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md`. Both are on
+astubbs/parallel-consumer#29's branch, which is where the confluentinc#857 work lives. The harness
+travels without its findings deliberately: an instrument and the investigation that used it have
+different lifetimes, and the investigation's notes are deleted when astubbs/parallel-consumer#29
+lands while the harness outlives it.
+<!-- file-refs: N/A - both notes live on the confluentinc#857 branch by design; the harness ships without them -->
+
+What the run exposed in the harness itself is fixed and covered in `bin/torture-overnight.sh`'s own
+header, which owns each rationale: the stall-recovery diagnostic was never passed, so nothing could
+be classified; `loss=0` meant "not measured" on exactly the failing runs; the drain verdict read a
+wedge as a recovery, twice, by window and then by magnitude; and `jstack` had no deadline, so one
+unresponsive JVM could consume a whole night. **The transactional gap is NOT among them** - what was
+fixed there is the harness's false CLAIM to coverage, not the coverage. It is still open below.
+
+**Machine-local:** the run's artefacts are `~/pc-soak-runs/torture-20260829T210914Z.tar.gz` on
+Antony's desktop, copied out of `/tmp` before it was reaped and checksum-verified. Nothing in the
+repo depends on it - the seeds above are the part that had to survive.
+
+## Known gaps that remain
+
+- **No time-bounded delivery assertion** - see above. This is the data-skip hunt, and it is design
+  work, not plumbing.
+- **No transactional coverage, and it cannot be fixed by widening the rotation.** No chaos scenario
+  is built for that mode. The vehicles are `RebalanceEoSDeadlockTest` and `TransactionTimeoutsTest`,
+  both outside the chaos group, reachable via `--groups`. Whether repeating either actually hunts the
+  unbounded revoke wait is still open.
+- Not containerised. A desktop passes everything; the constrained rig is where these defects live.
+  `test-pc-soak-harness-architecture.md` has the design, including what to reuse rather than build.
+- The run is foreground. For an unattended 8 hours, `nohup ... &` it and poll for the `DONE` marker
+  the script writes into its output directory - an agent cannot hold an hour-long foreground call.
+
+## Where things sit
+
+<!-- post-merge: checked-begin - written as it reads once the confluentinc#857 work has merged: the
+     harness is on master, the branch that carried it is gone, and the mentions below say what that
+     work CONTAINED rather than that it is open -->
+
+The harness was built on top of the confluentinc#857 work rather than on master, and depended on it:
+it packages the siloed log streams, and it drives the stall-recovery diagnostic, whose LIFT to
+`ChaosScenarioBase` was not on master - the flag itself is older, and on master the churn scenario
+accepted it and ignored it. **Cut from master the harness still RUNS, which is the trap:**
+`-Dpc.log.dir` is likewise accepted and does nothing there, so the specialised logs would be empty
+and a morning review would open a tarball of nothing.
+
+**Both of those dependencies left in the other direction**, to
+astubbs/parallel-consumer#381, which was cut fresh from master and carries the log silos and the
+diagnostic lift. The harness's real dependency is therefore that work, not the deadlock fix - what
+tied it to the 857 branch was the packaging it needed and the order things happened in, not the fix.
+The trap above is unchanged in shape: run it against a tree without those pieces and it produces an
+empty tarball rather than an error.
+
+`feats/overnight-torture-harness` was then absorbed into the 857 branch whole rather than carried as
+its own PR, because it contained that branch in its entirety - a PR from it would have shown the
+whole 857 diff to review a harness and its notes. Nothing depends on the ref.
+
+<!-- post-merge: checked-end -->

--- a/docs/inflight/test-pc-soak-harness-architecture.md
+++ b/docs/inflight/test-pc-soak-harness-architecture.md
@@ -1,0 +1,181 @@
+# A PC soak harness: containerised worker nodes, a contention schedule, and a reaping story
+
+<!-- inflight-type: feature -->
+<!-- inflight-impact: blind-spot -->
+
+**The goal is to break PC, and to capture the moment of the break with the context that led to it.**
+Not to demonstrate that it works.
+
+The defects this project finds are the ones that need time and load to appear, and the current suite
+gets minutes of both. A long soak against real containers buys the hours, and it is the only way to
+exercise autoscaling at all, since adaptive concurrency is a response to load over time and cannot be
+observed in a short test. It also gives the project something it has never had: a standing rig that
+exercises PC the way a deployment would, continuously, rather than a suite that runs and stops.
+
+## Shape
+
+- **Docker to start**, so it builds and runs on a laptop before it needs a rig.
+- **Worker nodes as constrained containers - one CPU, 4GB.** The constraint is the POINT, not a
+  compromise. A 32-core host hides thread starvation, GC pauses interacting with poll timeouts, and
+  the commit-response paths that only go wrong when the poll thread is genuinely starved. Several
+  defects in the confluentinc#857 family are visible only under contention, and one signature has
+  already been shown to replay red on a contended box and green on an uncontended one.
+- **A chaos producer** feeding the topic, with its own load profile.
+- **A chaos PC consumer whose USER FUNCTION latency follows a schedule** - reduced, stable, elevated
+  - to simulate downstream systems slowing and recovering. This is the piece that makes
+  astubbs/parallel-consumer#333's adaptive concurrency evaluable: without a controlled load
+  trajectory there is nothing for an admission target to track, and nothing to say whether it tracked
+  it well.
+- **External scaling too**: spawn and retire worker containers on the same indicators, so group
+  rebalances are driven by the workload rather than injected at random. That is a different rebalance
+  shape from the current suite's, and closer to the redeployment scenario every field report
+  describes.
+
+## The reaping is the work, not the looping
+
+A three-day run that fails once and buries the evidence costs three days and produces a rumour. Every
+lesson this repo has already paid for points at capture rather than duration.
+
+- **Silo the logs by concern at the logback level, aggressively.** Keep the master
+  everything-in-one-place log, and ROUTE COPIES to per-concern files - this is additive, so nothing
+  is lost and each question gets a file small enough to read. Worth its own stream: each stall probe
+  and detector; runtime state analysis that exists to aid testing rather than to run the product;
+  the test harness's own output; and each PC subsystem - commit/offset, rebalance/lifecycle,
+  shard/work state, autoscaling decisions. The rule that makes this easy to apply: **anything
+  tangential to running the product gets its own file**, because during analysis it is either the
+  only thing you want or the only thing in the way.
+
+- **Two permanent, never-truncated streams: every ERROR, and every WARN.** The ring buffer below is
+  for volume, and volume is the wrong thing to apply to a warning from two days ago - which is
+  precisely the line you will want when something fails on day three. These stay for the whole run.
+
+- **Classify errors, so that an unexpected one is a finding.** An error the system EXPECTS - a
+  retriable failure, a deliberately induced fault - is not an error, it is the harness working. The
+  useful signal is an error nobody forced, and it is invisible while both kinds share a stream.
+  `PCRetriableException.isPresentIn` already splits expected from unexpected on the processing path
+  and the close and revoke paths never ask; the same split is what makes a soak's error log
+  actionable. **A genuine, unforced error in a soak is a bug until shown otherwise.**
+- **Emit the autoscaling track record as structured data, not prose.** What the admission target was,
+  what drove the change, what the in-flight count and downstream latency were. A chart answers "did
+  it track the load" in seconds; a log does not answer it at all.
+- **Prefer time series over log lines for anything continuous.** PC already exposes metrics through
+  micrometer; scraping them to a file makes the whole run a dataset. This is the single biggest
+  difference between a soak that gets analysed and one that gets abandoned.
+- **Ring-buffer the verbose stream and flush it only on a failure.** Three days of DEBUG is
+  unusable and enormous - the chaos job log has already reached 126MB in minutes. Keep a rolling
+  window in memory, write it out when something fires.
+- **Capture the mechanism at the moment of failure, automatically**: a thread dump, plus PC's own
+  internal counters. The six thread dumps that finally identified the revoke deadlock are the only
+  reason it stopped being a signature and became a mechanism; every earlier sighting had the symptom
+  and not the cause.
+- **One line per iteration to a tally**, carrying the seed. Seeds outlive logs.
+
+## Two things that will otherwise be misread
+
+**A seed reproduces the SCHEDULE, not the outcome.** Real brokers, real containers and real timing
+mean the same seed can produce different results - which is a finding to record, not a bug in the
+harness. The seed makes the disturbance replayable; it does not make the system deterministic.
+
+**Report what the run REACHED, not only whether it passed.** The recurring failure in this repo is a
+green that never exercised the thing it claims to test: a mutation lane that scored nothing and
+exited 0, a deadlock probe whose window never opened, both arms of an A/B going green with the
+mechanism untouched. A soak with no notion of "did this run get to the interesting state" will
+manufacture the same false confidence at much greater length.
+
+## Where it can run
+
+GitHub-hosted runners cap a job at six hours, so multi-day runs cannot live there. Self-hosted has no
+GitHub-imposed job limit - the default `timeout-minutes` is 360 and can be raised - so the highcpu rig
+can host a run of days, either through the runner or over SSH. Building it Docker-first keeps both
+options open and keeps the laptop as the development loop.
+
+## Do not build what already exists
+
+Most of this is assembly, not invention. The bespoke part is small and this repo already owns it.
+
+**Already in this repo, and the hard part.** `ProgressProbe`, `KeyOrderLedger`, `ChaosConductor` and
+`ManagedPCInstance` are a working chaos conductor and correctness checker. They are calibrated,
+which is the expensive bit - the note on a timing bound manufacturing its own evidence is what that
+calibration cost. A containerised harness should DRIVE these, not replace them.
+
+**Kafka's own Trogdor** is a fault-injection and long-running-soak framework built for exactly this
+shape - agents, coordinator, workload specs, fault specs. Closest existing thing to the whole idea.
+Worth an evaluation before writing an orchestrator.
+
+**`kafka-verifiable-producer` / `kafka-verifiable-consumer`** ship with Kafka and do verifiable
+produce/consume with sequence tracking - a ready-made external oracle for loss and duplication,
+independent of PC's own accounting. An independent oracle is worth a lot here, because every
+correctness claim currently comes from PC's own counters.
+
+**Toxiproxy** gives the network faults this note admits are missing - latency, bandwidth limits,
+partitions between PC and the broker - and has a Testcontainers module, so it fits the existing
+harness rather than sitting beside it. This is the cheapest way to add a fault class nothing here
+currently exercises.
+
+**Testcontainers** is already a dependency and can orchestrate a multi-container topology including
+compose, so the container story does not need new tooling either.
+
+**Pumba** for container-level chaos (kill, pause, netem). This is the direct unblock for
+[`test-chaos-crash-fidelity-variant.md`](test-chaos-crash-fidelity-variant.md), which is parked
+precisely because every stop the conductor performs is an orderly `close()` - the fleet shares one
+JVM, so a real crash cannot be modelled. Containers make it possible: `SIGKILL` a worker and the
+member stops heartbeating with its assignment still held, which is the shape most field reports
+describe and the one the suite has never produced.
+
+**Prometheus and Grafana** for the time series - worth it for the SOAK specifically, and not for the
+PR suite. The failures here are temporal: "the fleet reached 95% and stopped" is a time-series
+question, and the Class 2 demotion turned on whether a frozen watermark later moved, which a chart
+answers instantly and a log does not answer at all. PC already exposes micrometer, so this is
+configuration rather than code. The cheap first step is dumping metrics to a file and analysing
+offline; Grafana earns its place when a human is watching a run that lasts days.
+
+**Logback already does the log routing**: `SiftingAppender` to split streams by logger or MDC, and
+`CyclicBufferAppender` for the ring-buffer-flush-on-failure pattern. No new dependency, and
+`logstash-logback-encoder` if the machine-readable stream should be JSON.
+
+**Jepsen is the wrong shape** - Clojure, and aimed at linearizability of stores - but its structure is
+worth stealing outright: generator, nemesis, checker. That is precisely conductor, chaos schedule and
+correctness ledger, and this repo has all three already.
+
+### Two decisions worth making deliberately, not by drift
+
+**Do NOT scrap the chaos harness for Trogdor.** Trogdor's workload and fault specs are about Kafka -
+produce this, consume that, break this node. It has no notion of the properties this project exists
+to defend: per-key ordering held under concurrency within one incarnation, partition and assignment
+epoch; duplicates bounded per disturbance; a watermark that is frozen versus one that is merely slow.
+`ProgressProbe` and `KeyOrderLedger` encode those, and their CALIBRATION is the expensive asset - the
+Class 2 demotion is what miscalibration cost, measured in a year of sightings that turned out to be a
+bound meeting a workload. **Take Trogdor for the layer we lack** - multi-node orchestration, fault
+injection and long-run coordination - and keep our detectors as the oracle it reports to. Evaluate,
+do not adopt wholesale.
+
+**Add `kafka-verifiable-producer` alongside our own accounting, not instead of it.** The argument for
+it is not that it is better; it is that it is INDEPENDENT. Every correctness claim in this project
+currently comes from PC counting its own work, and this codebase has repeatedly found bugs in exactly
+that counting - drifted in-flight counters, an encoder marking incomplete offsets complete, a
+sign-reversed shard count. A verifier that shares no code with PC is a second opinion those bugs
+cannot corrupt. The produce side is the easy win: sequence-numbered records, reconciled against what
+PC reports consuming. **`kafka-verifiable-consumer` mostly does not fit**, because it wants to BE the
+consumer, and here PC is - and it checks plain consumer semantics, which is the guarantee PC
+deliberately does not offer. So it cannot replace `KeyOrderLedger` and should not be asked to.
+
+**So the genuinely new work is narrow**: the downstream-latency schedule that drives autoscaling, the
+external scaler, the container topology, and the reaping described above.
+
+## Later, if it earns it
+
+Scale the rig out with OpenTofu against cloud instances, once the harness is worth running at a size
+one box cannot reach. **Deliberately last, and the preference for one beefier box is not just
+sequencing.** A distributed rig multiplies the reaping problem that decides whether any of this is
+worth running, and Docker on a single host gives for free what a fleet of instances makes work:
+log shipping is already central, and any "machine" in the fleet can be inspected AT RUNTIME - exec
+into it, take a thread dump, read its state while it is still wedged. That last one matters more here
+than anywhere: every sighting in this family that became a mechanism did so because something
+captured the process while it was still stuck, and every one that stayed a signature did not.
+
+## What this still is not
+
+Not production. No network partitions, no broker upgrades or failovers, no competing workloads from
+other applications, no multi-AZ latency. Worth stating so the results are not overclaimed: it
+exercises PC against load and churn, which is more than anything here does today, and less than a
+deployment.

--- a/docs/inflight/test-soak-instruments-have-no-lane.md
+++ b/docs/inflight/test-soak-instruments-have-no-lane.md
@@ -1,0 +1,61 @@
+# Two overnight instruments, and neither can reach the lane that already exists
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: ci -->
+
+`bin/torture-overnight.sh` and `bin/soak-deadlock-probe.sh` are both overnight soak instruments. Both
+are run by hand or not at all. **The gap is not that a scheduled soak lane needs building** - one
+exists and is the right shape - it is that neither script fits its contract, and both mismatches are
+design questions rather than renames.
+
+## The lane that exists
+
+`.github/workflows/experiments.yml` runs on `workflow_dispatch` **and** on a schedule, with a
+240-minute timeout, a tally-collection step and an artifact upload. `mutation-full-sweep.yml` shows a
+cron lane is established practice here, so nothing new has to be argued for.
+
+Its contract is narrow and deliberate:
+
+- the script must be `bin/exp-<name>.sh`,
+- `<name>` must be in the workflow's hardcoded allowlist (an allowlist, not a glob, because the input
+  is data and must never become code),
+- it is invoked as `bin/"$EXPERIMENT".sh ${ITERATIONS}` - **one positional argument**, an iteration
+  count the workflow validates before passing.
+
+## Mismatch 1: the A/B probe needs a second tree, and the lane can pass one number
+
+`soak-deadlock-probe.sh` takes `FIXED_TREE CONTROL_TREE [INVOCATIONS]`. The control arm is the whole
+point - it is the arm that must deadlock - and there is nowhere in the contract to name it.
+
+**This is not solved by re-ordering the arguments.** A CI run has one checkout, so a control arm has
+to be *manufactured*: revert the fix into a scratch worktree, run both, discard it. That is
+mechanical - the local A/B this session ran did exactly that with `git checkout <pre-fix-sha> -- <one
+file>` - but it puts "which commit is the control" inside the script or inside the workflow input,
+and both are decisions with a blast radius. A workflow input naming a SHA to revert is data that
+selects code, which is the shape the allowlist exists to prevent.
+
+## Mismatch 2: the torture harness is an eight-hour design against a four-hour cap
+
+Its whole method is hours of short cycles with a watchdog taking a thread dump before each kill;
+`branch-overnight-torture-harness.md` records a 214-cycle run. The lane caps at 240 minutes.
+
+Two ways out, and they are not equivalent. **Raise the cap** on the self-hosted runner, which is
+where a long soak belongs anyway and which no hosted runner would tolerate. Or **cut the run to fit**,
+which changes what the instrument measures: the value of a soak is in the tail, and a four-hour soak
+is not a shorter eight-hour soak, it is a different experiment with a worse chance of catching the
+thing.
+
+## What is NOT in question
+
+Neither script needs rewriting to be scheduled. Both already write a machine-readable tally, both
+already classify from the failsafe report rather than maven's exit code, and both already treat a run
+that executed no test as not-a-data-point - which is the discipline the lane's own tally step assumes.
+
+## The decision this is waiting on
+
+Whether a soak lane is worth the runner time at all. Both instruments were written during one
+investigation and neither has run since it ended, which is weak evidence for their value and no
+evidence against it - nothing has asked them a question lately. Until somebody decides, the honest
+<!-- post-merge: checked - past tense and names the PR, so it reads as a record once that PR has landed -->
+state is that astubbs/parallel-consumer#405 shipped two instruments with no trigger, and this note
+exists so that is a recorded choice rather than an oversight discovered in six months.


### PR DESCRIPTION
Extracted from astubbs/parallel-consumer#29, which was carrying it for no reason other than that it was written there.

## Description

An overnight torture harness for hunting the lock-ups and data-skips the confluentinc#857 family has not accounted for. It runs for hours in short cycles, and the cycle design is the interesting part: rather than teaching the harness to detect every way PC can wedge, each cycle gets a hard wall-clock budget and a watchdog that **takes a thread dump and then kills it** when that expires. Restarting every thirty minutes costs almost nothing against an eight-hour run, and the dump is what turns a hang into a diagnosis - the six captures that identified the revoke deadlock exist only because something dumped the stack while it was still stuck.

It arrives with `bin/test-torture-overnight.sh` (25 cases), which exists because the verdict logic - the part that decides what a run MEANT - has been wrong three times. Getting the drain verdict backwards reports the most interesting result in the family as the boring one, and nothing downstream would question it.

**Why it moves.** astubbs/parallel-consumer#29 is a revoke-path lock fix. A reviewer of that should not also be handed a 39KB eight-hour soak instrument. Cut from `master` so it does not inherit an unrelated review.

**It supersedes `feats/overnight-torture-harness`**, which is fully merged into astubbs/parallel-consumer#29 (`a0c5c7dc0`) with no commits outstanding, and which that PR has since moved ahead of. Basing this on the older branch would have silently reverted two content corrections: the "only issue upstream ever labelled a verified bug" claim was false and is now stated correctly, and a chaos scenario reaching `PERIODIC_TRANSACTIONAL_PRODUCER` now exists (`ChaosRevokeUnderWorkTransactionalIT`) where the note still said none could.

**What deliberately did not come with it.** The sightings. `test-857-churn-storm-async-stalls.md` and `test-no-progress-window-may-not-transfer-to-w1.md` stay on the confluentinc#857 branch: an instrument and the investigation that used it have different lifetimes, and those notes are deleted when that PR lands while this outlives it. Their references here are marked with the reason rather than dropped.

## Known weaknesses, stated rather than discovered later

This is an instrument that has not fully earned its keep, and the note says so:

- **`ProgressTracker.withDiagnostic(...)` was never wired**, so every stall it has ever produced ends `no consumer diagnostic supplied`. That is the single cheapest improvement available to it and it is not done here.
- **`-Dpc.log.dir` is accepted and does nothing on one path**, so a morning review can open a tarball of nothing.
- **The verdict logic is the part the Node-first rule is aimed at.** The `shell-justified:` marker says so outright: process orchestration (watchdog timers, `jstack` against a live PID, killing a wedged JVM, traps across an eight-hour run) is genuinely bash's domain, but if the verdict logic grows further it should move to `.mjs` rather than be defended by that comment.

## Checklist

- [x] Docs updated - the harness's two notes travel with it
- [ ] User-facing feature documentation data added under `docs/features/` - N/A - an internal test instrument, not a user-facing feature
- [x] Tests added/updated - `bin/test-torture-overnight.sh`, 25 cases, passing
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - `docs/inflight/branch-overnight-torture-harness.md` travels with the harness and predates this branch
- [x] Title & body reflect the final content of this PR
- [ ] Ran `ce-simplify` and `ce-code-review` locally - N/A - the content is unchanged from astubbs/parallel-consumer#29 apart from one citation repair; asking for `@claude review this` on this PR is the cheaper place to spend the review
