### PR TITLE
deps: exclude CVE-2026-82596 on LatencyUtils, a local-only record with no fixed release

### DIFF
--- a/docs/inflight/deps-cve-backlog.md
+++ b/docs/inflight/deps-cve-backlog.md
@@ -12,7 +12,7 @@ authenticated run possible (`authId`, `ossindex.skip`, `fail=true`) landed on `m
 astubbs#259; only the triage below was outstanding.
 
 Two of the five components were fixable and are fixed. Three are not, and the Jackson bump leaves one
-over-broad finding behind - **all five rows below** are carried as documented
+over-broad finding behind - **every row below** is carried as a documented
 `<excludeVulnerabilityIds>` entries in the root pom's `ossindex-maven-plugin` config. `fail` is
 already `true`; these exclusions are what lets the audit actually be *run* - by flipping
 `ossindex.skip`, or by the scheduled CI job - without going permanently red. The pom comments are the
@@ -115,6 +115,7 @@ not redundant and neither is a superset of the other:
 | `micrometer-core:1.13.15` (compile) | direct, `parallel-consumer-core` | standing: real, **not reachable**, no free fix | CVE-2026-40984 |
 | `netty-codec-http:4.1.136.Final` (compile) | `vertx-core:4.5.31` → `parallel-consumer-vertx` | standing: **unverifiable - no CVE record exists** | CVE-2026-59903 |
 | `HdrHistogram:2.2.2` (runtime) | `micrometer-core` → `parallel-consumer-core` | standing: **both CVEs officially disputed**, no fixed release | CVE-2026-14683, CVE-2026-14686 |
+| `LatencyUtils:2.0.3` (runtime) | `micrometer-core` → `parallel-consumer-core` | standing: **local-access-only**, no fixed release (added 2026-09-03, beside HdrHistogram) | CVE-2026-82596 |
 | `jackson-databind:2.18.9` (runtime) | `kafka-streams:3.9.2` → **`example-streams` only** | standing: **false positive** - out of the advisory's range | CVE-2026-54518 |
 | `jackson-databind:2.18.9` (runtime) | `kafka-streams:3.9.2` → **`example-streams` only** | **TEMPORARY (2026-08-11)** - real, unreachable here, fix merged but unreleased | CVE-2026-68497, CVE-2026-19032 |
 
@@ -184,6 +185,22 @@ Dependabot defect.
 
 **`2.2.2` is the newest version on Maven Central. There is no fixed release to move to.** It arrives
 via `micrometer-core`, so it is not independently upgradable either.
+
+### `LatencyUtils` - the same shape as HdrHistogram, arrived 2026-09-03
+
+CVE-2026-82596 (1.9), VulDB-assigned, published 2026-08-31, against `LatencyStats.recordDetectedPause`
+in the pause detector. The record says "the attack needs to be launched locally": a caller already
+executing code in the JVM corrupting the pause detector's own histogram, which is not a path from
+outside this library or its users. Not in GHSA, so no Dependabot alert will fire, and that is not a
+Dependabot defect.
+
+**`2.0.3` is the newest version on Maven Central, from 2014. There is no fixed release to move to.**
+It arrives via `micrometer-core`, beside HdrHistogram, so it is not independently upgradable either.
+It went red on every open PR the morning it was published (astubbs#427, astubbs#428, astubbs#429),
+which is what the audit is meant to do for a finding nobody has looked at; astubbs#430 is the look.
+
+Retire when LatencyUtils publishes a fixed release, `micrometer-core` drops the dependency, or the
+record is rejected or withdrawn.
 
 ### `jackson-databind` - one over-broad range survives the bump
 

--- a/docs/inflight/deps-cve-backlog.md
+++ b/docs/inflight/deps-cve-backlog.md
@@ -197,7 +197,7 @@ Dependabot defect.
 **`2.0.3` is the newest version on Maven Central, from 2014. There is no fixed release to move to.**
 It arrives via `micrometer-core`, beside HdrHistogram, so it is not independently upgradable either.
 It went red on every open PR the morning it was published (astubbs#427, astubbs#428, astubbs#429),
-which is what the audit is meant to do for a finding nobody has looked at; astubbs#430 is the look.
+which is what the audit is meant to do for a finding nobody has looked at; this entry is the look.
 
 Retire when LatencyUtils publishes a fixed release, `micrometer-core` drops the dependency, or the
 record is rejected or withdrawn.

--- a/pom.xml
+++ b/pom.xml
@@ -750,6 +750,17 @@
                         <excludeVulnerabilityId>CVE-2026-14683</excludeVulnerabilityId>
                         <excludeVulnerabilityId>CVE-2026-14686</excludeVulnerabilityId>
 
+                        <!-- org.latencyutils:LatencyUtils (via micrometer-core, beside HdrHistogram above
+                             and of the same kind). VulDB-assigned, published 2026-08-31, CVSS 1.9,
+                             "the attack needs to be launched locally": a local caller corrupting the
+                             pause detector's own histogram is not an attack on this library or its
+                             users. 2.0.3 is the newest release on Central (2014), so there is nothing
+                             to upgrade to, and it is transitive so it is not independently upgradable
+                             either. Not in GHSA, which is why Dependabot is silent.
+                             RETIRE WHEN: LatencyUtils publishes a fixed release, micrometer-core drops
+                             the dependency, or the record is rejected/withdrawn. -->
+                        <excludeVulnerabilityId>CVE-2026-82596</excludeVulnerabilityId>
+
                         <!-- io.netty:netty-codec-http (via vertx-core). No public record exists: not
                              in OSV, not in GHSA, and cveawg.mitre.org returns CVE_RECORD_DNE. The
                              neighbouring ids are the real Netty August 2026 batch (-59898, -59899,


### PR DESCRIPTION
No issue: a scan-lane repair, not a defect in this codebase.

## Description

`deps: whole-tree CVE scan` went red on every PR opened since the morning of 2026-09-03 (astubbs/parallel-consumer#427, astubbs/parallel-consumer#428 and astubbs/parallel-consumer#429 all show it; astubbs/parallel-consumer#426 scanned an hour earlier and passed). OSS Index began reporting CVE-2026-82596 against `org.latencyutils:LatencyUtils:2.0.3`, which `micrometer-core` pulls in transitively beside HdrHistogram.

This adds a **standing** exclusion, in the shape of the HdrHistogram pair directly above it in the root pom, with its retirement condition stated:

- VulDB-assigned, CVSS 1.9, "the attack needs to be launched locally": an attacker already executing code in the JVM corrupting the pause detector's own histogram. Not a reachable path from outside this library or its users.
- 2.0.3 is the newest LatencyUtils on Central, from 2014, so there is nothing to upgrade to; it is transitive, so it cannot be bumped on its own.
- Not in GHSA, so no Dependabot alert will ever fire for it. The pom comment is the only place the retirement condition can live, which is what `bin/check-cve-exclusions.sh` polices.

**Verified locally**: `bin/check-cve-exclusions.sh` accepts the entry; the OSS Index audit run the way `bin/check-ossindex-audit.sh` prescribes scanned every module and reported the tree clean with the exclusion in place. `bin/check-all.sh` green.

Retire when LatencyUtils publishes a fixed release, micrometer-core drops the dependency, or the record is rejected or withdrawn.

## Checklist

- [x] Docs updated - `docs/inflight/deps-cve-backlog.md` row and section added after review (the pom comment is the short form, that file the long form)
- [x] User-facing feature documentation data added under `docs/features/` - N/A - no feature
- [x] Tests added/updated - N/A - a pom exclusion; the scan lane and `bin/check-cve-exclusions.sh` are the tests, both run
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - nothing here that `gh` cannot show
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - one pom comment and one id; nothing to simplify or review beyond the reasoning above

