### PR TITLE
test(chaos) astubbs#119: the instance-stall line is worker saturation by stale heavy dwells, not a wedge - and the probe now dumps the accused member

### DIFF
--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -90,11 +90,11 @@ established:
 
 - The fleet-scoped `NO_PROGRESS` firings are a **timing proxy** - the backlog drains every time the
   detector fires. Its `## ANSWERED, 2026-08-28` and `## CONFIRMED, 2026-08-28` sections.
-- The per-instance `INSTANCE_STALL/NO_WORK_COMPLETED` firings are **a real wedge that never
-  recovers**: one member stays live, keeps taking work, and returns nothing while the fleet finishes
-  around it. Its `## CLASSIFIED, 2026-09-03` section, and the `What is still open` paragraph under
-  it, which names the next experiment. **Why the workers return nothing is open, and nothing
-  anywhere answers it.**
+- The per-instance `INSTANCE_STALL/NO_WORK_COMPLETED` firings are **a different line from the
+  fleet-scoped one and must not be read with it**: one member stays live, keeps taking work, and
+  returns nothing while the fleet finishes around it. What that member's workers are doing is the
+  churn note's question, not this file's - read from its `## CLASSIFIED, 2026-09-03` section
+  forward, and take the latest dated section as the current reading.
 
 **THE DETECTOR SILENCE PROBLEM IS WITHDRAWN.** This paragraph once reported a third of the
 astubbs#344 arms going red with `NO_PROGRESS` silent, and told readers to settle that before trusting

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -82,18 +82,26 @@ assignor arms, the captured seeds opened the window ZERO times. The chaos suite 
 luck; only a purpose-built probe finds it by construction. Two write-ups were retracted the same day
 for reading a green replay as evidence when the mechanism had never executed.
 
-**THE ASYNC LINE NOW HAS A REPLAYABLE SEED - the first this family has ever had.**
-`9086872209853284830` on `ChaosChurnStormIT` reproduces `NO_PROGRESS` in most runs on unmodified
-master, in minutes, on a laptop. Found by RANDOM-SEED HUNTING in CI, not by replaying anything.
-astubbs#344 was the obvious candidate - same commit mode, right symptom shape - and is **refuted**:
-both arms either side of it fail. Details in
-[`test-857-churn-storm-async-stalls.md`](test-857-churn-storm-async-stalls.md).
+**THE ASYNC LINE IS TWO LINES, AND NEITHER IS THE OPEN `NO_PROGRESS` QUESTION THIS PARAGRAPH USED
+TO POSE.** [`test-857-churn-storm-async-stalls.md`](test-857-churn-storm-async-stalls.md) **owns
+both** - its dated sections are the record, with the seeds, the sample sizes and the rulings-out.
+This file keeps only the shape, so that a reader arriving here is not told the opposite of what is
+established:
 
-**A DETECTOR SILENCE PROBLEM, and it bears on everything below.** Across the astubbs#344 arms, **a
-third of the failures went red with `NO_PROGRESS` not firing at all**. Since the 2026-08-25 demotion
-moved the Class 2 bound to non-gating, the liveness claim rests on `INSTANCE_STALL` and this
-detector. **A detector whose silence cannot be trusted is worse than one that is absent**, because
-the suite goes green on its say-so. Settle it before reading any quiet run from it as evidence.
+- The fleet-scoped `NO_PROGRESS` firings are a **timing proxy** - the backlog drains every time the
+  detector fires. Its `## ANSWERED, 2026-08-28` and `## CONFIRMED, 2026-08-28` sections.
+- The per-instance `INSTANCE_STALL/NO_WORK_COMPLETED` firings are **a real wedge that never
+  recovers**: one member stays live, keeps taking work, and returns nothing while the fleet finishes
+  around it. Its `## CLASSIFIED, 2026-09-03` section, and the `What is still open` paragraph under
+  it, which names the next experiment. **Why the workers return nothing is open, and nothing
+  anywhere answers it.**
+
+**THE DETECTOR SILENCE PROBLEM IS WITHDRAWN.** This paragraph once reported a third of the
+astubbs#344 arms going red with `NO_PROGRESS` silent, and told readers to settle that before trusting
+any quiet run. The observation was a grep counting one detector's name, so a failure caught by a
+different detector read as caught by none. The churn note's
+`## The detector "silence" is EXPLAINED, 2026-08-28` section owns the retraction. Anything below
+that leans on the silence claim predates it.
 
 **THE SYMPTOM IS A BUCKET, and this file only ever covered part of it.** Read from upstream's own
 comments rather than the mirror's summary: at least four distinguishable behaviours are reported,

--- a/docs/inflight/test-857-churn-storm-async-stalls.md
+++ b/docs/inflight/test-857-churn-storm-async-stalls.md
@@ -648,3 +648,26 @@ The 40s that remains is the last heavy records finishing their one legitimate 45
 the tail the scenario builds on purpose. The 13s extra above it in the eager arm, and the
 three-to-ten-fold worker occupancy, is the amplification. Whole-assignment revokes are the term
 that produces it.
