### PR TITLE
ci(codecov): a master push never cancels the previous one, so every base commit uploads

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,8 +38,27 @@ permissions:
   # the check cannot list them and correctly reports "cannot run" rather than inventing a baseline.
   actions: read
 
+# A PUSH TO MASTER GETS ITS OWN GROUP, KEYED BY SHA, SO NO MASTER RUN IS EVER CANCELLED. The
+# `build` job below is the only thing that uploads coverage for master, and Codecov compares every
+# pull request against the report for its merge-base commit. Keyed on the ref, a second push to master
+# inside the ~30 minutes that job takes cancelled the first one's run - `gh run list --event push
+# --branch master` showed roughly half of them `cancelled`, in bursts of up to five - and a cancelled
+# run uploads nothing, so Codecov held no report for that commit and every PR based on it was
+# compared against OLDER master data. That read as a coverage drop the branch had not made; the
+# files count in the diff block was the tell (docs/ci.md -> "Codecov"). The commit that shipped the
+# coverage-glob fix (astubbs/parallel-consumer#414) was itself cancelled this way.
+#
+# Per-SHA rather than `cancel-in-progress: false`, because a concurrency group does not queue: it
+# keeps one run in progress and at most ONE pending, and discards the rest (docs/ci.md -> "Why a
+# `concurrency` group is not a mutex", measured). A burst of three merges would still lose the
+# middle commit's upload. `repo-hygiene.yml` already keys its push runs on `github.sha` for the same
+# reason. The cost is concurrent GitHub-hosted `build` jobs during a merge burst, which is what they
+# are for; nothing here runs on the self-hosted box.
+#
+# Pull requests keep superseding their own older runs, keyed on the head ref as before. A
+# `workflow_dispatch` on master keys on the ref and no longer shares a group with push runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1256,8 +1256,18 @@ jobs:
       #
       # The two halves are collected in one step rather than two because this is one job; keeping the
       # outputs separate is what preserves the per-flag split.
+      #
+      # NO `if: always()` HERE - ONLY A COMPLETE BUILD MAY BECOME A BASE. Maven stops at the first
+      # failing module and a cancellation stops it wherever it is, and either way the modules that
+      # finished have written their jacoco reports. With `always()` the collector found those and the
+      # upload ran, so Codecov received a report for that master commit that LOOKED complete and held
+      # a fraction of the tree. Measured on master `ce6f39a47`: cancelled in module 3 of 11, and each
+      # flag uploaded exactly one file, core's; the PR based on it then compared 95 files against 84
+      # on a diff with no Java in it, and both per-flag gates went red. A truncated base is worse than
+      # none - with none, Codecov compares against the nearest older master commit that has one, and
+      # that one is whole. The PR lane keeps its `always()`: a red PR's coverage is still the coverage
+      # of that head, and nothing is ever compared AGAINST a PR head.
       - name: Collect jacoco report files for Codecov
-        if: always()
         id: coverage
         run: |
           unit=$(find . -type f -path '*/target/site/jacoco/jacoco.xml' | paste -sd, -)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1111,7 +1111,14 @@ which owns the outstanding proof and the condition for closing it.
 uploaded, which leaves Codecov with no report for that base commit and every PR comparing against
 older master data. The files count in the diff block tells them apart - equal on both sides is the
 glob, base short by more than the PR adds is the missing upload - and the inflight note above carries
-the measurement.
+the measurement. **The mechanism was `maven.yml`'s own concurrency group**: keyed on the ref, it
+cancelled master's in-progress `build` whenever another push to master landed inside the half hour
+that job takes, and `gh run list -R astubbs/parallel-consumer --workflow maven.yml --event push
+--branch master` showed that happening to roughly every other master commit. Push runs are now keyed
+per SHA, so no master run is ever superseded; the comment on the `concurrency:` block owns why that
+and not `cancel-in-progress: false`, which only ever holds one pending run and discards the rest. A
+base commit that predates that change can still lack a report, so the files-count tell stays useful
+until the merge-base of every open PR is a master commit that ran to completion.
 
 ### Reading it without a browser
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1116,9 +1116,14 @@ cancelled master's in-progress `build` whenever another push to master landed in
 that job takes, and `gh run list -R astubbs/parallel-consumer --workflow maven.yml --event push
 --branch master` showed that happening to roughly every other master commit. Push runs are now keyed
 per SHA, so no master run is ever superseded; the comment on the `concurrency:` block owns why that
