### PR TITLE
ci: make the PR's CI comments say what they mean, and survive their own failures

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -236,8 +236,13 @@ jobs:
               try { return m ? JSON.parse(m[1]) : null } catch { return null }
             }
 
-            const existing = (await github.rest.issues.listComments({ owner, repo, issue_number }))
-              .data.find(c => c.body.includes(marker))
+            // PAGINATE, and only trust our own comments. listComments returns 30 per page, so on a busy PR the
+            // report scrolls off page one and every push posts a fresh comment instead of updating - the delta
+            // disappears and the fifteen-comments problem returns. And the comment we find is now an INPUT: its
+            // payload steers the update-vs-post decision, so restrict it to comments this workflow could have
+            // written rather than to anything carrying the marker.
+            const all = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 })
+            const existing = all.find(c => c.body.includes(marker) && c.user?.type === 'Bot')
             const prev = readData(existing?.body)
             const cur = readData(body)
 
@@ -274,7 +279,12 @@ jobs:
             // comment is posted at the bottom, and the old one is retired: its marker renamed so later pushes
             // stop targeting it, and a link forward so a reader who lands on the stale one is not stranded.
             // Number-only movement still updates in place; only the VERDICT earns a new comment.
-            const statusChanged = prev && cur && prev.status !== cur.status
+            // A COMMENT WITH NO PAYLOAD MUST COUNT AS A CHANGE, not as "no change". Written `prev && cur && ...`
+            // this was falsy whenever prev was null - which is every comment posted before the payload existed,
+            // and such comments sit on open PRs right now. The first green-to-red after this merges would then
+            // have been edited in place silently: exactly the failure this change removes, on the run where it
+            // matters most. Unknown is not the same as unchanged.
+            const statusChanged = cur && (!prev || prev.status !== cur.status)
             if (existing && !statusChanged) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload })
             } else {
@@ -282,7 +292,7 @@ jobs:
               if (existing) {
                 const retired = existing.body
                   .replace(marker, '<!-- pc-throughput-report (superseded) -->')
-                  .replace(/^### /m, `### [superseded - status changed to ${cur?.status}] `)
+                  .replace(/^### /m, `### [superseded - status changed to ${String(cur?.status ?? 'unknown').replace(/[^a-zA-Z-]/g, '')}] `)
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id,
                   body: `${retired}\n\n<sub>Superseded by [a newer report](${created.data.html_url}).</sub>` })
               }

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -227,13 +227,58 @@ jobs:
             const marker = '<!-- pc-throughput-report -->'
             const { owner, repo } = context.repo
             const issue_number = context.issue.number
-            // Update in place rather than appending on every push: a PR with fifteen throughput
-            // comments is a PR where nobody reads the throughput comment.
+
+            // The reporter embeds one line of machine-readable state. Read it off both the new report and the
+            // previous comment, so this run can say what CHANGED rather than only what it measured - reading
+            // our own last comment is the only store available, since no series is kept anywhere by decision.
+            const readData = text => {
+              const m = /<!-- pc-throughput-data: (.*?) -->/.exec(text ?? '')
+              try { return m ? JSON.parse(m[1]) : null } catch { return null }
+            }
+
             const existing = (await github.rest.issues.listComments({ owner, repo, issue_number }))
               .data.find(c => c.body.includes(marker))
-            const payload = `${marker}\n${body}`
-            if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload })
-            else await github.rest.issues.createComment({ owner, repo, issue_number, body: payload })
+            const prev = readData(existing?.body)
+            const cur = readData(body)
+
+            // A delta, never a verdict: this test's own run-to-run spread is wide enough that a single-push
+            // difference is noise far more often than it is a change. Shown because an in-place update
+            // otherwise destroys the only record of what the previous push measured.
+            let delta = ''
+            if (prev && cur) {
+              const bits = []
+              if (prev.status !== cur.status) bits.push(`status **${prev.status} -> ${cur.status}**`)
+              if (typeof prev.rate === 'number' && typeof cur.rate === 'number' && prev.rate > 0) {
+                const pc = ((cur.rate - prev.rate) / prev.rate) * 100
+                bits.push(`rate ${prev.rate} -> ${cur.rate} (${pc >= 0 ? '+' : ''}${pc.toFixed(1)}%)`)
+              }
+              if (typeof prev.ratio === 'number' && typeof cur.ratio === 'number') bits.push(`ratio ${prev.ratio} -> ${cur.ratio}`)
+              if (bits.length) delta = `\n\n_Since the previous push: ${bits.join(', ')}. One push of difference sits inside this test's measured spread - read it as movement, not as a result._`
+            }
+
+            const payload = `${marker}\n${body}${delta}`
+
+            // NORMALLY UPDATE IN PLACE: a PR with fifteen throughput comments is a PR where nobody reads the
+            // throughput comment.
+            //
+            // EXCEPT WHEN THE STATUS CHANGES. Editing a comment thirty scrolls up produces no notification and
+            // no visible change to anyone reading the PR top to bottom, so a run that went green to red used to
+            // announce itself by silently rewriting a comment nobody was looking at. On a status change the old
+            // comment is retired - its marker renamed so later pushes stop targeting it - and a fresh one is
+            // posted at the bottom where it will be seen. Number-only movement still updates in place; only the
+            // VERDICT earns a new comment, or this is back to fifteen of them.
+            const statusChanged = prev && cur && prev.status !== cur.status
+            if (existing && !statusChanged) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload })
+            } else {
+              if (existing) {
+                const retired = existing.body
+                  .replace(marker, '<!-- pc-throughput-report (superseded) -->')
+                  .replace(/^### /m, `### [superseded - status changed to ${cur?.status}] `)
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: retired })
+              }
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: payload })
+            }
 
       # Exit 1 is a regression. Exit 2 is the check being UNABLE to measure, which this repo treats as
       # never-a-pass ("a skip is not a pass") - so it also fails, with its own message, because a lane

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -847,6 +847,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Post SpotBugs summary to PR
         if: always()
+        # A COMMENT WRITE MUST NOT FAIL THE JOB - the same reasoning as the throughput step above, and
+        # missing here for the same reason it was missing there. This step summarises analysis that has
+        # already run and already posted its annotations, so a rate limit or a 500 while posting would
+        # fail the lane for something that is not the lane's business.
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -870,8 +875,28 @@ jobs:
                 body = `## :warning: SpotBugs Report\n\n**${totalBugs} bug(s) found**${baselineNote}. See the annotations on the Files Changed tab for details.\n`;
               }
             }
-            const comments = await github.rest.issues.listComments({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number });
-            const existing = comments.data.find(c => c.body.includes('SpotBugs Report'));
+            // PAGINATE, AND ONLY TRUST OUR OWN COMMENTS - the same two-part fix the throughput step's
+            // lookup carries a few hundred lines above. Both halves are pre-existing on master and not
+            // introduced by this PR; they are fixed here because it is the same defect class in the same
+            // file, and a second branch to change two lines costs more than it saves.
+            //
+            // WHY THE PAGINATION BUG IS LATENT RATHER THAN VISIBLE, which is the part worth writing down:
+            // the issue-comments API returns 30 per page OLDEST FIRST, so a sticky comment born EARLY
+            // sits on page one forever and keeps being found. It only breaks when the comment is born
+            // LATE - created once the PR already has 30+ comments, it lands on page two, `find` never
+            // sees it again, and every later push takes the create branch. So it does not miss once and
+            // recover: it duplicates on EVERY push, and each duplicate is itself on page two. The busiest
+            // PRs in this repo today are 13, 11, 11, 10 and 9 comments, all comfortably above the fold,
+            // which is exactly why nobody has met it.
+            //
+            // The author filter is the other half. `includes('SpotBugs Report')` matches ANY comment
+            // carrying that string - including a human quoting the report - and `find` takes the oldest
+            // match, so a person who wrote about SpotBugs before the bot first posted would have their
+            // comment silently OVERWRITTEN by the next run. Restricting to a Bot author is what makes
+            // this lookup mean "the comment this workflow wrote" rather than "any comment on the topic".
+            const all = await github.paginate(github.rest.issues.listComments,
+              { owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, per_page: 100 });
+            const existing = all.find(c => c.body.includes('SpotBugs Report') && c.user?.type === 'Bot');
             if (existing) {
               await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
             } else {

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -293,6 +293,45 @@ jobs:
             // the bare form would still work; that is worth the framing, and the run link beside it
             // survives either way.
             //
+            // AND NOT AT THE CONVERSATION TIMELINE, WHICH WAS TRIED AND MEASURED RATHER THAN GUESSED.
+            // The obvious wish is to scroll the reader to this commit's row in the conversation they
+            // are already on, instead of navigating anywhere. It cannot be done, and the evidence is
+            // one `curl` of the rendered PR page:
+            //
+            //   * THERE IS NO PER-COMMIT ANCHOR. The only fragment targets GitHub emits on a PR
+            //     conversation are `#commits-pushed-<7char>`, `#issuecomment-<id>`,
+            //     `#pullrequestreview-<id>`, `#ref-pullrequest-<id>` and the issue itself. The commit
+            //     rows inside a push event carry no `id`, so the row this stamp names is not
+            //     addressable at all.
+            //   * `#commits-pushed-` IS A PUSH ANCHOR KEYED ON THE PUSH'S OLDEST COMMIT, NOT THE HEAD -
+            //     measured against a push whose contents were known exactly (three commits; the anchor
+            //     is the first of them).
+            //   * A SINGLE-COMMIT PUSH HAS NO ANCHOR EITHER, which is the half that kills the idea.
+            //     It renders as a lone commit row badged `octicon-git-commit` with NO `id`, where a
+            //     multi-commit push renders as `octicon-repo-push` and carries one. So the fragment
+            //     does not merely key on the wrong commit; for the one shape of push where head and
+            //     oldest COINCIDE, it does not exist. Parsing this PR's timeline items in DOM order and
+            //     reading which commits each contains shows it directly: two `repo-push` items holding
+            //     two commits each, one holding three, and a single commit sitting alone, anchorless,
+            //     between them.
+            //
+            // Grouping is also GitHub's rendering choice rather than a one-to-one record of pushes -
+            // consecutive pushes can be coalesced into one event - so even "the oldest commit of my
+            // push" is not a stable key for a push after the fact.
+            //
+            // Across this branch's 8 commits, the head sha was an anchor ZERO times. A stamp linking
+            // `#commits-pushed-${head}` would therefore never resolve; it would land the reader at the
+            // top of a long PR every time, while claiming to point at a commit. The failure is benign
+            // but it is not occasional, and a link that never does what it says is worse than one that
+            // always lands on the right commit - which is the one question this stamp exists to answer.
+            //
+            // Deriving the push's oldest commit instead was rejected on three counts: the issues
+            // timeline API returns `committed` events with NO push grouping, so it is not recoverable
+            // here; `github.event.before` exists on `synchronize` but not on `opened`; and the link
+            // would then target a different commit from the sha printed beside it - reintroducing, in
+            // a worse form, the two-abbreviations-of-one-commit confusion the seven-character change
+            // above exists to remove.
+            //
             // SEVEN CHARACTERS, because GitHub abbreviates to seven everywhere else on this page. At
             // nine the comment showed a second, different-looking abbreviation of the same commit, so
             // a reader had to stop and check it was even the same one.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -256,28 +256,36 @@ jobs:
               if (bits.length) delta = `\n\n_Since the previous push: ${bits.join(', ')}. One push of difference sits inside this test's measured spread - read it as movement, not as a result._`
             }
 