+
+**Same-defect sweep, 2026-09-07: the two other recorded seeds show the same shape.** Both replayed
+once on the same tree with the 20s early dump, both green, and every dumped member across the two
+runs was a working member, not a stalled one:
+
+| Seed | Where it came from | Run | Peak instance stall | Dumps | Workers in the dwell at each dump |
+|---|---|---|---|---|---|
+| `1630088991107806597` | the CI-hunted seed that went red twice in three CI runs | 89s | 66s | 5 members | 10/10 on four of them; 8/10 on instance 5, with 2 parked between tasks and one incomplete offset |
+| `5650361238717170909` | the 2026-09-04 sighting on a pom-only PR | 341s | 84s | 11 dumps, 6 of them instance 0 | 10/10 on every one |
+
+The long run is the more instructive. Instance 0 was dumped six times over three minutes, each a
+separate frozen stretch, holding `incompleteOffsets` of 759, 550, 555, 431 and 230 on successive
+dumps with `recordsInShards` to match - hundreds of records queued in its shards behind ten workers
+asleep in the dwell, draining a little between stretches. That is what a member looks like when it
+keeps being handed whole partitions' backlogs under churn: the same mechanism, with a longer tail
+because there was more to re-ingest. The Class 2 lag bound also tripped once in that run (154s
+against 150s), which is the same tail seen from the offset side. Neither run fired the gating
+detector, and neither would have told anyone anything without the dump.
+
+Instance 5 on the first seed is the case that matters for the detector: a member holding work, count
+frozen, with two workers parked between tasks - spare hands and nothing to hand them, because the
+records it holds are on the eight busy ones. A rule that accuses on "a free worker beside held work"
+accuses it; the rule that lands with the stacked follow-up accuses only nobody-in-user-code.