-and not `cancel-in-progress: false`, which only ever holds one pending run and discards the rest. A
-base commit that predates that change can still lack a report, so the files-count tell stays useful
-until the merge-base of every open PR is a master commit that ran to completion.
+and not `cancel-in-progress: false`, which only ever holds one pending run and discards the rest. **And a cancelled run did not leave Codecov with NO report - it left a truncated one.** The `build`
+job's collector ran on `always()`, so whichever modules had finished before the cancellation were
+uploaded as that commit's base: master `ce6f39a47` was cancelled in module 3 of 11 and each flag
+received exactly one file, core's. The collector now runs only on a successful build, since the same
+truncation follows a failing module, and a base that is missing is replaced by the nearest whole one
+where a base that is short is compared against as if it were whole. A base commit that predates both
+changes can still be short, so the files-count tell stays useful until the merge-base of every open
+PR is a master commit that ran to completion.
 
 ### Reading it without a browser
 

--- a/docs/inflight/ci-the-coverage-uploads-still-use-the-inert-glob.md
+++ b/docs/inflight/ci-the-coverage-uploads-still-use-the-inert-glob.md
@@ -82,9 +82,19 @@ The files count separates the two causes in one line:
 | Files, base vs head | **equal** - the flags hold unlike sets, not unlike files | **base is short** by more than the PR adds |
 | Clears when | this lands and master re-uploads | the base moves to a master commit whose run completed |
 
-This note does not fix the second cause and does not close on it. It is recorded here because the
-time it cost was spent attributing its deltas to the first, and the tell above is what would have
-separated them immediately.
+It was recorded here without a fix, because the time it cost was spent attributing its deltas to
+the first cause, and the tell above is what would have separated them immediately.
+
+**The mechanism, and its fix, 2026-09-07.** The cancellation was `maven.yml`'s own `concurrency`
+group, keyed on `github.ref` for push events: any push to master inside the half hour the `build`
+job takes cancelled the previous push's run, and with merges landing in bursts that was roughly
+every other master commit - `gh run list -R astubbs/parallel-consumer --workflow maven.yml --event
+push --branch master` shows the shape, runs of consecutive `cancelled` broken by a lone `success`.
+Push runs are now keyed per SHA, so no master run is superseded and every master commit uploads; the
+`concurrency:` block's comment owns why per-SHA rather than `cancel-in-progress: false`. What is
+still open on this cause is the same shape as the glob's: a PR whose merge-base predates the change
+can still find its base without a report, so the files-count tell above stays in use until every
+open PR's merge-base is a master commit that ran to completion.
 
 <!-- post-merge: checked-end -->
 ## A correction worth keeping

--- a/docs/inflight/ci-the-coverage-uploads-still-use-the-inert-glob.md
+++ b/docs/inflight/ci-the-coverage-uploads-still-use-the-inert-glob.md
@@ -91,10 +91,20 @@ job takes cancelled the previous push's run, and with merges landing in bursts t
 every other master commit - `gh run list -R astubbs/parallel-consumer --workflow maven.yml --event
 push --branch master` shows the shape, runs of consecutive `cancelled` broken by a lone `success`.
 Push runs are now keyed per SHA, so no master run is superseded and every master commit uploads; the
-`concurrency:` block's comment owns why per-SHA rather than `cancel-in-progress: false`. What is
-still open on this cause is the same shape as the glob's: a PR whose merge-base predates the change
-can still find its base without a report, so the files-count tell above stays in use until every
-open PR's merge-base is a master commit that ran to completion.
+`concurrency:` block's comment owns why per-SHA rather than `cancel-in-progress: false`.
+
+**The cancelled run did not leave Codecov with nothing - it uploaded a truncated base, which is the
+astubbs/parallel-consumer#431 sighting's "single truncated base upload" with its mechanism found.**
+The `build` job's collector ran on `always()`, so it found the reports of whichever modules had
+finished and uploaded them as that commit's base. Master `ce6f39a47` is the worked case: the run was
+cancelled in module 3 of 11, each flag's upload log says `Found 1 coverage files` and names core's
+report, and the pull request based on it - this fix's own, with no Java in its diff - compared a
+full-tree head against that base and read both per-flag gates red. Codecov's own comment carried the
+tell in words: "Report is N commits behind head on master". The collector now runs only on a
+successful build; a failing module truncates the tree the same way. What is still open on this cause
+is the same shape as the glob's: a PR whose merge-base predates the change can still find a short
+base, so the files-count tell above stays in use until every open PR's merge-base is a master commit
+that ran to completion.
 
 <!-- post-merge: checked-end -->
 ## A correction worth keeping