-            const payload = `${marker}\n${body}${delta}`
+            // AN IN-PLACE UPDATE LOOKS DEAD. The comment body can be identical to last week's and there is
+            // nothing on it to say a run happened - no timestamp, no commit, no link - so a reader cannot tell
+            // a fresh verdict from a stale one, and the honest reaction to that is to stop trusting it.
+            // Stamping the head sha and the run link is what makes "updated in place" legible as "updated".
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
+            const stamp = `\n\n<sub>Updated for \`${context.payload.pull_request.head.sha.slice(0, 9)}\` · [run ${context.runId}](${runUrl}) · ${new Date().toISOString().replace('T', ' ').slice(0, 16)} UTC</sub>`
+
+            const payload = `${marker}\n${body}${delta}${stamp}`
 
             // NORMALLY UPDATE IN PLACE: a PR with fifteen throughput comments is a PR where nobody reads the
             // throughput comment.
             //
             // EXCEPT WHEN THE STATUS CHANGES. Editing a comment thirty scrolls up produces no notification and
             // no visible change to anyone reading the PR top to bottom, so a run that went green to red used to
-            // announce itself by silently rewriting a comment nobody was looking at. On a status change the old
-            // comment is retired - its marker renamed so later pushes stop targeting it - and a fresh one is
-            // posted at the bottom where it will be seen. Number-only movement still updates in place; only the
-            // VERDICT earns a new comment, or this is back to fifteen of them.
+            // announce itself by silently rewriting a comment nobody was looking at. On a status change a fresh
+            // comment is posted at the bottom, and the old one is retired: its marker renamed so later pushes
+            // stop targeting it, and a link forward so a reader who lands on the stale one is not stranded.
+            // Number-only movement still updates in place; only the VERDICT earns a new comment.
             const statusChanged = prev && cur && prev.status !== cur.status
             if (existing && !statusChanged) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload })
             } else {
+              const created = await github.rest.issues.createComment({ owner, repo, issue_number, body: payload })
               if (existing) {
                 const retired = existing.body
                   .replace(marker, '<!-- pc-throughput-report (superseded) -->')
                   .replace(/^### /m, `### [superseded - status changed to ${cur?.status}] `)
-                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: retired })
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id,
+                  body: `${retired}\n\n<sub>Superseded by [a newer report](${created.data.html_url}).</sub>` })
               }
-              await github.rest.issues.createComment({ owner, repo, issue_number, body: payload })
             }
 
       # Exit 1 is a regression. Exit 2 is the check being UNABLE to measure, which this repo treats as

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -217,6 +217,13 @@ jobs:
         # would fail the check even when the lane and the verdict are both green. The report still lands
         # as an artifact for fork PRs; only the comment is skipped.
         if: always() && matrix.suite == 'performance' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        # THE SAME REASONING AS THE SIBLING STEP ABOVE, and it was missing here while that one had it.
+        # This step is REPORTING, not measuring: it makes one or two GitHub API writes inside the
+        # REQUIRED Performance Tests job, so a rate limit, a 500, or a script exception would fail the
+        # required check for a reason that has nothing to do with the lane or the verdict. The comment
+        # is the nice-to-have; the job's own result is not. A failure here is still visible - the step
+        # goes red in the job - it just does not take the check down with it.
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -253,11 +260,17 @@ jobs:
             if (prev && cur) {
               const bits = []
               if (prev.status !== cur.status) bits.push(`status **${prev.status} -> ${cur.status}**`)
+              // ORDERED AS THE REPORT'S OWN TABLE ORDERS THEM, most machine-independent first, with the
+              // rate LAST because it is the one number the report itself labels "this machine only".
+              // `share` was the omission worth fixing: it is the raw dimensionless shape the whole
+              // method rests on, it was already in the payload, and leaving it out meant the delta
+              // showed two derived numbers and skipped the measurement they come from.
+              if (typeof prev.ratio === 'number' && typeof cur.ratio === 'number') bits.push(`ratio ${prev.ratio} -> ${cur.ratio}`)
+              if (typeof prev.share === 'number' && typeof cur.share === 'number') bits.push(`share ${prev.share} -> ${cur.share}`)
               if (typeof prev.rate === 'number' && typeof cur.rate === 'number' && prev.rate > 0) {
                 const pc = ((cur.rate - prev.rate) / prev.rate) * 100
                 bits.push(`rate ${prev.rate} -> ${cur.rate} (${pc >= 0 ? '+' : ''}${pc.toFixed(1)}%)`)
               }
-              if (typeof prev.ratio === 'number' && typeof cur.ratio === 'number') bits.push(`ratio ${prev.ratio} -> ${cur.ratio}`)
               if (bits.length) delta = `\n\n_Since the previous push: ${bits.join(', ')}. One push of difference sits inside this test's measured spread - read it as movement, not as a result._`
             }
 
@@ -265,8 +278,32 @@ jobs:
             // nothing on it to say a run happened - no timestamp, no commit, no link - so a reader cannot tell
             // a fresh verdict from a stale one, and the honest reaction to that is to stop trusting it.
             // Stamping the head sha and the run link is what makes "updated in place" legible as "updated".
+            //
+            // THE SHA IS A LINK, AND THAT IS THE WHOLE ANSWER TO "IS THIS COMMENT CURRENT?". A static
+            // comment body cannot render the reader's local time - GitHub's sanitiser strips `<time>`,
+            // `<time-ago>` and `<local-time>` to their text, and the REST API does not expose a user's
+            // timezone - so a UTC string leaves every reader outside UTC doing arithmetic to work out
+            // whether this run is recent. The commit page does that work for them: it carries GitHub's
+            // own localised, relative timestamp. One click beats any string we can print here.
+            //
+            // POINTED AT THE COMMIT IN THIS PR, not at the bare commit. `/pull/N/commits/<sha>`
+            // resolves (checked) and keeps the PR framing - which commit of THIS review it is, with
+            // its neighbours - where `/commit/<sha>` drops the reader into the repository at large.
+            // The trade is that a commit force-pushed off the branch later stops resolving there while
+            // the bare form would still work; that is worth the framing, and the run link beside it
+            // survives either way.
+            //
+            // SEVEN CHARACTERS, because GitHub abbreviates to seven everywhere else on this page. At
+            // nine the comment showed a second, different-looking abbreviation of the same commit, so
+            // a reader had to stop and check it was even the same one.
+            //
+            // The UTC timestamp stays, and stays plain: it is the one thing the links cannot do, which
+            // is show at a glance that a run happened without navigating anywhere.
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`
-            const stamp = `\n\n<sub>Updated for \`${context.payload.pull_request.head.sha.slice(0, 9)}\` · [run ${context.runId}](${runUrl}) · ${new Date().toISOString().replace('T', ' ').slice(0, 16)} UTC</sub>`
+            const headSha = context.payload.pull_request.head.sha
+            const commitUrl = `${context.serverUrl}/${owner}/${repo}/pull/${context.payload.pull_request.number}/commits/${headSha}`
+            const stamp = `\n\n<sub>Updated for [\`${headSha.slice(0, 7)}\`](${commitUrl}) · [run ${context.runId}](${runUrl})`
+              + ` · ${new Date().toISOString().replace('T', ' ').slice(0, 16)} UTC</sub>`
 
             const payload = `${marker}\n${body}${delta}${stamp}`
 
@@ -288,13 +325,39 @@ jobs:
             if (existing && !statusChanged) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload })
             } else {
+              // RETIRE FIRST, THEN CREATE - the order is the whole safety property, and it was the
+              // wrong way round. There is no transaction across two API calls, so one of them can fail
+              // after the other succeeded, and the two orders fail very differently:
+              //
+              //   create then retire  -> the retire fails and TWO comments carry the live marker.
+              //                          `listComments` is oldest-first and `all.find` takes the first
+              //                          match, so every later run latches onto the STALE one and
+              //                          updates it forever, while the newer report sits orphaned.
+              //                          Silent, self-perpetuating, and worst on the status change it
+              //                          exists to announce.
+              //   retire then create  -> the create fails and NO comment carries the live marker. The
+              //                          next run simply posts a fresh one. Degraded, obvious, and it
+              //                          recovers by itself.
+              //
+              // The forward link costs a third write, so it is best-effort and last: by the time it
+              // runs, the marker state is already correct whether or not it succeeds. Losing it strands
+              // a reader on a comment that still says, in words, that it was superseded.
+              const retiredBody = pointer => `${existing.body
+                .replace(marker, '<!-- pc-throughput-report (superseded) -->')
+                .replace(/^### /m, `### [superseded - status changed to ${String(cur?.status ?? 'unknown').replace(/[^a-zA-Z-]/g, '')}] `)
+                }\n\n<sub>Superseded by ${pointer}.</sub>`
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id,
+                  body: retiredBody('a newer report further down this conversation') })
+              }
               const created = await github.rest.issues.createComment({ owner, repo, issue_number, body: payload })
               if (existing) {
-                const retired = existing.body
-                  .replace(marker, '<!-- pc-throughput-report (superseded) -->')
-                  .replace(/^### /m, `### [superseded - status changed to ${String(cur?.status ?? 'unknown').replace(/[^a-zA-Z-]/g, '')}] `)
-                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id,
-                  body: `${retired}\n\n<sub>Superseded by [a newer report](${created.data.html_url}).</sub>` })
+                try {
+                  await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id,
+                    body: retiredBody(`[a newer report](${created.data.html_url})`) })
+                } catch (e) {
+                  core.warning(`could not link the retired throughput comment forward: ${e.message}`)
+                }
               }
             }
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -381,19 +381,29 @@ jobs:
               // The forward link costs a third write, so it is best-effort and last: by the time it
               // runs, the marker state is already correct whether or not it succeeds. Losing it strands
               // a reader on a comment that still says, in words, that it was superseded.
