### PR TITLE
test(core): the Lincheck shard harness assigns the partition it already claims to model

### DIFF
--- a/docs/inflight/core-stale-arrival-guard-needs-a-null-safety-decision.md
+++ b/docs/inflight/core-stale-arrival-guard-needs-a-null-safety-decision.md
@@ -81,3 +81,25 @@ NullAway lane.
 Until both are answered, this stays parked. The mechanism it guards is documented in
 `PartitionState#epochIsStale`'s three-checkpoint javadoc, which also records why re-checking per
 record or consulting the live epoch closes nothing.
+
+## 2026-09-03: a fourth fixture, found by a harness rather than by the prototype
+
+Added beside the text above rather than over it - the decision is unchanged, its evidence is not.
+
+`ShardManagerLincheckTest` reached `ProcessingShard.isWorkContainerStale`'s unguarded deref of
+`PartitionStateManager.getPartitionState` and reported `NullPointerException` in CI. It is the same
+shape as the three fixtures named above - a harness driving a `PCModuleTestEnv` whose partition was
+never assigned - and it had simply never taken the branch before: the branch needs an arrival to find
+a RESIDENT at its offset, and while every revoke sweep removed the resident and, under KEY ordering,
+the empty shard with it, every add was an insertion into nothing. A sweep that DECLINES leaves the
+resident in place, so the next add takes the branch.
+
+**The sighting was on astubbs/parallel-consumer#431's branch, which is still open**, and the
+declining sweep is what that PR adds - so the reach is not yet available on `master`, and
+`ShardManagerLincheckTest` was re-measured green here without the fixture change. Recorded now rather
+than when that PR lands, because the datum is about this note's question and does not depend on its
+outcome: the unguarded call is reachable from a *state the product deliberately creates*, not only
+from a test shortcut, which is a datum for the second bullet under "The decision needed".
+
+Fixed as a fixture - the harness now assigns its partition, which is what its own constructor claims
+to model - so this note's policy question is untouched.

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/utils/ThreadUtils.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/utils/ThreadUtils.java
@@ -66,4 +66,27 @@ public class ThreadUtils {
     public static void sleepSecondsLog(int seconds) {
         sleepLog(seconds * 1000);
     }
+
+    /**
+     * Joins {@code thread} for at most {@code timeout}, restoring the interrupt flag if interrupted.
+     * <p>
+     * It lives here rather than in the one test that calls it today because this wrapper is what gets
+     * hand-rolled: `join` with a timeout plus an interrupt restore is four lines that every thread-racing test
+     * in {@code state} needs, and a second private copy is how the drift starts. Putting it in the shared
+     * utility on the way past is cheaper than deduplicating two copies later.
+     * <p>
+     * A {@code null} thread is a no-op, so a {@code finally} block can call this before it knows whether the
+     * thread was ever started - which is the shape that makes it usable for cleanup and not only for the happy
+     * path.
+     */
+    public static void joinQuietly(Thread thread, Duration timeout) {
+        if (thread == null) {
+            return;
+        }
+        try {
+            thread.join(timeout.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
 }

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/ShardManagerLincheckTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/ShardManagerLincheckTest.java
@@ -6,6 +6,7 @@ package bz.stub.parallelconsumer.state;
 import bz.stub.parallelconsumer.ParallelConsumerOptions;
 import bz.stub.parallelconsumer.internal.PCModuleTestEnv;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.jetbrains.lincheck.datastructures.IntGen;
 import org.jetbrains.lincheck.datastructures.Operation;
 import org.jetbrains.lincheck.datastructures.Param;
@@ -104,6 +105,31 @@ public class ShardManagerLincheckTest {
 
     private static final String TOPIC = "lincheck-topic";
 
+    /**
+     * The partition every record here belongs to, ASSIGNED in the constructor.
+     * <p>
+     * Not decoration. {@code PartitionStateManager.getPartitionState} is an unguarded
+     * {@code partitionStates.get(tp)}, so with no assignment it answers {@code null} for every container in
+     * this harness - and {@link ProcessingShard#addWorkContainer} dereferences it, through
+     * {@code isWorkContainerStale}, the moment an arrival finds a RESIDENT at its offset. While every
+     * revoke sweep removes the resident - and, under KEY ordering, the empty shard with it - that branch is
+     * unreachable here, because every {@code addWork} is an insertion into nothing. A sweep that DECLINES
+     * leaves the resident in place, the next {@code addWork} takes the branch, and the harness reports
+     * {@code NullPointerException} on the fixture rather than on the shard map. That is where this was
+     * measured: astubbs/parallel-consumer#431's branch, which adds the declining sweep and is still open.
+     * <p>
+     * <b>So on master this is latent, and fixing it here is deliberate.</b> The harness is green without the
+     * assignment today - re-measured, not assumed - and would go red the moment that PR lands, on its
+     * fixture rather than on the thing it tests. A harness whose fixture contradicts its own comment is a
+     * false green waiting for a schedule, so it is corrected where the correction is cheap and separable.
+     * <p>
+     * Assigning the partition is what the fixture already claims to model - the constructor's "ordinary
+     * steady state of a running consumer", which has its partition assigned. It does not touch the parked
+     * policy question of whether an absent {@code PartitionState} should be an error, which
+     * {@code docs/inflight/core-stale-arrival-guard-needs-a-null-safety-decision.md} owns.
+     */
+    private static final TopicPartition TP = new TopicPartition(TOPIC, 0);
+
     private final PCModuleTestEnv module = new PCModuleTestEnv(ParallelConsumerOptions.<String, String>builder()
             .ordering(KEY)
             .build());
@@ -146,6 +172,10 @@ public class ShardManagerLincheckTest {
     }
 
     public ShardManagerLincheckTest() {
+        // The partition these records came from is assigned first, so the shard's staleness question has an
+        // answer instead of a null - see TP.
+        module.workManager().onPartitionsAssigned(UniLists.of(TP));
+
         // Initial state: one record already tracked, i.e. the shard exists and is not empty. This is the
         // ordinary steady state of a running consumer, not a state contrived to expose anything.
         sm.addWorkContainer(EPOCH, records[0]);

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/ShardPopulationRaceTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/state/ShardPopulationRaceTest.java
@@ -5,6 +5,7 @@ package bz.stub.parallelconsumer.state;
  */
 
 import bz.stub.parallelconsumer.ParallelConsumerOptions;
+import bz.stub.parallelconsumer.internal.utils.ThreadUtils;
 import bz.stub.parallelconsumer.internal.PCModuleTestEnv;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import pl.tlinkowski.unij.api.UniLists;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -212,7 +214,7 @@ class ShardPopulationRaceTest {
                     var thread = new Thread(() -> sm.removeShardIfEmpty(ShardKey.ofKey(this)), "shard-collector");
                     collector.set(thread);
                     thread.start();
-                    joinQuietly(thread, 500);
+                    ThreadUtils.joinQuietly(thread, Duration.ofMillis(500));
                 }
                 return super.offset();
             }
@@ -257,13 +259,5 @@ class ShardPopulationRaceTest {
 
     private ConsumerRecord<String, String> recordAt(long offset) {
         return new ConsumerRecord<>(TOPIC, 0, offset, "a-key", "value-" + offset);
-    }
-
-    private static void joinQuietly(Thread thread, long millis) {
-        try {
-            thread.join(millis);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
     }
 }


### PR DESCRIPTION
No fork issue exists for this work: it is test-harness hygiene extracted from astubbs/parallel-consumer#431, tracked only as in-flight notes. It depends on nothing.

## Description

**Two test-harness fixes extracted from astubbs/parallel-consumer#431 so they can land independently of the fix.** Neither touches production code.

### 1. `ShardManagerLincheckTest` assigns the partition it already claims to model

`PartitionStateManager.getPartitionState` is an unguarded `partitionStates.get(tp)`, so a harness that never assigns its partition gets `null` for every container in it - and `ProcessingShard.addWorkContainer` dereferences that, through `isWorkContainerStale`, the moment an arrival finds a **resident** at its offset. The harness's own constructor comment claims to model "the ordinary steady state of a running consumer", which has its partition assigned. It did not. The fix is one `onPartitionsAssigned` in the constructor, the same idiom `WorkManagerLincheckTest` already uses.

**Re-measured on master rather than carried over, and one claim from the original commit does *not* hold here:**

- **The NPE is not reachable on master.** `ShardManagerLincheckTest` is green with the fixture change reverted (1 test / 0 failures, lane 37s). The branch needs a sweep that **declines** to leave the resident in place, and that is what astubbs/parallel-consumer#431 adds. So on master this is latent - the harness would go red on its own fixture the moment that PR merges, on the fixture rather than on the shard map it exists to test. Fixing it here is deliberate: it is cheap, separable, and a harness whose fixture contradicts its own comment is a false green waiting for a schedule.
- **The teeth do still hold on master.** Restoring the astubbs#345 defect this harness regression-tests against - the `containsKey`-then-`get` pair in `ShardManager.removeWorkFromShardFor` with an unconditional deref - turns it **red** on the fixed fixture: `revokeSweep(0): NullPointerException ... Cannot invoke ProcessingShard.removeWorkAtOffset(long) because the return value of Map.get(Object) is null`, against `revokeSweep(0)` - the sweep racing itself, the route the harness javadoc records. `ShardManager` restored, empty diff verified.

The fixture javadoc and the dated paragraph in `docs/inflight/core-stale-arrival-guard-needs-a-null-safety-decision.md` are reworded accordingly - both said the declining sweep *had* landed, which is true on that PR's branch and false here. The note keeps the sighting, because the datum it contributes (the unguarded call is reachable from a state the product deliberately creates, not only from a test shortcut) does not depend on that PR's outcome. It does not touch the parked policy question that note owns.

### 2. One `joinQuietly` for the state tests

The same join-with-timeout-and-restore-the-interrupt wrapper was hand-rolled in two `state` tests on astubbs/parallel-consumer#431's branch. **Only one of them exists on master**, so what lands here is the hoist, not a deduplication: the wrapper moves into the shared test `ThreadUtils`, `ShardPopulationRaceTest` calls it, its private copy goes, and the javadoc says why a single-caller helper is hoisted rather than claiming a second caller that is not here. Behaviour unchanged - `500` becomes `Duration.ofMillis(500)` and nothing else moves.

### Evidence

- Lincheck lane green, 2m51s (build included): `ShardManagerLincheckTest` 1/0/0/0, `WorkManagerLincheckTest` 2/0/0/0, `RetryQueueLincheckTest` 1/0/0/0, `PartitionStateLincheckTest` 1/0/0/0, `LincheckSuperHashCodeProbeTest` 2/0/0/0, `LincheckToolchainProbeTest` 2/0/0/0.
- `ShardPopulationRaceTest` 4/0/0/0, `ShardManagerTest` 5/0/0/0, `RetryQueueTest` 7/0/0/0 - fresh surefire.
- Core unit module 860 tests / 0 failures / 0 errors / 8 skipped; whole reactor 962/0/0/8 via `bin/ci-unit-test.sh`.
- `bin/check-all.sh`: 19 ran, 16 passed, 0 failed.

## Checklist

- [x] Docs updated - `docs/inflight/core-stale-arrival-guard-needs-a-null-safety-decision.md` gains the dated sighting, corrected for master.
- [x] N/A - test-only change, no user-facing behaviour.
- [x] Tests added/updated - both commits are test changes; the harness's teeth were re-verified by restoring the defect it regression-tests against.
- [x] `docs/inflight/` working note - N/A as a `pr-`/`branch-` note: nothing here that `gh` cannot show. The one durable finding (the unguarded deref is reachable from a real product state) is recorded in the note that already owns that question, rather than in a second note deleted at merge.
- [x] Title & body reflect the final content of this PR
- [x] N/A - asked for `@claude review this` on the PR instead. The reuse finding behind commit 2 came from a `ce-simplify` pass on the source branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rEzrWYFr6oEzy6porczd3
