### PR TITLE
docs(inflight): two notes for refactoring the God class and the five classes below it

### DIFF
--- a/docs/inflight/core-decompose-abstract-parallel-eos-stream-processor.md
+++ b/docs/inflight/core-decompose-abstract-parallel-eos-stream-processor.md
@@ -1,0 +1,265 @@
+# Decompose `AbstractParallelEoSStreamProcessor`: the seams, the old attempts and their ideas, and what to merge first
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: refactor -->
+
+Recorded 2026-09-08, from a session that read every branch that ever attempted this, the upstream
+drafts they were proposed as, every open PR's own changes to the class, and ranked what has to land
+before a cut is safe. **This note owns the decision; [`docs/refactoring.md`](../refactoring.md)
+keeps the heading "Decompose the God class" as a pointer here**, because other notes and the manifest
+cite it by that name. The fork-to-upstream registration is the manifest's
+`refactor-thread-model-god-class` entry, which stays the source of truth for which branch maps to
+which upstream PR.
+
+The five classes below it in size have their own note,
+[`core-shrink-the-five-next-largest-classes.md`](core-shrink-the-five-next-largest-classes.md); the
+two are separate because their blockers are different PRs.
+
+## What is in the class, and why the size is not written here
+
+The class holds the control loop, the lifecycle state machine, the rebalance callbacks, commit
+orchestration, worker-pool construction and its rejection guard, the user-function runner, and the
+mailbox the workers post into. Read the method list rather than a description of it:
+
+```bash
+grep -nE '^\s{4}(public|protected|private)[^=;]*\(' \
+  parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java
+```
+
+**Size is deliberately not written down.** It was recorded as a line count once, and was still being
+cited as that after the class had grown by most of a thousand lines - a stale figure reads as current
+state forever, and nothing goes red. Ask `wc -l` on the path above instead.
+
+**One argument built on that stale figure is falsified, and the falsification is the reason to act.**
+`docs/ideation/2026-08-17-actor-collection-revival-ideation.html` reasons from "the file has moved one
+line in 3.5 years, which is the clearest evidence that branch-shaped goals don't move it", and
+proposes tracking progress by the line count. Measured 2026-09-03: the class was the size that
+ideation quotes on the ideation's own date and was over a thousand lines larger a fortnight later.
+The dated record is left as written, per [`docs/citations.md`](../citations.md); the correction lives
+here, where the live decision is. It does not weaken the case for decomposing - it inverts the reason.
+**The class is not inert, it is accreting**, and every engine change of the last month landed inside
+it: the revoke-commit request protocol, the worker-pool shutdown guards, task accounting, direct pull
+as a bolt-on pool.
+
+**Landing this unblocks whole-file static analysis, one file at a time.** The new-code analysis
+profile is scoped to changed *lines* rather than changed *files* purely because of size: touching a
+class this large would otherwise inherit every latent finding in it. Line scoping misses a finding
+reported away from the edit that caused it. Each file that comes down to a reviewable size can be
+promoted to file scoping on its own; [`static-analysis-rule-profiles.md`](static-analysis-rule-profiles.md)
+owns the profiles and carries the promotion list, which is empty until the first cut lands.
+[`static-spotbugs-rule-registry.md`](static-spotbugs-rule-registry.md) holds a detector gated on the
+same event.
+
+## The seams, from the only split that ever compiled
+
+The 2022 attempt is one tree from one base, catalogued under `branch_accounting` in
+`src/docs/development/upstream-map.yaml` (`bin/inflight.mjs branch <ref>` answers for any of them):
+`origin/refactor/function-runner` at the root, `origin/refactor/extract-controller` and
+`origin/refactor/state-machine` as siblings on it, and `origin/refactor/control-loop` as the
+integration branch that merged both and then did the real work - it compiles, with tests migrated and
+a review pass. **It was proposed upstream as confluentinc#488**, whose body is the whole design in four
+lines: *function runner, worker pool, worker; controller, rebalance handler, configuration validator,
+subscription interface; state machine; control loop.* **No ref since 2023 has added any of its classes
+to main code**, so it has no successor. Reading it as a branch to merge is wrong: it predates the
+package rename, every engine change since, and the test suite as it now exists. Read it as a map.
+
+| Seam | The 2022 class | Where it is on master today | What moved since, and the verdict |
+|---|---|---|---|
+| **Lifecycle** | `StateMachine` on `origin/refactor/state-machine` - the `State` field, the failure reason, close, drain, the draining and closing transitions, `maybeCloseConsumer` | Same method names, still on the God class: `transitionToDraining`, `transitionToClosing`, `doClose`, `innerDoClose`, `areMyThreadsDone`. The `State` enum is unchanged | Close now interleaves with the revoke-commit protocol (`completePendingRevokeCommitFromClose`, `failPendingRevokeCommitOnControlThreadExit`) and the pool-shutdown guards. **Still the cleanest single cut, and the one whose method set still maps one to one.** First rung |
+| **Rebalance and subscription** | `RebalanceHandler` implementing `ConsumerRebalanceListener` and a `SubscriptionHandler` interface, on `origin/refactor/extract-controller`; commit-on-revoke inline. Its javadoc states the second reason for the cut: *so the user doesn't have access to the public rebalance interface methods* | `subscribe` and the three callbacks on the God class, now the fastest-growing region: revoke hands a `RevokeCommitRequest` to the control thread and waits (`commitOnRevokeViaTheControlThread`, `waitForTheTakenRequest`), with the decline and failure paths astubbs#451 added | The 2022 content is obsolete; **the seam is still right**, and it is where the request-and-wait protocol belongs. Second rung, and the one that removes the most |
+| **Worker pool and runner** | `PCWorkerPool` and `FunctionRunner` on `origin/refactor/function-runner`; `ExternalEngineRunner` with `VertxRunner` and `ReactorRunner` as runner subclasses on `origin/refactor/control-loop` | `setupWorkerPool`, `requireRejectionIsVisible`, `submitWorkToPool`, `makeBatches`, `runUserFunction` and `runUserFunctionInternal` on the God class, plus the static `UserFunctions` entry point; `ExternalEngine` still subclasses the God class | astubbs#360 changes the pool's type and moves queue-depth reading into `UserFunctionTaskAccounting`; astubbs#361 adds `DirectPullWorkerPool` beside it. **Cut this after both land**, or the cut and the two PRs fight over the same methods |
+| **Control loop** | `ControlLoop` on `origin/refactor/control-loop` - the pass, commit timing, `maybeAcquireCommitLock`, `maybeWakeupPoller` | `controlLoop`, `controlLoopPass`, `isTimeToCommitNow`, `maybeAcquireCommitLock`, `checkPipelinePressure` and the load-factor family on the God class | astubbs#361 removes work distribution from the pass entirely under direct pull. Cut after it |
+| **Mailbox** | `WorkMailbox` wrapping the blocking queue and `ControllerEventMessage` as a nested type | `workMailBox` is an inline field; `ControllerEventMessage` is already its own class; `processWorkCompleteMailBox` and `addToMailbox` on the God class | The actor section of `docs/refactoring.md` names a first slice - stop waking the control thread by interrupting it - and says it belongs *with* this decomposition, not before it. The mailbox cut is where that slice goes |
+| **Configuration validation** | `ConfigurationValidator` on `origin/refactor/control-loop` | `validateConfiguration`, `checkGroupIdConfigured`, `checkAutoCommitIsDisabled` and the reflective `getAutoCommitEnabled` on the God class | Untouched by any open PR. A free cut at any time, and the brittle consumer-by-classname check `docs/refactoring.md` lists moves with it |
+
+The 2022 queue reworks on top of this family (`origin/refactor/worker-queues`, the two
+`origin/refactor/gpt3-*` branches) are not decomposition and are superseded by measurement; their
+record is branch-only, on `origin/perf/engine-concurrency` (astubbs#363):
+`git show aebf9d02b:docs/inflight/parked-2022-central-queue-rework.md` for the retraction of the "1/3
+as fast" verdict, and `git show aebf9d02b:docs/inflight/perf-direct-pull-measured.md` for the
+rebuilt-and-measured direct-pull engine that astubbs#361 carries.
+
+## The older upstream drafts, and the ideas worth keeping from each
+
+Every one of these was written by the same author as upstream maintainer, so "upstream draft" and
+"fork branch" name the same commits: the fork remote holds the working branches, and
+`origin/upstream/*` holds the copies upstream had when it closed them unmerged in the 2023 sweep.
+`src/docs/development/upstream-pr-analysis.adoc` Group C ranks them and rules *keep ideas, not code*;
+the manifest's `sweep-2023-actor-ipc` and `refactor-thread-model-god-class` entries register them.
+What follows is the idea in each, read from its own body, javadoc and commits - which is the part the
+adoc's one-line verdicts do not carry.
+
+- **confluentinc#488, "Refactor God class to components"** (`origin/refactor/control-loop`, 2022-12).
+  The seam table above *is* confluentinc#488. Its checklist left one item nobody has since answered:
+  *ordering of components in new classes* - which class owns construction order once the God class
+  no longer does. Decide it at the first cut, because `PCModule` is where that order lives today and
+  [`core-pcmodule-injection-seam.md`](core-pcmodule-injection-seam.md) records that its registration
+  is already write-only.
+- **confluentinc#325, "New IPC system using lightweight Lambda actor queue"**
+  (`origin/improvements/lambda-actor-bus`, 2022-07). The bus itself is separable, the manifest
+  verified: a handful of files under `io.confluent.csid.actors` whose only PC coupling is one marker
+  interface. **The payload that matters here is not the bus, it is the six interfaces the branch
+  puts on the God class** - `ControllerInternalAPI` ("Internal thread safe API for the Controller"),
+  `BrokerPollerAPI`, `WorkManagerIPCAPI`, `Supervisable`, `MultithreadingAPI` ("all these methods
+  should go through the Actor system") and `ThreadSafe`. They partition the class's surface **by who
+  may call it**, which is the same partition the seam table makes by *what it does*, from the other
+  side. The 2026-08-17 ideation calls this the strangler seam: interface segregation lands as a pure
+  refactor, and the transport underneath becomes a swap rather than a bet. Take the interfaces with
+  the cuts; leave the bus for the thread-model decision.
+- **confluentinc#524, "Use Actor for commit commands"** (`origin/improvements/commit-command-actor`,
+  2022-12). The commit seam as a command actor, on top of the two below. Not a decomposition step -
+  it changes *which thread* commits - so it is gated on the thread-model decision. Its `CommitData`
+  type, a value object for what a commit carries between threads, is the reusable idea and would be
+  wanted by the rebalance cut regardless.
+- **confluentinc#270, "Shared nothing architecture - Partition Events"**
+  (`origin/improvements/rebalance-messages`, 2022-04, tracker confluentinc#200, mirror astubbs#142).
+  Rebalance events reach the controller as messages instead of the callback thread mutating shared
+  state; its body names the consequence for the poller - *BrokerPoller can't access state - when
+  performing commit, must request or be sent commit offset data by state owner* (confluentinc#419) -
+  and removes the separate `onPartitionsLost` path as indistinguishable from revoke. **This is the
+  design the rebalance cut should leave room for**: a `RebalanceHandler` that today calls into the
+  God class directly can later post a message instead, if the seam is drawn at the callback rather
+  than inside it.
+- **confluentinc#271, "Major package restructure"**
+  (`origin/upstream/improvements/package-restructure`, 2022-04). Six commits that never got a body,
+  but the tree says what it meant: `controller`, `kafkabridge` (`ConsumerRebalanceHandler`,
+  `OffsetCommitter`), `sharedstate` (`PartitionEventMessage`, `CommitRequest`, `CommitResponse`),
+  `offsets`, and `internal` for what is left, plus a `ControllerEventBus` and a
+  `PartitionEpochTracker`. **It is the package layout for the seams above**, and the adoc's verdict -
+  *blast radius too large on its own; fold into C1/C2* - still holds: move a class into its package
+  as it is cut, never as a sweep.
+- **confluentinc#45, "direct work loading, direct result processing"** (`origin/direct-ringbuffer`,
+  2020-12) and its 2022 descendants, the `gpt3-*` branches. Superseded: astubbs#361 is the finished,
+  measured form of the same idea. Nothing to take.
+- **`origin/massive-refactor`** (2020-12, the first attempt, never proposed upstream). Introduced
+  `WorkMailbox`, `PartitionState`, `KafkaQueueManager` and the self-tuning load factor in one
+  21-commit branch; `PartitionState` and the load factor landed by other routes, the rest did not. Its
+  lesson is the one `docs/refactoring.md` records for `origin/move-cons-to-pc`, three weeks earlier
+  still: the earliest attempt moved the consumer back into the controller so commits were in line with
+  control, and the record does not say why it stopped. **Both stopped because they were one branch.**
+- **`origin/improvements/interrupt-reason`** (2022-07). An `InterruptibleThread` that carries a
+  *reason* with the interrupt. It is the ancestor of the first slice in
+  [`waking-a-thread-by-interrupting-it-2026-08-17.md`](../solutions/workflow-issues/waking-a-thread-by-interrupting-it-2026-08-17.md),
+  which chose a message over a reason-bearing interrupt; the mailbox cut is where that lands.
+- **`origin/improvements/poller-bus-actor`** (2022-07). The poller as an actor, on a *second*,
+  unreconciled actor base; its own commit says the two bases must be unified first. Gated on the
+  thread-model decision, and out of scope for the cuts - it belongs to `BrokerPollSystem`'s note.
+- **`origin/refactor/infinite-retry`** (2022-11). Moves timeout-retry into the controller so the
+  poller only forwards the error. A control-loop concern; revisit at that cut, not before.
+
+**The ideation's other keeper, stated once so it is not re-derived:** encode the current census of
+concurrency primitives in the engine as an ArchUnit rule that fails when it rises, so every cut is
+graded by what it *deletes* rather than what it moves. That is the falsifiable, mechanism-neutral
+target the line count was wrongly asked to be;
+[`static-archunit-main-code-rules.md`](static-archunit-main-code-rules.md) is where such a rule would
+live.
+
+## Merge before you cut
+
+Measured 2026-09-08 by diffing every open PR's tip against **its own merge base** with master, on
+this class and the ten next largest, with the package rename normalised. **Measure from the merge
+base, never two-dot against master's tip**: the two-dot form counts everything master added since the
+branch forked as the branch's own deletions, and made every stale draft look like it rewrote the
+engine. Most of those turned out to carry nothing but the package rename in their imports. The script
+is at the end of this note; re-run it rather than trusting the ranking below to have stayed true.
+
+Ordered by how much of the class each rewrites, weighted by readiness. The ones that touch this class
+directly:
+
+1. **astubbs#360, virtual threads for the user function.** Root of the engine stack. Changes what
+   `setupWorkerPool` returns and pulls queue-depth accounting out into its own class - a piece of this
+   decomposition already done. Its base is three weeks stale but every parent has merged.
+2. **astubbs#361, direct pull with an O(1) shard scan.** The largest single removal from the control
+   loop on any open branch: work selection leaves the pass. Depends only on astubbs#360 now; its other
+   declared parents (astubbs#335, astubbs#336, astubbs#358, astubbs#201) are merged.
+3. **astubbs#352, the commit-failure seam.** Second-largest standalone rewrite of the class, and it
+   also reaches `ProducerManager`, `BrokerPollSystem` and the options. No declared parents.
+4. **The astubbs#225 producer-recovery stack** - astubbs#472, astubbs#474, astubbs#410, astubbs#420,
+   then the conflicting leaves astubbs#434 and astubbs#408. Fresh, linear, mergeable at the root. It
+   rewrites the revoke and close paths on this class and a third of `ProducerManager`, so the
+   lifecycle and rebalance cuts should wait for at least the root four.
+5. **astubbs#226, the health-check surface.** A modest hook into this class, on a base from early
+   August. Rename it and rebase it, or close it; do not cut around it.
+
+**Do not wait for these.** astubbs#333, astubbs#392 and astubbs#456 (adaptive concurrency and the two
+navigator rungs) are the biggest numbers in the scan, but they are one linear stack based on
+astubbs#361 through astubbs#363 and inherit whatever the cut does once astubbs#361 lands; sequence them
+after. astubbs#362 and astubbs#363 are records and harness. The astubbs#242 proxy stack and the
+astubbs#255 Streams stack touch this class only through the package rename. The drafts that carry
+only the rename in their imports need `bin/rename-packages.sh`, not a merge slot.
+
+## Recommended cut order
+
+1. **Configuration validation** - unblocked today, and a rehearsal of the mechanics.
+2. **Lifecycle** (`StateMachine`) - smallest of the real cuts, maps cleanly, blocked only on the
+   astubbs#225 root.
+3. **Rebalance and subscription** (`RebalanceHandler`) - biggest removal, blocked on the same. Draw
+   the seam at the callback so confluentinc#270's message form stays possible.
+4. **Worker pool and runner** - after astubbs#360 and astubbs#361.
+5. **Control loop** - after astubbs#361.
+6. **Mailbox**, carrying the interrupt-to-message slice.
+
+With each cut, put the matching confluentinc#325 interface on the new class's surface, and move the
+class into its confluentinc#271 package. Each cut can promote its file to file-scoped analysis on its
+own; do not wait for the whole set.
+
+## Rules that bind the cut
+
+- [`parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md`](../../parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/AGENTS.md)
+  owns the field rules: `@GuardedBy` in the same change that moves a fixed race, `@ThreadConfined`
+  asserted at the entry point, and the ledger of known shared state. Moving a field to a new class
+  moves its ledger entry.
+- `ControllerThreadOnly` and `assertOnControlThread` are the thread-ownership contract. A cut that
+  moves a method across that boundary has changed the thread model, not just the file.
+- [`two-threads-one-consumer-why-the-commit-seam-keeps-deadlocking.md`](../solutions/architecture-patterns/two-threads-one-consumer-why-the-commit-seam-keeps-deadlocking.md)
+  is why the rebalance cut must not change *which thread* commits on revoke while moving the code
+  that does it, and
+  [`the-revoke-path-commit-did-not-drain-the-mailbox-2026-09-07.md`](../solutions/logic-errors/the-revoke-path-commit-did-not-drain-the-mailbox-2026-09-07.md)
+  is the most recent defect from a callback running on a thread that does not own the state it needs -
+  the exact hazard a rebalance class on its own file hides better than the monolith does.
+  [`core-control-thread-contract-debts.md`](core-control-thread-contract-debts.md) lists the debts
+  that cut inherits.
+- [`a-mirror-of-state-another-component-owns-is-a-contract-nobody-wrote.md`](../solutions/architecture-patterns/a-mirror-of-state-another-component-owns-is-a-contract-nobody-wrote.md):
+  a new class that caches something the God class still owns has created exactly the contract
+  confluentinc#270 was written to remove. Pass the owner, not a copy.
+- The shared-nothing thread model (confluentinc#200, mirror astubbs#142) is the larger rework
+  `docs/refactoring.md` says to do this alongside. Doing the cuts first is compatible with it: every
+  seam above is a boundary that model would also need.
+
+## Prior art checked
+
+- `bin/inflight.mjs prior-art` across every ref for the class name, the five seam names and
+  "decompos": no plan or note proposes the cut; the hits are the analysis registries gated on it
+  and the plan for splitting *branches*, which is about PR stacks despite the name and lives only on
+  `origin/docs/god-branch-decomposition-plan`:
+  `git show 90188f0bb:docs/plans/2026-08-31-001-process-god-branch-decomposition-plan.md`.
+- `gh pr list --state merged` by file: the merged engine work of the last month is inside the class,
+  none of it extracts.
+- `gh issue list --state all` and `gh pr view -R confluentinc/parallel-consumer` for each draft
+  above: confluentinc#200 and confluentinc#186 are the open upstream trackers; none has a fork PR.
+- `git log --all --diff-filter=A` for the five class names in main code since 2023: nothing.
+
+## Reproduce the merge-base measurement
+
+Ranks every open PR by its own changes to the listed classes, from its merge base, normalising the
+package rename. Run from any checkout after `git fetch --all --prune`.
+
+```bash
+NEW=bz/stub/parallelconsumer; OLD=io/confluent/parallelconsumer
+REL="internal/AbstractParallelEoSStreamProcessor.java state/PartitionState.java state/WorkContainer.java \
+     ParallelConsumerOptions.java state/ShardManager.java internal/BrokerPollSystem.java"
+pkgof() { git cat-file -e "$1:parallel-consumer-core/src/main/java/$NEW/ParallelConsumerOptions.java" 2>/dev/null && echo "$NEW" || echo "$OLD"; }
+gh pr list -R astubbs/parallel-consumer --limit 100 --json number,headRefName --jq '.[] | "\(.number)\t\(.headRefName)"' |
+while IFS=$'\t' read -r n ref; do
+  git rev-parse -q --verify "origin/$ref" >/dev/null || continue
+  mb=$(git merge-base origin/master "origin/$ref"); bp=$(pkgof "$mb"); rp=$(pkgof "origin/$ref"); tot=0; line=""
+  for r in $REL; do
+    a="parallel-consumer-core/src/main/java/$bp/$r"; b="parallel-consumer-core/src/main/java/$rp/$r"
+    git cat-file -e "origin/$ref:$b" 2>/dev/null || continue
+    st=$(git diff --numstat "$mb:$a" "origin/$ref:$b" 2>/dev/null | awk '{print $1, $2}'); [ -z "$st" ] && continue
+    set -- $st; [ "$1$2" = 00 ] && continue
+    line="$line ${r##*/}(+$1/-$2)"; tot=$((tot + $1 + $2))
+  done
+  [ "$tot" -gt 0 ] && printf '%5d\t%s\t%s\t%s\n' "$tot" "$n" "$ref" "$line"
+done | sort -rn
+```

--- a/docs/inflight/core-shrink-the-five-next-largest-classes.md
+++ b/docs/inflight/core-shrink-the-five-next-largest-classes.md
@@ -1,0 +1,178 @@
+# Shrink the five next-largest classes: `PartitionState`, `WorkContainer`, `ParallelConsumerOptions`, `ShardManager`, `BrokerPollSystem`
+
+<!-- inflight-type: task -->
+<!-- inflight-impact: refactor -->
+
+Recorded 2026-09-08 alongside
+[`core-decompose-abstract-parallel-eos-stream-processor.md`](core-decompose-abstract-parallel-eos-stream-processor.md),
+which owns the God class, the merge-base measurement script, and the rules that bind any cut in the
+engine. This note is the same question for the five classes below it in size: what each one holds,
+which open PRs rewrite it and so must land first, which notes already track a defect inside it, and
+where a cut would go. The per-file lines `docs/refactoring.md` keeps for these classes are the small
+tidy-ups; they stay there, and nothing here restates them.
+
+**Which five, and why not others.** Rank main code by `wc -l` and take the five below the God class:
+
+```bash
+git ls-files 'parallel-consumer-*/src/main/java/**/*.java' | xargs wc -l | sort -rn | head -12
+```
+
+`ProducerManager`, `PartitionStateManager`, `WorkManager` and `ProcessingShard` sit just under these
+and share their blockers; they are named where a cut reaches them but get no section of their own.
+
+**The order across the five, by what is blocked on least:** `ParallelConsumerOptions` and
+`BrokerPollSystem` are cuttable once astubbs#352 is decided; `WorkContainer` once astubbs#468 and
+astubbs#359 land; `ShardManager` once astubbs#431 and astubbs#361 land; `PartitionState` last, behind
+three fresh PRs and the whole astubbs#225 stack.
+
+## `PartitionState`
+
+**What it holds.** Two things wearing one class: the per-partition **offset ledger** (the incomplete
+offsets map, highest seen and highest succeeded, the bootstrap truncation in
+`maybeTruncateBelowOrAbove`, the epoch check) and the **commit-payload encoder** (`tryToEncodeOffsets`,
+`updateBlockFromEncodingResult`, the pressure threshold, the `dirty` flag and `getCommitDataIfDirty`),
+plus a metrics block of gauges and distribution summaries that is a third concern on its own.
+
+**The seam.** The encoder half talks to `OffsetMapCodecManager` and nothing else in the class; the
+ledger half is what the control loop and the shard manager read. The `refactors/offsets-class` and
+`refactors/refactor-psm-and-ps` branches of 2022 attempted exactly this split (`docs/refactoring.md`,
+"Offsets/state classes", tied to confluentinc#233, mirror astubbs#117) and are the prior art to read.
+
+**Merge first.**
+- astubbs#470 (open, on today's master): async commit success waits for the broker's answer. Small,
+  and it changes when `onOffsetCommitSuccess` may run.
+- astubbs#469 (draft, on today's master): the two flags that cross threads, `allowedMoreRecords` and
+  `fencedForRevocation`, measured then fenced or redesigned. **This is the thread-model decision for
+  the class**; splitting before it means deciding it twice.
+  [`bug-allowed-more-records-crosses-threads-unfenced.md`](bug-allowed-more-records-crosses-threads-unfenced.md)
+  is the defect it answers.
+- astubbs#460 (draft, ten commits behind): the offset-metadata rider adds roughly half the class's
+  current size to the encoder half. Decide it before drawing the encoder seam, because it decides
+  what the encoder's output type is.
+- The astubbs#225 stack (astubbs#472 onward) adds the completed-but-uncommitted ledger to this class
+  and `PartitionStateManager`. `docs/refactoring.md`'s `PartitionState` entry already records the
+  replay-order trap astubbs#410 reintroduces; a cut that moves `addNewIncompleteRecord` must keep
+  the register-then-publish order that entry explains.
+
+**Also on this class.**
+[`a-throwing-meter-registry-kills-the-poll-thread-and-strands-close.md`](../solutions/runtime-errors/a-throwing-meter-registry-kills-the-poll-thread-and-strands-close.md)
+is why `initMetrics` and `deregisterMetrics` are shaped as they are; a metrics extraction must keep
+that shape.
+
+## `WorkContainer`
+
+**What it holds.** The record and its epoch, the **execution-state machine** (`onQueueingForExecution`,
+`endFlight`, `isClaimableFrom`, `ExecutionState`, the atomic claim astubbs#335 added), the **retry
+schedule** (`getDelayUntilRetryDue`, `computeRetryDueAt`, the user-supplied delay provider and its
+broken-provider guard), the failure history, and identity (`equals`, `hashCode`, `compareTo`).
+
+**The seam.** The retry schedule is a pure function of the failure history and the options, and is
+the cut with no thread-model content. The execution state is the part every other class touches and
+should stay.
+
+**Merge first.**
+- astubbs#468 (open, one commit behind): equality becomes identity so the stale sweep removes only the
+  container it inspected. This decides what `equals` means, which any extraction of the identity
+  methods must build on, and it also reaches `ProcessingShard`.
+- astubbs#359 (draft, three weeks behind): record residence time. Adds a third of the class's current
+  size, all timing; if it lands, the timing fields are their own cut.
+- astubbs#295 (open) and the astubbs#242 stack above it add the verdict-free return, an additive
+  change to the execution state. Cut after or around it; it does not conflict with a retry-schedule
+  extraction.
+
+**Also on this class.**
+[`a-guard-outlives-the-claim-that-motivated-it.md`](../solutions/best-practices/a-guard-outlives-the-claim-that-motivated-it.md)
+was written against a guard here; read it before keeping or moving any of the defensive checks in
+the execution-state methods.
+
+## `ParallelConsumerOptions`
+
+**What it holds.** The public builder, the validation family (`validate`, `producerSourceValidation`,
+`transactionsValidation`, `loadFactorValidation`), the deprecated fields and their shims
+(`setCommitInterval`, `defaultMessageRetryDelay`, `isUsingTransactionalProducer`, the reflective
+auto-commit work-around flag), and a growing set of engine switches.
+
+**The seam.** Validation into a `ConfigurationValidator`, which is the class the 2022
+`origin/refactor/control-loop` branch already cut for the God class's half of it - the two
+validators belong together. The deprecated members are release-gated removals, listed under
+*Breaking changes queued for next major version* in `docs/refactoring.md`, and are not a refactor.
+
+**Merge first.**
+- astubbs#360 and astubbs#361 each add an engine switch here (`useVirtualThreads`,
+  `directPullEngine`) with a system-property default. Take them before touching the builder, or the
+  validators and the new switches conflict.
+- astubbs#352 adds the commit-failure options and reaches the validation methods.
+- astubbs#333, astubbs#392 and astubbs#456 add the largest block of options on any branch - the
+  admission and rate-limiting surface. Sequence after the cut; they inherit it.
+
+**Nothing else tracks a defect in this class.** It is the one of the five where a cut is a pure
+mechanical move.
+
+## `ShardManager`
+
+**What it holds.** The shard map and its three counters (`getNumberOfWorkQueuedInShardsAwaitingSelection`,
+`getNumberOfRecordsInShards`, `getNumberOfRecordsParkedForRetry`), **work selection**
+(`getWorkIfAvailable`, `getWorkableRecords`, the iteration resume point), the success and failure
+paths that retire or re-queue a container, the stale sweep, and a metrics block.
+
+**The seam.** Selection is the hot path and the thing astubbs#361 rewrites; the counters are the
+conservation figures astubbs#336 introduced; retirement is the retry-queue pairing astubbs#431 is
+about. Three concerns, three PRs, and each PR is the reason not to cut its concern yet.
+
+**Merge first.**
+- astubbs#431 (draft, one commit behind, conflicting on a fresh conflict): the rebalance callbacks
+  decline the retry queue's write lock. It rewrites the lock discipline across this class and
+  `ProcessingShard`, and
+  [`pr-431-must-pair-its-queue-removal-with-the-shard-removal.md`](pr-431-must-pair-its-queue-removal-with-the-shard-removal.md)
+  says what it still owes. Cut retirement after it.
+- astubbs#468: the stale sweep, as above.
+- astubbs#361: selection. `ShardOccupancy` and the O(1) scan replace the walk in
+  `getWorkIfAvailable`; a selection extraction before it would be extracting the code that PR
+  deletes.
+- [`core-shard-selection-counter-can-now-be-derived-by-scan.md`](core-shard-selection-counter-can-now-be-derived-by-scan.md)
+  is deferred and says the selection counter can become derived; that is a counter-half decision to
+  take at the counter cut.
+
+**Constraint no PR removes.** `processingShards` is pinned by a test on purpose - the engine's
+`AGENTS.md` owns the reason. A cut may move the field only by moving the pin with it.
+[`bug-shard-displacement-orphans-the-retry-queue-entry.md`](bug-shard-displacement-orphans-the-retry-queue-entry.md)
+and [`bug-processing-shard-available-work-undercount.md`](bug-processing-shard-available-work-undercount.md)
+are open defects in the retirement and counter paths; fix or carry them, do not obscure them.
+
+## `BrokerPollSystem`
+
+**What it holds.** The poll thread's own control loop (`controlLoop`, `handlePoll`,
+`pollBrokerForRecords`), **back-pressure by pausing the subscription** (`managePauseOfSubscription`,
+`doPause`, `resumeIfPaused`, `shouldThrottle`, the paused-partition diagnostics), the poller's copy of
+the **close sequence** (`doClose`, `closeAndWait`, `transitionToClosing`, `maybeCloseConsumerManager`),
+and the consumer-commit-mode commit path (`retrieveOffsetsAndCommit`, `maybeDoCommit`).
+
+**The seam.** Pause-and-resume is a self-contained policy over `ConsumerManager` and the work
+manager's load figure; it is the cut with no thread-model content. The close sequence and the commit
+path are the two-thread contract itself and must not move without the thread-model decision:
+[`two-threads-one-consumer-why-the-commit-seam-keeps-deadlocking.md`](../solutions/architecture-patterns/two-threads-one-consumer-why-the-commit-seam-keeps-deadlocking.md)
+explains why the two `isResponsibleForCommits` methods look contradictory and are not, and
+[`a-mirror-of-state-another-component-owns-is-a-contract-nobody-wrote.md`](../solutions/architecture-patterns/a-mirror-of-state-another-component-owns-is-a-contract-nobody-wrote.md)
+was written against this class's `runState` mirror.
+
+**Merge first.**
+- astubbs#352 touches the commit path lightly and is the only open PR that changes this class beyond
+  the package rename.
+- Nothing else. The open defects here are the blockers instead:
+  [`bug-poller-death-leaves-the-consumer-open-in-consumer-commit-modes.md`](bug-poller-death-leaves-the-consumer-open-in-consumer-commit-modes.md)
+  and [`bug-shutdown-teardown-race.md`](bug-shutdown-teardown-race.md) are both in the close sequence,
+  and a cut that moves it should fix them on the way or leave them legible.
+
+**The larger question this class is the subject of.** confluentinc#200 (mirror astubbs#142) proposes
+removing the poll thread altogether, and `origin/improvements/poller-bus-actor` tried the poller as an
+actor; both are catalogued in `docs/refactoring.md` under "Thread model". A pause-policy extraction is
+compatible with either outcome. Anything larger is that decision, not a refactor.
+
+## Prior art checked
+
+- `bin/inflight.mjs prior-art` for each of the five class names: the hits are the defect notes cited
+  above and the 2022 `refactors/offsets-class` family; no note proposes a split of any of the five.
+- `gh pr list --state merged` by file for the last month: every merged change to these classes was a
+  fix inside it (astubbs#335, astubbs#336, astubbs#451, astubbs#467); none extracted.
+- `git log --all --diff-filter=A` since 2023 for a `*Validator`, `*Encoder`, `*Policy` or
+  `*Schedule` beside these classes in main code: nothing.

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -368,41 +368,15 @@ cosmetic - see the last bullet.*
   `docs/solutions/architecture-patterns/two-threads-one-consumer-why-the-commit-seam-keeps-deadlocking.md`.
 
 ### Decompose the God class - `AbstractParallelEoSStreamProcessor`
-- Control loop + lifecycle/state machine + commit orchestration + threading +
-  rebalance listener + deprecated options in one class. Design ref: draft
-  `confluentinc#488`. Do alongside the [confluentinc#200](https://github.com/confluentinc/parallel-consumer/issues/200) (mirror astubbs#142) work; high risk.
-- **Size is deliberately not written down here.** It was recorded as 1533 lines and was still being
-  cited as that after the class had grown by most of a thousand - a stale figure reads as current
-  state forever, and nothing goes red. Ask instead:
-  `wc -l parallel-consumer-core/src/main/java/bz/stub/parallelconsumer/internal/AbstractParallelEoSStreamProcessor.java`
-- **And one argument built on that figure is now falsified, which is worth more than the figure.**
-  `docs/ideation/2026-08-17-actor-collection-revival-ideation.html` reasons from "the file has moved
-  one line in 3.5 years, which is the clearest evidence that branch-shaped goals don't move it", and
-  proposes tracking progress by that line count. Measured 2026-09-03: the class was 1534 lines at
-  that ideation's own date and is over a thousand lines larger now - it moved in a fortnight what the
-  argument said it had not moved in three and a half years. The dated record is left as written, per
-  `docs/citations.md`; the correction belongs here, where the live decision is. It does not weaken the
-  case for decomposing - it inverts the reason. The class is not inert, it is accreting, and a
-  line-count target measures growth this section did not predict rather than progress against it.
-- **Two branches already attempted it, and one of them got much further** (both catalogued in
-  `branch_accounting` in `src/docs/development/upstream-map.yaml`; `bin/inflight.mjs branch <name>`
-  answers from any checkout):
-  - `origin/refactor/state-machine` @8f90da8a - extracts the lifecycle state machine only.
-  - `origin/refactor/control-loop` @c3a0f28ae - **the furthest any attempt reached**: it compiles,
-    with tests migrated and a review pass. It cuts along **`ControlLoop` / `Controller` /
-    `StateMachine` / `PCWorkerPool` / `WorkMailbox`**. Those five names are the useful part: this
-    section argues about *whether* to split without recording what a working split actually cut
-    along, and someone starting fresh would re-derive the seams rather than start from a set that
-    was shown to compile. `origin/refactor/controller-extract-base` was a marker for this work and
-    was deleted 2026-09-03 (an ancestor of master, nothing lost).
-- **Landing this unblocks whole-FILE static analysis, and it can be taken piecemeal.** The
-  new-code analysis profile is scoped to changed *lines* rather than changed *files* purely because
-  of size: touching a class this large would otherwise inherit every latent finding in it. Line
-  scoping is the weaker choice - it misses a finding reported away from the edit that caused it - so
-  each file that comes down to a reviewable size can be promoted to file scoping on its own, without
-  waiting for the whole decomposition.
-  [`docs/inflight/static-analysis-rule-profiles.md`](inflight/static-analysis-rule-profiles.md) owns
-  the profiles and carries the promotion list.
+- **Promoted to
+  [`docs/inflight/core-decompose-abstract-parallel-eos-stream-processor.md`](inflight/core-decompose-abstract-parallel-eos-stream-processor.md)
+  on 2026-09-08**, which owns the seams, the old upstream drafts and their ideas, the PRs that must
+  merge before each cut, and the cut order. This heading stays because notes and the manifest cite it
+  by name; nothing else about the decomposition lives here. The five classes below it in size are
+  [`docs/inflight/core-shrink-the-five-next-largest-classes.md`](inflight/core-shrink-the-five-next-largest-classes.md).
+  Design ref: draft `confluentinc#488`. Do alongside the
+  [confluentinc#200](https://github.com/confluentinc/parallel-consumer/issues/200) (mirror astubbs#142)
+  work; high risk.
 
 ### Actor / IPC message bus for commits & results
 - Replace shared-state coordination with a lightweight actor/mailbox. Design refs:


### PR DESCRIPTION
## Description

**Two `docs/inflight/` notes that turn "decompose the God class" from a heading into a plan: the seams, the old upstream drafts and the idea worth keeping from each, the open PRs that must merge before each cut, and a cut order. Plus the same treatment for the five classes below it in size.**

`docs/inflight/core-decompose-abstract-parallel-eos-stream-processor.md` owns `AbstractParallelEoSStreamProcessor`:

- **The seams**, read from the only split that ever compiled - `origin/refactor/control-loop`, which is the same commits as upstream draft confluentinc/parallel-consumer#488. Each seam is mapped to where its methods sit on master today and what changed there since. No ref since 2023 has added any of its classes, so the branch is a map, not a merge candidate.
- **The older upstream drafts and their ideas**, read from their own bodies and javadoc rather than the analysis doc's one-line verdicts: the six caller-partitioned interfaces in confluentinc/parallel-consumer#325, the rebalance-as-messages shape in confluentinc/parallel-consumer#270 that decides where the rebalance seam is drawn, the package layout in confluentinc/parallel-consumer#271, `CommitData` from confluentinc/parallel-consumer#524, and why confluentinc/parallel-consumer#45 and the 2022 queue branches are superseded by astubbs/parallel-consumer#361.
- **Merge before you cut**: every open PR ranked by its *own* changes to the class, measured from its merge base with the package rename normalised. A two-dot diff against master's tip had made every stale draft look like an engine rewrite when most carried only the rename in their imports; the script that measures it correctly is in the note so the ranking can be re-run rather than trusted.
- **A cut order**, and the rules in the engine's `AGENTS.md` and the solution write-ups that bind each cut.

`docs/inflight/core-shrink-the-five-next-largest-classes.md` does the same per class for `PartitionState`, `WorkContainer`, `ParallelConsumerOptions`, `ShardManager` and `BrokerPollSystem`: what each holds, where a cut goes, which PRs block it, and which defect notes sit inside it.

**`docs/refactoring.md` loses the body of its "Decompose the God class" section.** The heading stays as a pointer because two other notes and the manifest cite it by name; the inflight rules forbid stating the content twice. Nothing else in that file changes.

**What this PR does not do.** It changes no code. It does not add the missing `branch_accounting` entry for `origin/refactor/gpt3-central-queue-direct-pull`, and it does not correct the retracted "mostly dead-ends" line for the 2022 queue branches - both were surfaced by the same session and are small enough to ride a follow-up or this PR on request.

## Checklist

- [x] Docs updated - or `N/A`
- [ ] User-facing feature documentation data added under `docs/features/` - N/A - internal planning notes, no user-facing change
- [ ] Tests added/updated - N/A - docs only
- [ ] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - the PR is itself two inflight notes, and carries nothing `gh` cannot show
- [x] Title & body reflect the final content of this PR
- [ ] Ran `ce-simplify` and `ce-code-review` locally - N/A - docs only; `bin/check-all.sh` ran green (the self-reference and file-refs gates each caught one thing, both fixed before the commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvLM7eS6VXLtGANTVvUH7i