-              const retiredBody = pointer => `${existing.body
+              //
+              // The note is passed WHOLE rather than as a noun slotted into a fixed "Superseded by X"
+              // sentence, because the two writes cannot honestly promise the same thing. The first runs
+              // BEFORE the create, and the create can fail - `continue-on-error` on this step swallows
+              // it by design - so the report it points at may never exist. It must therefore not name a
+              // PLACE: a retired comment reading "further down this conversation" when nothing was
+              // posted sends a reader looking for a report that is not there, and does so permanently,
+              // because the retired marker no longer matches the lookup above and no later run ever
+              // revisits this comment to correct it. Only the second note, written once `created`
+              // demonstrably exists, may point at it.
+              const retiredBody = note => `${existing.body
                 .replace(marker, '<!-- pc-throughput-report (superseded) -->')
                 .replace(/^### /m, `### [superseded - status changed to ${String(cur?.status ?? 'unknown').replace(/[^a-zA-Z-]/g, '')}] `)
-                }\n\n<sub>Superseded by ${pointer}.</sub>`
+                }\n\n<sub>${note}</sub>`
               if (existing) {
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id,
-                  body: retiredBody('a newer report further down this conversation') })
+                  body: retiredBody('Superseded - a fresh report should follow for this push.') })
               }
               const created = await github.rest.issues.createComment({ owner, repo, issue_number, body: payload })
               if (existing) {
                 try {
                   await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id,
-                    body: retiredBody(`[a newer report](${created.data.html_url})`) })
+                    body: retiredBody(`Superseded by [a newer report](${created.data.html_url}).`) })
                 } catch (e) {
                   core.warning(`could not link the retired throughput comment forward: ${e.message}`)
                 }

--- a/bin/check-throughput-regression.mjs
+++ b/bin/check-throughput-regression.mjs
@@ -95,9 +95,21 @@ const rateFrom = text =>
 // path, while the exit that actually fires in practice - the bootstrapping 404 below - returned
 // earlier and wrote nothing. Two exits, one reporting, and the silent one was the common case. If you
 // add an exit, it writes a report or it is the same bug again.
