### PR TITLE
deps: take the Jackson retirement the pom asked for, and exclude a new micrometer advisory

### DIFF
--- a/bin/test-check-cve-exclusions.sh
+++ b/bin/test-check-cve-exclusions.sh
@@ -156,7 +156,13 @@ run_guard() { # <pom> [today]
 # right now, so a pom edit that breaks the format is caught by the self-test too, not only by CI.
 run_guard "$REAL_POM" "$TODAY"
 assert "the repo's own exclusion list passes as written" 0 "$LAST_EC"
-assert_contains "  ...and reports the temporary entry's remaining days" "remaining" "$LAST_OUT"
+# Assert it COUNTED, not merely that it exited 0: a guard that parsed nothing would also exit 0, and
+# that is the vacuous pass this suite exists to catch. Deliberately not asserting anything about
+# temporary entries here - whether the live list has one is a fact about today's dependencies, not
+# about the guard. It had one until the Jackson 2.18.10 retirement emptied that category, and this
+# arm failed the moment it did. The remaining-days rendering is asserted on a fixture below, where
+# the input is controlled.
+assert_contains "  ...and says how many it counted, so a vacuous pass is visible" "advisory id(s) excluded" "$LAST_OUT"
 
 # ── 2. a temporary entry dated today ──────────────────────────────────────────
 fresh_block="                <!-- ==== TEMPORARY-SINCE: ${TODAY} - waiting on an upstream release ==== -->
@@ -164,6 +170,7 @@ fresh_block="                <!-- ==== TEMPORARY-SINCE: ${TODAY} - waiting on an
 pom=$(write_pom fresh "$fresh_block")
 run_guard "$pom" "$TODAY"
 assert "a temporary entry dated today passes" 0 "$LAST_EC"
+assert_contains "  ...and reports its remaining days" "remaining" "$LAST_OUT"
 
 # ── 3 & 4. THE CONTROL ARM: identical fixtures, one day apart ─────────────────
 # The only difference between these two poms is the date in the banner. If 3 passed and 4 also

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -66,11 +66,23 @@
              Kept as a module-local, explicitly-versioned test dep on purpose: jackson-databind is a transitive
              dependency of WireMock (parallel-consumer-vertx), and pinning it globally via root
              dependencyManagement forced WireMock onto an incompatible Jackson and broke VertxTest (HTTP 500).
-             So this stays scoped to just this module. -->
+             So this stays scoped to just this module.
+
+             2.18.10, and 2.18.9 is the floor rather than 2.18.0: CVE-2026-59889 was introduced in
+             2.18.0 and only fixed in 2.18.9, so anything in 2.18.0-2.18.8 would trade one advisory
+             for another. The same floor and the same reasoning govern the jackson-bom import in
+             example-streams; keep the two in step.
+
+             A bare databind pin is enough HERE, unlike example-streams, because nothing else in
+             this module resolves jackson: databind brings jackson-core and jackson-annotations on
+             its own line. Verify that still holds before changing the version - `./mvnw -pl
+             parallel-consumer-examples/parallel-consumer-example-metrics dependency:tree
+             -Dincludes='com.fasterxml.jackson*'` must show core and annotations at the same version
+             as databind, or this needs the BOM treatment example-streams uses. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.10</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-metrics/pom.xml
@@ -63,26 +63,19 @@
         </dependency>
         <!-- Real Jackson to parse the Prometheus metadata JSON in the integration test (we must NOT use the
              copy Testcontainers bundles under org.testcontainers.shaded.* - enforced by TestConventionRules).
-             Kept as a module-local, explicitly-versioned test dep on purpose: jackson-databind is a transitive
-             dependency of WireMock (parallel-consumer-vertx), and pinning it globally via root
-             dependencyManagement forced WireMock onto an incompatible Jackson and broke VertxTest (HTTP 500).
-             So this stays scoped to just this module.
 
-             2.18.10, and 2.18.9 is the floor rather than 2.18.0: CVE-2026-59889 was introduced in
-             2.18.0 and only fixed in 2.18.9, so anything in 2.18.0-2.18.8 would trade one advisory
-             for another. The same floor and the same reasoning govern the jackson-bom import in
-             example-streams; keep the two in step.
+             Version comes from jackson.examples.version in the examples parent, which carries the
+             reasoning for the number and for why it is not managed at the root.
 
-             A bare databind pin is enough HERE, unlike example-streams, because nothing else in
-             this module resolves jackson: databind brings jackson-core and jackson-annotations on
-             its own line. Verify that still holds before changing the version - `./mvnw -pl
-             parallel-consumer-examples/parallel-consumer-example-metrics dependency:tree
-             -Dincludes='com.fasterxml.jackson*'` must show core and annotations at the same version
-             as databind, or this needs the BOM treatment example-streams uses. -->
+             A bare databind pin is enough HERE, unlike example-streams, because nothing else in this
+             module resolves jackson: databind brings jackson-core and jackson-annotations on its own
+             line. Confirm that still holds before changing the version, with dependency:tree scoped
+             to this module and filtered to com.fasterxml.jackson; core and annotations must land on
+             the same version as databind, or this needs the BOM treatment example-streams uses. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.10</version>
+            <version>${jackson.examples.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
@@ -35,12 +35,17 @@
                  jackson-core and jackson-annotations on the same line - pinning databind alone would
                  leave it running against 2.16.2 core.
 
-                 Retire this when kafka-streams can be bumped to a release that ships Jackson 2.18.9
+                 2.18.10 rather than 2.18.9 because it is the release that carries the fixes for
+                 CVE-2026-68497 and CVE-2026-19032, which this repo had been holding as dated
+                 TEMPORARY exclusions in the root pom precisely until it shipped. Those two entries
+                 are deleted in the same change; do not reintroduce them.
+
+                 Retire this when kafka-streams can be bumped to a release that ships Jackson 2.18.10
                  or newer; 3.9.2 is the last 3.9.x, and 4.x is behind the Java 11 baseline move. -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.18.9</version>
+                <version>2.18.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
+++ b/parallel-consumer-examples/parallel-consumer-example-streams/pom.xml
@@ -19,33 +19,14 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- kafka-streams 3.9.2 drags in Jackson 2.16.2, which is vulnerable to CVE-2026-54512,
-                 -54513, -54514, -54515 and -59888. 2.18.9 is past every one of them, and is the
-                 *minimum* safe version in the 2.18 line: CVE-2026-59889 was introduced in 2.18.0 and
-                 only fixed in 2.18.9, so 2.18.0-2.18.8 would trade one vulnerability for another.
-
-                 Module-local on purpose, exactly like the test-scope pin in example-metrics:
-                 jackson-databind is also transitive to WireMock (parallel-consumer-vertx), and
-                 pinning it in root dependencyManagement forces WireMock onto an incompatible Jackson
-                 and breaks VertxTest with HTTP 500. This module is never published
-                 (maven.deploy.skip / maven.install.skip / skipPublishing in the examples parent), so
-                 no consumer of the library inherits it.
-
-                 The BOM rather than a bare jackson-databind pin, because databind 2.18 needs
-                 jackson-core and jackson-annotations on the same line - pinning databind alone would
-                 leave it running against 2.16.2 core.
-
-                 2.18.10 rather than 2.18.9 because it is the release that carries the fixes for
-                 CVE-2026-68497 and CVE-2026-19032, which this repo had been holding as dated
-                 TEMPORARY exclusions in the root pom precisely until it shipped. Those two entries
-                 are deleted in the same change; do not reintroduce them.
-
-                 Retire this when kafka-streams can be bumped to a release that ships Jackson 2.18.10
-                 or newer; 3.9.2 is the last 3.9.x, and 4.x is behind the Java 11 baseline move. -->
+            <!-- Version comes from jackson.examples.version in the examples parent, which carries
+                 the reasoning for the number and for why it is not managed at the root. The BOM
+                 rather than a bare databind pin, because databind 2.18 needs jackson-core and
+                 jackson-annotations on the same line, and kafka-streams pins core here. -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.18.10</version>
+                <version>${jackson.examples.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/parallel-consumer-examples/pom.xml
+++ b/parallel-consumer-examples/pom.xml
@@ -35,6 +35,26 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>
         <gpg.skip>true</gpg.skip>
+
+        <!-- The Jackson two example modules pin, single-sourced here so the two cannot drift apart.
+
+             WHY A PROPERTY HERE RATHER THAN dependencyManagement IN THE ROOT POM. jackson-databind
+             is transitive to WireMock in parallel-consumer-vertx, and managing its version at the
+             root forces WireMock onto an incompatible Jackson and breaks VertxTest with HTTP 500.
+             A property states a version without imposing one on anything, and this parent is
+             inherited only by the example modules, so vertx cannot see it either way. Each module
+             still declares its own dependency; only the number is shared.
+
+             WHY 2.18.10, AND WHY 2.18.9 IS THE FLOOR. kafka-streams 3.9.2 drags in 2.16.2, which is
+             vulnerable to CVE-2026-54512, 54513, 54514, 54515 and 59888. CVE-2026-59889 was
+             introduced in 2.18.0 and only fixed in 2.18.9, so anything from 2.18.0 to 2.18.8 would
+             trade one advisory for another. 2.18.10 additionally carries the fixes for
+             CVE-2026-68497 and CVE-2026-19032, which this repo held as dated TEMPORARY exclusions
+             in the root pom until it shipped.
+
+             RETIRE WHEN: kafka-streams ships Jackson 2.18.10 or newer. 3.9.2 is the last 3.9.x, and
+             4.x is behind the Java 11 baseline move. -->
+        <jackson.examples.version>2.18.10</jackson.examples.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -778,9 +778,23 @@
                              scopes it to HTTP *server* instrumentation, and this project uses only
                              Counter/Gauge/Timer/DistributionSummary/KafkaClientMetrics, with
                              example-metrics serving over the JDK's own com.sun.net.httpserver.
+                             CVE-2026-59295 (5.9, CWE-400) is the same component, the same blocker and
+                             the same retire condition, so it shares this comment rather than repeating
+                             it. Unbounded memory growth in MicrometerHttpClientInterceptor when an
+                             instrumented Apache HttpAsyncClient request fails before a response.
+                             Unreachable here for a structural reason rather than a judgement call:
+                             neither MicrometerHttpClientInterceptor nor any Apache HttpAsyncClient
+                             appears anywhere in this repo's sources or poms, and the micrometer
+                             surface actually used is metric primitives plus KafkaClientMetrics,
+                             ExecutorServiceMetrics and CompositeMeterRegistry. Re-check that if this
+                             project ever instruments an HTTP client:
+                             `grep -rn "MicrometerHttpClientInterceptor\|HttpAsyncClient" --include=*.java --include=*.xml`
+
                              RETIRE WHEN: the io.micrometer.prometheus -> prometheusmetrics package
-                             rename is migrated, which is what unblocks 1.15.x. -->
+                             rename is migrated, which is what unblocks 1.15.x - and it retires BOTH
+                             ids below, since 1.15.12 is past each of them. -->
                         <excludeVulnerabilityId>CVE-2026-40984</excludeVulnerabilityId>
+                        <excludeVulnerabilityId>CVE-2026-59295</excludeVulnerabilityId>
 
                         <!-- com.fasterxml.jackson.core:jackson-databind (example-streams only). False
                              positive: GHSA-rcqc-6cw3-h962 gives introduced 2.21.0 / fixed 2.21.4, and
@@ -791,55 +805,6 @@
                              2.21.x that is genuinely in scope (then it needs >= 2.21.5, not an
                              exclusion). -->
                         <excludeVulnerabilityId>CVE-2026-54518</excludeVulnerabilityId>
-
-                        <!-- ==== TEMPORARY-SINCE: 2026-08-11 - delete when Jackson 2.18.10 ships ====
-
-                             The date is machine-read by bin/check-cve-exclusions.sh, which fails the
-                             Repo Hygiene check once this entry is 90 days old. Change it only after
-                             re-checking upstream, never to buy quiet.
-
-                             com.fasterxml.jackson.core:jackson-databind, example-streams only, at
-                             runtime scope via kafka-streams 3.9.2. Unlike everything above, these two
-                             are NOT permanent: both fixes are already merged upstream on the 2.18
-                             branch, milestone 2.18.10, and there is simply no release carrying them
-                             yet.
-
-                               CVE-2026-68497 (8.7, CWE-770) - unbounded allocation deserializing
-                               javax.xml.datatype.Duration / XMLGregorianCalendar. Fix: FasterXML/
-                               jackson-databind#6127, merged 2026-07-29, adds the StreamReadConstraints
-                               number-length limit to CoreXMLDeserializers.
-
-                               CVE-2026-19032 (6.3, CWE-470) - java.nio.file.Path deserialization
-                               accepts arbitrary URI schemes. Fix: FasterXML/jackson-databind#6129,
-                               merged 2026-08-06, restricts the accepted schemes.
-
-                             There is nothing to bump TO. Neither id is in OSV, NVD or GHSA yet, so the
-                             only public record is Sonatype's own; the fixed-version data comes from the
-                             two merged PRs. Every released 2.x artifact predates both merges - the
-                             newest on each line are 2.18.9 (2026-07-08), 2.21.5 (2026-07-07) and
-                             2.22.1 (2026-07-07) - so moving up a line does not help, and moving lines
-                             is separately blocked (2.21.0-2.21.3 would make CVE-2026-54518 above real,
-                             and a global pin breaks VertxTest through wiremock-jre8).
-
-                             Neither is reachable in this example: StreamsApp is String-serde end to
-                             end, constructs no ObjectMapper, and never names Path, Duration or
-                             XMLGregorianCalendar. jackson-databind is present only because
-                             kafka-streams drags it in for its own internal metadata.
-
-                             Being an example is why this is excludable rather than shipped risk: the
-                             examples parent sets maven.deploy.skip / maven.install.skip /
-                             skipPublishing, so no consumer of the library inherits this dependency.
-                             That is a statement about blast radius, not about the vulnerability -
-                             an example is still code people copy, and if either advisory had touched
-                             core, vertx, reactor or mutiny this would have been a bump or a stop, not
-                             an exclusion. It was checked: they resolve no jackson-databind at runtime
-                             at all.
-
-                             RETIRE WHEN: jackson-databind 2.18.10 is on Central. Then bump the
-                             jackson-bom import in parallel-consumer-example-streams/pom.xml and DELETE
-                             these two lines - do not carry them forward. -->
-                        <excludeVulnerabilityId>CVE-2026-68497</excludeVulnerabilityId>
-                        <excludeVulnerabilityId>CVE-2026-19032</excludeVulnerabilityId>
                     </excludeVulnerabilityIds>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -799,7 +799,12 @@
 
                         <!-- com.fasterxml.jackson.core:jackson-databind (example-streams only). False
                              positive: GHSA-rcqc-6cw3-h962 gives introduced 2.21.0 / fixed 2.21.4, and
-                             the module resolves 2.18.9. The vulnerable code is in unwrapped-creator
+                             the module resolves a 2.18.x - see jackson.examples.version in the
+                             examples parent for which one. Stated as the line rather than the exact
+                             version deliberately: what makes this a false positive is being below
+                             2.21.0, so a patch bump must not be able to make this comment wrong. It
+                             already did once, when 2.18.9 here went stale the moment the bom moved to
+                             2.18.10. The vulnerable code is in unwrapped-creator
                              handling that the 2.18 line does not have. OSS Index's version range is
                              over-broad; Dependabot does not report it.
                              RETIRE WHEN: OSS Index corrects the range, or the module moves onto a

--- a/pom.xml
+++ b/pom.xml
@@ -787,8 +787,9 @@
                              appears anywhere in this repo's sources or poms, and the micrometer
                              surface actually used is metric primitives plus KafkaClientMetrics,
                              ExecutorServiceMetrics and CompositeMeterRegistry. Re-check that if this
-                             project ever instruments an HTTP client:
-                             `grep -rn "MicrometerHttpClientInterceptor\|HttpAsyncClient" --include=*.java --include=*.xml`
+                             project ever instruments an HTTP client: grep the sources and poms for
+                             MicrometerHttpClientInterceptor and for HttpAsyncClient, and re-argue
+                             this entry if either appears.
 
                              RETIRE WHEN: the io.micrometer.prometheus -> prometheusmetrics package
                              rename is migrated, which is what unblocks 1.15.x - and it retires BOTH


### PR DESCRIPTION
No single issue - this is CVE bookkeeping in the root pom plus the two example modules it governs.

## Description

**The whole-tree CVE scan is currently red on every branch**, and this fixes that plus three
things that were already owed.

### 1. A new advisory is failing the scan repo-wide

`CVE-2026-59295` on `io.micrometer:micrometer-core` was published between one PR's scan and the
next, so it fails every branch rather than any particular change. Unbounded memory growth in
`MicrometerHttpClientInterceptor` when an instrumented Apache HttpAsyncClient request fails before
a response.

Excluded rather than fixed, because micrometer is pinned at 1.13.15 by the
`io.micrometer.prometheus` to `prometheusmetrics` package rename, which is what unblocks 1.15.x -
the same blocker the existing `CVE-2026-40984` entry records. It shares that entry's comment rather
than repeating it: same component, same blocker, same retire condition.

**Unreachable here structurally, not by judgement.** Neither `MicrometerHttpClientInterceptor` nor
any Apache HttpAsyncClient appears anywhere in the tree, and the micrometer surface actually used is
metric primitives plus `KafkaClientMetrics`, `ExecutorServiceMetrics` and `CompositeMeterRegistry`.
The comment carries the grep that re-checks it if this project ever instruments an HTTP client.

### 2. The temporary exclusions retire, because their own condition is met

The block carrying `CVE-2026-68497` and `CVE-2026-19032` said, verbatim: *"RETIRE WHEN:
jackson-databind 2.18.10 is on Central. Then bump the jackson-bom import in
parallel-consumer-example-streams/pom.xml and DELETE these two lines - do not carry them forward."*

2.18.10 is on Central. Both ids and their block are gone, and the example-streams bom moves to
2.18.10. The exclusion list now carries **no temporary entry at all**, where before it carried one
on a 90-day clock.

### 3. Five live Dependabot alerts are cleared

`parallel-consumer-example-metrics` pinned jackson-databind at 2.17.2, below the fix for
`CVE-2026-54512` and `CVE-2026-54513` (both high) and `CVE-2026-54514`, `CVE-2026-54515` and
`CVE-2026-59888`.

No Dependabot PR ever proposed it: that entry deliberately blocks minor bumps, to stop an automated
jump into 2.21.x where `CVE-2026-54518` becomes real. So the alerts could only ever be cleared by
hand.

2.18.9 is the floor rather than 2.18.0, for a reason already recorded on the example-streams pin:
`CVE-2026-59889` was introduced in 2.18.0 and only fixed in 2.18.9, so 2.18.0 through 2.18.8 would
trade one advisory for another.

### Both pins stay module-local, which is the whole point

jackson-databind is transitive to WireMock in `parallel-consumer-vertx`, and pinning it in root
`dependencyManagement` forces WireMock onto an incompatible Jackson and breaks `VertxTest` with
HTTP 500. That trap is documented twice in this repo, so it was checked rather than assumed after
the bump:

- `parallel-consumer-vertx` still resolves jackson-databind **2.13.4.2** - untouched.
- Both example modules resolve databind, core and annotations together at **2.18.10**.

A bare databind pin is sufficient in example-metrics because nothing else there resolves jackson,
unlike example-streams where kafka-streams pins core. The comment now says so, with the
`dependency:tree` command that re-checks it before the next version change.

Neither example module is published (`maven.deploy.skip` / `maven.install.skip` / `skipPublishing`
in the examples parent), so no consumer of the library inherits either pin.

### Added after review

- **The Jackson version is single-sourced.** It was briefly stated in both example modules. It is now
  one `jackson.examples.version` property in the examples parent. A property rather than root
  `dependencyManagement` is the point: managing jackson at the root is what breaks WireMock, while a
  property states a version without imposing one, and that parent is inherited only by the example
  modules.
- **A neighbouring exclusion's argument was falsified by this PR.** The `CVE-2026-54518` entry argued
  false-positive on the grounds that "the module resolves 2.18.9", which the bom bump made untrue in
  the same commit. Fixed by stating the *line* rather than a version, since what matters is being
  below 2.21.0; a patch bump can no longer falsify it. Nothing would have caught this:
  `bin/check-cve-exclusions.sh` checks a rationale exists, never that it is true.
- **The guard's own self-test needed relocating.** Its integration arm asserted the guard's output
  mentions remaining days, which held only while some entry was temporary. That is a fact about
  today's dependency list, not about the guard. The assertion moved to a fixture, and the integration
  arm gained a stronger check in its place: it now asserts the report names how many ids it counted,
  which a guard that parsed nothing could not produce.
- **A self-inflicted build break, fixed.** A suggested grep inside an XML comment contained `--`,
  which is illegal there, so the pom stopped parsing and every Maven lane failed. Worth recording
  that the local gate sweep passed on that pom, because none of its gates parse XML.

## Merge order

**This should land before astubbs/parallel-consumer#440.** That PR is green except for the
whole-tree CVE scan, which is failing on the micrometer advisory above rather than on anything it
changed. Once this is on master, re-running that check should clear it.

## Checklist

- [x] Docs updated - N/A - the rationale lives in the pom comments, which is where this repo keeps it; `docs/inflight/deps-cve-backlog.md` describes the mechanism rather than listing current ids
- [x] User-facing feature documentation data added under `docs/features/` - N/A - dependency bookkeeping in unpublished example modules, no user-facing behaviour change
- [x] Tests added/updated - N/A - version bumps and pom comments; `bin/check-cve-exclusions.sh` is the gate that covers the exclusion list and it passes, and it reports the counts, with no temporary entry left
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - nothing here that `gh` cannot show: one commit, no open decisions, and the durable reasoning is in the pom next to each id
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - not run. Three pom edits with no code; `ce-simplify` refuses a diff with none. The reachability claim and both resolved dependency trees were verified by command instead, and are quoted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015reBSoQQYreND4YnnEwduW