### PR DESCRIPTION
## Description

**Draft: the fix cannot be proven before it lands, because it changes what happens to pushes on master.**

Codecov compares a pull request against the coverage report of its merge-base commit. On master the only upload comes from `maven.yml`'s `build` job, about thirty minutes on a GitHub-hosted runner. The workflow's concurrency group was keyed on `github.ref` for push events with `cancel-in-progress: true`, so any push to master inside that window cancelled the previous push's run. Merges here land in bursts: of the last forty master runs, 21 were `cancelled`, in runs of up to five consecutive commits. The commit that shipped the coverage-glob fix (astubbs/parallel-consumer#414) was itself cancelled this way.

A cancelled run uploads nothing, so Codecov holds no report for that commit, and every PR whose merge-base it is falls back to older master data. That is the "second, independent cause" the inflight note `docs/inflight/ci-the-coverage-uploads-still-use-the-inert-glob.md` recorded and deliberately did not fix: `codecov/project/unit` and `codecov/project/integration` going red, and the same PR flipping green to red between heads with no code change.

**Two changes, and this PR's own first CI run supplied the evidence for the second.**

1. Push runs are keyed on `github.sha`, so no master run shares a group with another and none is superseded. Pull requests still cancel their own older runs on the head ref. One incidental change, named by the review: a `workflow_dispatch` run on master used to share the `refs/heads/master` group with push runs and could cancel or be cancelled by one; it now keys on the ref alone and neither side touches the other.
2. Master's coverage collector no longer runs on `if: always()`. A cancelled run did not leave Codecov with no report, it left a **truncated** one: this PR's base, master `ce6f39a47`, was cancelled in module 3 of 11 and each flag's upload log reads `Found 1 coverage files`, core's. This PR then compared a full-tree head (95 files) against that base (84 files) with no Java in its diff, and both per-flag gates went red. Codecov's comment said so in words: "Report is 3 commits behind head on master". A failing module truncates the tree the same way, so the guard is a successful build, not merely an uncancelled one. A missing base is replaced by the nearest whole one; a short base is compared against as if whole. This is the mechanism behind the truncated-base sighting in astubbs/parallel-consumer#431.

**Rejected**: `cancel-in-progress: false`. A concurrency group deduplicates rather than queues (one in progress, at most one pending, the rest discarded, measured in `docs/ci.md`), so a burst of three merges would still lose the middle upload. `repo-hygiene.yml` already keys push runs per SHA.

**Cost**: concurrent GitHub-hosted `build` jobs during a merge burst. Nothing in the push lane touches the self-hosted box.

**Not fixed here, deliberately**: the unproven inert-glob repair (same note), and the two-band oscillation of master's own `unit` figure (astubbs/parallel-consumer#462). Both are different mechanisms. A base predating this change can still lack a report, so the files-count tell stays useful until every open PR's merge-base is a master commit that ran to completion; both docs say so.

**Proof, after merge**: the per-flag gates on this PR are expected to stay red until its merge-base is a master commit built under both changes, so their colour here proves nothing either way. After merge,

```
gh run list -R astubbs/parallel-consumer --workflow maven.yml --event push --branch master --json conclusion,headSha
```

should show no `cancelled` runs, through at least one burst of consecutive merges. Locally: the YAML parses and `bin/check-all.sh` is green.

## Checklist

- [x] Docs updated - `docs/ci.md` Codecov section and the inflight note's second-cause section
- [x] User-facing feature documentation data added under `docs/features/` - N/A - CI-only change
- [x] Tests added/updated - N/A - a workflow concurrency expression; the proof is the post-merge run list above
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - the existing note `ci-the-coverage-uploads-still-use-the-inert-glob.md` owns this cause and was updated in the same commit
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - config-only change, one expression and two doc paragraphs; will ask `@claude review this` on the PR instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiUrBMpa4ao7vx8YCEN3Ld