--- a/docs/inflight/test-857-churn-storm-async-stalls.md
+++ b/docs/inflight/test-857-churn-storm-async-stalls.md
@@ -577,7 +577,9 @@ instance 0`, no stop, in the whole timeline), so its stretch is the longest.
 
 **What the dump shows**, taken 20s into the freeze on instances 0, 10 and 12 by the new
 `-Dchaos.instanceStallDumpAfterSeconds=20` (a 150s default keeps a gating run's dump at the firing
-and nowhere else):
+and nowhere else - the two thresholds are then EQUAL, so the firing sample trips both branches and
+the sampler takes one dump for it, not two, which
+`InstanceStallProbeIT.takesOneThreadDumpPerFiringInTheDefaultConfiguration` counts):
 
 - all ten `pc-pool-*-PC-<id>` workers `TIMED_WAITING` in `ChaosScenarioBase.newInstance`'s heavy
   branch - the `Thread.sleep(Math.min(left, 1_000))` loop - on every one of the three instances;

--- a/docs/inflight/test-857-churn-storm-async-stalls.md
+++ b/docs/inflight/test-857-churn-storm-async-stalls.md
@@ -1,7 +1,7 @@
 # `ChaosChurnStormIT` stalls - three sightings no known defect explains
 
 <!-- inflight-type: bug -->
-<!-- inflight-impact: stall -->
+<!-- inflight-impact: misdirection -->
 <!-- inflight-labels: concurrency -->
 
 **Commit mode: `PERIODIC_CONSUMER_ASYNCHRONOUS`** (`ChaosChurnStormIT`, verified in source). This is
@@ -550,3 +550,101 @@ the wedge rather than a second timing proxy.
 an unrelated branch nine minutes later and passes on three other branches in the same window, so it
 is master-state rather than either branch's doing. Noted here only because the two arriving together
 is what a reader of this run's checks will see.
+
+## DIAGNOSED, 2026-09-07: the instance-stall line is worker saturation by stale heavy dwells under eager rebalance churn - the control loop is healthy
+
+The thread dump the `## CLASSIFIED, 2026-09-03` section asked for has been taken, and it overturns
+that section's reading. The samples there were right; the sentence "a wedge that never recovers"
+was not. Nothing in PC is stuck. The accused member's ten workers are all inside the scenario's own
+45-second heavy dwell, most of them on records whose partition was revoked while they slept, and
+ordinary records queue in the executor behind them until they too go stale.
+
+**How the seed behaves on master `9999144b5`.** Seed `6077035105695` replayed three times under
+`-Dchaos.diagnoseStallRecovery=true`, on a 32-core box at load ~2 with nothing else running: green
+every time, ~105s each, `maxInstanceStall` 52.9s, 53.0s and 53.0s - the schedule is deterministic
+to the second. **The seed reproduces the frozen shape every time. It does not reproduce the
+firing**, because the run finishes about 46s into the freeze and the bound is 150s. The 2026-09-03
+replays fired only because their tail outlasted the bound; that run's own record says `done=true`,
+so it finished too. The only core change between the two trees is a `volatile` on
+`lastCommitTime` and a confinement assertion on the retry-queue iterator (astubbs#433), neither
+of which can shorten a tail.
+
+**The frozen window IS the tail.** In every replay the fleet's consumed count has already passed
+100,000 when instance 0's `res` freezes; the wait that remains is for the last few keys. In that
+window *every* member's `res` is frozen - there is nothing left to complete. Instance 0 is singled
+out by the detector only because it is the one member the conductor never stops (one `Starting
+instance 0`, no stop, in the whole timeline), so its stretch is the longest.
+
+**What the dump shows**, taken 20s into the freeze on instances 0, 10 and 12 by the new
+`-Dchaos.instanceStallDumpAfterSeconds=20` (a 150s default keeps a gating run's dump at the firing
+and nowhere else):
+
+- all ten `pc-pool-*-PC-<id>` workers `TIMED_WAITING` in `ChaosScenarioBase.newInstance`'s heavy
+  branch - the `Thread.sleep(Math.min(left, 1_000))` loop - on every one of the three instances;
+- `pc-control-PC-<id>` parked in `processWorkCompleteMailBox`, waiting for results that are not
+  coming; `pc-broker-poll-PC-<id>` in `Selector.select`. The control loop is idle and healthy.
+- instance 0's engine counters at the same instant: `incompleteOffsets=2 recordsInShards=2
+  parkedForRetry=0`, against `out=17` climbing to `22` two samples later. **At least fifteen of the
+  records it had out belonged to partitions it no longer owned.**
+
+**The mechanism, and it is arithmetic rather than chance.** The scenario uses the eager assignor
+(it never sets `useCooperativeAssignor`), so every rebalance revokes a member's whole assignment:
+instance 0 logged 28 `Partitions revoked` lines in the 50s window, one every ~2s. Each revoke bumps
+the epoch under every dwell in flight, so a heavy record's result is dropped as stale when its
+sleep ends and the record is redelivered to the partition's next owner - which starts a fresh 45s
+dwell while the old one keeps sleeping (the dwell is deliberately non-interruptible). A 45s dwell
+against a ~2-3s rebalance period spawns fifteen to twenty concurrent copies per heavy record; 25
+heavy records against 160 worker slots fleet-wide saturates them. Ordinary records are then
+dispatched into an executor queue behind sleeping workers (`out` reaching 30 on a 10-worker
+instance is that queue), and by the time a worker frees they are stale too: `out` drops 30 to 15
+in one sample with `res` unmoved, which is the skip path, not the success path. Progress happens
+only in rebalance lulls - the one 6s gap between revokes in the replay-2 tail is where 26 of its
+last 30 consumptions landed.
+
+**Ruled in and out, against the list the CLASSIFIED section left:**
+
+- `bug-worker-future-swallows-framework-exceptions.md` - **refuted here.** A swallowed framework
+  exception leaves a worker idle in the pool's `take()`; every worker in the dump is running user
+  code.
+- "a REDELIVERY CHAIN of heavy records" - **confirmed**, and it is the whole explanation. The
+  supply arithmetic that ruled out clustering (25 heavy records cannot occupy 160 workers) omitted
+  the multiplier.
+- the control-thread wedge, the phantom counter, the order recorder - stayed ruled out.
+
+**What this makes the detector.** `INSTANCE_STALL/NO_WORK_COMPLETED` names its prey as "this
+instance's control loop is holding work and finishing nothing". Here the control loop is finishing
+everything it is given; the workers are busy in user code. On this scenario the detector is
+therefore a timing proxy for the length of the tail - the same verdict this file reached for
+`NO_PROGRESS` - and it fires when churn keeps the heavy records stale for longer than 150s. Every
+CI firing on record fits: instance 42, 14 and 0 were live members with work out late in a run.
+
+**What is still open, 2026-09-07.**
+
+- **The detector cannot tell workers-busy from workers-idle, and that is the gap to close.** A
+  member holding work with every worker running user code is saturated, not stalled; one holding
+  work with a free worker is PC's problem. The pool's active count, or the `-PC-<id>` worker
+  threads' states, is the discriminator - the dump reads it by hand today. Until it does, an
+  `INSTANCE_STALL` red on this scenario is not evidence of a PC defect.
+- **Whether the amplification is a product concern.** At-least-once plus eager rebalances plus
+  records longer than the rebalance period multiplies load by design; PC already skips stale work at
+  dispatch. The cooperative-sticky assignor is the standard answer, and the control arm below
+  measures how much of the tail it removes on this seed.
+
+**Control arm, same seed, one term changed: the cooperative-sticky assignor.** A scratch edit
+setting `useCooperativeAssignor(true)` on the scenario's instance config, run once, then reverted -
+it is not a change this file proposes to the scenario, whose eager churn is deliberate. Under it a
+rebalance revokes only the partitions that move, so the prediction was fewer stale dwells, a smaller
+`out`, fewer duplicates, and a tail no longer than one honest heavy dwell. All four held:
+
+| | eager (replay 6) | cooperative (replay 7) |
+|---|---|---|
+| `Partitions revoked` on instance 0 in the tail | 28 | 3 |
+| workers in the heavy dwell at the 20s dump, instances 0 / 10 / 12 | 10 / 10 / 10 | 8 / 1 / 4 |
+| instance 0 `out` at the dump | 17, climbing to 22 | 8, climbing to 9 |
+| `maxInstanceStall` | 53.0s | 40.1s |
+| duplicates in the ledger | 286 | 210 |
+
+The 40s that remains is the last heavy records finishing their one legitimate 45s sleep, which is
+the tail the scenario builds on purpose. The 13s extra above it in the eager arm, and the
+three-to-ten-fold worker occupancy, is the amplification. Whole-assignment revokes are the term
+that produces it.

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosChurnStormIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosChurnStormIT.java
@@ -41,6 +41,20 @@ import java.util.concurrent.atomic.AtomicLong;
  * than a distinct defect. A run that drains reproduces a known result; a run that stays FLAT is the
  * finding worth reporting.
  * <p>
+ * <b>The instance-stall line - also answered, 2026-09-07, do not re-derive</b>: seed
+ * {@code 6077035105695} replays the shape behind every {@code INSTANCE_STALL/NO_WORK_COMPLETED}
+ * firing on this scenario - one live member's returned-result count frozen while its records-out
+ * climbs - on every run, and a thread dump taken inside that window
+ * ({@code -Dchaos.instanceStallDumpAfterSeconds=20} with the diagnostic above) shows all ten of its
+ * workers inside {@code HEAVY_SLEEP}, the control thread idle on its mailbox, and most of the
+ * records out belonging to partitions it no longer owns. It is worker saturation by redelivered
+ * heavy dwells: the eager assignor revokes the whole assignment every few seconds under this churn,
+ * so each 45s dwell is stale before it ends and is redelivered while the old copy keeps sleeping. A
+ * cooperative-assignor control arm on the same seed removes the amplification and leaves one honest
+ * dwell. The detector therefore fires on the length of the tail, not on a PC defect; the record,
+ * the dumps and the arithmetic are in {@code docs/inflight/test-857-churn-storm-async-stalls.md},
+ * "DIAGNOSED, 2026-09-07".
+ * <p>
  * Seed protocol: {@code -Dchaos.seed=<long>} replays a schedule; unset = random seed, always logged.
  * Excluded from default suites via {@code @Tag("chaos")}; run with {@code -Dincluded.groups=chaos}.
  * <p>

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/InstanceStallProbeIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/InstanceStallProbeIT.java
@@ -10,8 +10,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.IntFunction;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -193,6 +195,54 @@ class InstanceStallProbeIT {
         // a further full window with still nothing returned is a further violation
         probe.sampleInstanceProgress(pastBound(firstFire));
         assertThat(probe.getViolations()).hasSize(2);
+    }
+
+    /** Every instance whose threads the sampler asked for, in call order - the dump COUNT is the
+     * property under test, so a ledger rather than a flag. */
+    private static final class DumpLedger implements IntFunction<String> {
+        final List<Integer> dumped = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public String apply(int instanceId) {
+            dumped.add(instanceId);
+            return "  \"pc-control-PC-" + instanceId + "\" WAITING\n";
+        }
+    }
+
+    /**
+     * A firing takes ONE thread dump, and the default configuration is the case that needs saying so:
+     * {@link ProgressProbe#INSTANCE_STALL_DUMP_AFTER} defaults to
+     * {@link ProgressProbe#INSTANCE_STALL_BOUND} itself, so the first sample past the bound satisfies
+     * the early-dump condition and the violation condition on the same {@code stalledMs}. Taking the
+     * dump in both branches paid a second {@code ThreadMXBean#getThreadInfo(ids, true, true)} - the
+     * expensive lock-info form - to print the same stacks twice, in the sample where the run is
+     * already failing, and the unconfigured case is precisely the gating one.
+     * <p>
+     * Counting through the seam rather than reading the log is the point: the previous test on this
+     * detector asserted only {@code violations.hasSize(1)}, which the double dump satisfied happily.
+     */
+    @Test
+    void takesOneThreadDumpPerFiringInTheDefaultConfiguration() {
+        FakeInstance instance = new FakeInstance(8);
+        instance.outForProcessing = 4;
+        DumpLedger dumps = new DumpLedger();
+        ProgressProbe probe = probeWatching(instance).withThreadDumpSource(dumps);
+
+        probe.sampleInstanceProgress(T0);
+        Instant firstFire = pastBound(T0);
+        probe.sampleInstanceProgress(firstFire);
+
+        assertWithMessage("the firing itself, so the dump count below is a count per FIRING")
+                .that(probe.getViolations()).hasSize(1);
+        assertWithMessage("one dump, of the accused member - at the default both branches trip on this "
+                + "one sample, and each dump is a full getThreadInfo with lock info")
+                .that(dumps.dumped).containsExactly(8);
+
+        // the re-armed stretch earns its own dump: the duplicate is what goes, not the coverage
+        probe.sampleInstanceProgress(pastBound(firstFire));
+        assertThat(probe.getViolations()).hasSize(2);
+        assertWithMessage("each firing carries its own single dump")
+                .that(dumps.dumped).containsExactly(8, 8).inOrder();
     }
 
     @Test

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/InstanceStallProbeIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/InstanceStallProbeIT.java
@@ -11,9 +11,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Non-vacuity regression for {@link ProgressProbe}'s instance-progress detector
@@ -289,5 +291,57 @@ class InstanceStallProbeIT {
         // it is called from inside the awaitility condition, so it must neither throw the wait off
         // course nor return "" - an empty string is indistinguishable from a fleet with no members
         assertThat(probe.instanceProgressSnapshot()).contains("unreadable");
+    }
+
+    /**
+     * The dump taken when {@code INSTANCE_STALL/NO_WORK_COMPLETED} fires selects threads by the
+     * {@code -PC-<id>} suffix PC puts on every thread it owns, and the match must be exact: instance
+     * 1's suffix is a substring of instance 14's, so a {@code contains} match would fold a healthy
+     * member's stacks into the accused one's dump and the reader would diagnose the wrong instance.
+     * Parked threads stand in for PC's own, since what is under test is the selection, not the naming
+     * - {@code CloseInterruptLivelockTest} pins the naming against a real PC.
+     */
+    @Test
+    void threadDumpSelectsTheExactInstanceSuffixOnly() throws InterruptedException {
+        CountDownLatch release = new CountDownLatch(1);
+        Thread mine = parked("pc-pool-3-thread-2-PC-1", release);
+        Thread lookalike = parked("pc-control-PC-14", release);
+        try {
+            String dump = ProgressProbe.instanceThreadDump(1);
+
+            assertWithMessage("the accused instance's own thread, with its state and a frame to read")
+                    .that(dump).contains("\"pc-pool-3-thread-2-PC-1\" WAITING");
+            assertThat(dump).contains("CountDownLatch");
+            assertWithMessage("-PC-1 is a substring of -PC-14; only a suffix match keeps instance 14 out")
+                    .that(dump).doesNotContain("PC-14");
+        } finally {
+            release.countDown();
+            mine.join(5_000);
+            lookalike.join(5_000);
+        }
+    }
+
+    /**
+     * No matching threads is a finding, not an empty dump: it means the instance's threads are gone
+     * or the naming contract moved, and an empty string would read as "nothing was running".
+     */
+    @Test
+    void threadDumpSaysSoWhenTheInstanceHasNoThreads() {
+        assertThat(ProgressProbe.instanceThreadDump(999_999)).contains("no threads named *-PC-999999");
+    }
+
+    private static Thread parked(String name, CountDownLatch until) {
+        Thread thread = new Thread(() -> {
+            try {
+                until.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }, name);
+        thread.setDaemon(true);
+        thread.start();
+        // WAITING, not RUNNABLE: the dump's state column is asserted, so the thread must be parked first
+        await().atMost(Duration.ofSeconds(5)).until(() -> thread.getState() == Thread.State.WAITING);
+        return thread;
     }
 }

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntFunction;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -338,13 +339,34 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
     private final Map<Integer, InstanceProgressMark> instanceProgressMarks = new ConcurrentHashMap<>();
     /** Instances already given an early stall dump in their CURRENT frozen stretch - one per stretch, not per sample. */
     private final java.util.Set<Integer> stallDumpedThisStretch = ConcurrentHashMap.newKeySet();
+    /**
+     * How the accused member's threads are read: {@link #instanceThreadDump} in every real run.
+     * <p>
+     * The seam exists because the cost this file guards is the NUMBER of
+     * {@link #instanceThreadDump} calls one firing makes, and a log line cannot show that - the
+     * default configuration once took two, because {@link #INSTANCE_STALL_DUMP_AFTER} defaults to
+     * {@link #INSTANCE_STALL_BOUND} and both branches then fire on the same sample.
+     * {@code InstanceStallProbeIT#takesOneThreadDumpPerFiringInTheDefaultConfiguration} counts
+     * through here, so a return to two dumps fails a test rather than merely doubling a log.
+     */
+    private volatile IntFunction<String> threadDumpSource = ProgressProbe::instanceThreadDump;
     @Getter
     private volatile long peakInstanceStallMs = 0;
 
     /**
      * How long an instance may hold work and return nothing before its threads are dumped -
      * {@code -Dchaos.instanceStallDumpAfterSeconds=<n>}, defaulting to the bound itself, so an
-     * unconfigured run dumps exactly once per firing and nowhere else. Lower it under
+     * unconfigured run dumps exactly once per firing and nowhere else.
+     * <p>
+     * <b>That "exactly once" is held by {@link #sampleInstanceProgress}, not by the default.</b> At
+     * the default the two thresholds are EQUAL, so the first sample past the bound satisfies the
+     * early-dump condition and the violation condition together - taking the dump in both branches
+     * gives the gating, unconfigured run two near-identical dumps from one
+     * {@code ThreadMXBean#getThreadInfo(ids, true, true)} each, at the moment the run is already
+     * failing. The sampler therefore takes at most one dump per sample and the violation branch
+     * points at the early dump when that branch already took it.
+     * <p>
+     * Lower it under
      * {@code -Dchaos.diagnoseStallRecovery=true} to see inside a stretch the run outlives: the
      * tokens from {@link #instanceProgressSnapshot} can show a member frozen for the whole tail of a
      * run that still finishes under the bound, and then there is no firing to hang a dump on.
@@ -419,6 +441,15 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
      */
     public ProgressProbe withInstanceProgress(Supplier<List<InstanceProgressView>> fleetSupplier) {
         this.instanceProgressSupplier = fleetSupplier;
+        return this;
+    }
+
+    /**
+     * Replaces the thread-dump reader for a broker-free seam test - see {@link #threadDumpSource}
+     * for why counting the calls is the property, and package-private because no run may swap it.
+     */
+    ProgressProbe withThreadDumpSource(IntFunction<String> source) {
+        this.threadDumpSource = source;
         return this;
     }
 
@@ -663,14 +694,16 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
             }
             long stalledMs = Duration.between(mark.getSince(), now).toMillis();
             if (stalledMs > peakInstanceStallMs) peakInstanceStallMs = stalledMs;
-            if (stalledMs > INSTANCE_STALL_DUMP_AFTER.toMillis() && stallDumpedThisStretch.add(id)) {
+            boolean earlyDumpedThisSample =
+                    stalledMs > INSTANCE_STALL_DUMP_AFTER.toMillis() && stallDumpedThisStretch.add(id);
+            if (earlyDumpedThisSample) {
                 // Diagnostic only, and only when the property lowers it below the bound: a stretch that
                 // ends before the bound leaves no violation and no dump, so a wedge that clears when
                 // the run happens to finish first was invisible - which is how seed 6077035105695 read
                 // as clean on a tree where its instance 0 sat frozen for the whole tail of the run.
                 log.warn("INSTANCE_STALL early dump ({}s frozen, bound {}s) for instance {}: {}\n{}",
                         stalledMs / 1000, INSTANCE_STALL_BOUND.getSeconds(), id, view.engineSnapshot(),
-                        instanceThreadDump(id));
+                        threadDumpSource.apply(id));
             }
             if (stalledMs > INSTANCE_STALL_BOUND.toMillis()) {
                 violate("INSTANCE_STALL/NO_WORK_COMPLETED: instance " + id + " holds work (queued="
@@ -682,8 +715,19 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
                 // The dump is taken HERE, inside the sample that fired, because the accused instance's
                 // threads are what the violation is a claim about, and nothing else captures them - a
                 // gating run aborts on this violation and a CI log outlives the JVM by nothing.
-                log.warn("INSTANCE_STALL thread dump for instance {} at the moment the detector fired: {}\n{}",
-                        id, view.engineSnapshot(), instanceThreadDump(id));
+                //
+                // Unless this same sample already took it: at the DEFAULT the two thresholds are equal,
+                // so the first sample past the bound satisfies both branches, and dumping again would
+                // pay a second getThreadInfo(ids, true, true) to print the same stacks. See
+                // INSTANCE_STALL_DUMP_AFTER for the contract this keeps.
+                if (earlyDumpedThisSample) {
+                    log.warn("INSTANCE_STALL thread dump for instance {} at the moment the detector fired: {}"
+                                    + "\n  (its threads are in the early dump logged immediately above - same sample)",
+                            id, view.engineSnapshot());
+                } else {
+                    log.warn("INSTANCE_STALL thread dump for instance {} at the moment the detector fired: {}\n{}",
+                            id, view.engineSnapshot(), threadDumpSource.apply(id));
+                }
                 instanceProgressMarks.put(id, new InstanceProgressMark(returned, incarnation, now)); // re-arm
                 stallDumpedThisStretch.remove(id); // the re-armed stretch may earn its own early dump
             }

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
@@ -248,6 +248,15 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
         /** Records this instance currently has out for processing ({@code WorkManager}'s own count). */
         long outForProcessing();
 
+        /**
+         * One line of engine counters for a stall dump, read straight off the live {@code WorkManager}
+         * - what the instance holds and whether any of it is parked for retry, which the three
+         * progress counters above cannot say. Default empty so a scripted view need not fake it.
+         */
+        default String engineSnapshot() {
+            return "";
+        }
+
         /** Monotone count of work results returned - see {@code ManagedPCInstance#workResultsReturned}. */
         long workResultsReturned();
 
@@ -296,6 +305,21 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
                 public Object incarnationMarker() {
                     return pc.getParallelConsumer();
                 }
+
+                @Override
+                public String engineSnapshot() {
+                    var parallelConsumer = pc.getParallelConsumer();
+                    if (parallelConsumer == null) {
+                        return "no PC";
+                    }
+                    var wm = parallelConsumer.getWm();
+                    var sm = wm.getSm();
+                    return "closedOrFailed=" + parallelConsumer.isClosedOrFailed()
+                            + " incompleteOffsets=" + wm.getNumberOfIncompleteOffsets()
+                            + " recordsInShards=" + sm.getNumberOfRecordsInShards()
+                            + " parkedForRetry=" + sm.getNumberOfRecordsParkedForRetry()
+                            + " lowestRetryIn=" + wm.getLowestRetryTime().map(Duration::toString).orElse("none");
+                }
             };
         }
     }
@@ -312,8 +336,21 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
     /** Fleet supplier for the instance-progress probe; null (ambient mode, or not wired) = inactive. */
     private volatile Supplier<List<InstanceProgressView>> instanceProgressSupplier;
     private final Map<Integer, InstanceProgressMark> instanceProgressMarks = new ConcurrentHashMap<>();
+    /** Instances already given an early stall dump in their CURRENT frozen stretch - one per stretch, not per sample. */
+    private final java.util.Set<Integer> stallDumpedThisStretch = ConcurrentHashMap.newKeySet();
     @Getter
     private volatile long peakInstanceStallMs = 0;
+
+    /**
+     * How long an instance may hold work and return nothing before its threads are dumped -
+     * {@code -Dchaos.instanceStallDumpAfterSeconds=<n>}, defaulting to the bound itself, so an
+     * unconfigured run dumps exactly once per firing and nowhere else. Lower it under
+     * {@code -Dchaos.diagnoseStallRecovery=true} to see inside a stretch the run outlives: the
+     * tokens from {@link #instanceProgressSnapshot} can show a member frozen for the whole tail of a
+     * run that still finishes under the bound, and then there is no firing to hang a dump on.
+     */
+    static final Duration INSTANCE_STALL_DUMP_AFTER = Duration.ofSeconds(
+            Long.getLong("chaos.instanceStallDumpAfterSeconds", INSTANCE_STALL_BOUND.getSeconds()));
 
     /** per-partition committed-offset watermarks for the Class 2 (lag stagnation) probe */
     private final Map<TopicPartition, Long> lastCommitted = new ConcurrentHashMap<>();
@@ -621,10 +658,20 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
             boolean holdsWork = queued > 0 || outForProcessing > 0;
             if (advanced || !holdsWork) {
                 instanceProgressMarks.put(id, new InstanceProgressMark(returned, incarnation, now));
+                stallDumpedThisStretch.remove(id);
                 continue;
             }
             long stalledMs = Duration.between(mark.getSince(), now).toMillis();
             if (stalledMs > peakInstanceStallMs) peakInstanceStallMs = stalledMs;
+            if (stalledMs > INSTANCE_STALL_DUMP_AFTER.toMillis() && stallDumpedThisStretch.add(id)) {
+                // Diagnostic only, and only when the property lowers it below the bound: a stretch that
+                // ends before the bound leaves no violation and no dump, so a wedge that clears when
+                // the run happens to finish first was invisible - which is how seed 6077035105695 read
+                // as clean on a tree where its instance 0 sat frozen for the whole tail of the run.
+                log.warn("INSTANCE_STALL early dump ({}s frozen, bound {}s) for instance {}: {}\n{}",
+                        stalledMs / 1000, INSTANCE_STALL_BOUND.getSeconds(), id, view.engineSnapshot(),
+                        instanceThreadDump(id));
+            }
             if (stalledMs > INSTANCE_STALL_BOUND.toMillis()) {
                 violate("INSTANCE_STALL/NO_WORK_COMPLETED: instance " + id + " holds work (queued="
                         + queued + ", outForProcessing=" + outForProcessing
@@ -632,8 +679,92 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
                         + INSTANCE_STALL_BOUND.getSeconds() + "s) at " + returned
                         + " results returned - completions are counted on PC's control thread, so this "
                         + "instance's control loop is holding work and finishing nothing");
+                // The dump is taken HERE, inside the sample that fired, because the accused instance's
+                // threads are what the violation is a claim about, and nothing else captures them - a
+                // gating run aborts on this violation and a CI log outlives the JVM by nothing.
+                log.warn("INSTANCE_STALL thread dump for instance {} at the moment the detector fired: {}\n{}",
+                        id, view.engineSnapshot(), instanceThreadDump(id));
                 instanceProgressMarks.put(id, new InstanceProgressMark(returned, incarnation, now)); // re-arm
+                stallDumpedThisStretch.remove(id); // the re-armed stretch may earn its own early dump
             }
+        }
+    }
+
+    /** Enough frames to see past the executor plumbing to whatever a worker is actually parked in. */
+    private static final int STALL_DUMP_FRAMES = 40;
+
+    /**
+     * Every thread belonging to one fleet member, with its state, the lock it is waiting for and who
+     * holds it, and its top {@value #STALL_DUMP_FRAMES} frames - the discriminator an
+     * {@code INSTANCE_STALL/NO_WORK_COMPLETED} firing has never had.
+     * <p>
+     * <b>Why this exists.</b> The per-instance tokens in {@link #instanceProgressSnapshot} classified
+     * the churn storm's instance-stall line as a live member that keeps accepting work and returns
+     * nothing ({@code docs/inflight/test-857-churn-storm-async-stalls.md}, the {@code CLASSIFIED}
+     * section) - and then stopped, because a counter can say the workers return nothing but not
+     * what they are doing instead. Only their stacks say that, and a gating run destroys them at
+     * the moment of detection, so the dump has to be taken by the detector itself.
+     * <p>
+     * <b>Membership is by thread name, and it is exact.</b> PC names every thread it owns with the
+     * instance's {@code myId} as a suffix - the worker pool, the control thread and the broker-poll
+     * thread all end {@code -PC-<instanceId>}, which {@code ManagedPCInstance#start} sets. The match is
+     * {@code endsWith}, not {@code contains}: {@code -PC-1} is a suffix of nothing but instance 1,
+     * whereas a substring match would fold instance 14's threads into it.
+     * <p>
+     * <b>An empty result is reported as such, never as an empty string.</b> No matching threads means
+     * either the instance's threads have already exited or the naming does not match, and both are
+     * findings a reader must not mistake for "nothing was happening" -
+     * {@code docs/solutions/best-practices/silence-from-an-instrument-that-could-not-have-spoken-is-not-evidence.md}.
+     * For the same reason a bean that throws yields a marker rather than propagating: this runs on
+     * the sampler thread, and the violation it accompanies has already been recorded.
+     * <p>
+     * Package-private so {@code InstanceStallProbeIT} can pin the exact-suffix rule and the
+     * explicit-absence marker broker-free. The naming itself is PC's contract, not this file's:
+     * {@code CloseInterruptLivelockTest} finds a real PC's control thread by
+     * {@code "pc-control-" + myId}, so a rename there fails that test before it silently empties
+     * this dump.
+     */
+    static String instanceThreadDump(int instanceId) {
+        String suffix = "-PC-" + instanceId;
+        try {
+            long[] ids = Thread.getAllStackTraces().keySet().stream()
+                    .filter(t -> t.getName().endsWith(suffix))
+                    .mapToLong(Thread::getId)
+                    .toArray();
+            if (ids.length == 0) {
+                return "  (no threads named *" + suffix + " exist - the instance's threads have exited, or "
+                        + "the naming contract this dump relies on has changed)";
+            }
+            java.lang.management.ThreadMXBean bean = java.lang.management.ManagementFactory.getThreadMXBean();
+            StringBuilder out = new StringBuilder();
+            for (java.lang.management.ThreadInfo info : bean.getThreadInfo(ids, true, true)) {
+                if (info == null) continue; // exited between the name scan and the bean read
+                out.append("  \"").append(info.getThreadName()).append("\" ").append(info.getThreadState());
+                if (info.getLockName() != null) {
+                    out.append(" waiting on ").append(info.getLockName());
+                    if (info.getLockOwnerName() != null) {
+                        out.append(" held by \"").append(info.getLockOwnerName()).append("\"");
+                    }
+                }
+                out.append('\n');
+                StackTraceElement[] frames = info.getStackTrace();
+                int shown = Math.min(frames.length, STALL_DUMP_FRAMES);
+                for (int i = 0; i < shown; i++) {
+                    out.append("      at ").append(frames[i]).append('\n');
+                }
+                if (frames.length > shown) {
+                    out.append("      ... ").append(frames.length - shown).append(" more\n");
+                }
+                for (var monitor : info.getLockedMonitors()) {
+                    out.append("      holds monitor ").append(monitor).append('\n');
+                }
+                for (var sync : info.getLockedSynchronizers()) {
+                    out.append("      holds ").append(sync).append('\n');
+                }
+            }
+            return out.toString();
+        } catch (RuntimeException e) {
+            return "  (thread dump unreadable: " + e + ")";
         }
     }
 


### PR DESCRIPTION
Serves astubbs/parallel-consumer#119 (the confluentinc/parallel-consumer#857 mirror); closes nothing.

## Description

The `ChaosChurnStormIT` instance-stall line - one live member's returned-result count frozen while its records-out climbs, classified on 2026-09-03 as "a wedge that never recovers" - is diagnosed, and it is not a wedge. A thread dump taken inside the frozen window shows all ten of the accused member's workers asleep in the scenario's own 45s heavy dwell, the control thread idle on its mailbox, and most of the records out belonging to partitions the member no longer owns. The eager assignor revokes the whole assignment every ~2s under this churn, so each heavy dwell is stale before it ends and is redelivered while the old copy keeps sleeping: 45s against a 2s period is fifteen-plus copies per heavy record, which saturates 160 workers from 25 records. Ordinary records queue in the executor behind them and go stale before running, so progress happens only in rebalance lulls.

A cooperative-assignor control arm on the same seed (one term changed, scratch edit reverted) cuts instance 0's revokes from 28 to 3, its dwelling workers from 10 to 8, records out from 17-22 to 8-9, duplicates from 286 to 210, and the peak stall to one honest dwell. The swallowed worker-future candidate is refuted: every worker is running user code. The redelivery chain the note had left open is confirmed.

**What ships:**

- `ProgressProbe` dumps the accused instance's threads - selected by PC's exact `-PC-<id>` name suffix - at the moment `INSTANCE_STALL/NO_WORK_COMPLETED` fires, with the live `WorkManager` counters beside it, so a CI firing carries its own discriminator. `-Dchaos.instanceStallDumpAfterSeconds=<n>` lowers the threshold for a diagnostic run (one dump per frozen stretch); the default is the bound, so a gating run is byte-for-byte unchanged until it fires.
- `InstanceStallProbeIT` pins the exact-suffix selection and the explicit no-threads marker, broker-free.
- `docs/inflight/test-857-churn-storm-async-stalls.md` carries the diagnosis, the dumps, the arithmetic and the control arm as a dated section beside the 2026-09-03 reading; its impact moves from `stall` to `misdirection`. `ChaosChurnStormIT`'s calibration javadoc records the verdict and the seed.
- `docs/inflight/bug-857-family.md` points at the churn note for the instance-stall line and withdraws the detector-silence claim the churn note retracted on 2026-08-28. Both are pointers with no reading of their own.

**What this makes the detector.** On this scenario `INSTANCE_STALL` fires on the length of the tail, not on a PC defect - the same verdict the fleet-level `NO_PROGRESS` line already carries. The gap is that the detector cannot tell workers busy in user code from workers idle with work held; that is the follow-up, stacked on this branch.

**Same-defect sweep.** The two other recorded instance-stall seeds (`1630088991107806597`, the CI-hunted one, and `5650361238717170909`, the 2026-09-04 sighting) each replayed once with the early dump: both green, sixteen dumps between them, every dumped member with its workers in the heavy dwell. Recorded in the churn note's "Same-defect sweep, 2026-09-07" paragraph. The detector gap applies to every scenario that arms the instance-progress probe, not only the churn storm; astubbs/parallel-consumer#459 closes it, stacked on this PR.

## Checklist

- [x] Docs updated - the churn note, the family ledger, and the scenario's calibration javadoc
- [x] User-facing feature documentation data added under `docs/features/` - N/A - test harness and inflight docs only
- [x] Tests added/updated - two broker-free cases in `InstanceStallProbeIT`; the chaos scenario replayed five times locally
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - the churn note IS the working note; every finding was recorded there as it happened
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - asked for @claude review on the PR instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkbcNHqYFUH4yYXgJ7nFxN