-const writeReport = body => {
+// EVERY report carries a machine-readable payload, and that is not decoration. The PR comment is
+// updated in place, so without it each push destroys the only record of what the previous push
+// measured, and the reader gets a number with nothing to compare it to. The workflow reads this back
+// off its own last comment to render a delta and to notice when the STATUS changed.
+//
+// The status is set into `reportStatus` on the line before each call rather than passed as an
+// argument. That is deliberate: the report bodies are template literals containing escaped
+// backticks, and an earlier attempt to add a second argument landed the status INSIDE the prose of
+// all six messages, because the closing `) it matched was an escaped one in the text. A separate
+// assignment cannot go wrong that way.
+let reportStatus = 'unset'
+const writeReport = (body, data = {}) => {
   mkdirSync('target', { recursive: true })
-  writeFileSync(REPORT, body + '\n')
+  const payload = JSON.stringify({ status: reportStatus, ...data })
+  writeFileSync(REPORT, `${body}\n\n<!-- pc-throughput-data: ${payload} -->\n`)
   console.log(body.replace(/[|*#]/g, '').replace(/\n{2,}/g, '\n'))
 }
 
@@ -117,6 +129,7 @@ if (!(observedRate > 0)) {
   // A missing rate is a finding, not a quiet pass: the test did not run, or the emitter is no longer
   // reached, and both look identical to a clean lane otherwise.
   console.error(`check-throughput-regression: no usable rate for ${SUBJECT} in ${summaryFile}.`)
+  reportStatus = 'no-rate'
   writeReport(`### 🟠 Throughput — no rate to report
 
 The performance lane ran but produced no usable \`recordsPerSecond\` for \`${SUBJECT}\`. Either the test did not run, or \`ThroughputReport\` is no longer reached.
@@ -126,6 +139,7 @@ The performance lane ran but produced no usable \`recordsPerSecond\` for \`${SUB
 }
 if (!(observedControl > 0)) {
   console.error('check-throughput-regression: no control class ran, so machine speed cannot be cancelled.')
+  reportStatus = 'no-control'
   writeReport(`### 🟠 Throughput — no control ran
 
 | | |
@@ -153,6 +167,7 @@ try {
   // workflow therefore always failed its own check, blaming the wrong thing.
   const err = `${e?.stderr ?? ''}${e?.stdout ?? ''}${e?.message ?? ''}`
   if (/404|could not find any workflows|not found/i.test(err)) {
+    reportStatus = 'bootstrapping'
     writeReport(`### ⚪ Throughput — no reference yet (bootstrapping)
 
 | | |
@@ -169,6 +184,7 @@ The numbers above are this run's, recorded here rather than left in a job log.`)
   const firstLine = err.trim().split('\n')[0]
   console.error('check-throughput-regression: could not list master baseline runs.')
   console.error(`  ${firstLine}`)
+  reportStatus = 'check-failed'
   writeReport(`### 🟠 Throughput — the check could not run
 
 | | |
@@ -191,6 +207,7 @@ ${firstLine}
 // throughput reporting displayed no throughput report. A report saying "here are this run's numbers,
 // there is nothing to compare them against yet" is the useful thing to post, not silence.
 if (runs.length === 0) {
+  reportStatus = 'no-reference'
   writeReport(`### ⚪ Throughput — no reference yet
 
 | | |
@@ -240,9 +257,14 @@ try {
 } finally { rmSync(work, { recursive: true, force: true }) }
 
 if (reference.length === 0) {
+  // "No comparable reference" has been read as "no baseline exists". Baselines usually DO exist here
+  // - they just ran a different set of tests, most often because the PR itself enabled or disabled
+  // some. Say how many were found and what this run's case set is, so the reader can tell a matrix
+  // change they made from one they did not.
   const why = mismatched.length
-    ? `every candidate ran a different set of test cases than this run (${mismatched.join(', ')}) - the test matrix changed, so the runs are not comparable`
+    ? `${mismatched.length} baseline run(s) were found and none ran the same set of test cases as this run (${mismatched.join(', ')}), so none is comparable. This is usually the PR's own doing: enabling or disabling a test in this lane changes the matrix.`
     : 'master baseline runs exist but carry no usable artifact yet'
+  reportStatus = 'incomparable'
   writeReport(`### ⚪ Throughput — no comparable reference
 
 | | |
@@ -290,6 +312,8 @@ const report = `### ${icon} Throughput — ${word}
 Runs used: ${reference.map(r => r.sha).join(', ')}
 </details>`
 
-writeReport(report)
+reportStatus = word
+writeReport(report, { ratio: Number(ratio.toFixed(3)), rate: observedRate,
+                      share: Number(observedShare.toFixed(3)), refs: reference.length })
 console.log(`\nreport written to ${REPORT}`)
 process.exit(verdict.exit)

--- a/bin/check-throughput-regression.mjs
+++ b/bin/check-throughput-regression.mjs
@@ -100,6 +100,13 @@ const rateFrom = text =>
 // measured, and the reader gets a number with nothing to compare it to. The workflow reads this back
 // off its own last comment to render a delta and to notice when the STATUS changed.
 //
+// THE `pc-throughput-data` MARKER IS WRITTEN HERE AND PARSED IN TWO OTHER PLACES, deliberately
+// unshared: the reader in `.github/workflows/maven.yml` is a YAML-embedded github-script that cannot
+// import this module, and the one in `bin/test-check-throughput-regression.mjs` is independent ON
+// PURPOSE - a test that parsed with the producer's own code would agree with it by construction,
+// which is the exact failure the runtime test replaced. Nothing enforces that the three agree, so if
+// you change the marker's shape, `grep -rn pc-throughput-data` is the list you must change.
+//
 // The status is set into `reportStatus` on the line before each call rather than passed as an
 // argument. That is deliberate: the report bodies are template literals containing escaped
 // backticks, and an earlier attempt to add a second argument landed the status INSIDE the prose of

--- a/bin/check-throughput-regression.mjs
+++ b/bin/check-throughput-regression.mjs
@@ -245,7 +245,10 @@ try {
     const missing = CONTROLS.filter(c => !classes.has(c))
     const caseSet = classes.get('__cases__')
     if (observedCases && caseSet && caseSet !== observedCases) {
-      mismatched.push(sha.slice(0, 9))
+      // Keep the READING, not just the sha. Refusing to compute a verdict is right; hiding the
+      // numbers is not - a reader wants to see roughly where this run sits even when nothing here
+      // can be a control, and withholding them sends them to the job logs to find out.
+      mismatched.push({ sha: sha.slice(0, 9), rate, subject, control })
       continue
     }
     if (subject > 0 && control > 0 && missing.length === 0) {
@@ -262,8 +265,19 @@ if (reference.length === 0) {
   // some. Say how many were found and what this run's case set is, so the reader can tell a matrix
   // change they made from one they did not.
   const why = mismatched.length
-    ? `${mismatched.length} baseline run(s) were found and none ran the same set of test cases as this run (${mismatched.join(', ')}), so none is comparable. This is usually the PR's own doing: enabling or disabling a test in this lane changes the matrix.`
+    ? `${mismatched.length} baseline run(s) were found and none ran the same set of test cases as this run, so none is comparable. This is usually the PR's own doing: enabling or disabling a test in this lane changes the matrix.`
     : 'master baseline runs exist but carry no usable artifact yet'
+
+  // SHOW THE NUMBERS ANYWAY, flagged. Refusing to compute a verdict from an incomparable run is the
+  // right call; refusing to SHOW it is a different decision that nobody asked for, and it sends the
+  // reader to the job logs to find out roughly where they stand. Every borrowed row carries the
+  // caveat beside it, so a number cannot be lifted out of this table without its warning.
+  const rows = mismatched.length
+    ? `\n\n| Run | Rate | Subject | Comparable? |\n|---|---|---|---|\n| **this run** | **${observedRate} rec/s** | ${observedSubject.toFixed(1)}s | — |\n` +
+      mismatched.map(m => `| \`${m.sha}\` | ${m.rate} rec/s | ${m.subject.toFixed(1)}s | ⚠️ different test set - not a control |`).join('\n') +
+      `\n\nThe baseline rows are shown for orientation only. They ran a different workload, so a difference between them and this run is not a measurement of anything - do not read one as a regression or an improvement.`
+    : ''
+
   reportStatus = 'incomparable'
   writeReport(`### ⚪ Throughput — no comparable reference
 
@@ -272,7 +286,7 @@ if (reference.length === 0) {
 | **This run** | ${observedRate} rec/s |
 | Subject time | ${observedSubject.toFixed(1)}s |
 
-${why}.
+${why}${rows}
 
 Refusing to compare against a run whose workload differs, rather than averaging the difference in and calling the result a verdict.`)
   process.exit(NOTHING_IN_SCOPE)

--- a/bin/check-throughput-regression.mjs
+++ b/bin/check-throughput-regression.mjs
@@ -42,7 +42,7 @@ import { readFileSync, writeFileSync, existsSync, globSync, mkdtempSync, rmSync,
 import { tmpdir } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { verdictFor, FAIL_BELOW, WARN_BELOW } from './lib/throughput-verdict.mjs'
+import { verdictFor, displayRatio, headlineFor, FAIL_BELOW, WARN_BELOW } from './lib/throughput-verdict.mjs'
 
 // Anchored like the shell original's `cd "$ROOT"`. Without it the relative paths below resolve
 // against the caller's directory, and the gate reports "nothing in scope" - a clean tree - when what
@@ -156,6 +156,31 @@ if (!(observedControl > 0)) {
 None of the control classes (\`${CONTROLS.join(', ')}\`) produced a time, so machine speed cannot be cancelled and no comparison is possible. The raw number above is recorded but comparable to nothing.
 
 **Not a pass.**`)
+  process.exit(CANNOT)
+}
+// THE THIRD NOT-A-PASS GUARD, AND IT WAS THE ONLY ONE MISSING. `verdictFor` has a `no-subject`
+// sentinel that nothing between here and the call site could ever produce a report for: the
+// destructure below leaves `ratio` undefined, `${ratio.toFixed(3)}` throws while the template is
+// being built, and Node exits 1 - which is this file's own code for VIOLATION. A subject test that
+// did not run therefore read as a REGRESSION, and did it while writing no report at all, breaking
+// the "EVERY EXIT WRITES A REPORT" rule stated above by the one exit that never reached writeReport.
+//
+// Ordered AFTER the control guard, not before it as in `verdictFor`. When both are absent the
+// broader fact is the useful one - nothing in the lane produced per-method times - and naming the
+// subject alone would send the reader looking at one test.
+if (!(observedSubject > 0)) {
+  console.error(`check-throughput-regression: no per-method time for ${SUBJECT}, so there is nothing to compare.`)
+  reportStatus = 'no-subject'
+  writeReport(`### 🟠 Throughput — the subject test did not run
+
+| What | Value |
+|---|---|
+| **This run** | ${observedRate} rec/s |
+| Control tests took | ${observedControl.toFixed(1)}s |
+
+The control classes produced times but \`${SUBJECT}\` — the test this check exists to measure — produced none. Either it did not run in this lane, or its failsafe report did not reach the glob.
+
+**Not a pass.** A rate was reported without the test that earns it, and that looks identical to a clean lane from the outside.`)
   process.exit(CANNOT)
 }
 
@@ -312,12 +337,9 @@ const spread = `${Math.min(...shares).toFixed(3)} – ${Math.max(...shares).toFi
 // 1.713 is the subject's time divided by the CONTROLS' time in the SAME run; the only figure that
 // says anything about master is the comparison. The headline sentence exists so the common question
 // is answered before anyone reaches a number, and every row is now named in words rather than in the
-// vocabulary of the method.
-const faster = ratio >= 1
-const magnitude = Math.abs(1 - ratio) < 0.005
-  ? 'the same speed as'
-  : `about ${pct(Math.abs(1 - ratio))} ${faster ? 'faster' : 'slower'} than`
-const headline = `**This branch is ${magnitude} master**, on the one test this measures.`
+// vocabulary of the method. It lives in lib/throughput-verdict.mjs beside the noise floor it has to
+// disclose, so a bound and its caveat cannot drift apart, and so it can be asserted without a run.
+const headline = headlineFor(ratio)
 
 const report = `### ${icon} Throughput — ${word}
 
@@ -325,7 +347,7 @@ ${headline}
 
 | What | Value | Meaning |
 |---|---|---|
-| **Compared with master** | **${ratio.toFixed(3)}** | above 1.00 is faster, below is slower |
+| **Compared with master** | **${displayRatio(ratio)}** | above 1.00 is faster, below is slower |
 | Subject test took | ${observedSubject.toFixed(1)}s | the test under measurement |
 | Control tests took | ${observedControl.toFixed(1)}s | the other tests in this same run |
 | Subject ÷ controls, here | ${observedShare.toFixed(3)} | **not a speed** - a shape that cancels machine speed |

--- a/bin/check-throughput-regression.mjs
+++ b/bin/check-throughput-regression.mjs
@@ -142,7 +142,7 @@ if (!(observedControl > 0)) {
   reportStatus = 'no-control'
   writeReport(`### 🟠 Throughput — no control ran
 
-| | |
+| What | Value |
 |---|---|
 | **This run** | ${observedRate} rec/s |
 
@@ -170,7 +170,7 @@ try {
     reportStatus = 'bootstrapping'
     writeReport(`### ⚪ Throughput — no reference yet (bootstrapping)
 
-| | |
+| What | Value |
 |---|---|
 | **This run** | ${observedRate} rec/s |
 | Subject time | ${observedSubject.toFixed(1)}s |
@@ -187,7 +187,7 @@ The numbers above are this run's, recorded here rather than left in a job log.`)
   reportStatus = 'check-failed'
   writeReport(`### 🟠 Throughput — the check could not run
 
-| | |
+| What | Value |
 |---|---|
 | **This run** | ${observedRate} rec/s |
 | Subject time | ${observedSubject.toFixed(1)}s |
@@ -210,7 +210,7 @@ if (runs.length === 0) {
   reportStatus = 'no-reference'
   writeReport(`### ⚪ Throughput — no reference yet
 
-| | |
+| What | Value |
 |---|---|
 | **This run** | ${observedRate} rec/s |
 | Subject time | ${observedSubject.toFixed(1)}s |
@@ -281,7 +281,7 @@ if (reference.length === 0) {
   reportStatus = 'incomparable'
   writeReport(`### ⚪ Throughput — no comparable reference
 
-| | |
+| What | Value |
 |---|---|
 | **This run** | ${observedRate} rec/s |
 | Subject time | ${observedSubject.toFixed(1)}s |
@@ -300,20 +300,40 @@ const verdict = { icon, word, exit: v.failed ? VIOLATION : 0 }
 const shares = reference.map(r => (r.subject / r.control))
 const spread = `${Math.min(...shares).toFixed(3)} – ${Math.max(...shares).toFixed(3)}`
 
+// LEAD WITH THE ANSWER, IN WORDS. A reviewer read "Subject share, this run: 1.713" as "this build is
+// 1.7x faster than master" - a reasonable reading of those words, and wrong by a factor of twenty.
+// 1.713 is the subject's time divided by the CONTROLS' time in the SAME run; the only figure that
+// says anything about master is the comparison. The headline sentence exists so the common question
+// is answered before anyone reaches a number, and every row is now named in words rather than in the
+// vocabulary of the method.
+const faster = ratio >= 1
+const magnitude = Math.abs(1 - ratio) < 0.005
+  ? 'the same speed as'
+  : `about ${pct(Math.abs(1 - ratio))} ${faster ? 'faster' : 'slower'} than`
+const headline = `**This branch is ${magnitude} master**, on the one test this measures.`
+
 const report = `### ${icon} Throughput — ${word}
 
-| | |
-|---|---|
-| **Subject share, this run** | ${observedShare.toFixed(3)} |
-| **Reference share (median)** | ${referenceShare.toFixed(3)} |
-| **Ratio** | **${ratio.toFixed(3)}** |
-| Subject time | ${observedSubject.toFixed(1)}s |
-| Control time | ${observedControl.toFixed(1)}s |
-| Reported rate | ${observedRate} rec/s |
+${headline}
+
+| What | Value | Meaning |
+|---|---|---|
+| **Compared with master** | **${ratio.toFixed(3)}** | above 1.00 is faster, below is slower |
+| Subject test took | ${observedSubject.toFixed(1)}s | the test under measurement |
+| Control tests took | ${observedControl.toFixed(1)}s | the other tests in this same run |
+| Subject ÷ controls, here | ${observedShare.toFixed(3)} | **not a speed** - a shape that cancels machine speed |
+| Subject ÷ controls, master | ${referenceShare.toFixed(3)} | median of recent master runs |
+| Reported rate | ${observedRate} rec/s | this machine only; not comparable across runners |
 
 **Allowable range** 🟢 ≥ ${WARN_BELOW.toFixed(2)} · 🟡 ${FAIL_BELOW.toFixed(2)}–${WARN_BELOW.toFixed(2)} (about a ${pct(1 - WARN_BELOW)} loss) · 🔴 < ${FAIL_BELOW.toFixed(2)} (about a ${pct(1 - FAIL_BELOW)} loss)
 
-<details><summary>How this is derived, and what it cannot tell you</summary>
+<details><summary>What the numbers mean, and what they cannot tell you</summary>
+
+**The one that gets misread.** \`Subject ÷ controls\` is a shape, not a speed. 1.7 means the subject took 1.7 times as long as the control tests **in the same run** - it says nothing about master on its own, and a reviewer has already read it as "1.7x faster than master". Only **Compared with master** answers that question.
+
+**Why a shape and not a rate.** A rate depends on which runner you drew. A shape does not: every test here processes a fixed number of records, so a runner twice as slow doubles the subject and the controls together and leaves their ratio alone. That is the whole trick, and it is why the reported rate is shown last and labelled as this machine only.
+
+**Reading the comparison.** \`master ÷ this run\`. Above 1.00 the subject is proportionally quicker here than on master; below 1.00 it is slower. 0.50 means it takes twice as long relative to its controls - that is the failing bound, not a small one.
 
 **By conservation, not by correction.** Every test in this lane processes a fixed number of records, so within one run the ratio of one test's time to another's is invariant under machine speed — a runner twice as slow doubles both terms and leaves the ratio alone. There is no machine-index correction to be wrong, because nothing needed correcting. \`share = subjectSeconds / controlSeconds\`, both from this same run.
 

--- a/bin/lib/throughput-verdict.mjs
+++ b/bin/lib/throughput-verdict.mjs
@@ -61,6 +61,13 @@
 export const FAIL_BELOW = 0.50
 export const WARN_BELOW = 0.70
 
+// THE RUN-TO-RUN SPREAD OF THE QUANTITY THE VERDICT IS BUILT FROM, taken from the measurement table
+// above: the share moved 16.6-17.2% across eight runs of one unchanged commit. Rounded UP to the
+// higher figure, because a floor that understates its own noise is the thing this constant exists to
+// stop. It is not a threshold - nothing branches on it - it is what the headline sentence has to
+// disclose so a small difference is not read as a finding.
+export const NOISE_FLOOR = 0.17
+
 // A TRUE median: on an even-sized set, average the two middle values. The first version took the
 // lower-middle, which systematically understates the reference share and so makes every verdict
 // ratio stricter than the calibrated bound claims - with the default ten reference runs, always.
@@ -90,4 +97,48 @@ export function verdictFor(observed, reference) {
   const word = ratio < FAIL_BELOW ? 'FAIL' : ratio < WARN_BELOW ? 'FLAG' : 'OK'
   return { kind: 'verdict', observedShare, referenceShare, ratio, icon, word,
            failed: ratio < FAIL_BELOW }
+}
+
+/** Which of the three bands a ratio falls in. Same expression as `icon`/`word`, named once. */
+export const bandOf = ratio => (ratio < FAIL_BELOW ? 'fail' : ratio < WARN_BELOW ? 'flag' : 'ok')
+
+/**
+ * The ratio as the report should PRINT it.
+ *
+ * `ratio.toFixed(3)` rounds, and at a bound the rounding crosses it: 0.4996 prints as `0.500` beside
+ * a 🔴 whose bound the very same comment prints as "< 0.50", and 0.6996 prints as `0.700` beside a
+ * 🟡. A reader who does the honest thing - check the number against the stated range - then gets the
+ * opposite answer from the icon, in a report whose whole redesign was about not being misread.
+ * Narrow window, but the fix is to widen the precision until the printed value lands in the same
+ * band as the raw one, so the two can never disagree.
+ */
+export const displayRatio = ratio => {
+  for (const dp of [3, 4, 5, 6, 9]) {
+    const shown = ratio.toFixed(dp)
+    if (bandOf(Number(shown)) === bandOf(ratio)) return shown
+  }
+  // `String(n)` round-trips a double exactly, so this last resort cannot disagree with its own band.
+  return String(ratio)
+}
+
+/**
+ * The report's headline sentence.
+ *
+ * SAY THE SIZE OF THE RULER IN THE SAME BREATH AS THE MEASUREMENT. The first version stated "This
+ * branch is about 8% faster than master" flatly, two paragraphs above the same comment's own
+ * statement that this test moves 13-17% run to run - so the report contradicted itself and the
+ * headline won, because the headline is what gets read. A difference smaller than the instrument's
+ * spread is a reading, not a result, and the sentence now says which of the two it is.
+ *
+ * The verb matters as much as the caveat: "measured about 8% faster" is a fact about this run,
+ * "is about 8% faster" is a claim about the branch, and only the first one is true.
+ */
+export const headlineFor = ratio => {
+  const pct = n => `${(n * 100).toFixed(0)}%`
+  const diff = Math.abs(1 - ratio)
+  if (diff < 0.005) return '**This branch measured the same speed as master**, on the one test this measures.'
+  const sentence = `**This branch measured about ${pct(diff)} ${ratio >= 1 ? 'faster' : 'slower'} than master**, on the one test this measures.`
+  return diff < NOISE_FLOOR
+    ? `${sentence} That is INSIDE this test's own run-to-run spread of about ${pct(NOISE_FLOOR)}, so read it as a reading and not as a result - re-running the same commit moves it by about as much.`
+    : `${sentence} That is larger than this test's own run-to-run spread of about ${pct(NOISE_FLOOR)}, so it is worth looking at.`
 }

--- a/bin/test-check-throughput-regression.mjs
+++ b/bin/test-check-throughput-regression.mjs
@@ -11,7 +11,7 @@
 // red on a quiet day, and the first person to hit one switches the gate off - taking the collection
 // with it. So this asserts what the gate must NOT do at least as hard as what it must.
 
-import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs'
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, globSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
@@ -93,27 +93,66 @@ check('flag bound is a 30% loss', WARN_BELOW, 0.70)
 // reporter will look. Anything already there is saved and put back, because a developer with a real
 // report on disk should not lose it to a self-test. `no-control` is the cheapest path to reach: a
 // summary carrying a rate, with no control classes present.
+//
+// FOUR THINGS BELOW EXIST BECAUSE "IT RUNS THE REPORTER" IS NOT THE SAME AS "IT CHECKED THE RUN",
+// and the first version of this block made all four mistakes at once:
+//
+//   * THE FIXTURE IS ONLY HALF THE INPUT. The reporter also globs `**/target/failsafe-reports/`, so a
+//     developer holding real failsafe XML gives it a control class, which takes it OFF the no-control
+//     path and out to `gh run list` - a networked, credentialed, non-deterministic run wearing this
+//     test's name. The precondition is asserted and fails LOUDLY, because a skip is not a pass.
+//   * A STALE REPORT SCORES AS A FRESH ONE. `target/throughput-report.md` is removed before the spawn,
+//     so the assertions can only read a file this run produced. Without that, a reporter that wrote
+//     nothing at all passes against last week's output.
+//   * THE SPAWN RESULT WAS DISCARDED. A reporter that writes the right report and then returns the
+//     WRONG exit code passed every assertion, while the workflow branches on that code
+//     (`steps.throughput.outputs.code`). Exit 2 is CANNOT-MEASURE, which is what no-control means.
+//   * `finally` DOES NOT RUN ON Ctrl-C. Node terminates on SIGINT with no listener installed, so an
+//     interrupted test left the developer's real files replaced by the fixture. The handlers restore
+//     and then re-raise with the default disposition.
 {
   const root = fileURLToPath(new URL('..', import.meta.url))
   const summary = join(root, 'target/performance-throughput.txt')
   const report = join(root, 'target/throughput-report.md')
   const saved = [summary, report].map(f => [f, existsSync(f) ? readFileSync(f, 'utf8') : null])
-  try {
-    mkdirSync(join(root, 'target'), { recursive: true })
-    writeFileSync(summary,
-      'PC-THROUGHPUT test=MultiInstanceHighVolumeTest processed=3 expected=3 elapsedMs=1 recordsPerSecond=75000 outcome=PASSED\n')
-    spawnSync(process.execPath, [join(root, 'bin/check-throughput-regression.mjs')], { encoding: 'utf8' })
-    const text = existsSync(report) ? readFileSync(report, 'utf8') : ''
-    const m = /<!-- pc-throughput-data: (.*?) -->/.exec(text)
-    const data = m ? JSON.parse(m[1]) : {}
-    check('the report carries a machine-readable payload', Boolean(m), true)
-    check('the payload names a real status', data.status, 'no-control')
-    check('the status did not land inside the message', text.includes('control classes (`'), true)
-  } finally {
+  const restore = () => {
     for (const [f, body] of saved) {
       if (body === null) rmSync(f, { force: true })
       else writeFileSync(f, body)
     }
+  }
+  const onSignal = sig => { restore(); process.removeListener(sig, onSignal); process.kill(process.pid, sig) }
+  for (const sig of ['SIGINT', 'SIGTERM']) process.on(sig, onSignal)
+  try {
+    const stray = globSync('**/target/failsafe-reports/TEST-*.xml', { cwd: root })
+    if (stray.length) {
+      console.error(`FAIL  leftover failsafe reports (${stray.length}) would take the reporter off the`)
+      console.error('      no-control path and out to the network - run `./mvnw clean` and retry.')
+      failures++
+    } else {
+      mkdirSync(join(root, 'target'), { recursive: true })
+      rmSync(report, { force: true })
+      writeFileSync(summary,
+        'PC-THROUGHPUT test=MultiInstanceHighVolumeTest processed=3 expected=3 elapsedMs=1 recordsPerSecond=75000 outcome=PASSED\n')
+      const run = spawnSync(process.execPath, [join(root, 'bin/check-throughput-regression.mjs')], { encoding: 'utf8' })
+      check('the reporter ran', run.error === undefined, true)
+      // 2 is CANNOT, the documented code for "the check could not measure". Pinned here because the
+      // workflow reads it and this is the only place the four-value contract is asserted at all.
+      check('the reporter exited CANNOT for no-control', run.status, 2)
+      const text = existsSync(report) ? readFileSync(report, 'utf8') : ''
+      const m = /<!-- pc-throughput-data: (.*?) -->/.exec(text)
+      const data = m ? JSON.parse(m[1]) : {}
+      check('the report carries a machine-readable payload', Boolean(m), true)
+      check('the payload names a real status', data.status, 'no-control')
+      // ABSENCE, NOT PRESENCE. The first version asserted the message's opening text was still there -
+      // which stayed true whether or not the status had been injected into it, so the assertion
+      // written to catch that exact bug could not fail. Split the payload off and assert the status
+      // literal appears NOWHERE in the prose a human reads.
+      check('the status did not land inside the message', text.split('<!-- pc-throughput-data:')[0].includes('no-control'), false)
+    }
+  } finally {
+    for (const sig of ['SIGINT', 'SIGTERM']) process.removeListener(sig, onSignal)
+    restore()
   }
 }
 

--- a/bin/test-check-throughput-regression.mjs
+++ b/bin/test-check-throughput-regression.mjs
@@ -96,6 +96,19 @@ check('flag bound is a 30% loss', WARN_BELOW, 0.70)
   // licence to print six digits at every reader.
   check('an ordinary ratio still prints three places', displayRatio(0.98042), '0.980')
   check('a value exactly on a bound is already consistent', displayRatio(0.5), '0.500')
+
+  // The ladder can be exhausted, and then the FALLBACK is the only thing keeping the promise. A ratio
+  // a hair under the bound rounds to "0.500..." at every rung of [3,4,5,6,9] - each one reading 'flag'
+  // against a raw 'fail' - so the loop returns nothing and `String(ratio)` has to carry it. That works
+  // because `String` yields the shortest representation that round-trips the double exactly, so the
+  // printed text always parses back into its own band. Pinned because it is the one path in this
+  // function no other case reaches, and a "tidy-up" replacing the fallback with a final `toFixed`
+  // would silently reintroduce the contradiction the rest of this block exists to prevent.
+  const hair = 0.5 - 1e-12
+  check('the raw value is a fail', bandOf(hair), 'fail')
+  check('every rung of the ladder disagrees with it', [3, 4, 5, 6, 9].map(dp => bandOf(Number(hair.toFixed(dp)))).join(), 'flag,flag,flag,flag,flag')
+  check('so the fallback prints it exactly', displayRatio(hair), String(hair))
+  check('and the printed value keeps the raw band', bandOf(Number(displayRatio(hair))), 'fail')
 }
 
 // --- the headline must disclose the noise floor it sits inside -------------------------------------

--- a/bin/test-check-throughput-regression.mjs
+++ b/bin/test-check-throughput-regression.mjs
@@ -15,7 +15,8 @@ import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, globSync } 
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
-import { verdictFor, FAIL_BELOW, WARN_BELOW, median } from './lib/throughput-verdict.mjs'
+import { verdictFor, bandOf, displayRatio, headlineFor,
+         FAIL_BELOW, WARN_BELOW, NOISE_FLOOR, median } from './lib/throughput-verdict.mjs'
 
 let failures = 0
 const check = (desc, actual, expected) => {
@@ -80,6 +81,38 @@ check('a missing control is not a pass', verdictFor({ subject: 27, control: 0 },
 check('fail bound is a 50% loss', FAIL_BELOW, 0.50)
 check('flag bound is a 30% loss', WARN_BELOW, 0.70)
 
+// --- the printed number must never contradict the icon beside it -----------------------------------
+{
+  // The report prints the ratio and, two lines below, the bounds it was judged against. Rounding to
+  // three places crosses those bounds: 0.4996 is a FAIL that prints as "0.500", and the report's own
+  // "Allowable range" line says 🔴 is < 0.50. A reader checking the number against the stated range
+  // then reaches the opposite conclusion from the icon. These pin BOTH boundaries, in both
+  // directions, because the bug is symmetric and only one side of it was ever noticed.
+  check('a fail that rounds up to the bound keeps its band', bandOf(Number(displayRatio(0.4996))), 'fail')
+  check('and prints enough digits to show it', displayRatio(0.4996), '0.4996')
+  check('a flag that rounds up to the bound keeps its band', bandOf(Number(displayRatio(0.6996))), 'flag')
+  check('and prints enough digits to show it', displayRatio(0.6996), '0.6996')
+  // Away from a boundary nothing widens - three places stays the normal case, so this is not a
+  // licence to print six digits at every reader.
+  check('an ordinary ratio still prints three places', displayRatio(0.98042), '0.980')
+  check('a value exactly on a bound is already consistent', displayRatio(0.5), '0.500')
+}
+
+// --- the headline must disclose the noise floor it sits inside -------------------------------------
+{
+  // A single run's difference smaller than this test's own spread is a reading, not a result. Stating
+  // it flatly is what a reviewer read as a finding, in a comment that separately printed the spread.
+  check('the noise floor is the measured share spread', NOISE_FLOOR, 0.17)
+  const small = headlineFor(1.08)
+  check('a difference inside the spread says so', small.includes('INSIDE'), true)
+  check('and still gives the number', small.includes('about 8% faster'), true)
+  check('and does not claim the branch IS faster', /branch is about/.test(small), false)
+  const big = headlineFor(0.50)
+  check('a difference outside the spread is not caveated away', big.includes('INSIDE'), false)
+  check('and is called out as worth looking at', big.includes('larger than'), true)
+  check('no measurable difference says exactly that', headlineFor(1.0).includes('the same speed as master'), true)
+}
+
 
 // THE REPORT MUST CARRY A REAL STATUS, CHECKED BY RUNNING IT RATHER THAN BY GREPPING FOR ONE.
 //
@@ -114,7 +147,11 @@ check('flag bound is a 30% loss', WARN_BELOW, 0.70)
   const root = fileURLToPath(new URL('..', import.meta.url))
   const summary = join(root, 'target/performance-throughput.txt')
   const report = join(root, 'target/throughput-report.md')
-  const saved = [summary, report].map(f => [f, existsSync(f) ? readFileSync(f, 'utf8') : null])
+  // The second case's fixture. It is in `saved` so restore() deletes it however this block exits -
+  // leaving a stray failsafe report behind would fail the precondition on the NEXT run of this test,
+  // and read as the developer's own dirty tree rather than as this test's litter.
+  const controlXml = join(root, 'target/failsafe-reports/TEST-VeryLargeMessageVolumeTest.xml')
+  const saved = [summary, report, controlXml].map(f => [f, existsSync(f) ? readFileSync(f, 'utf8') : null])
   const restore = () => {
     for (const [f, body] of saved) {
       if (body === null) rmSync(f, { force: true })
@@ -149,6 +186,32 @@ check('flag bound is a 30% loss', WARN_BELOW, 0.70)
       // written to catch that exact bug could not fail. Split the payload off and assert the status
       // literal appears NOWHERE in the prose a human reads.
       check('the status did not land inside the message', text.split('<!-- pc-throughput-data:')[0].includes('no-control'), false)
+
+      // SECOND RUNTIME PATH: no-subject. Worth reaching by running the reporter rather than by
+      // reasoning about it, because the bug it guards was that the path did not exist - `verdictFor`
+      // returned its `no-subject` sentinel, the destructure left `ratio` undefined, and the template
+      // threw on `ratio.toFixed(3)`. Node exits 1 for an uncaught throw, which is this file's code for
+      // VIOLATION, so a subject test that never ran was reported as a REGRESSION and wrote no report
+      // at all. Exit code and report are therefore both asserted: either alone would have passed
+      // against some version of the bug.
+      //
+      // Reached offline by giving the reporter a CONTROL time and no subject time, which clears the
+      // two earlier guards and stops before the `gh run list` the verdict path needs. That ordering is
+      // load-bearing for this test staying hermetic.
+      mkdirSync(join(root, 'target/failsafe-reports'), { recursive: true })
+      writeFileSync(controlXml,
+        '<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="VeryLargeMessageVolumeTest">\n' +
+        '<testcase name="shouldProcess" classname="bz.stub.parallelconsumer.integrationTests.VeryLargeMessageVolumeTest" time="80.0"/>\n' +
+        '</testsuite>\n')
+      rmSync(report, { force: true })
+      const noSubject = spawnSync(process.execPath, [join(root, 'bin/check-throughput-regression.mjs')], { encoding: 'utf8' })
+      check('the reporter exited CANNOT for no-subject', noSubject.status, 2)
+      const subjText = existsSync(report) ? readFileSync(report, 'utf8') : ''
+      const sm = /<!-- pc-throughput-data: (.*?) -->/.exec(subjText)
+      check('the no-subject exit wrote a report at all', Boolean(sm), true)
+      check('and its payload names the status', sm ? JSON.parse(sm[1]).status : null, 'no-subject')
+      check('and the status did not land inside the message',
+        subjText.split('<!-- pc-throughput-data:')[0].includes('no-subject'), false)
     }
   } finally {
     for (const sig of ['SIGINT', 'SIGTERM']) process.removeListener(sig, onSignal)

--- a/bin/test-check-throughput-regression.mjs
+++ b/bin/test-check-throughput-regression.mjs
@@ -106,7 +106,8 @@ check('flag bound is a 30% loss', WARN_BELOW, 0.70)
   // would silently reintroduce the contradiction the rest of this block exists to prevent.
   const hair = 0.5 - 1e-12
   check('the raw value is a fail', bandOf(hair), 'fail')
-  check('every rung of the ladder disagrees with it', [3, 4, 5, 6, 9].map(dp => bandOf(Number(hair.toFixed(dp)))).join(), 'flag,flag,flag,flag,flag')
+  const rungs = [3, 4, 5, 6, 9].map(dp => bandOf(Number(hair.toFixed(dp))))
+  check('every rung of the ladder disagrees with it', rungs.join(), 'flag,flag,flag,flag,flag')
   check('so the fallback prints it exactly', displayRatio(hair), String(hair))
   check('and the printed value keeps the raw band', bandOf(Number(displayRatio(hair))), 'fail')
 }
@@ -225,6 +226,28 @@ check('flag bound is a 30% loss', WARN_BELOW, 0.70)
       check('and its payload names the status', sm ? JSON.parse(sm[1]).status : null, 'no-subject')
       check('and the status did not land inside the message',
         subjText.split('<!-- pc-throughput-data:')[0].includes('no-subject'), false)
+
+      // THIRD RUNTIME PATH: no-rate - and it is the LAST one reachable without a test seam, which is
+      // the useful part. The reporter has eight `writeReport` exits; exactly three of them are decided
+      // from local files before any network call (`no-rate`, `no-control`, `no-subject`), and the other
+      // five - `bootstrapping`, `check-failed`, `no-reference`, `incomparable`, and the verdict itself
+      // - sit behind `gh run list` and an artifact download. So this one costs nothing, and the open
+      // seam question is about those five specifically rather than about "the rest of them".
+      //
+      // The case is a summary that EXISTS and is non-blank but carries no usable `recordsPerSecond`.
+      // A missing or blank summary exits NOTHING_IN_SCOPE several lines earlier - a different
+      // contract, and conflating the two would assert the wrong exit code here.
+      rmSync(report, { force: true })
+      writeFileSync(summary,
+        'PC-THROUGHPUT test=MultiInstanceHighVolumeTest processed=0 expected=3 elapsedMs=1 recordsPerSecond=0 outcome=FAILED\n')
+      const noRate = spawnSync(process.execPath, [join(root, 'bin/check-throughput-regression.mjs')], { encoding: 'utf8' })
+      check('the reporter exited CANNOT for no-rate', noRate.status, 2)
+      const rateText = existsSync(report) ? readFileSync(report, 'utf8') : ''
+      const rateM = /<!-- pc-throughput-data: (.*?) -->/.exec(rateText)
+      check('the no-rate exit wrote a report at all', Boolean(rateM), true)
+      check('and its payload names the status', rateM ? JSON.parse(rateM[1]).status : null, 'no-rate')
+      check('and the status did not land inside the message',
+        rateText.split('<!-- pc-throughput-data:')[0].includes('no-rate'), false)
     }
   } finally {
     for (const sig of ['SIGINT', 'SIGTERM']) process.removeListener(sig, onSignal)

--- a/bin/test-check-throughput-regression.mjs
+++ b/bin/test-check-throughput-regression.mjs
@@ -11,6 +11,10 @@
 // red on a quiet day, and the first person to hit one switches the gate off - taking the collection
 // with it. So this asserts what the gate must NOT do at least as hard as what it must.
 
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
 import { verdictFor, FAIL_BELOW, WARN_BELOW, median } from './lib/throughput-verdict.mjs'
 
 let failures = 0
@@ -76,6 +80,44 @@ check('a missing control is not a pass', verdictFor({ subject: 27, control: 0 },
 check('fail bound is a 50% loss', FAIL_BELOW, 0.50)
 check('flag bound is a 30% loss', WARN_BELOW, 0.70)
 
+
+// THE REPORT MUST CARRY A REAL STATUS, CHECKED BY RUNNING IT RATHER THAN BY GREPPING FOR ONE.
+//
+// The first version of this test asserted each status literal appeared somewhere in the source. It
+// passed while all six had been inserted INSIDE the prose of their own messages - the report read
+// "control classes (`...`, 'no-control') produced a time" and the payload came out `{}`. Grepping
+// for a string proves the string exists, not that it is in the right place.
+//
+// The reporter chdirs to the repo root (so it always finds the lane's own target/), which means this
+// cannot be isolated with a scratch cwd - it has to run in the repo and put its fixture where the
+// reporter will look. Anything already there is saved and put back, because a developer with a real
+// report on disk should not lose it to a self-test. `no-control` is the cheapest path to reach: a
+// summary carrying a rate, with no control classes present.
+{
+  const root = fileURLToPath(new URL('..', import.meta.url))
+  const summary = join(root, 'target/performance-throughput.txt')
+  const report = join(root, 'target/throughput-report.md')
+  const saved = [summary, report].map(f => [f, existsSync(f) ? readFileSync(f, 'utf8') : null])
+  try {
+    mkdirSync(join(root, 'target'), { recursive: true })
+    writeFileSync(summary,
+      'PC-THROUGHPUT test=MultiInstanceHighVolumeTest processed=3 expected=3 elapsedMs=1 recordsPerSecond=75000 outcome=PASSED\n')
+    spawnSync(process.execPath, [join(root, 'bin/check-throughput-regression.mjs')], { encoding: 'utf8' })
+    const text = existsSync(report) ? readFileSync(report, 'utf8') : ''
+    const m = /<!-- pc-throughput-data: (.*?) -->/.exec(text)
+    const data = m ? JSON.parse(m[1]) : {}
+    check('the report carries a machine-readable payload', Boolean(m), true)
+    check('the payload names a real status', data.status, 'no-control')
+    check('the status did not land inside the message', text.includes('control classes (`'), true)
+  } finally {
+    for (const [f, body] of saved) {
+      if (body === null) rmSync(f, { force: true })
+      else writeFileSync(f, body)
+    }
+  }
+}
+
 if (failures === 0) { console.log('\nAll throughput-verdict self-tests passed'); process.exit(0) }
 console.error(`\n${failures} throughput-verdict self-test(s) failed`)
 process.exit(1)
+

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -1844,9 +1844,11 @@ Every earlier capture had to argue this; this one does not.
 <!-- post-merge: checked-end -->
 
 **Intermittent on the same branch, which is a small addition to the rate question.** The same lane
-passed on four earlier heads of that branch and failed on the fifth, all within about three hours
-and none of them carrying Java. That is consistent with the standing intermittency and is not a
-rate - it is one branch's run of five.
+passed on four earlier heads of that branch, failed on this one, and passed again on the next head
+that completed - all within about four hours, and none of them carrying Java. So the failure did not
+reproduce on a re-run of nearly the same tree, which is what "intermittent" has to mean here. That is
+consistent with the standing intermittency and **is not a rate**: it is a handful of runs on one
+branch, gathered while doing something else, not an experiment anybody designed.
 
 **Still not replayed.** Six seeds now exist for the verification the first 2026-08-26 section asks
 for - replay one with astubbs#29's `tryLock()` applied and read whether the poll thread is still

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -1800,6 +1800,62 @@ which is why the capture is worth attributing to the merge rather than to the br
 
 <!-- post-merge: checked-end -->
 
+## 2026-09-01, sixth capture: the DRAIN arm again - a seed, and the cheapest control arm yet
+
+**This adds no new signature, and is written down for the seed.** Same arm as the fifth capture,
+same SLO, same discriminator: `Chaos Pain Suite`,
+`ChaosRevokeUnderWorkDrainIT.revokeUnderDrainingStopsStaysProtocolHonest`, killed by
+`no instance may end the run with an unclassified failure cause`, with the poll thread found
+`BLOCKED` on an `AtomicBoolean` monitor held by its own control thread.
+<!-- post-merge: checked-begin -->
+Seen on astubbs/parallel-consumer#407's CI
+([run 33572473589](https://github.com/astubbs/parallel-consumer/actions/runs/33572473589), job
+100069358626), at head `ee173c87d`.
+<!-- post-merge: checked-end -->
+
+```
+instance 48: RuntimeException: Error from poll control thread: Timeout waiting for commit response
+PT10S to request ConsumerOffsetCommitter.CommitRequest(id=9d62549c-...) ...
+POLL THREAD AT TIMEOUT: BLOCKED - the poll thread is waiting to acquire a monitor, so this is
+contention or a lock-ordering defect, NOT a slow broker. Lock:
+java.util.concurrent.atomic.AtomicBoolean@6786a236, held by: pc-control-PC-48.
+Top frames: [...commitOffsetsThatAreReady(AbstractParallelEoSStreamProcessor.java:1780),
+             ...onPartitionsRevoked(AbstractParallelEoSStreamProcessor.java:580),
+             ConsumerRebalanceListenerInvoker.invokePartitionsRevoked, ... ThreadConfinedConsumer.poll]
+```
+
+**The line numbers moved again, which is the fifth capture's warning coming true.** That capture
+recorded `:1589` / `:552` against the first four's `:1585` / `:548`, and said to match future
+captures by method and monitor rather than by line. This one reads `:1780` / `:580` - a drift of
+nearly two hundred lines - and the method, monitor and holder pair are unchanged. Anyone filing by
+line number would have missed it; the guidance is now load-bearing rather than precautionary.
+
+**Seed `1075685698131288762`** - recorded before the log expires:
+
+    ./mvnw -Pci -pl parallel-consumer-core -am verify -DskipUTs=true \
+      -Dincluded.groups=chaos -Dexcluded.groups= -Dchaos.seed=1075685698131288762
+
+<!-- post-merge: checked-begin -->
+**The strongest not-PR-introduced control arm in this file, because the diff contains no Java at
+all.** astubbs/parallel-consumer#407 is one workflow file, three Node scripts and one markdown note.
+There is no compiled change for the chaos suite to reach, so ruling the branch out needs no frame
+resolution and no reasoning about which subsystem it touched - the category of change excludes it.
+Every earlier capture had to argue this; this one does not.
+<!-- post-merge: checked-end -->
+
+**Intermittent on the same branch, which is a small addition to the rate question.** The same lane
+passed on four earlier heads of that branch and failed on the fifth, all within about three hours
+and none of them carrying Java. That is consistent with the standing intermittency and is not a
+rate - it is one branch's run of five.
+
+**Still not replayed.** Six seeds now exist for the verification the first 2026-08-26 section asks
+for - replay one with astubbs#29's `tryLock()` applied and read whether the poll thread is still
+found `BLOCKED` on the same monitor. None has been replayed, and
+[`revoke-path-commit-deadlock-between-poll-and-control-threads.md`](../solutions/runtime-errors/revoke-path-commit-deadlock-between-poll-and-control-threads.md)
+still records its verification status as Unproven. **A seventh capture of this signature is worth
+less than one replay of any of the six**, and this entry exists only because the seed would
+otherwise expire with the log.
+
 ## Delete when
 
 The `CLASS2_STALL` entries above are superseded by this section and kept only as the record of how a

--- a/docs/inflight/test-load-tightness-flakes.md
+++ b/docs/inflight/test-load-tightness-flakes.md
@@ -18,6 +18,7 @@ baseline for comparison is 15/20 runs fully clean, zero stall-class failures.
 | `PartitionStateCommittedOffsetIT.committedOffsetRemoved[3] none` | 1 sighting (2026-08-05) | `RebalanceInProgressException` out of the test's own setup |
 | `ParallelEoSStreamProcessorTest.inFlightMessagesCommittedIfProcessedDuringShutdown[1]` | 1/15 (2026-08-07) | `assertCommits(of(1))`, "1 record completed during shutdown", in the transactional arm |
 | `PartitionStateCommittedOffsetIT.committedOffsetRemoved[2] earliest` | 1 sighting (2026-08-25, astubbs#353, [job 97859037375](https://github.com/astubbs/parallel-consumer/actions/runs/32865269364/job/97859037375)) | `checkHowManyRecordsWithKeyPresent` expected 2 got 1 - the `[1] latest` assertion signature (solved 2026-08-05 as a nudge race) appearing on the `earliest` parameter; `probe clean` autopsy (test-side, not consumer-group progress), on a branch with no Java <!-- post-merge: checked --> |
+| `PartitionStateCommittedOffsetIT.committedOffsetRemoved[1] latest` | 1 sighting (2026-09-01, astubbs#407, [job 100057065090](https://github.com/astubbs/parallel-consumer/actions/runs/33568429332/job/100057065090)) | `checkHowManyRecordsWithKeyPresent` expected 2 got 1 - the assertion the `[2]` row carries, but the record that SURVIVED is the compactor rather than the original, which the 2026-08-05 mechanism cannot produce; `probe clean`, `forkCount=4`, on a branch with no Java <!-- post-merge: checked --> |
 | `TransactionTimeoutsTest.commitTimeout[2]` | 1 sighting (2026-08-06, astubbs#204) | incompletes `[8]` where the parameter pins `[8, 12]` |
 
 **On `inFlightMessagesCommittedIfProcessedDuringShutdown[1]` - read the parameter index before
@@ -99,6 +100,41 @@ bug in exactly this area (a rebalance-time commit killing the broker-poll thread
 **Explicitly NOT a member: `RebalanceEoSDeadlockTest.noDeadlockOnRevoke`** (1/20). Per the astubbs#68 record
 its contended failure maps to the real confluentinc#857 deadlock - that sighting is live confirmation the
 deadlock is still on master, with its fix waiting in astubbs#29.
+
+## `committedOffsetRemoved[1] latest` - the same assertion as the `[2]` row, failing from the other side (2026-09-01)
+
+<!-- post-merge: checked-begin - names astubbs#407 in the past tense as the branch the sighting came
+     from, which stays true once that work has landed -->
+
+`Integration Tests` on astubbs#407's head `7517bd983`
+([job 100057065090](https://github.com/astubbs/parallel-consumer/actions/runs/33568429332/job/100057065090)),
+`forkCount=4`, one failure in 161 integration tests. Recorded rather than diagnosed, per this
+ledger's own rule: the evidence expires with the logs.
+
+**WHICH record survived is the whole point, and it is the reverse of the solved case.** The assertion
+is the `checkHowManyRecordsWithKeyPresent("key-" + offset, 2)` inside `causeCommittedOffsetToBeRemoved`,
+and the scan came back holding exactly one:
+
+    offset = 202, key = key-50, value = compactor
+
+The 2026-08-05 diagnosis - the nudge race, and the scan-window half now recorded in that method's own
+javadoc - was that **the reader stopped early**: extra nudge records pushed the compaction records past
+a caller-supplied window, so the scan found the ORIGINAL `value-50` and reported the compactor missing.
+Here the scan plainly reached offset 202, because it is holding the compactor; what is absent is the
+original. A window that stops short cannot produce that, so **this is not the solved bug wearing its
+signature again**, and reading it as one would send the next person to a fix that is already in the
+tree. The reading the evidence supports is that the earlier `key-50` was compacted away before the
+scan ran - an ordering the test does not control - but that is a hypothesis from one sighting, not a
+diagnosis, and it has not been reproduced.
+
+**Master state, not astubbs#407's.** That branch changes one workflow and two Node scripts, and no
+Java at all, so nothing in it is reachable from the code under test.
+
+**Do not merge it into the `[2] earliest` row above.** That row carries the same assertion text and the
+same `probe clean` autopsy, but on the other parameter, and whether the two share a cause is precisely
+what is open. Two sightings on two parameters is not yet a rate on either.
+
+<!-- post-merge: checked-end -->
 
 ## `commitTimeout[2]`, for whoever picks it up (seen 2026-08-06 on astubbs#204)
 


### PR DESCRIPTION
Follow-up to astubbs/parallel-consumer#401, which began as review of the throughput comment it posts and grew into the comment-posting steps around it.

Three strands, and the third was not planned: **the comments now say what they mean** (a reviewer read `1.713` as "1.7x faster than master" when the real figure was `1.081`), **they survive their own failures** (a failed write no longer fails a required job, or leaves a PR with two live markers), and **the SpotBugs comment stops destroying human comments** - its lookup matched any comment containing "SpotBugs Report", oldest first, so a human quoting the bot had their comment silently overwritten.

## What review asked for, and what was already true

Two of the four asks were already implemented, which is worth stating rather than silently "fixing":

- **Run on every push** — it already does. The check is a step in the performance job.
- **Update the comment rather than appending** — it already does, deliberately: "a PR with fifteen throughput comments is a PR where nobody reads the throughput comment."

## The real gaps

**The comment could not show a delta, because it kept no readings.** Each report now ends with one machine-readable line — status, rate, ratio, share — and the workflow reads it back off its own previous comment to render *"since the previous push: ratio X → Y, share X → Y, rate X → Y (+n%)"*. Reading our own last comment is the only store available: no series is kept anywhere, by an explicit earlier decision, and updating in place otherwise destroys the only record of what the last push measured.

It is labelled a delta and **not** a verdict. This test's run-to-run spread on one unchanged commit is wide enough that a single push of difference is noise far more often than it is a change.

**A status change edited a comment nobody was looking at.** Editing something thirty scrolls up produces no notification and no visible change to a reader going top to bottom, so a run that went green→red announced itself silently. Now a fresh comment is posted at the bottom and the old one is retired — marker renamed so later pushes stop targeting it, and a link forward so a reader who lands on the stale one is not stranded. Number-only movement still updates in place; only the verdict earns a new comment.

**The retire happens BEFORE the create**, and the order is the safety property. There is no transaction across two API calls, so one can fail after the other succeeded. Creating first and failing to retire leaves *two* comments carrying the live marker — and since the lookup paginates oldest-first and takes the first match, every later run latches onto the stale one forever while the new report sits orphaned. Retiring first fails the other way: no live marker at all, so the next run simply posts a fresh one. The forward link costs a third write and is therefore best-effort and last, since by then the marker state is already correct.

**An in-place update looked dead.** The body could be identical to last week's with nothing to say a run had happened. Every report now carries a stamp: the head SHA **as a link** to that commit in this PR, a link to the run, and the time. The SHA link is the part that matters — a static comment body cannot render the reader's local time (GitHub's sanitiser strips `<time>`, `<time-ago>` and `<local-time>`, and the REST API exposes no user timezone), but the commit page it links to carries GitHub's own localised relative timestamp. Nobody has to do arithmetic on a UTC string; they click. It is abbreviated to seven characters to match GitHub's own abbreviation everywhere else on the page.

**"No comparable reference" read as "no baseline exists".** Baselines usually do exist; they just ran a different set of tests, most often because the PR itself enabled or disabled some. The message now says how many were found and that a matrix change is usually the PR's own doing — and the readings are shown, with **"different test set - not a control" in its own column on every borrowed row**, so a number cannot be lifted out of the table without its warning.

## The report must not contradict itself

Three fixes from the `@claude review` round, all about the report misleading a reader who does exactly the right thing with it.

**The headline stated a difference flatly against an undisclosed noise floor.** "This branch is about 8% faster than master" sat two paragraphs above the same comment's own statement that this test moves 13-17% run to run — so the report contradicted itself and the headline won, because the headline is what gets read. It now discloses the floor in the same sentence, and the verb changed with it: "**measured** about 8% faster" is a fact about this run; "**is** about 8% faster" was a claim about the branch.

**The printed ratio could contradict its own icon.** `toFixed(3)` rounds, and at a bound the rounding crosses it: `0.4996` printed as `0.500` beside a 🔴 whose bound the very same comment prints as "< 0.50". The displayed value now widens its precision until it lands in the same verdict band as the raw one. Away from a bound nothing changes.

**A subject test that did not run was reported as a regression.** `verdictFor`'s `no-subject` sentinel had no guard: the destructure left `ratio` undefined, the template threw on `ratio.toFixed(3)`, and Node exits 1 for an uncaught throw — which is this script's own code for VIOLATION. It failed loudly for the wrong reason *and* wrote no report at all, breaking the file's own "every exit writes a report" rule by the single exit that never reached `writeReport`. Pre-existing, taken here because the fix is a ten-line guard mirroring the two beside it.

## The posting step could fail the required check

It makes one or two GitHub API writes inside the REQUIRED Performance Tests job and, unlike its sibling, had no `continue-on-error` — so a rate limit, a 500 or a script exception failed the check for a reason unrelated to the lane or the verdict. The comment is the nice-to-have; the job's own result is not.

## One more comment step, same defect class

Riding in rather than taking its own branch, because it is the same file and the same reasoning. **All of it is pre-existing on master; none is introduced here.**

The **SpotBugs** summary step called `listComments` unpaginated. That is latent rather than live, and the reason is worth stating: the API returns 30 per page **oldest first**, so a sticky comment born *early* stays on page one forever and keeps working. It only breaks when the comment is born *late* — created once a PR already has 30+ comments, it lands on page two, `find` never sees it again, and every later push takes the create branch. So it would not miss once and recover; it would duplicate on **every** push. Measured exposure, so as not to overstate it: the busiest PRs in this repo today are 13, 11, 11, 10 and 9 comments, all comfortably above the fold.

It also matched **any** comment containing "SpotBugs Report" — including a human quoting it — and took the oldest match, so somebody who asked a question about the report before the bot first posted would have had their comment silently overwritten. It now requires a Bot author, the same way the throughput lookup does.

And it posted with no `continue-on-error`, the same omission fixed above.

This was the only remaining unpaginated `listComments` in the tree; `bin/quarantine-lane-report.sh` already passes `--paginate`.

## A mistake worth reading, because the test missed it

The status began as a second argument to `writeReport`. Inserting it meant locating each call's closing paren, and the report bodies are template literals containing escaped backticks — so **all six insertions landed inside the prose**, producing ``control classes (`...`, 'no-control') produced a time`` and an empty payload.

The self-test written to prevent exactly that **passed on all six**, because it grepped for the literal rather than checking where it was.

So the status is now set into a variable on the line *before* each call, which cannot fail that way, and the test **runs the reporter** and reads the payload back as the workflow does. Verified in both directions: reintroducing the corruption fails it with `expected no-control, got unset`; the previous test stayed green.

## Coverage, stated rather than implied

The reporter has **eight** `writeReport` exits, and the split that matters is not covered-versus-uncovered but **local versus networked**. Exactly three are decided from local files before any network call — `no-rate`, `no-control`, `no-subject` — and the runtime test now drives **all three**, each reached by shaping only the files on disk so the case stays hermetic. Exit code *and* report are asserted every time, because either alone would pass against some version of the bug the guard exists for.

The other five — `bootstrapping`, `check-failed`, `no-reference`, `incomparable`, and the **main verdict path** — sit behind `gh run list` and an artifact download. Reaching them offline means putting a test seam into production code, and that is a design call left open rather than made here. What has changed is its *scope*: it is a question about those five specifically, not about "the rest of them", and no free coverage is being left on the table while it is pending.

The two pure helpers the verdict path depends on (the headline sentence and the ratio display) are unit-tested directly — including `displayRatio`'s ladder-exhausted fallback, the one branch of it no other case reaches — so the findings from both review rounds are covered even though the path that renders them is not. The **incomparable** path is still verified by parse and by reading, not by execution. That is weaker, and it is why this section exists.

## The second review round asked for one thing

It did not ask for the design to change. `continue-on-error` swallowing a failed create *after* the
old comment has been retired is the right trade, and the reviewer explicitly declined to reverse it.
The **wording** written into the retired comment was the defect: it named a PLACE - "Superseded by a
newer report further down this conversation" - and that write happens before the create that may
never succeed.

**The false pointer is permanent, not transient**, which is what made it worth fixing rather than
noting. The retired marker `<!-- pc-throughput-report (superseded) -->` is not a substring of the
live marker the lookup searches for, so no later run ever finds that comment again to correct it.
The next push heals the *live* comment - `existing` comes back falsy, so it takes the create-fresh
branch - and leaves the orphan untouched forever.

`retiredBody` now takes the whole trailing note rather than a noun slotted into a fixed
"Superseded by X" sentence, because the two writes cannot honestly promise the same thing. The
pre-create note claims only what is already true when it is written - this reading is superseded, a
fresh report should follow for this push - and names no place. The post-create note, written once
the new comment demonstrably exists, still links straight at it.

The round's other two questions came back as no-change, which is the useful outcome for both.
`displayRatio`'s boundary behaviour was traced by hand and found correct - including the adversarial
case that exhausts the entire `[3, 4, 5, 6, 9]` ladder and falls through to `String(ratio)`, which
holds because that is the shortest representation round-tripping the double exactly. That fallback
was the one branch of the function no test reached, so it is now pinned, **verified in both
directions**: replacing it with a final `toFixed(9)` fails exactly the two new assertions and
nothing else. The SpotBugs author guard was judged better bundled than split, and stays bundled.

## One sighting, riding along

The `Chaos Pain Suite` went red on one head of this branch carrying the confluentinc#857 revoke-path
discriminator - the poll thread found BLOCKED on a monitor held by its own control thread, inside
`onPartitionsRevoked` -> `commitOffsetsThatAreReady`. **Not this PR's defect and not fixed here**:
the diff has no Java in it at all, and the lane passed again on the next head that completed.

It is the sixth capture of a signature already documented five times, so it is recorded for its
**seed**, which dies with the log, and for the two things it does add. The frame line numbers moved
again - `:1780` / `:580` against the fifth capture's `:1589` / `:552` - which turns that capture's
"match by method and monitor, not by line" advice from precautionary into load-bearing. And because
this branch carries no compiled change the chaos suite could reach, it is the cheapest
not-PR-introduced control arm in that file: every earlier capture had to argue the branch was
innocent, this one does not.

## Checklist

- [x] Docs updated — the reasoning lives in the reporter and workflow headers, where the next editor meets it
- [ ] User-facing feature documentation data added under `docs/features/` — N/A - CI reporting, not a library feature
- [x] Tests added/updated — the self-test runs the reporter rather than grepping its source, and now covers a second path plus the two new pure helpers
- [ ] `docs/inflight/` working note started at the PR's first commit — N/A - a scoped follow-up to astubbs/parallel-consumer#401, fully described here and in the commit bodies
- [x] Title & body reflect the final content of this PR
- [ ] Ran `ce-simplify` and `ce-code-review` locally — N/A - asking for `@claude review this` on the PR instead



