### PR TITLE
test(core): the rebalance-callback rule sees method references and a declared contract

### DIFF
--- a/docs/inflight/core-retry-queue-needs-a-runtime-controller-ownership-guard.md
+++ b/docs/inflight/core-retry-queue-needs-a-runtime-controller-ownership-guard.md
@@ -1,0 +1,86 @@
+# The retry queue's waiting methods have a declared contract and no runtime guard
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: reliability -->
+<!-- inflight-labels: concurrency -->
+<!-- inflight-state: deferred - the static half has landed; this half needs a decision on what "fail loudly" does inside consumer.poll() -->
+
+`RetryQueue.remove`, `add`, `removeAll` and `clear` take the write lock unconditionally, so a caller that is
+not allowed to wait must never reach them - which in this engine means the controller thread and nothing else.
+That contract is now DECLARED, by
+[`@ControllerThreadOnly`](../../parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ControllerThreadOnly.java),
+and CHECKED statically, by `ArchitectureTest.rebalanceCallbacksMustNotBlock`, which reports a reach into an
+annotated method exactly as it reports a reach into a deny-listed JDK blocking call. This note is the other
+half: the runtime guard that would hold the same contract where a static walk cannot follow.
+
+## The shape, copied from a guard this repo already runs
+
+astubbs/parallel-consumer#393 did it for the consumer, and the pattern is two pieces:
+
+- `ConsumerOffsetCommitter` holds a `volatile Optional<Thread> owningThread`, set once by `claim()` when the
+  poll thread's control loop starts, and read by `isOwner()` - `Thread.currentThread().equals(owningThread
+  .orElse(null))`. The claim is a LIFECYCLE step taken by the owning thread itself, not a constructor
+  argument, because the object is built before the thread that will own it exists.
+- `PCModule.consumerManager()` wraps the user's consumer in `ThreadConfinedConsumer` (grep
+  `thread-confinement`), whose own comment states the rule this note copies: ownership is claimed when the
+  loop starts, and calls before that are allowed from any thread.
+
+Applied to `RetryQueue`: the controller claims the queue when the control loop starts; every
+`@ControllerThreadOnly` method asserts that `Thread.currentThread()` is the owner and fails loudly instead of
+taking the lock; and the guard is UNARMED while no controller has claimed, so unit tests that drive a
+`RetryQueue` directly - and any init-time use - are unaffected. Unarmed-by-default is the part that makes this
+cheap to land: it changes nothing until a real control loop exists.
+
+## Which annotation, and why the pairing rule makes this note necessary
+
+`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md` owns the rule - "Declare thread
+confinement with `@ThreadConfined`, and assert it at the entry point". Infer's `@ThreadConfined` is CONSUMED by
+RacerD and never checked, so an unpaired one silences a detector and is worse than no annotation at all. The
+two existing patterns are named there: `RetryQueue.RetryQueueIterator` carries `@ThreadConfined(ThreadConfined
+.ANY)` plus an `assertOnOwningThread` at every entry point with `RetryQueueIteratorConfinementTest` failing
+when the two disagree, and `ThreadConfinedConsumer` is the older hand-rolled version of the same idea for the
+poll thread. Both were established by astubbs/parallel-consumer#433.
+
+**The guard this note describes is that shape with a NAMED thread rather than `ANY`** - the control thread,
+which the rule says is the right value when the code really does pin one, and which is what gives the
+assertion something specific to compare against. `@ControllerThreadOnly` is deliberately not that annotation:
+no analyser reads it, so it silences nothing and the pairing rule's rationale does not reach it. When the
+runtime guard lands, the marker may fold into the `@ThreadConfined` + assertion pair.
+
+## What it covers that the static rule cannot
+
+The ArchUnit rule's own javadoc enumerates its blind spots, and each one is a way for a poll-thread call to
+arrive at a waiting acquire with the rule green:
+
+- **A stored reference.** ArchUnit's model gives a reference invoked now (a stream stage) the same shape as
+  one invoked later (a metrics gauge, an executor task), so the rule cannot say WHEN a reach happens - it is
+  conservative about immediate reaches and silent about deferred ones.
+- **A user-supplied `ConsumerRebalanceListener`.** Dynamic dispatch through an interface is out of reach of any
+  deny list, and a user listener is exactly the code the walk cannot start from.
+- **A `synchronized` block.** A `MONITORENTER` is not an access, so it is invisible at any depth - the reason
+  the rule would not have caught confluentinc#857 itself.
+
+A runtime owner check does not care how the call arrived. It costs one reference compare per call on a path
+that is already taking a lock.
+
+## Open design questions - these are what defer it
+
+- **What "fail loudly" means on the poll thread**, which is the binding one. The call is inside
+  `consumer.poll()`, so a thrown exception leaves a Kafka rebalance callback abnormally and its blast radius
+  is the group, not the caller; "log an error and decline the removal" is the alternative. Throwing is the
+  better signal in a test and the worse one in production, which is the trade to settle - and
+  astubbs/parallel-consumer#431 settles the same trade for the static half by declining rather than throwing,
+  which is the precedent to weigh rather than a decision already taken here.
+- **Claim and release across a restart.** `ConsumerOffsetCommitter.claim()` is called once and never released.
+  A controller that stops and starts again, or a second `ParallelEoSStreamProcessor` in the same JVM, needs a
+  decision on whether a claim can be replaced, refused, or dropped at close - and on what an assertion does in
+  the window between them.
+
+## Where to look when picking this up
+
+- `ConsumerOffsetCommitter`, grep `owningThread` and `isOwner` - the reference implementation, including why
+  the claim is invisible to a grep for `.claim(`.
+- `PCModule`, grep `thread-confinement` - where a wrapper is wired, and the "claimed when the loop starts"
+  rule stated in a comment.
+- `docs/inflight/static-archunit-main-code-rules.md`, "the rule now enforces a contract the CODEBASE declares"
+  - what the static half does and what it measured.

--- a/docs/inflight/static-archunit-main-code-rules.md
+++ b/docs/inflight/static-archunit-main-code-rules.md
@@ -171,6 +171,56 @@ wait, owned by astubbs#44 - and grew on 2026-08-31 when the rule's deny list was
 defect-class sweep and immediately found a second, pre-existing defect on master
 ([`bug-retry-queue-write-lock-on-the-rebalance-path.md`](bug-retry-queue-write-lock-on-the-rebalance-path.md)).
 
+**Update 2026-09-07: the walk now follows METHOD REFERENCES, and the list grew by twelve because of it.**
+`notReachBlockingCalls()` followed `getMethodCallsFromSelf()` and nothing else, and ArchUnit models
+`retryQueue::remove` as a method REFERENCE, which that accessor never returns. So
+`ShardManager.removeStaleContainers` - `.map(retryQueue::remove)`, a real unbounded write-lock acquire - was
+invisible to the rule from every rebalance callback, including `onPartitionsAssigned`, which the list did not
+mention at all. `getMethodReferencesFromSelf()` is now walked beside the calls, through one shared
+`inspectReach()` that applies the same deny-list check, the same `root => target` exemption key, the same
+synchronized-method check and the same enqueue to both kinds.
+
+**This is the "a complete-looking allowlist is evidence about the WALK" case, and it is the third blind spot
+this rule has had.** The list read as finished while three callbacks sat on a waiting acquire; nothing was
+wrong with the entries, only with what could reach the point of being entered. Widening the walk with the
+entries untouched is what measured it - the rule went from green to eighteen violations - and the twelve new
+`root => target` keys that produced are in the list with astubbs/parallel-consumer#431 named as the owner that
+deletes them. Recording them rather than shipping the rule green is deliberate, and it is the argument below
+applied to itself: a gate that arrives green has measured nothing.
+
+**Update 2026-09-07: the rule also enforces a contract the CODEBASE declares, not only a JDK deny list.**
+`@ControllerThreadOnly`
+(`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ControllerThreadOnly.java`) marks a
+method that may wait, and a reach into one is reported exactly as a deny-listed call is - same exemption key,
+same message shape, calls and method references alike. It closes a gap the deny list cannot: a
+`tryLock()`-based sibling of `RetryQueue.remove` would take the very same lock and be correctly absent from
+the list, so once both live on one class nothing but a declared contract can tell a waiting acquire from a
+declining one. astubbs/parallel-consumer#431 is the change that creates that pair.
+
+**It is deliberately NOT Infer's `@ThreadConfined`**, which arrived with astubbs/parallel-consumer#433 and is
+the subject of a rule in `parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md`. That one
+is CONSUMED by RacerD, so it must be paired with a runtime assertion or it silences a detector; this one is
+read by no analyser and silences nothing, so it is checked here and nowhere else. The runtime half - a
+named-thread `@ThreadConfined` plus an `assertOnOwningThread`, in the `RetryQueue.RetryQueueIterator` /
+`ThreadConfinedConsumer` shape - is tracked in
+[`core-retry-queue-needs-a-runtime-controller-ownership-guard.md`](core-retry-queue-needs-a-runtime-controller-ownership-guard.md).
+
+**The standing proof is a positive control, because a measurement in a commit message protects nothing.**
+`RebalanceCallbackRuleControlTest` hands the real rule object - not a copy - two hand-imported fixtures under
+`archfixture/`: one reaching a deny-listed acquire through a method reference, one reaching an annotated
+method that waits for nothing at all, so no entry in the deny list can match it. Both are hand-imported
+because the rule's own `@AnalyzeClasses` carries `DoNotIncludeTests`, which is also what keeps a deliberate
+violation from turning the production rule permanently red. Each half was checked by removal: drop the
+reference hop and both cases fail; drop the annotation block and the annotated case fails.
+
+**Constructor calls were the obvious next widening and were measured and rejected**, which is worth recording
+because it reads as free. Enqueuing `getConstructorCallsFromSelf()` turns every factory call into a reach into
+whatever the constructed object wires up: `PCModule.workManager()` contains `new WorkManager(..)`, whose
+constructor registers a metrics gauge as a method reference, and that gauge reads the retry queue under its
+read lock - a red rule on a path no callback takes. The general limit under it is that ArchUnit's model has
+the same shape for a reference invoked now (a stream stage) and one invoked later (a gauge, an executor task),
+so a reference-walking rule is conservative by construction, and cannot say WHEN a reach happens.
+
 **The tension is real and is not resolved here.** The argument for the entries: each names a defect
 that exists on master, has a tracking note, and was not introduced by the branch that had to decide
 what to do about it - the alternative was leaving a rule permanently red on inherited work, which

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ControllerThreadOnly.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/ControllerThreadOnly.java
@@ -1,0 +1,68 @@
+package bz.stub.parallelconsumer.state;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This method may WAIT, so only a thread that is allowed to wait may call it - which in this engine means the
+ * controller thread. It must never be reached from a Kafka rebalance callback, because those run on the
+ * broker-poll thread inside {@code consumer.poll()} with the whole consumer group waiting on them, so a wait
+ * there is spent out of {@code max.poll.interval.ms} and can evict the member;
+ * {@code ArchitectureTest.rebalanceCallbacksMustNotBlock} is the check, and it reports a reach into an
+ * annotated method exactly as it reports a reach into a deny-listed JDK blocking call - for a direct call and
+ * for a method reference alike.
+ * <p>
+ * <b>What the check cannot see, taken unchanged from that rule's own javadoc</b>, because an annotation that
+ * implies more coverage than exists is the false green the rule was written against: a {@code synchronized}
+ * BLOCK is a {@code MONITORENTER} instruction rather than an access, so it is invisible at any depth; a
+ * reference that is STORED rather than invoked (a metrics gauge, an executor task) has the same shape in
+ * ArchUnit's model as one invoked immediately, so the walk is conservative in one direction and blind in the
+ * other about WHEN a reach happens; and dynamic dispatch through an interface - a user-supplied
+ * {@link org.apache.kafka.clients.consumer.ConsumerRebalanceListener}, above all - is out of reach whatever is
+ * annotated. A green run means "no callback statically reaches an annotated method or a deny-listed call",
+ * never "nothing here waits".
+ * <p>
+ * <b>This is NOT Infer's {@code @ThreadConfined}, and the difference is the reason both exist.</b> The engine's
+ * own rule - {@code parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md}, "Declare thread
+ * confinement with {@code @ThreadConfined}, and assert it at the entry point" - requires that one to be paired
+ * with a runtime assertion, because RacerD CONSUMES it: an unpaired declaration silences a detector and is
+ * worse than no annotation at all. This marker is read by no analyser. It silences nothing, so the pairing
+ * rationale does not apply to it; the only thing that acts on it is
+ * {@code ArchitectureTest.rebalanceCallbacksMustNotBlock}, which reports a reach INTO an annotated method and
+ * so fires on the wrong CALLER rather than trusting the callee. It is the static half of the contract, and it
+ * is deliberately a marker with no {@code value()}: the thread it names is the one the engine has exactly one
+ * of.
+ * <p>
+ * <b>The runtime half is not implemented</b> - the astubbs/parallel-consumer#393-style ownership guard, which
+ * is {@code @ThreadConfined} with a NAMED thread plus an {@code assertOnOwningThread} at each entry point, in
+ * the shape astubbs/parallel-consumer#433 established for {@link RetryQueue.RetryQueueIterator} and
+ * {@code ThreadConfinedConsumer}. It is tracked in
+ * {@code docs/inflight/core-retry-queue-needs-a-runtime-controller-ownership-guard.md}; when it lands, this
+ * marker may fold into it.
+ * <p>
+ * <b>Why it lives in this package.</b> Main code declares no annotation TYPES of its own - this is the
+ * first; the Infer annotations it uses are a third party's - so rather than invent a home for it, it sits
+ * beside the class it governs, {@link RetryQueue}.
+ * Move it up a package when a second, unrelated class needs it.
+ *
+ * <b>There is no declining alternative on {@link RetryQueue} yet.</b> Every annotated method takes the write
+ * lock unconditionally, so a caller that must not wait has nowhere to go but off this class - which is exactly
+ * what astubbs/parallel-consumer#431 is for: it adds a {@code tryLock()}-based path and routes the rebalance
+ * sweeps onto it. Until then this marker names the callers that are already wrong, and the rule's
+ * {@code KNOWN_BLOCKING_VIOLATIONS} carries them as open debt.
+ *
+ * @author Antony Stubbs
+ * @see RetryQueue#remove(WorkContainer)
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ControllerThreadOnly {
+}

--- a/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/RetryQueue.java
+++ b/parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/state/RetryQueue.java
@@ -91,6 +91,7 @@ public class RetryQueue {
     /**
      * Clear the set
      */
+    @ControllerThreadOnly
     public void clear() {
         lock.writeLock().lock();
         try {
@@ -119,6 +120,7 @@ public class RetryQueue {
      * @param workContainer to add
      * @return true if the element was not already present
      */
+    @ControllerThreadOnly
     public boolean add(final WorkContainer<?, ?> workContainer) {
         lock.writeLock().lock();
         try {
@@ -138,12 +140,18 @@ public class RetryQueue {
     }
 
     /**
-     * Remove a work container from the set. Method follows Set.remove() behaviour, returning true if the element was
-     * present.
+     * Remove a work container from the set, WAITING for the write lock. Method follows Set.remove() behaviour,
+     * returning true if the element was present.
+     * <p>
+     * {@link ControllerThreadOnly} states the contract and names its check: the broker-poll thread must not reach
+     * this method, because a rebalance callback that waits here waits inside {@code poll()}. There is no declining
+     * alternative on this class yet - the sweeps that need one are the subject of
+     * astubbs/parallel-consumer#431, which adds a {@code tryLock()}-based path and routes those callers onto it.
      *
-     * @param workContainer
-     * @return
+     * @param workContainer the container to remove
+     * @return true if the element was present
      */
+    @ControllerThreadOnly
     public boolean remove(final WorkContainer<?, ?> workContainer) {
         lock.writeLock().lock();
         try {
@@ -165,6 +173,7 @@ public class RetryQueue {
      * @param toRemove collection of work containers to remove
      * @return true if the set was modified
      */
+    @ControllerThreadOnly
     public <K, V> boolean removeAll(List<WorkContainer<K, V>> toRemove) {
         // GUARD ON THE CALLER'S OWN LIST, never on `unique`. The original fast path read
         // `unique.isEmpty()` with no lock held while writers mutate it under the write lock, so the

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/ArchitectureTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/ArchitectureTest.java
@@ -10,8 +10,10 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaMethodReference;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.lang.ArchRule;
 
@@ -20,14 +22,14 @@ import java.util.Deque;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import bz.stub.parallelconsumer.internal.ConsumerManager;
+import bz.stub.parallelconsumer.state.ControllerThreadOnly;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
-
-import com.tngtech.archunit.core.domain.JavaAccess;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
@@ -106,22 +108,59 @@ class ArchitectureTest {
      * <p><b>The exemption list is the known-open debt, not a way to pass.</b> Each entry is a real
      * violation with an owner; adding to it should feel like taking on a defect, because it is.
      *
-     * <p><b>WHAT THIS RULE CANNOT SEE, and it is not a detail.</b> ArchUnit matches method CALLS.
-     * A {@code synchronized} block compiles to a {@code MONITORENTER} instruction, which is not a
-     * call, so <b>no {@code synchronized} block is visible to this rule at any depth</b>. The
+     * <p><b>WHAT THIS RULE CANNOT SEE, and it is not a detail.</b> ArchUnit matches ACCESSES - a call, a
+     * reference, a field read. A {@code synchronized} block compiles to a {@code MONITORENTER} instruction,
+     * which is none of those, so <b>no {@code synchronized} block is visible to this rule at any depth</b>. The
      * consequence is worth stating without softening: <b>this rule would NOT have caught
      * confluentinc#857</b>, whose defect was {@code synchronized (commitCommand)} inside
      * {@code onPartitionsRevoked}. It fires today only because the remaining violation happens to
      * use {@code Thread.sleep}. A green run therefore means "reaches none of the calls named in
-     * {@link #BLOCKING_CALLS}", never "nothing here blocks" - and reading it as the latter is
+     * {@link #BLOCKING_CALLS} and no method the codebase itself declares as waiting", never "nothing here
+     * blocks" - and reading it as the latter is
      * exactly the false green this rule exists to prevent elsewhere.
+     *
+     * <p><b>Since 2026-09-07 this rule enforces a CODEBASE-DECLARED contract as well as the JDK deny list.</b>
+     * A reach into a method annotated {@link ControllerThreadOnly} is reported exactly as a deny-listed call
+     * is - same {@code root => target} exemption key, same message shape, calls and method references alike.
+     * The deny list can only name waits it recognises by JDK signature, and that is a narrower question than
+     * the rule asks. A {@code tryLock()}-based sibling of {@code RetryQueue.remove} would take the SAME lock and
+     * be correctly absent from the list, so once both live on one class no entry in it can tell a waiting
+     * acquire from a declining one - only the method's own declared contract can.
+     * astubbs/parallel-consumer#431 is the change that creates that pair, and this half of the rule is what
+     * keeps it honest afterwards. {@code RebalanceCallbackRuleControlTest} holds the standing proof, on a
+     * fixture whose annotated method waits for nothing at all - a field write - so nothing in
+     * {@link #BLOCKING_CALLS} can match it and the annotation check is the only thing that can report it.
+     *
+     * <p><b>A METHOD REFERENCE is not a method call either - walked since 2026-09-03, and it cost a path
+     * before it was.</b> ArchUnit models {@code retryQueue::remove} as a method REFERENCE, which
+     * {@code getMethodCallsFromSelf()} does not return, so a walk built on that accessor alone never followed
+     * one. {@code ShardManager.removeStaleContainers} reached {@code RetryQueue.remove}'s write lock exactly
+     * that way, from {@code onPartitionsAssigned} as well as from the revoke and lost callbacks, and this rule
+     * reported none of it: measured on 2026-09-02, with every exemption deleted the unfixed tree reported six
+     * violations, all through the one DIRECT call and nothing at all on {@code onPartitionsAssigned}, while
+     * rewriting that reference as a lambda over a direct call took the same tree to nine.
+     * {@code notReachBlockingCalls()} now follows {@code getMethodReferencesFromSelf()} beside the calls;
+     * re-measured on 2026-09-03, restoring {@code .map(retryQueue::remove)} takes this rule from green to a
+     * report naming all three callbacks. {@code RebalanceCallbackRuleControlTest} is the standing proof of
+     * that, so the hop cannot be dropped again without something going red.
+     *
+     * <p><b>The general lesson survives the fix, because the next blind spot will not be this one:</b> an
+     * exemption list that looks complete is evidence about what the walk can see, never about what the
+     * callback reaches.
      *
      * <p>Two narrower limits follow from the same mechanism. Synchronized <em>methods</em> ARE
      * detectable, because the modifier survives into the class file, and this rule now flags them -
      * so the blind spot is blocks specifically, not monitors in general. And the walk
-     * follows statically resolvable calls only, so a monitor or a wait behind dynamic dispatch through
+     * follows statically resolvable accesses only, so a monitor or a wait behind dynamic dispatch through
      * an interface - a user-supplied {@code ConsumerRebalanceListener}, for instance - is out of reach
      * whatever the deny list says.
+     *
+     * <p><b>And what walking references cannot tell you is WHEN the reference runs.</b> A reference passed to
+     * a stream stage is invoked on this thread before the statement finishes; one handed to a metrics registry
+     * or an executor is invoked later, somewhere else. The model has the same shape for both, so this rule
+     * treats every reference as an immediate reach - which is right for the defect it was widened to catch and
+     * conservative everywhere else. It is also why constructor calls are not walked; see
+     * {@link #notReachBlockingCalls()} for that measurement.
      *
      * <p>Closing the block gap needs bytecode inspection rather than ArchUnit. Until someone wants
      * that, the honest position is that this rule covers a named, enumerable set and says so.
@@ -176,6 +215,14 @@ class ArchitectureTest {
      * {@code verified bug} label - one of a couple of dozen that carry it. Tracked in
      * {@code docs/inflight/bug-857-transactional-revoke-wait.md};
      * remove this entry when that lands.
+     *
+     * <p><b>The twelve entries below are debt this rule's own widening MADE VISIBLE, not debt it created.</b>
+     * The reaches were always there; the walk could not see them, so the list read as complete while three
+     * callbacks sat on an unbounded write-lock acquire - which is the exact false green
+     * {@link #rebalanceCallbacksMustNotBlock()} exists to prevent. Every one of them is owned by
+     * astubbs/parallel-consumer#431 and is deleted by it. Recording them here rather than shipping the rule
+     * green is deliberate: a gate that arrives green has measured nothing, and an exemption with a named owner
+     * is a defect on the books, which a reach nobody can see is not.
      */
     private static final Set<String> KNOWN_BLOCKING_VIOLATIONS = new HashSet<>(Arrays.asList(
             "bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor.onPartitionsRevoked"
@@ -194,7 +241,58 @@ class ArchitectureTest {
             "bz.stub.parallelconsumer.state.WorkManager.onPartitionsLost"
                     + "(java.util.Collection) => java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock()",
             "bz.stub.parallelconsumer.state.WorkManager.onPartitionsRevoked"
-                    + "(java.util.Collection) => java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock()"
+                    + "(java.util.Collection) => java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock()",
+
+            // ---- Debt this commit MADE VISIBLE rather than introduced. Twelve entries, all one defect. ----
+            // The widened walk and the @ControllerThreadOnly check each report reaches that were always there
+            // and that the old rule could not see. Owner for every entry below:
+            // astubbs/parallel-consumer#431, which routes these sweeps onto a declining tryLock() path - when
+            // it lands, all twelve go with it, together with the six WriteLock entries above.
+
+            // 1. The METHOD REFERENCE the old walk could not follow: ShardManager.removeStaleContainers does
+            // `.map(retryQueue::remove)`, so all three callbacks reach the write lock through it. The revoke and
+            // lost roots collide with the six pre-existing keys above and are already covered; the ASSIGNED
+            // roots are new here, because nothing had ever reported a reach on that callback at all.
+            "bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor.onPartitionsAssigned"
+                    + "(java.util.Collection) => java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock()",
+            "bz.stub.parallelconsumer.state.PartitionStateManager.onPartitionsAssigned"
+                    + "(java.util.Collection) => java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock()",
+            "bz.stub.parallelconsumer.state.WorkManager.onPartitionsAssigned"
+                    + "(java.util.Collection) => java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock()",
+
+            // 2. The DECLARED contract: every rebalance callback reaches RetryQueue.remove, which is
+            // @ControllerThreadOnly - by direct call through ShardManager.removeWorkFromShardFor on the revoke
+            // and lost paths, and by method reference through ShardManager.removeStaleContainers on all three.
+            // Keyed on the annotated method rather than on the JDK lock, so these are separate keys from the
+            // three above even where the root is the same - which is the point: the two halves of the rule
+            // answer different questions and neither one silences the other.
+            "bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor.onPartitionsAssigned"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)",
+            "bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor.onPartitionsRevoked"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)",
+            "bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor.onPartitionsLost"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)",
+            "bz.stub.parallelconsumer.state.PartitionStateManager.onPartitionsAssigned"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)",
+            "bz.stub.parallelconsumer.state.PartitionStateManager.onPartitionsRevoked"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)",
+            "bz.stub.parallelconsumer.state.PartitionStateManager.onPartitionsLost"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)",
+            "bz.stub.parallelconsumer.state.WorkManager.onPartitionsAssigned"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)",
+            "bz.stub.parallelconsumer.state.WorkManager.onPartitionsRevoked"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)",
+            "bz.stub.parallelconsumer.state.WorkManager.onPartitionsLost"
+                    + "(java.util.Collection) => bz.stub.parallelconsumer.state.RetryQueue"
+                    + ".remove(bz.stub.parallelconsumer.state.WorkContainer)"
     ));
 
     private static DescribedPredicate<JavaMethod> areRebalanceCallbacks() {
@@ -210,50 +308,114 @@ class ArchitectureTest {
         };
     }
 
+    /**
+     * The walk. Three access kinds are followed, and the second is the one that had to be added.
+     * <p>
+     * <b>A method CALL and a method REFERENCE are different accesses in ArchUnit's model</b>, returned by
+     * different accessors and never by each other's. {@code getMethodCallsFromSelf()} alone therefore misses
+     * {@code retryQueue::remove} entirely, which is how the retry queue's write lock stayed off this rule's
+     * report while three callbacks reached it - see the rule's own javadoc. Both kinds carry the same
+     * {@code getTarget().getFullName()} and both resolve to a {@link JavaMethod}, so one deny-list check and
+     * one enqueue serve both.
+     * <p>
+     * <b>CONSTRUCTOR calls are deliberately NOT walked, and that was measured rather than assumed.</b>
+     * {@code getConstructorCallsFromSelf()} exists and enqueuing what it returns is a two-line change; doing it
+     * on 2026-09-03 turned this rule red on a reach no callback makes.
+     * {@code OffsetMapCodecManager.loadPartitionStateForAssignment} calls {@code PCModule.workManager()}, a lazy
+     * singleton accessor whose body contains {@code new WorkManager(..)}, whose constructor calls
+     * {@code initMetrics()}, which registers {@code WorkManager::getNumberOfWorkQueuedInShardsAwaitingSelection}
+     * as a gauge - and that reads the retry queue under its read lock. In production the accessor returns an
+     * object built long before, and the gauge runs on a metrics scrape; statically it is a path from
+     * {@code onPartitionsAssigned} to {@code ReadLock.lock()}. Walking constructors makes every factory call a
+     * reach into whatever the constructed object wires up, so the widening buys a shape nobody has hit and
+     * costs a false red today. Revisit it with a way to tell an invoked reference from a stored one.
+     */
     private static ArchCondition<JavaMethod> notReachBlockingCalls() {
         return new ArchCondition<>("not reach a blocking call, transitively") {
             @Override
             public void check(JavaMethod root, ConditionEvents events) {
                 Set<String> visited = new HashSet<>();
-                Deque<JavaMethod> queue = new ArrayDeque<>();
+                // JavaCodeUnit rather than JavaMethod, so a constructor can be enqueued alongside a method
+                Deque<JavaCodeUnit> queue = new ArrayDeque<>();
                 queue.add(root);
                 while (!queue.isEmpty()) {
-                    JavaMethod current = queue.poll();
+                    JavaCodeUnit current = queue.poll();
                     if (!visited.add(current.getFullName())) {
                         continue;
                     }
                     for (JavaMethodCall call : current.getMethodCallsFromSelf()) {
-                        String target = call.getTarget().getFullName();
-                        if (BLOCKING_CALLS.contains(target)
-                                && !KNOWN_BLOCKING_VIOLATIONS.contains(root.getFullName() + " => " + target)) {
-                            events.add(SimpleConditionEvent.violated(root,
-                                    root.getFullName() + " reaches blocking call " + target
-                                            + " via " + current.getFullName()
-                                            + " - a rebalance callback runs inside poll() and must not wait. "
-                                            + "Decline instead (tryLock), or move the work off the poll thread."));
-                        }
-                        // only walk our own code; the JDK and Kafka client are the boundary
-                        // resolveMember() on a method call already yields a JavaMethod, so an instanceof
-                        // here is a null check wearing a type check - which is what BadInstanceof flagged.
-                        call.getTarget().resolveMember().ifPresent(reached -> {
-                            if (reached.getOwner().getPackageName().startsWith("bz.stub.parallelconsumer")) {
-                                // A synchronized METHOD keeps its modifier in the class file, so unlike a
-                                // synchronized block it is visible here. Entering one from a rebalance
-                                // callback is an unbounded wait on whoever holds the monitor.
-                                if (reached.getModifiers().contains(JavaModifier.SYNCHRONIZED)) {
-                                    events.add(SimpleConditionEvent.violated(root,
-                                            root.getFullName() + " reaches synchronized method "
-                                                    + reached.getFullName() + " via " + current.getFullName()
-                                                    + " - entering a monitor from a rebalance callback waits "
-                                                    + "for whoever holds it, inside poll()."));
-                                }
-                                queue.add(reached);
-                            }
-                        });
+                        inspectReach(root, current, "call", call.getTarget().getFullName(),
+                                call.getTarget().resolveMember(), events, queue);
+                    }
+                    for (JavaMethodReference reference : current.getMethodReferencesFromSelf()) {
+                        inspectReach(root, current, "method reference", reference.getTarget().getFullName(),
+                                reference.getTarget().resolveMember(), events, queue);
                     }
                 }
             }
         };
+    }
+
+    /**
+     * One reach, whatever kind of access produced it: check the target against the deny list, then - once it is
+     * resolved as our own code - against {@link ControllerThreadOnly} and the synchronized-method modifier,
+     * then walk into it.
+     * <p>
+     * The deny-list check runs on the target's NAME and needs no resolution, which is what lets it cover the JDK.
+     * The annotation check necessarily runs on the resolved member, so it can only ever fire on this codebase -
+     * which is the whole point of it: it is the half of the rule the JDK deny list cannot express.
+     *
+     * @param kind     how {@code target} was reached, for the violation message - a reader has to be able to
+     *                 tell a {@code foo::bar} reach from a {@code foo.bar()} one, because the fix differs
+     * @param resolved the reached code unit, absent when the target is outside the imported classes; the JDK and
+     *                 the Kafka client are the boundary and are deliberately not walked
+     */
+    private static void inspectReach(JavaMethod root,
+                                     JavaCodeUnit from,
+                                     String kind,
+                                     String target,
+                                     Optional<? extends JavaCodeUnit> resolved,
+                                     ConditionEvents events,
+                                     Deque<JavaCodeUnit> queue) {
+        if (BLOCKING_CALLS.contains(target)
+                && !KNOWN_BLOCKING_VIOLATIONS.contains(root.getFullName() + " => " + target)) {
+            events.add(SimpleConditionEvent.violated(root,
+                    root.getFullName() + " reaches blocking " + kind + " " + target
+                            + " via " + from.getFullName()
+                            + " - a rebalance callback runs inside poll() and must not wait. "
+                            + "Decline instead (tryLock), or move the work off the poll thread."));
+        }
+        // resolveMember() already yields a code unit, so an instanceof here is a null check wearing a type
+        // check - which is what BadInstanceof flagged.
+        resolved.ifPresent(reached -> {
+            if (reached.getOwner().getPackageName().startsWith("bz.stub.parallelconsumer")) {
+                // A method the codebase itself declares as "may wait", reported exactly like a deny-listed JDK
+                // call: same root => target exemption key, same message shape. The owner is checked too because
+                // the annotation targets TYPE as well as METHOD, and a class-level declaration that the walk
+                // ignored would be a silent gap rather than a narrower rule.
+                if ((reached.isAnnotatedWith(ControllerThreadOnly.class)
+                        || reached.getOwner().isAnnotatedWith(ControllerThreadOnly.class))
+                        && !KNOWN_BLOCKING_VIOLATIONS.contains(root.getFullName() + " => " + target)) {
+                    events.add(SimpleConditionEvent.violated(root,
+                            root.getFullName() + " reaches @ControllerThreadOnly " + kind + " " + target
+                                    + " via " + from.getFullName()
+                                    + " - that method declares that it may wait, and a rebalance callback runs "
+                                    + "inside poll() and must not wait. "
+                                    + "Decline instead (tryLock), or move the work off the poll thread."));
+                }
+                // A synchronized METHOD keeps its modifier in the class file, so unlike a synchronized block
+                // it is visible here. Entering one from a rebalance callback is an unbounded wait on whoever
+                // holds the monitor.
+                if (reached.getModifiers().contains(JavaModifier.SYNCHRONIZED)) {
+                    events.add(SimpleConditionEvent.violated(root,
+                            root.getFullName() + " reaches synchronized method "
+                                    + reached.getFullName() + " via " + from.getFullName()
+                                    + " - entering a monitor from a rebalance callback waits "
+                                    + "for whoever holds it, inside poll()."));
+                }
+                queue.add(reached);
+            }
+        });
     }
 
     private static ArchCondition<JavaField> beInAllowedClasses(Set<String> allowedClassNames) {

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/RebalanceCallbackRuleControlTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/RebalanceCallbackRuleControlTest.java
@@ -1,0 +1,93 @@
+package bz.stub.parallelconsumer;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.archfixture.BlockingReachThroughAMethodReference;
+import bz.stub.parallelconsumer.archfixture.ControllerThreadOnlyReachFromARebalanceCallback;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The positive control for {@code ArchitectureTest.rebalanceCallbacksMustNotBlock}: proof that it can still
+ * FAIL, and specifically that it fails on the shape it was blind to.
+ * <p>
+ * <b>A rule that is green because the code complies and a rule that is green because it cannot see is the same
+ * green.</b> That is not hypothetical here - it is what happened. Until 2026-09-03 the walk followed only
+ * {@code getMethodCallsFromSelf()}, so {@code ShardManager.removeStaleContainers}'s
+ * {@code .map(retryQueue::remove)} reached {@code RetryQueue.remove}'s unbounded write-lock acquire from all
+ * three rebalance callbacks while the rule reported nothing on {@code onPartitionsAssigned} at all. Measured
+ * again on 2026-09-03 before this test was written: restoring that method reference to the production tree
+ * left the un-widened rule green at 3 tests / 0 failures.
+ * <p>
+ * So the rule now carries a fixture that reaches a deny-listed acquire through a method reference, and this
+ * test asserts the rule reports it. Widen the deny list, refactor the walk, swap the ArchUnit version - if any
+ * of that quietly stops the reference hop from being followed, this goes red instead of the whole rule going
+ * quiet.
+ * <p>
+ * <b>Why the fixture is imported by hand rather than by {@code @AnalyzeClasses}.</b> The rule's own import
+ * carries {@link com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests}, so it cannot see anything
+ * in the test tree - which is exactly what keeps a deliberate violation from turning the production rule
+ * permanently red. The control therefore imports the fixture package itself and hands those classes to
+ * {@link ArchitectureTest#rebalanceCallbacksMustNotBlock}, the same rule object the build evaluates - not a
+ * copy of it, because a copied rule controls for a copy.
+ * <p>
+ * <b>The second control covers the other half of the rule</b>, added when the walk started reporting a reach
+ * into a method the codebase declares {@link bz.stub.parallelconsumer.state.ControllerThreadOnly}. Its fixture
+ * waits for nothing, so no entry in the rule's JDK deny list can match it - if the annotation check is dropped
+ * or narrowed, that test is the only thing that goes red.
+ *
+ * @author Antony Stubbs
+ * @see BlockingReachThroughAMethodReference
+ * @see ControllerThreadOnlyReachFromARebalanceCallback
+ */
+class RebalanceCallbackRuleControlTest {
+
+    @Test
+    void theRuleReportsABlockingAcquireReachedThroughAMethodReference() {
+        JavaClasses fixture = new ClassFileImporter()
+                .importPackagesOf(BlockingReachThroughAMethodReference.class);
+
+        AssertionError violation = assertThrows(AssertionError.class,
+                () -> ArchitectureTest.rebalanceCallbacksMustNotBlock.check(fixture),
+                "the rule saw a rebalance callback reach a blocking write-lock acquire through a method "
+                        + "reference and reported nothing - which is the false green this control exists to "
+                        + "catch, and the state the rule was actually in until 2026-09-03");
+
+        assertThat(violation).hasMessageThat()
+                .contains(BlockingReachThroughAMethodReference.class.getName() + ".onPartitionsRevoked");
+        assertThat(violation).hasMessageThat()
+                .contains("java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock()");
+        assertThat(violation).hasMessageThat()
+                .contains("reaches blocking method reference");
+    }
+
+    @Test
+    void theRuleReportsAControllerThreadOnlyMethodReachedByCallAndByMethodReference() {
+        JavaClasses fixture = new ClassFileImporter()
+                .importPackagesOf(ControllerThreadOnlyReachFromARebalanceCallback.class);
+
+        AssertionError violation = assertThrows(AssertionError.class,
+                () -> ArchitectureTest.rebalanceCallbacksMustNotBlock.check(fixture),
+                "the rule saw a rebalance callback reach a method the codebase declares @ControllerThreadOnly "
+                        + "and reported nothing - the contract is then prose again, which is the state this "
+                        + "check was added to leave behind");
+
+        assertThat(violation).hasMessageThat()
+                .contains(ControllerThreadOnlyReachFromARebalanceCallback.class.getName()
+                        + ".onPartitionsAssigned");
+        // Both kinds of access, because the annotation has to hold for a stored reference as well as a call -
+        // asserting only one of them would leave the other free to be dropped silently.
+        assertThat(violation).hasMessageThat()
+                .contains("reaches @ControllerThreadOnly call");
+        assertThat(violation).hasMessageThat()
+                .contains("reaches @ControllerThreadOnly method reference");
+        assertThat(violation).hasMessageThat()
+                .contains("retireOnTheControllerThread");
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/archfixture/BlockingReachThroughAMethodReference.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/archfixture/BlockingReachThroughAMethodReference.java
@@ -1,0 +1,51 @@
+package bz.stub.parallelconsumer.archfixture;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import java.util.Collection;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A defect on purpose: the exact shape that walked past
+ * {@code ArchitectureTest.rebalanceCallbacksMustNotBlock} for as long as that rule followed only method CALLS.
+ * <p>
+ * This class is <b>not production code and must never be referenced by any</b>. It exists so
+ * {@code RebalanceCallbackRuleControlTest} can point the real rule at a reach it is supposed to report, and
+ * fail if it does not - the positive control for a rule whose whole job is to be green.
+ * <p>
+ * It mirrors {@code ShardManager.removeStaleContainers} as it stood before 2026-09-03: a method named like a
+ * Kafka rebalance callback, a helper one hop away, and inside that helper a stream stage whose operation is a
+ * METHOD REFERENCE to a blocking lock acquire. Nothing here is a method call to a name in the rule's deny
+ * list, which is why the un-widened walk saw nothing.
+ * <p>
+ * <b>Do not "tidy" the method reference into a lambda.</b> A lambda body compiles to a synthetic method whose
+ * accesses the old walk DID follow, so the same code written that way is reported either way and this fixture
+ * stops controlling for anything.
+ *
+ * @author Antony Stubbs
+ */
+public class BlockingReachThroughAMethodReference {
+
+    /** Fair, like {@code RetryQueue}'s, though nothing here depends on that - only on the acquire being a wait. */
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
+
+    /**
+     * Named so the rule's own {@code areRebalanceCallbacks()} predicate selects it. The signature does not
+     * matter to the predicate - only the name and the owning package do.
+     */
+    public void onPartitionsRevoked(Collection<String> partitions) {
+        sweep(partitions);
+    }
+
+    /**
+     * One hop from the callback, so the control exercises the transitive walk and not just the root's own
+     * accesses.
+     */
+    private void sweep(Collection<String> partitions) {
+        partitions.stream()
+                .map(ignoredPartition -> lock.writeLock())
+                .forEach(ReentrantReadWriteLock.WriteLock::lock);
+    }
+}

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/archfixture/ControllerThreadOnlyReachFromARebalanceCallback.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/archfixture/ControllerThreadOnlyReachFromARebalanceCallback.java
@@ -1,0 +1,67 @@
+package bz.stub.parallelconsumer.archfixture;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.state.ControllerThreadOnly;
+
+import java.util.Collection;
+
+/**
+ * A defect on purpose, the sibling of {@link BlockingReachThroughAMethodReference}: a rebalance callback
+ * reaching a method the codebase itself declares {@link ControllerThreadOnly}, once by CALL and once by METHOD
+ * REFERENCE.
+ * <p>
+ * This class is <b>not production code and must never be referenced by any</b>. It exists so
+ * {@code RebalanceCallbackRuleControlTest} can point the real rule at a reach it is supposed to report, and
+ * fail if it does not.
+ * <p>
+ * <b>Nothing here waits, and that is the point.</b> The annotated method's body is a field write - it contains
+ * no call in {@code ArchitectureTest.BLOCKING_CALLS} and no monitor, so the JDK deny-list has nothing to match
+ * and the only thing that can report this reach is the annotation. That is exactly the shape the annotation was
+ * added for: {@code RetryQueue.remove} is reported through {@code WriteLock.lock()} either way, whereas a
+ * declared contract has to hold for a method whose wait the walk cannot name.
+ * <p>
+ * <b>Do not "tidy" the method reference into a lambda</b>, for the reason
+ * {@link BlockingReachThroughAMethodReference} gives: a lambda body compiles to a synthetic method the walk
+ * follows as an ordinary call, and this half of the control then controls for nothing.
+ *
+ * @author Antony Stubbs
+ */
+public class ControllerThreadOnlyReachFromARebalanceCallback {
+
+    private String lastSwept = "";
+
+    /** Read only so the field is not a write-only one, which the analysers would rightly flag. */
+    public String getLastSwept() {
+        return lastSwept;
+    }
+
+    /**
+     * Named so the rule's own {@code areRebalanceCallbacks()} predicate selects it. Deliberately a DIFFERENT
+     * callback name from {@link BlockingReachThroughAMethodReference}'s, so a report naming this class can only
+     * have come from this fixture.
+     */
+    public void onPartitionsAssigned(Collection<String> partitions) {
+        sweep(partitions);
+    }
+
+    /**
+     * One hop from the callback, so the control exercises the transitive walk rather than only the root's own
+     * accesses - and it reaches the same annotated method both ways, so the two reported reaches differ only in
+     * the kind of access that produced them.
+     */
+    private void sweep(Collection<String> partitions) {
+        retireOnTheControllerThread("the direct call");
+        partitions.forEach(this::retireOnTheControllerThread);
+    }
+
+    /**
+     * Declares the contract without implementing a wait - see the class javadoc for why that is deliberate.
+     */
+    @ControllerThreadOnly
+    private void retireOnTheControllerThread(String partition) {
+        this.lastSwept = partition;
+    }
+}


### PR DESCRIPTION
No fork issue exists for this work: the defect class was found by the confluentinc#857 defect-class sweep and is tracked only as an in-flight note, so this PR cites none rather than a loosely related one. It depends on nothing.

## Description

**Extracted from astubbs/parallel-consumer#431 so the gate lands ahead of, and independently of, the fix.** That PR fixes one instance of the defect class - rebalance callbacks waiting for the retry queue's write lock. This PR is the part of it that catches the *class*, and it carries no behaviour change: `RetryQueue`'s only edit is four annotations and a javadoc.

### The third blind spot, and why it is the one that matters

`ArchitectureTest.rebalanceCallbacksMustNotBlock` followed `getMethodCallsFromSelf()` and nothing else. ArchUnit models `retryQueue::remove` as a method **reference**, which that accessor never returns, so `ShardManager.removeStaleContainers` - `.map(retryQueue::remove)`, a real unbounded write-lock acquire - was invisible to the rule from all three callbacks.

What makes it worse than a missing entry: `KNOWN_BLOCKING_VIOLATIONS` named `onPartitionsRevoked` and `onPartitionsLost` and read as an exhaustive account of the debt. `onPartitionsAssigned` had never been reported at all - not because it was clean, but because nothing could see it. **An exemption list that looks complete is evidence about what the walk can see, never about what the callback reaches.**

`notReachBlockingCalls()` now follows `getMethodReferencesFromSelf()` beside the calls, through one shared `inspectReach()` applying the same deny-list check, the same `root => target` exemption key, the same synchronized-method check and the same enqueue to both kinds.

### `@ControllerThreadOnly` - a declared contract, not only a JDK deny list

`RetryQueue.remove`, `add`, `removeAll` and `clear` take the write lock unconditionally. That "controller thread only" rule was prose in one javadoc, which nothing reads. It is now a declaration, and a reach into an annotated method is reported exactly as a deny-listed call is - same exemption key, same message shape, calls and method references alike, owner TYPE checked as well as the method.

It is **deliberately not Infer's `@ThreadConfined`**, and the marker's javadoc says so. `parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md` requires that one to be paired with a runtime assertion because RacerD *consumes* it, so an unpaired declaration silences a detector and is worse than nothing. This marker is read by no analyser and silences nothing. The runtime half is deliberately unimplemented and filed as `docs/inflight/core-retry-queue-needs-a-runtime-controller-ownership-guard.md`.

### Red first: 12 new exemptions, all owned by astubbs/parallel-consumer#431

With master's exemption list **untouched**, the widened rule reports 18 violations = 12 distinct `root => target` keys, every one a reach that was always there:

| Count | Key shape | Why it is new |
|---|---|---|
| 3 | `onPartitionsAssigned` on `AbstractParallelEoSStreamProcessor`, `PartitionStateManager`, `WorkManager` => `ReentrantReadWriteLock$WriteLock.lock()` | reached via the `retryQueue::remove` reference in `ShardManager.removeStaleContainers`; the revoke/lost roots for that target collide with the six pre-existing keys and stay covered by them |
| 9 | all three callbacks x all three classes => `RetryQueue.remove` | the `@ControllerThreadOnly` reach - by direct call via `ShardManager.removeWorkFromShardFor` on revoke/lost, by method reference via `ShardManager.removeStaleContainers` on all three |

All 12 are in `KNOWN_BLOCKING_VIOLATIONS` with astubbs/parallel-consumer#431 named as the owner that deletes them - along with the six that were already there. **After that PR lands, its `ArchitectureTest` diff collapses to deleting the exemptions this PR introduces.**

Shipping the rule green instead was rejected: a gate that arrives green has measured nothing, and an exemption with a named owner is a defect on the books, which a reach nobody can see is not.

### The standing control

`RebalanceCallbackRuleControlTest` hands the **real** rule object two hand-imported fixtures under `archfixture/`:

- `BlockingReachThroughAMethodReference` - reaches `WriteLock.lock()` one hop away through a method reference in a stream stage.
- `ControllerThreadOnlyReachFromARebalanceCallback` - reaches an annotated method twice, by call and by reference, whose body **waits for nothing** (a field write), so nothing in `BLOCKING_CALLS` can match it and the annotation check is the only thing that can report it.

Hand-imported because the rule's own `@AnalyzeClasses` carries `DoNotIncludeTests` - which is also what stops a deliberate violation turning the production rule permanently red.

Each half checked by removal, each restored byte-identical:

- reference walk deleted -> `RebalanceCallbackRuleControlTest` 2 tests / **2 failures**, both fixtures unreported.
- annotation block deleted from `inspectReach` -> 2 tests / **1 failure**; the blocking fixture still reported, nothing on `onPartitionsAssigned`.

### Rejected, measured rather than assumed

Walking `getConstructorCallsFromSelf()` turns every factory call into a reach into whatever the constructed object wires up - `PCModule.workManager()` contains `new WorkManager(..)`, whose constructor registers a gauge that reads the retry queue under its read lock. It buys a shape nobody has hit and costs a false red. The limit underneath is recorded on the rule: ArchUnit gives a reference invoked *now* and one invoked *later* the same shape, so a reference-walking rule cannot say **when** a reach happens.

### Evidence

- `ArchitectureTest` 3/0/0/0, `RebalanceCallbackRuleControlTest` 2/0/0/0, `RetryQueueTest` 7/0/0/0, `ShardManagerTest` 5/0/0/0 - fresh surefire.
- Core unit module 862 tests / 0 failures / 0 errors / 8 skipped; whole reactor 964/0/0/8 via `bin/ci-unit-test.sh`.
- `bin/check-all.sh`: 19 ran, 16 passed, 0 failed.

## Checklist

- [x] Docs updated - `docs/inflight/static-archunit-main-code-rules.md` gains the 2026-09-07 measurements beside its dated text; `docs/inflight/core-retry-queue-needs-a-runtime-controller-ownership-guard.md` is new and files the runtime half.
- [x] N/A - no user-facing feature: this is a test gate plus a marker annotation with no runtime behaviour.
- [x] Tests added/updated - `RebalanceCallbackRuleControlTest` and two `archfixture/` fixtures are the standing control for both halves of the rule.
- [x] `docs/inflight/` working note - N/A as a `pr-`/`branch-` note: this PR's whole content is a gate and its record, and that record is written where it is owned (`static-archunit-main-code-rules.md`, which already tracks `KNOWN_BLOCKING_VIOLATIONS`) rather than into a second note that would be deleted on merge. The new `core-` note is the deferred work this PR *does not* do.
- [x] Title & body reflect the final content of this PR
- [x] N/A - asked for `@claude review this` on the PR instead. The measurements it would look for (red first, both control removals, the constructor rejection) were taken by hand and are in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rEzrWYFr6oEzy6porczd3
