### PR TITLE
test(core): simpleBatchTest asserted a batch count its own random keys decided

### DIFF
--- a/docs/inflight/test-untracked-ci-flakes.md
+++ b/docs/inflight/test-untracked-ci-flakes.md
@@ -15,6 +15,12 @@ astubbs#265, and `OffsetEncodingBackPressureTest.backPressureShouldPreventTooMan
 (4/45, the most frequent), which asserted an offset that back pressure exists to stop advancing -
 written up in
 [`back-pressure-freezes-the-frontier-the-test-asserted-2026-08-24.md`](../solutions/test-flakiness/back-pressure-freezes-the-frontier-the-test-asserted-2026-08-24.md).
+Also fixed and out: `simpleBatchTest` in `CoreBatchTest`, `ReactorBatchTest`, `MutinyBatchTest` and
+`VertxBatchTest` (six sightings, the most in this register), which asserted a batch count of
+`ceil(records / batchSize)` over an input whose key distribution it randomised - under KEY ordering a
+key drawn three times out of five forces a fourth batch, deterministically, and the library is right to
+produce it -
+[`a-randomised-key-draw-decided-a-batch-count-the-test-computed-from-the-record-count-2026-09-08.md`](../solutions/test-flakiness/a-randomised-key-draw-decided-a-batch-count-the-test-computed-from-the-record-count-2026-09-08.md).
 Also fixed and out: `MdcContextPropagationTest.anEmptyCallerContextIsHandledAndNothingLeaks`, which
 asserted a null MDC on a runner thread two other classes had left holding `{}` (four sightings, the
 last one master's own build for the astubbs#415 merge; fixed twice over, by two sessions that did not see each other) -
@@ -26,7 +32,6 @@ Where their diagnoses generalised, the rule is in [`docs/solutions/`](../solutio
 <!-- post-merge: checked - the row states the fix and the lift as things that happened -->
 | `ProducerManagerTest.producedRecordsCantBeInTransactionWithoutItsOffsetDirect` | 1 seen (2026-08-12) | Not from the original scan - found while babysitting astubbs#287. **Fixed by astubbs#265**, which deleted the wall-clock assertion rather than repairing it. astubbs#262, its owner, lifted the quarantine and deleted the registry entry - see below |
 | `JStreamParallelEoSStreamProcessorTest.testConsumeAndProduce` and `.testFlatMapProduce` | 1 seen (2026-09-01) | Not from the original scan - found in a **local** core unit run on a parallel re-cut of astubbs#207, not on astubbs#207 itself. Both failed together on produced-record count (`Expected size: 1/2 but was: 0`), i.e. the returned stream carried nothing. **Mechanism now known and owned by astubbs#116** - see below | <!-- post-merge: checked -->
-| `simpleBatchTest` in **all three** of `ReactorBatchTest`, `MutinyBatchTest` and `VertxBatchTest` | 6 seen (2026-08-18, 2026-08-19, 2026-08-25, 2026-09-01, 2026-09-02, 2026-09-05) | Not from the original scan - each found while babysitting a branch. Same Awaitility `ConditionTimeout`, same alias 'expected number of batches' (30s), same shared `BatchTestMethods` lambda. UNDIAGNOSED, but the third, fourth and fifth sightings independently carry the **same three-way key collision** in the failing batch contents, which points at the test's own randomised input - see below, and classify (contention vs product vs expectation) before touching |
 | `Mutation Tests (PIT, PR-scoped)` lane | 1 seen (2026-09-02, astubbs#207, [run 33610711974](https://github.com/astubbs/parallel-consumer/actions/runs/33610711974)) | Not a test - the LANE hit its `timeout-minutes: 30` cap and was cancelled, on a **markdown-only** delta from a head where it had scored in 19m18s with the same class set. The cap had about a third headroom over a normal run, so it flapped on a slow runner. Addressed 2026-09-07: the bound is now `timeout-minutes: 20` on the PIT **step**, so a hit ends that step and the job still reports, where a hit on the old job cap cancelled the whole row. It arrived with the fold into `scan: repo` and outlived it - astubbs#463 un-folded PIT into its own `mutation` job again and the step bound moved with the step ([`ci-fewer-jobs-ruleset-edits.md`](ci-fewer-jobs-ruleset-edits.md)). Still `continue-on-error: true`, so it never gates a merge <!-- post-merge: checked --> |
 | `ManagedPCInstanceLifecycleTest.rapidToggleShouldNotCreateDuplicateInstances` | 3 seen (2026-09-02, astubbs#207, [job 100175277225](https://github.com/astubbs/parallel-consumer/actions/runs/33607572165/job/100175277225); 2026-09-07, astubbs#428, [job 101592337448](https://github.com/astubbs/parallel-consumer/actions/runs/34072492940/job/101592337448); 2026-09-07, astubbs#452, [job 101607850077](https://github.com/astubbs/parallel-consumer/actions/runs/34078008311/job/101607850077)) - the first two the first run of a branch that had just taken a change to how this lane runs; the third a re-run after a merge from master, with no `.github/` change in the merged range | Not from the original scan - **arrived on master with astubbs#29 and failed on the first PR to merge it**. `consumeCount` 0, repetition 1 of 5, `forkCount=4`, `probe clean`. Every wait in the test is a fixed sleep, and its assertion names a cause it cannot discriminate - see below <!-- post-merge: checked --> |
 | `RegistrationRaceStaleResidentIT.freshArrivalCollidingWithStaleShardResidentMustStillGetProcessed` | Recurring, always at the guard ceiling, across unrelated branches - `bin/inflight.mjs codecov test freshArrivalCollidingWithStaleShardResidentMustStillGetProcessed` enumerates every recorded outcome, so no total is kept here; the dated sightings are 2026-09-01; 2026-09-03 seven times - once on a producer branch, twice on astubbs#419, twice in a row on astubbs#429, whose same head then passed on a deliberate re-run, once on a `ce-optimize` measurement branch, and once on astubbs#438, and once on astubbs#433; on astubbs#442 four times - 2026-09-05 at 7075b26f, at 2ee84193 three heads later, and at 4fc15b8b, a head that differs from the green 69ecd0d1 before it by one markdown file, so the same-code control arm is the run immediately preceding it; and 2026-09-06 at eb1e88a1, again a documentation-only head; 2026-09-05 on astubbs#452 at 9071c9baa ([job 101230691107](https://github.com/astubbs/parallel-consumer/actions/runs/33938334747/job/101230691107)) and on astubbs#449 at 0182f0862 ([job 101270402248](https://github.com/astubbs/parallel-consumer/actions/runs/33952704824/job/101270402248)), the latter a docs-only branch; and 2026-09-04 on astubbs#444, whose SAME HEAD then passed on a deliberate re-run of just that job - the identical `mid-loop pause point (offset 25)` guard every time, in the catch-all shard of a two-shard run, so still roughly one in two on that lane) | Not from the original scan - found while babysitting astubbs#257. Failed its **saturation/pause-point setup guard**, not the confluentinc#909 signature assertion, so it proves nothing about the defect it reproduces - see below **It also has a same-day cross-branch control**: `bin/inflight.mjs codecov test freshArrivalCollidingWithStaleShardResidentMustStillGetProcessed` shows it failing on two unrelated branches within an hour with the identical `mid-loop pause point (offset 25)` signature, while passing on both of those same branches at neighbouring commits - so it is master-state and test-side, not any one branch's regression, answered from recorded history rather than by re-running builds. **And a WITHIN-branch control, which establishes something none of the others can**: astubbs#433 ran the same content twice, passing at `01fb0c4` and failing at `53ef4d6` after a re-cut that changed only the commit split and merged one unrelated reactor-test commit - so one tree produced both outcomes. The controls above rule out branch content; this one rules out the tree entirely, leaving only the runner. The astubbs#444 sighting is one more of the same-day cross-branch kind: the identical signature had appeared on `ci/shard-integration-gate` ninety minutes earlier, while `docs/codex-strategy-conversation` passed the same test in the same hour. **astubbs#438 is the strongest of these controls and needs no neighbouring commit at all**: the documentation-only heads above still sit on branches whose earlier commits changed Java, so the tree that was built carries those changes - whereas astubbs#438's whole branch diff is `bin/` and `docs/`, compiling no Java and changing no test, so the tree built there IS master's. A branch that cannot have caused an integration failure produced one. Confirm with `gh pr diff 438 -R astubbs/parallel-consumer --name-only | grep -vE '^(bin/|docs/)'`, which prints nothing - asked of the pull request rather than of `origin/feats/inflight-rank-cli`, because that branch is deleted on merge and the check has to outlive it. <!-- post-merge: checked --> |
@@ -428,128 +433,6 @@ Cleared on mechanism the same way as the first two: astubbs#452's whole diff is
 `PERIODIC_CONSUMER_ASYNCHRONOUS` + `UNORDERED` path against a fresh topic can reach. Not re-diagnosed
 here - the fixed-sleep defect and assertion-attribution problem above already cover it. Not
 quarantined for the same reason as before: quarantine needs a rate, not a third data point.
-<!-- post-merge: checked-end -->
-
-### `simpleBatchTest` - three modules, one shared helper, and a lead nobody has tested
-
-2026-08-18 it was `ReactorBatchTest`. 2026-08-19 it was `MutinyBatchTest`, on
-astubbs/parallel-consumer#320 - and the failure is the same one, not a similar one: the alias, the
-30-second timeout and the lambda all come from `BatchTestMethods` in **core**, which both wrapper
-modules drive. One sighting looked like a Reactor flake. Two, in different modules, means the
-Reactor and Mutiny wrappers are not the variable.
-
-**Sixth sighting, 2026-09-05, `ReactorBatchTest` parameter `[3]` on astubbs/parallel-consumer#442 at f1e87d81, the Unit Tests lane** - identical code had passed that lane at the three previous heads of the same PR. Same alias, same 30s, expected 3 batches and got 4 - and the dump shows **key 66 at offsets 0, 1 and 2**, three records on one key out of five, which is the three-way collision the third, fourth and fifth sightings each carried. Four in a row now. Recorded and re-run on the same head, not diagnosed. <!-- post-merge: checked -->
-
-The 2026-08-19 assertion is the useful part, because it is off by exactly one in the direction that
-matters: **`Expected size: 3 but was: 4`** - grep `BatchTestMethods` for `expected number of
-batches`. The test received the right records in one batch too many, so this is a batch-BOUNDARY
-question, not a lost-work question. Two readings, and they need separating rather than assuming:
-
-- **Contention.** The runner is slow or loaded, so work arrives spread out and the batcher closes a
-  batch early. Test-side, and the honest fix is making the test drive the boundary it asserts
-  instead of racing it.
-- **Product.** The batcher can split a batch under a timing the library is supposed to tolerate,
-  in which case an over-eager boundary is a real defect and the test is right to complain.
-
-**No sighting is on a branch whose diff contains main Java**, which is what rules out "a PR broke
-it" and makes it master state - the same reasoning applied to `ProducerManagerTest` below. That is
-also why none was quarantined on the branch that met it: quarantine is master-state and needs a
-diagnosis, and no sighting has one.
-
-The 2026-08-18 sighting passed on re-run, and so did the 2026-08-25 one - three consecutive clean
-re-runs of the same test, so **1 failure in 4 local runs, not deterministic**. A re-run is diagnosis
-here, not a way to go green - it distinguishes flaky from deterministic - and AGENTS.md's ban is on
-the automatic `surefire.rerunFailingTestsCount` that hid this whole ledger, not on re-running a job
-to learn something.
-
-#### The 2026-08-25 sighting: a third module, and the first look at what was in the batches
-
-`VertxBatchTest`, KEY ordering, on a local macOS full unit run of the branch that added
-`ShardMapIsNeverReplacedArchTest` - one new core test class plus docs, no main Java. Same
-`Expected size: 3 but was: 4`. **Three modules now, so the wrapper is definitively not the
-variable.**
-
-What is new is the payload the assertion printed. The five records carried keys `29, 36, 36, 36,
-71` - a **three-way key collision** - and arrived as `{o0, o4}`, `{o1}`, `{o2}`, `{o3}`, so every
-key-36 record came alone. Meanwhile `simpleBatchTest` computes its expectation from the record count
-and nothing else: grep `BatchTestMethods` for `expectedNumOfBatches`, which is
-`ceil(numRecsExpected / batchSizeSetting)` for every ordering except PARTITION. **The keys are
-random** - `KafkaTestUtils.getRandomKey` draws from `defaultKeys`, a hundred integers - so the shard
-distribution the batcher works against varies run to run while the expected batch count does not.
-
-That is a third reading to separate, not a diagnosis, and it displaces neither of the two above:
-
-- **Expectation-versus-input.** The test randomises the key distribution and then asserts a batch
-  count that only holds for some distributions. A rare draw would explain a rare failure without any
-  contention or product defect at all.
-
-The experiment that settles it is cheap and has a control arm, and **nobody has run it**: pin the
-keys through the Lombok setter on `KafkaTestUtils`'s `defaultKeys`, force a three-way collision
-under KEY ordering, and predict a deterministic failure; then five distinct keys, and predict it
-always passes. If both hold, this is
-the test's own input and neither the runner nor the batcher. If the collision case passes, the draw
-is a red herring and contention-versus-product stands as before.
-
-<!-- post-merge: checked-begin -->
-#### The 2026-09-01 sighting: the collision reproduces, in a second module, unprompted
-
-`ReactorBatchTest`, KEY ordering (`simpleBatchTest(ProcessingOrder)[3]` - `@EnumSource` orders the
-enum `UNORDERED, PARTITION, KEY`, so index 3 is KEY, the same parameter as 2026-08-25). Seen on the
-Unit Tests lane of astubbs/parallel-consumer#393, the thread-confinement extraction. Same
-`Expected size: 3 but was: 4`.
-
-**This is the first sighting whose branch carried main Java, so the master-state argument above is
-restated here rather than reused.** It still holds, for two reasons specific to
-astubbs/parallel-consumer#393. Relative to the head the failure was first seen on, the commit under
-test changed only comments and one core test fixture, and that fixture is loaded by two core
-ownership tests `ReactorBatchTest` never touches. That PR's one behavioural change to a poll path
-moves an existing `updateCache()` call from after `pollingBroker.set(true)` to before it - a
-reordering, not an addition, so the poll does no more work than master's does. Neither could reach a
-batch boundary in another module.
-
-**What makes the sighting worth recording is the payload, because it is the 2026-08-25 one again.**
-The five records carried keys `34, 62, 34, 34, 77` by offset - a **three-way collision on key 34** -
-and arrived as `{o0, o1}`, `{o4}`, `{o2}`, `{o3}`. 2026-08-25 saw keys `29, 36, 36, 36, 71`, a
-three-way collision on key 36, arriving as `{o0, o4}`, `{o1}`, `{o2}`, `{o3}`. Two independent
-draws, different modules, different collided key, **same shape**: one key drawn three times, two
-drawn once, and four batches where the expectation is `ceil(5 / 2) = 3`.
-
-That is what the expectation-versus-input reading predicts, and it is no longer resting on a single
-observation. Under KEY ordering the three colliding records share a shard and must be processed in
-order, so they cannot batch with each other however fast the runner is; only the two singletons are
-free to pair with anything. A three-way collision therefore forces at least four batches on
-arithmetic, while `expectedNumOfBatches` - grep `BatchTestMethods` for it - is computed from the
-record count alone and stays at three.
-
-**It still is not a diagnosis, and the experiment named above is still the thing that settles it**
-(pin `defaultKeys` through the Lombok setter on `KafkaTestUtils`, force the collision, predict a
-deterministic failure; then five distinct keys, predict it always passes). What has changed is the
-prior: the collision is now the leading reading rather than one of three equals, and a control arm
-that failed to reproduce under a forced collision would be a genuinely surprising result. Recorded
-while the CI log carrying the payload still existed - those logs expire, and the payload is the
-whole value of the sighting.
-<!-- post-merge: checked-end -->
-
-<!-- post-merge: checked-begin - a dated sighting against a PR number and a sha, both durable -->
-#### The 2026-09-02 sighting: the same shape a third time, on a branch with no Java at all
-
-`ReactorBatchTest`, KEY ordering (`simpleBatchTest(ProcessingOrder)[3]` again), on the Unit Tests
-lane of astubbs/parallel-consumer#414 at `36cd68593`. Same `Expected size: 3 but was: 4`, the alias
-timing out at 30.53s. That branch's diff was workflow YAML and docs - no Java of any kind - so the
-master-state argument needs no restating: nothing in it can reach a batch boundary in any module.
-
-**The payload is the 2026-08-25 and 2026-09-01 shape for the third time.** Keys by offset
-`49, 74, 74, 74, 59` - a **three-way collision on key 74** - arriving as `{o0, o1}`, `{o4}`, `{o2}`,
-`{o3}`: the two singletons paired, the three colliding records one to a batch, four batches against
-an expectation of three. Three independent draws, two modules between them, three different
-collided keys, one shape.
-
-What it changes is not the diagnosis - that is still the unrun pin-the-keys experiment above, and a
-third collision-shaped payload moves the prior very little past where the second left it. What it
-changes is the cost: this is the second day running that the flake failed a PR's required Unit Tests
-lane outright, each time on a branch that could not have caused it, so it now charges a CI round to
-work that has nothing to do with it. That is the condition under which a cheap unrun experiment
-stops being deferrable.
 <!-- post-merge: checked-end -->
 
 ### `ProducerManagerTest.producedRecordsCantBeInTransactionWithoutItsOffsetDirect` - a helper defect, not a test defect

--- a/docs/solutions/test-flakiness/a-randomised-key-draw-decided-a-batch-count-the-test-computed-from-the-record-count-2026-09-08.md
+++ b/docs/solutions/test-flakiness/a-randomised-key-draw-decided-a-batch-count-the-test-computed-from-the-record-count-2026-09-08.md
@@ -1,0 +1,142 @@
+---
+title: "A randomised key draw decided the batch count, and the test computed its expectation from the record count"
+date: 2026-09-08
+category: test-flakiness
+module: parallel-consumer-core
+problem_type: test_design_bug
+component: testing
+severity: medium
+root_cause: exact_expectation_derived_from_record_count_while_the_randomised_key_distribution_decides_it_under_order_restricted_shards
+resolution_type: test_fix_controls_the_input_distribution_and_keeps_the_exact_assertion
+status: "SOLVED - test-side fix. The mechanism is confirmed by a three-arm controlled experiment with a control arm, and the exact CI signature reproduces deterministically on demand. The product behaviour is correct and unchanged."
+applies_when:
+  - "A test asserts an EXACT count of something the engine derives from how records are DISTRIBUTED, not from how many there are"
+  - "The input distribution is randomised by a shared test helper the assertion never inspects"
+  - "The ordering mode is KEY or PARTITION, so a shard hands out at most one record per work-retrieval round"
+  - "A flake reproduces at a rate near a combinatorial probability rather than near a timing one"
+symptoms:
+  - "ConditionTimeoutException, alias 'expected number of batches', 30 seconds"
+  - "Expected size: 3 but was: 4"
+  - "Only the KEY parameter fails - simpleBatchTest(ProcessingOrder)[3] - never [1] or [2]"
+  - "The dumped batch contents carry one key drawn three times out of five records"
+  - "Fires across parallel-consumer-reactor, -mutiny and -vertx alike, on branches whose diff contains no main Java"
+  - "Passes on re-run of the identical head, and is invisible to any load or contention arm"
+related_components:
+  - BatchTestMethods
+  - KafkaTestUtils
+  - ProcessingShard
+  - AbstractParallelEoSStreamProcessor
+tags: [batching, key-ordering, shards, randomised-input, expectation-versus-input, awaitility, flake]
+---
+
+# A randomised key draw decided the batch count, and the test computed its expectation from the record count
+
+`BatchTestMethods.simpleBatchTest` sends five records at `batchSize=2` and asserts, exactly, that they
+arrive in `ceil(5 / 2) = 3` batches. Six sightings across `ReactorBatchTest`, `MutinyBatchTest` and
+`VertxBatchTest` between 2026-08-18 and 2026-09-05 timed that assertion out at 30 seconds with
+`Expected size: 3 but was: 4`, always on the `KEY` parameter, always on a branch that could not have
+caused it. It was carried as undiagnosed in
+[`docs/inflight/test-untracked-ci-flakes.md`](../../inflight/test-untracked-ci-flakes.md) with three
+readings live: contention, a product defect in the batcher, and expectation-versus-input.
+
+**It is the third, and none of the other two is involved.** The rule worth keeping is the general one:
+
+> **An exact count is only assertable over an input the test controls.** If the engine derives the
+> number from how the records are *distributed* and the helper randomises that distribution, the
+> assertion is a lottery whose odds are set by a draw nobody reads - and no amount of re-running,
+> load-shedding or timeout-loosening touches it.
+
+## The mechanism, in two lines of product code
+
+Under `KEY` ordering a shard is per key, and `ProcessingShard.getWorkIfAvailable` breaks out of its
+scan after taking one record when `isOrderRestricted()` - so a shard yields **at most one record per
+work-retrieval round**. `AbstractParallelEoSStreamProcessor.makeBatches` then partitions whatever that
+round returned into chunks of `batchSize`. Batches are therefore
+`sum over rounds of ceil(recordsTakenInThatRound / batchSize)`, and the number of rounds is decided by
+how many records are on distinct keys.
+
+`KafkaTestUtils.sendRecords` draws keys **with replacement** from a hundred-integer pool, so five
+records can land two, three or more to a key. Five distinct keys give one round of five and three
+batches. One key drawn three times gives rounds of 3, 1, 1 and **four** batches. The expectation
+`ceil(records / batchSize)` never moves, because it is computed from the record count alone.
+
+The library is right and the test is wrong. Three records on one key cannot share a batch without
+breaking the ordering guarantee `KEY` exists to provide.
+
+## The experiment, with its control arm
+
+Three arms, KEY ordering, `batchSize=2`, five records, everything but the key distribution held
+identical; predictions stated before each run. Batches were counted directly rather than through the
+30-second await, so a failing arm costs no more than a passing one.
+
+| Arm | Keys | Prediction | Result |
+|---|---|---|---|
+| A - control, as the test ships | random, with replacement | 3 batches in ~all reps; a 3-way collision is about 1 draw in 1000 | **20/20 gave 3.** Two reps happened to draw a 2-way collision and still gave 3 |
+| B - forced 3-way collision | `7,7,7,8,9` | 4 batches every time | **20/20 gave 4**, sizes `2+1+1+1` |
+| C - forced distinct keys | `1,2,3,4,5` | 3 batches every time | **20/20 gave 3**, sizes `2+2+1` |
+
+`2+1+1+1` is the shape recorded in all four sightings whose batch contents were captured - two
+singleton keys paired into one batch, then the three colliding records one to a batch each.
+
+Supplementary arms pin the predicate more precisely than "3-way collision":
+
+| Arm | Keys | Result |
+|---|---|---|
+| D | `7,7,8,8,9` - two 2-way collisions | **3 of 5 reps gave 3, 2 of 5 gave 4** |
+| E | `7,7,7,7,8` | 5/5 gave 4 |
+| F | `7,7,7,7,7` | 5/5 gave 5 |
+
+So **any** key collision can cost an extra batch, and a 3-way collision did so every time. Arm D is the
+arm that matters for the rule: the same input produced two different counts, which is proof that no
+expectation computed over a colliding input can be exact.
+
+**The literal CI signature reproduces on demand.** Pointing `simpleBatchTest` itself at
+`7,7,7,8,9` and running `CoreBatchTest#simpleBatchTest` fails 1 of its 3 parameters in 31.7s with
+`ConditionTimeoutException`, alias `expected number of batches`, `Expected size: 3 but was: 4` -
+character for character what CI reported six times.
+
+## Why the rate looks the way it does
+
+Five draws from a hundred keys give a 3-way-or-worse collision about once in a thousand. Only the
+`KEY` parameter is exposed, in four classes per unit run (core plus three wrappers), so roughly one
+unit-lane run in 250 should carry one. Six sightings over three weeks of pull-request runs is the
+order of magnitude that predicts - which is the corroboration a contention reading never had, since
+contention would have to explain why the failure spared `UNORDERED` and `PARTITION` entirely.
+
+## The fix, and why it is not a loosened assertion
+
+Keeping the exact count means removing the randomness from the input, not weakening what is asserted.
+`KafkaTestUtils.sendRecordsWithDistinctKeys` draws **without** replacement - the distribution stays
+arbitrary, the collision cannot happen - and `simpleBatchTest` uses it. The exact-count assertion is
+unchanged and is now actually justified.
+
+That leaves `KEY` behaving like `UNORDERED` for that test, so the KEY-specific guarantee moves into a
+new test of its own rather than being lost: `BatchTestMethods.keyOrderNeverBatchesTwoRecordsOfOneKey`
+sends a deliberate 3-way collision and asserts what is deterministic about it - every record delivered
+exactly once, no batch over `batchSize`, and **no batch holding two records of one key**. Net coverage
+goes up: the behaviour that broke the old expectation was never tested before.
+
+**Residual, stated rather than glossed.** Distinct keys remove the collision but not the theoretical
+possibility that a retrieval round splits unevenly (rounds of 1, 1, 3 would also give four batches).
+That was not observed in 41 reps of arms A and C, it has never been sighted on the `UNORDERED`
+parameter which has always been exposed to exactly the same split, and it is a different mechanism from
+the one diagnosed here. If `[1]` and `[3]` ever fail together with no key collision in the payload,
+that is the thing to look at - and the fix would be to make the test wait for all records to be
+queued before the first retrieval, not to loosen the count.
+
+## Other instances of the class - searched, and none found
+
+The class is *an exact count asserted over an input whose distribution the test randomises*. Every
+caller of `KafkaTestUtils.sendRecords` and every `Math.ceil` in test code was read:
+
+- `BatchTestMethods.batchFailureTest` - computes the same `ceil` but asserts
+  `hasSizeGreaterThanOrEqualTo`. A collision can only add batches, so it cannot fail this way. Dismissed.
+- `BatchTestMethods.averageBatchSizeTest` - `UNORDERED`, where each record is its own shard. Not exposed.
+- `TransactionalBatchProduceTest`, `MdcContextPropagationTest`, `OffsetEncodingBackPressureUnitTest` -
+  all `UNORDERED` (the last by the base class default) and all asserting record counts, not batch counts.
+- `TransactionMarkersTest` - `PARTITION`, and its own comment says `// just so we dont need to use keys`,
+  which is this hazard already understood at one call site.
+- `BitSetEncoder` - main code, unrelated ceiling arithmetic.
+
+So it is a single site, not a pattern. The guard against it recurring is
+`sendRecordsWithDistinctKeys` existing and saying in its javadoc when to reach for it.

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/BatchTestMethods.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/BatchTestMethods.java
@@ -5,6 +5,7 @@ package bz.stub.parallelconsumer;
  * Modifications Copyright (C) 2026 Antony Stubbs and contributors
  */
 
+import bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder;
 import bz.stub.parallelconsumer.internal.utils.KafkaTestUtils;
 import bz.stub.parallelconsumer.internal.utils.ProgressBarUtils;
 import bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
@@ -13,15 +14,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import me.tongfei.progressbar.ProgressBar;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import pl.tlinkowski.unij.api.UniLists;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static bz.stub.parallelconsumer.internal.utils.StringUtils.msg;
 import static bz.stub.parallelconsumer.AbstractParallelEoSStreamProcessorTestBase.defaultTimeout;
+import static bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.KEY;
 import static bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.PARTITION;
 import static bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder.UNORDERED;
 import static java.time.Duration.ofSeconds;
@@ -136,6 +141,24 @@ public abstract class BatchTestMethods<POLL_RETURN> {
     }
 
 
+    /**
+     * Asserts the EXACT number of batches the records arrive in, which only holds while every record sits on its
+     * own shard - hence {@link KafkaTestUtils#sendRecordsWithDistinctKeys(int)} below rather than
+     * {@link KafkaTestUtils#sendRecords(int)}.
+     * <p>
+     * {@code sendRecords} draws its keys with replacement. Under {@link ProcessingOrder#KEY} two records drawn onto
+     * one key share a shard, a shard yields at most one record per work-retrieval round, and the same five records
+     * then arrive in four batches instead of three - against an {@code expectedNumOfBatches} computed from the
+     * record count alone. It is not a timing failure and no re-run makes it less likely: it is decided entirely by
+     * a draw the test never inspects. Keeping the exact-count assertion therefore means removing the randomness
+     * from the input, not loosening the assertion.
+     * <p>
+     * The KEY-ordering behaviour this can no longer exercise - records on one key never sharing a batch - is
+     * covered by {@link #keyOrderNeverBatchesTwoRecordsOfOneKey()}.
+     * <p>
+     * Measured and written up in
+     * {@code docs/solutions/test-flakiness/a-randomised-key-draw-decided-a-batch-count-the-test-computed-from-the-record-count-2026-09-08.md}.
+     */
     @SneakyThrows
     public void simpleBatchTest(ParallelConsumerOptions.ProcessingOrder order) {
         int batchSizeSetting = 2;
@@ -145,7 +168,7 @@ public abstract class BatchTestMethods<POLL_RETURN> {
 
         setupParallelConsumer(batchSizeSetting, ParallelConsumerOptions.DEFAULT_MAX_CONCURRENCY, order);
 
-        var recs = getKtu().sendRecords(numRecsExpected);
+        var recs = getKtu().sendRecordsWithDistinctKeys(numRecsExpected);
         List<PollContext<String, String>> batchesReceived = new CopyOnWriteArrayList<>();
 
         //
@@ -175,6 +198,66 @@ public abstract class BatchTestMethods<POLL_RETURN> {
     }
 
     public abstract void simpleBatchTestPoll(List<PollContext<String, String>> batchesReceived);
+
+    /**
+     * Two records that share a key never share a batch under {@link ProcessingOrder#KEY} - whatever the batch size.
+     * <p>
+     * A shard is per key and an order-restricted shard hands out at most one record per work-retrieval round
+     * ({@code ProcessingShard.getWorkIfAvailable}, grep {@code isOrderRestricted}), so three records on one key
+     * need three batches to themselves and the run takes at least four batches to deliver five records at a batch
+     * size of two. That is correct behaviour and it is why {@code ceil(records / batchSize)} is not a valid
+     * expectation for an input whose key distribution the test does not control - see {@link #simpleBatchTest}.
+     * <p>
+     * <b>Core only, deliberately.</b> The batching and shard arithmetic under test is the core engine's and is
+     * identical whichever module drives it; what the wrapper modules add is their own poll signature, which
+     * {@link #simpleBatchTest} already covers in each of them.
+     */
+    @SneakyThrows
+    public void keyOrderNeverBatchesTwoRecordsOfOneKey() {
+        final int batchSizeSetting = 2;
+        final String collidingKey = "one-key-three-records";
+        final List<String> keys = UniLists.of(collidingKey, collidingKey, collidingKey, "second-key", "third-key");
+
+        setupParallelConsumer(batchSizeSetting, ParallelConsumerOptions.DEFAULT_MAX_CONCURRENCY, KEY);
+        getPC().setTimeBetweenCommits(ofSeconds(1));
+
+        var recs = getKtu().sendRecordsWithKeys(keys);
+        List<PollContext<String, String>> batchesReceived = new CopyOnWriteArrayList<>();
+
+        //
+        simpleBatchTestPoll(batchesReceived);
+
+        // wait on the RECORDS, not on a batch count - the batch count is what this test is measuring
+        waitAtMost(defaultTimeout).alias("every record delivered")
+                .failFast(() -> getPC().isClosedOrFailed())
+                .untilAsserted(() -> assertThat(batchesReceived.stream().mapToLong(PollContext::size).sum())
+                        .isEqualTo(keys.size()));
+
+        assertThat(batchesReceived)
+                .as("batch size")
+                .allSatisfy(receivedBatchEntry -> assertThat(receivedBatchEntry).hasSizeLessThanOrEqualTo(batchSizeSetting))
+                .as("all messages processed")
+                .flatExtracting(PollContext::getConsumerRecordsFlattened).hasSameElementsAs(recs);
+
+        for (var batch : batchesReceived) {
+            var keysInBatch = batch.getConsumerRecordsFlattened().stream()
+                    .map(ConsumerRecord::key)
+                    .collect(Collectors.toList());
+            assertThat(keysInBatch)
+                    .as("no batch may hold two records of one key under KEY ordering - batch %s", keysInBatch)
+                    .doesNotHaveDuplicates();
+        }
+
+        assertThat(batchesReceived)
+                .as("%s records on one key need %s batches to themselves, so ceil(%s / %s) cannot be the expectation",
+                        3, 3, keys.size(), batchSizeSetting)
+                .hasSizeGreaterThanOrEqualTo(3);
+
+        assertThat(getPC().isClosedOrFailed()).isFalse();
+
+        baseTest.awaitForCommit(keys.size());
+        getPC().closeDrainFirst();
+    }
 
     @SneakyThrows
     public void batchFailureTest(ParallelConsumerOptions.ProcessingOrder order) {

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CoreBatchTest.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/CoreBatchTest.java
@@ -97,4 +97,13 @@ public class CoreBatchTest extends ParallelEoSStreamProcessorTestBase implements
         batchTestMethods.batchFailureTest(order);
     }
 
+    /**
+     * Core only - see {@link BatchTestMethods#keyOrderNeverBatchesTwoRecordsOfOneKey()} for why the wrapper
+     * modules do not repeat it.
+     */
+    @Test
+    public void keyOrderNeverBatchesTwoRecordsOfOneKey() {
+        batchTestMethods.keyOrderNeverBatchesTwoRecordsOfOneKey();
+    }
+
 }

--- a/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/utils/KafkaTestUtils.java
+++ b/parallel-consumer-core/src/test/java/bz/stub/parallelconsumer/internal/utils/KafkaTestUtils.java
@@ -383,6 +383,56 @@ public class KafkaTestUtils {
     }
 
     /**
+     * Sends {@code quantity} records whose keys are all DISTINCT - drawn from {@link #getDefaultKeys()} without
+     * replacement, so no two records can land on the same shard.
+     * <p>
+     * <b>Reach for this instead of {@link #sendRecords(int)} whenever the assertion depends on how the records are
+     * DISTRIBUTED rather than on the records themselves.</b> {@code sendRecords} draws keys WITH replacement, so
+     * a run can put two or more records on one key. Under {@link
+     * bz.stub.parallelconsumer.ParallelConsumerOptions.ProcessingOrder#KEY} those records share a shard, and a
+     * shard yields at most one record per work-retrieval round - so the same five records reach the user function
+     * in a different number of batches depending on a draw the test never sees. That is what made
+     * {@code BatchTestMethods.simpleBatchTest} fail across three modules at roughly one run in a thousand.
+     *
+     * @throws IllegalArgumentException if there are not enough keys to go round - the caller is asking for
+     *                                  something this cannot deliver, and silently repeating a key is exactly the
+     *                                  failure this method exists to remove
+     */
+    public List<ConsumerRecord<String, String>> sendRecordsWithDistinctKeys(final int quantity) {
+        var consumerRecords = generateRecordsWithDistinctKeys(quantity);
+        send(consumerSpy, consumerRecords);
+        return consumerRecords;
+    }
+
+    /**
+     * @see #sendRecordsWithDistinctKeys(int)
+     */
+    public List<ConsumerRecord<String, String>> generateRecordsWithDistinctKeys(final int quantity) {
+        if (quantity > defaultKeys.size()) {
+            throw new IllegalArgumentException("Cannot draw " + quantity + " distinct keys from a pool of " + defaultKeys.size());
+        }
+        var keyPool = new ArrayList<>(defaultKeys);
+        var records = new ArrayList<ConsumerRecord<String, String>>(quantity);
+        for (int i = 0; i < quantity; i++) {
+            records.add(makeRecord(0, removeRandomKey(keyPool).toString(), "0," + i));
+        }
+        return records;
+    }
+
+    /**
+     * Sends one record per given key, in the order given - for a test that needs a SPECIFIC shard distribution
+     * (a deliberate key collision, say) and so must state it rather than draw for it.
+     */
+    public List<ConsumerRecord<String, String>> sendRecordsWithKeys(final List<String> keys) {
+        var records = new ArrayList<ConsumerRecord<String, String>>(keys.size());
+        for (int i = 0; i < keys.size(); i++) {
+            records.add(makeRecord(0, keys.get(i), "0," + i));
+        }
+        send(consumerSpy, records);
+        return records;
+    }
+
+    /**
      * Checks that the ordering of the results is the same as the ordering of the input records.
      * <p>
      * <b>Only valid where a record cannot be REDELIVERED</b> - one instance, a {@code MockConsumer}, no


### PR DESCRIPTION
## Description

Diagnoses and fixes the most-sighted flake in
[`docs/inflight/test-untracked-ci-flakes.md`](https://github.com/astubbs/parallel-consumer/blob/master/docs/inflight/test-untracked-ci-flakes.md):
`simpleBatchTest` timing out at 30s with `Expected size: 3 but was: 4` in `ReactorBatchTest`,
`MutinyBatchTest` and `VertxBatchTest`, six times since 2026-08-18, always on the KEY parameter and
always on a branch whose diff could not have caused it.

**The cause is expectation-versus-input - the third of the three readings the register kept live.
It is not contention, and it is not a batching defect. The library is correct and this PR changes
no main code.**

Under KEY ordering a shard is per key, and `ProcessingShard.getWorkIfAvailable` breaks out of its
scan after taking one record when `isOrderRestricted()` - so a shard yields at most one record per
work-retrieval round, and `makeBatches` partitions each round into chunks of `batchSize`. The batch
count is therefore decided by how many records sit on *distinct* keys. `KafkaTestUtils.sendRecords`
draws keys **with replacement** from a hundred-key pool, so five records can land three to a key,
while `expectedNumOfBatches` is `ceil(records / batchSize)` - computed from the record count alone
and blind to the draw. Three records on one key cannot share a batch without breaking the ordering
guarantee KEY exists to provide, so four batches is right and the expectation is wrong.

### The experiment, with its control arm

Three arms, KEY ordering, `batchSize=2`, five records, everything but the key distribution held
identical; predictions stated before each run.

| Arm | Keys | Prediction | Result |
|---|---|---|---|
| A - control, as shipped | random, with replacement | ~all 3 | **20/20 gave 3** (two reps drew a 2-way collision and still gave 3) |
| B - forced 3-way collision | `7,7,7,8,9` | 4 | **20/20 gave 4**, sizes `2+1+1+1` |
| C - forced distinct keys | `1,2,3,4,5` | 3 | **20/20 gave 3**, sizes `2+2+1` |

`2+1+1+1` is the shape every captured sighting payload carried. Supplementary arms: `7,7,8,8,9`
gave 3 three times and 4 twice - the same input, two counts, which is what proves no exact
expectation can survive a colliding draw; `7,7,7,7,8` gave 4 five times; `7,7,7,7,7` gave 5 five
times.

**Red then green.** Pointing `simpleBatchTest` itself at `7,7,7,8,9` fails 1 of its 3 parameters in
31.7s with the CI signature character for character - `ConditionTimeoutException`, alias
`expected number of batches`, 30 seconds, `Expected size: 3 but was: 4`. With this fix, green in all
four modules.

**Rate check, as corroboration not proof:** five draws from a hundred keys collide three ways about
once in a thousand; only KEY is exposed, four classes run it per unit lane, so roughly one run in
250 should carry one - the order of magnitude six sightings over three weeks predicts. A contention
reading never had to explain why UNORDERED and PARTITION were spared entirely.

### The fix keeps the exact assertion

It removes the randomness from the *input* rather than loosening what is asserted.
`KafkaTestUtils.sendRecordsWithDistinctKeys` draws **without** replacement - the distribution stays
arbitrary, the collision cannot happen - so the exact-count assertion is now actually justified.

That would leave KEY behaving like UNORDERED for that test, so the KEY-specific guarantee gets a
test of its own rather than being lost: `keyOrderNeverBatchesTwoRecordsOfOneKey` sends a deliberate
3-way collision and asserts what is deterministic about it - every record delivered exactly once, no
batch over `batchSize`, and **no batch holding two records of one key**. Net coverage rises: the
behaviour that broke the old expectation was never tested at all.

### Other instances of the class - searched, none found

The class is *an exact count asserted over an input whose distribution the test randomises*. Every
`sendRecords` caller and every `Math.ceil` in test code was read. Checked and dismissed:
`batchFailureTest` (same ceil, but `hasSizeGreaterThanOrEqualTo` - a collision can only add
batches); `averageBatchSizeTest`, `TransactionalBatchProduceTest`, `MdcContextPropagationTest` and
`OffsetEncodingBackPressureUnitTest` (all UNORDERED, where every record is its own shard);
`TransactionMarkersTest` (PARTITION, and its own comment already says `// just so we dont need to
use keys`); `BitSetEncoder` (main code, unrelated ceiling arithmetic).

### Register and write-up

The register row is retired into the header's fixed-and-out list. The payloads, the arms, the rate
arithmetic and the stated residual are migrated to
`docs/solutions/test-flakiness/a-randomised-key-draw-decided-a-batch-count-the-test-computed-from-the-record-count-2026-09-08.md`.

**Residual, stated rather than glossed:** distinct keys remove the collision but not the theoretical
possibility of an uneven retrieval split (rounds of 1, 1, 3 would also give four batches). Not
observed in 41 reps of arms A and C, never sighted on the UNORDERED parameter which has always been
exposed to exactly the same split, and a different mechanism from the one diagnosed here.

## Checklist

- [x] Docs updated - the flake register and a new `docs/solutions/test-flakiness/` write-up
- [ ] User-facing feature documentation data added under `docs/features/` - N/A - test-only change, no user-facing behaviour
- [x] Tests added/updated - `simpleBatchTest` now controls its key distribution, and `keyOrderNeverBatchesTwoRecordsOfOneKey` is new
- [ ] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - the durable record is the solution write-up plus the register edit, both in this PR; a working note would restate them
- [x] Title & body reflect the final content of this PR
- [ ] Ran `ce-simplify` and `ce-code-review` locally - N/A - will ask for `@claude review this` on the PR instead, which is the route that can open inline threads
