### PR TITLE
test(chaos) confluentinc#857: the churn storm's 30s no-progress window is crossed by its own churn; widened to the measured 60s

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -184,14 +184,27 @@ jobs:
           # layer along. If the probe stops firing, the lane is broken and must go red until it is fixed;
           # docs/solutions/best-practices/a-stress-probe-is-an-instrument-you-built-not-a-test.md owns why.
           #
-          # 7m42s measured on ubuntu-latest (about 2m50s locally), nearly all of it
+          # COST: 7m42s when this entry was written (about 2m50s locally), nearly all of it
           # WorkManagerLincheckTest, whose inverted arm cannot stop early and always pays its full
           # bound. bin/lincheck-test.sh's header owns the five flags that each fail silently on their
           # own.
+          #
+          # THE TIMEOUT IS 60, NOT SIZED TO THAT 7m42s, and deliberately so (owner ruling,
+          # 2026-09-09). Successful runs of this lane had drifted to 12m55s-19m58s by then and one
+          # crossed the old cap of 20 - and because Lincheck is a REQUIRED merge context, a cap
+          # inside the lane's own run-time distribution fails unrelated PRs at random, which is the
+          # false red this repo treats as worse than no signal. 60 is headroom, not a measurement.
+          #
+          # RAISING IT DOES NOT DELETE THE COST EVIDENCE, which is the usual objection and the reason
+          # this comment exists: the drifted durations are recorded in
+          # docs/inflight/test-lincheck-lane-open-items.md, and codecov keeps this lane's wall clock
+          # per commit (bin/inflight.mjs codecov slow), so the drift stays readable without a
+          # required check going red to report it. WHY the lane got 2-3x slower is still
+          # undiagnosed and still open in that note.
           - suite: lincheck
             name: "Lincheck"
             cmd: "bin/lincheck-test.sh"
-            timeout: 20
+            timeout: 60
             scenarios: ""
             shard: ""
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -195,15 +195,20 @@ jobs:
           # inside the lane's own run-time distribution fails unrelated PRs at random, which is the
           # false red this repo treats as worse than no signal. 60 is headroom, not a measurement.
           #
-          # RAISING IT DOES NOT DELETE THE COST EVIDENCE, which is the usual objection and the
-          # reason this comment exists. Codecov records per-test duration per commit, for longer
-          # than a CI log is kept, so the drift stays readable without a required check going red to
-          # report it - and it names the cost rather than totalling it:
+          # THE CAUSE IS RUNNER SPEED, NOT THE CODE. Nearly all of this lane is
+          # WorkManagerLincheckTest's checkpoint-three tear stress arm - a fixed
+          # iterations-times-invocations budget that cannot stop early, so its wall clock is a
+          # function of runner CPU speed alone. On 2026-09-09 the job ran 5-8.5 min until ~01:00
+          # UTC, 12-20 min until ~04:00 on EVERY branch including docs-only ones, then 7-8 min
+          # again. Codecov records that one test between 292s and 720s on commits an hour apart:
           #   bin/inflight.mjs codecov test stressMustNotRediscoverTheCheckpointThreeTear
-          # That ONE test was recorded between 292s and 720s across six commits on 2026-09-09, which
-          # is most of the old 20-minute cap on its own. WHY it moves that much is undiagnosed and
-          # open in docs/inflight/test-lincheck-lane-open-items.md, which carries the job-level
-          # durations too.
+          # A change that appears on branches sharing no code and reverses on a clock is ordinary
+          # ubuntu-latest variance. 20 was 2.6x the priced cost, which that variance exceeds; 60 is
+          # sized so it no longer does. Do NOT re-price the test's budget instead - that class's own
+          # comment records the starve-and-count procedure the number came from, and lowering it
+          # because CI was slow is not that procedure.
+          # docs/inflight/test-lincheck-lane-open-items.md carries the durations and the reproduce
+          # commands.
           #
           # WHAT IT COSTS: bin/lincheck-test.sh has no internal cap, so this job timeout is the only
           # backstop against a genuine hang, and the runner minutes a hang can burn go from 20 to 60.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -195,12 +195,19 @@ jobs:
           # inside the lane's own run-time distribution fails unrelated PRs at random, which is the
           # false red this repo treats as worse than no signal. 60 is headroom, not a measurement.
           #
-          # RAISING IT DOES NOT DELETE THE COST EVIDENCE, which is the usual objection and the reason
-          # this comment exists: the drifted durations are recorded in
-          # docs/inflight/test-lincheck-lane-open-items.md, and codecov keeps this lane's wall clock
-          # per commit (bin/inflight.mjs codecov slow), so the drift stays readable without a
-          # required check going red to report it. WHY the lane got 2-3x slower is still
-          # undiagnosed and still open in that note.
+          # RAISING IT DOES NOT DELETE THE COST EVIDENCE, which is the usual objection and the
+          # reason this comment exists. Codecov records per-test duration per commit, for longer
+          # than a CI log is kept, so the drift stays readable without a required check going red to
+          # report it - and it names the cost rather than totalling it:
+          #   bin/inflight.mjs codecov test stressMustNotRediscoverTheCheckpointThreeTear
+          # That ONE test was recorded between 292s and 720s across six commits on 2026-09-09, which
+          # is most of the old 20-minute cap on its own. WHY it moves that much is undiagnosed and
+          # open in docs/inflight/test-lincheck-lane-open-items.md, which carries the job-level
+          # durations too.
+          #
+          # WHAT IT COSTS: bin/lincheck-test.sh has no internal cap, so this job timeout is the only
+          # backstop against a genuine hang, and the runner minutes a hang can burn go from 20 to 60.
+          # That is the trade being made, named rather than discovered later.
           - suite: lincheck
             name: "Lincheck"
             cmd: "bin/lincheck-test.sh"

--- a/docs/inflight/bug-857-family.md
+++ b/docs/inflight/bug-857-family.md
@@ -93,7 +93,12 @@ This file keeps only the shape, so that a reader arriving here is not told the o
 established:
 
 - The fleet-scoped `NO_PROGRESS` firings are a **timing proxy** - the backlog drains every time the
-  detector fires. Its `## ANSWERED, 2026-08-28` and `## CONFIRMED, 2026-08-28` sections.
+  detector fires. Its `## ANSWERED, 2026-08-28` and `## CONFIRMED, 2026-08-28` sections. **Acted on
+  2026-09-09**: nine firings across four seeds, all drained, and `ChaosChurnStormIT`'s window widened
+  to 60s -
+  [`test-no-progress-window-may-not-transfer-to-w1.md`](test-no-progress-window-may-not-transfer-to-w1.md)
+  owns the verdict and the replay grid. **The five `NO_PROGRESS` seeds recorded in this file below
+  were part of that grid** - do not replay them again expecting news.
 - The per-instance `INSTANCE_STALL/NO_WORK_COMPLETED` firings are **a different line from the
   fleet-scoped one and must not be read with it**: one member stays live, keeps taking work, and
   returns nothing while the fleet finishes around it. What that member's workers are doing is the

--- a/docs/inflight/test-857-churn-storm-async-stalls.md
+++ b/docs/inflight/test-857-churn-storm-async-stalls.md
@@ -231,6 +231,15 @@ if it did. That is the same error the Class 2 entries made for a year.
 
 ## ANSWERED, 2026-08-28: it DRAINS. This line is a timing proxy, not a wedge.
 
+> STATUS: **BEYOND ARGUMENT 2026-09-09, on this section's own terms.** It asked for "a second firing,
+> ideally on a different seed". There are now nine firings on four seeds, all drained, none flat - the
+> six below plus `5650361238717170909` (this file's 2026-09-08 sighting), `3717713223451201639` on the
+> hosted runner, and `87978223167568` replayed locally. The scenario's no-progress window was widened
+> to 60s on that verdict.
+> [`test-no-progress-window-may-not-transfer-to-w1.md`](test-no-progress-window-may-not-transfer-to-w1.md)
+> **owns the verdict, the replay grid and which term moved**; what is added here is only that this
+> section's stated bar was met.
+
 The discriminator ran, on the first firing. Consumed after the violation: flat at 94878 for three
 samples, then 99665, 100138, and on past the 100000 target - while inFlight fell from 114 to 67.
 **It stalled, held, recovered and completed.**

--- a/docs/inflight/test-lincheck-lane-open-items.md
+++ b/docs/inflight/test-lincheck-lane-open-items.md
@@ -468,9 +468,19 @@ ever measured on the runner that runs it, which is the same question
 [`test-no-progress-window-may-not-transfer-to-w1.md`](test-no-progress-window-may-not-transfer-to-w1.md)
 answered for `NO_PROGRESS` by measuring the distribution instead of the crossings.
 
-**Do not raise the timeout as the first move.** A cap crossed by a lane whose cost has drifted is
-evidence about the cost, and raising it deletes that evidence with nothing going red to say so - the
-lane entry's own "the fix is NOT a retry" paragraph, one layer along.
+**Owner ruling, 2026-09-09: the cap is raised to 60 minutes, and the cost question stays open.**
+`Lincheck` is a REQUIRED merge context, so a cap sitting inside the lane's own run-time distribution
+fails unrelated PRs at random - a false red, which this repo treats as worse than no signal at all,
+and it is not a price worth paying to keep a cost measurement in a place that reports it by breaking
+merges.
+
+**The evidence is not lost by raising it**, which is the objection this ruling has to answer. The
+durations above are recorded here, and `bin/inflight.mjs codecov slow` keeps this lane's wall clock
+per commit, so the drift stays readable without a required check going red to report it. **Why the
+lane got 2-3x slower is undiagnosed and stays open** - the first place its own matrix comment says to
+look is the machine-dependent stress hit rate two sections up, and the number nobody has is what this
+lane costs on the runner class that actually runs it. Whoever picks that up should read the drift
+from codecov rather than re-deriving it from job pages, which expire.
 
 ## Disproven, recorded so it is not re-raised
 

--- a/docs/inflight/test-lincheck-lane-open-items.md
+++ b/docs/inflight/test-lincheck-lane-open-items.md
@@ -451,6 +451,27 @@ author's call rather than a review fix.
   success while its transformer failed per-class would have made every calibration verdict read
   "not found".
 
+## The lane's 20-minute job timeout now sits inside its own run-time distribution, 2026-09-09
+
+**Sighting, recorded rather than diagnosed.** The `Lincheck` job hit its `timeout: 20` in
+`.github/workflows/maven.yml` and GitHub reported it as *cancelled* - the only non-success job in an
+otherwise wholly green run on a branch that touches no code this lane compiles
+([job 102324330280](https://github.com/astubbs/parallel-consumer/actions/runs/34306516342/job/102324330280),
+22m13s). It is not that branch's doing, and the three runs immediately before it on other branches
+say why: 14m49s, 12m55s and **19m58s**, the last clearing the cap by two seconds.
+
+So the budget is being ridden, not exceeded once. The entry's own comment prices this lane at
+*"7m42s measured on ubuntu-latest"*, and the runs above are 1.7-2.9x that. Whether the cause is the
+runner class, a change in what the arms explore, or the machine-dependent hit rate this note already
+owns two sections up, nobody has looked - and the number to check first is whether the bound was
+ever measured on the runner that runs it, which is the same question
+[`test-no-progress-window-may-not-transfer-to-w1.md`](test-no-progress-window-may-not-transfer-to-w1.md)
+answered for `NO_PROGRESS` by measuring the distribution instead of the crossings.
+
+**Do not raise the timeout as the first move.** A cap crossed by a lane whose cost has drifted is
+evidence about the cost, and raising it deletes that evidence with nothing going red to say so - the
+lane entry's own "the fix is NOT a retry" paragraph, one layer along.
+
 ## Disproven, recorded so it is not re-raised
 
 The claim that core's `<argLine>@{argLine} ${lincheck.jvm.args}</argLine>` feeds a literal

--- a/docs/inflight/test-lincheck-lane-open-items.md
+++ b/docs/inflight/test-lincheck-lane-open-items.md
@@ -468,6 +468,13 @@ ever measured on the runner that runs it, which is the same question
 [`test-no-progress-window-may-not-transfer-to-w1.md`](test-no-progress-window-may-not-transfer-to-w1.md)
 answered for `NO_PROGRESS` by measuring the distribution instead of the crossings.
 
+**The very next run settled whether the raise was needed.** With the cap at 60, this lane PASSED at
+**20m8s** on the branch that raised it
+([job 102334638957](https://github.com/astubbs/parallel-consumer/actions/runs/34309813133/job/102334638957)) -
+eight seconds past the old cap, on a green run. Under the old 20 it would have been killed and read
+as a red on a PR that changes nothing this lane compiles, which is the exact failure the ruling below
+was made against.
+
 **Owner ruling, 2026-09-09: the cap is raised to 60 minutes, and the cost question stays open.**
 `Lincheck` is a REQUIRED merge context, so a cap sitting inside the lane's own run-time distribution
 fails unrelated PRs at random - a false red, which this repo treats as worse than no signal at all,
@@ -475,12 +482,20 @@ and it is not a price worth paying to keep a cost measurement in a place that re
 merges.
 
 **The evidence is not lost by raising it**, which is the objection this ruling has to answer. The
-durations above are recorded here, and `bin/inflight.mjs codecov slow` keeps this lane's wall clock
-per commit, so the drift stays readable without a required check going red to report it. **Why the
-lane got 2-3x slower is undiagnosed and stays open** - the first place its own matrix comment says to
-look is the machine-dependent stress hit rate two sections up, and the number nobody has is what this
-lane costs on the runner class that actually runs it. Whoever picks that up should read the drift
-from codecov rather than re-deriving it from job pages, which expire.
+job-level durations above are recorded here, and Codecov keeps per-test duration per commit for
+longer than a CI log survives - so the drift stays readable without a required check going red to
+report it. Read it there rather than from job pages, which expire:
+
+    bin/inflight.mjs codecov test stressMustNotRediscoverTheCheckpointThreeTear
+
+**And that command already narrows the question to one test.** `WorkManagerLincheckTest`'s stress
+arm - the one this lane's matrix comment names as "nearly all of it", because an inverted arm cannot
+stop early and always pays its full bound - was recorded between **292s and 720s** across six
+commits on 2026-09-09 alone, all passing. The upper end is most of the old 20-minute cap by itself,
+and the spread is 2.5x on a fixed bound, which is the machine-dependent stress hit rate this note
+already owns two sections up rather than a new mystery. **Why it varies that much is undiagnosed and
+stays open**; the number nobody has is what the arm costs on the runner class that actually runs it,
+which is the same prerequisite that section states.
 
 ## Disproven, recorded so it is not re-raised
 

--- a/docs/inflight/test-lincheck-lane-open-items.md
+++ b/docs/inflight/test-lincheck-lane-open-items.md
@@ -451,51 +451,48 @@ author's call rather than a review fix.
   success while its transformer failed per-class would have made every calibration verdict read
   "not found".
 
-## The lane's 20-minute job timeout now sits inside its own run-time distribution, 2026-09-09
+## The lane's job timeout was raised to 60, and the cause of the crossings was runner speed, 2026-09-09
 
-**Sighting, recorded rather than diagnosed.** The `Lincheck` job hit its `timeout: 20` in
-`.github/workflows/maven.yml` and GitHub reported it as *cancelled* - the only non-success job in an
-otherwise wholly green run on a branch that touches no code this lane compiles
+**Sighting.** The `Lincheck` job hit its `timeout: 20` in `.github/workflows/maven.yml` and GitHub
+reported it as *cancelled* - the only non-success job in an otherwise wholly green run on a branch
+that touches no code this lane compiles
 ([job 102324330280](https://github.com/astubbs/parallel-consumer/actions/runs/34306516342/job/102324330280),
-22m13s). It is not that branch's doing, and the three runs immediately before it on other branches
-say why: 14m49s, 12m55s and **19m58s**, the last clearing the cap by two seconds.
+22m13s). Successful runs on other branches over the same hours sat at 14m49s, 12m55s and 19m58s, the
+last clearing the cap by two seconds.
 
-So the budget is being ridden, not exceeded once. The entry's own comment prices this lane at
-*"7m42s measured on ubuntu-latest"*, and the runs above are 1.7-2.9x that. Whether the cause is the
-runner class, a change in what the arms explore, or the machine-dependent hit rate this note already
-owns two sections up, nobody has looked - and the number to check first is whether the bound was
-ever measured on the runner that runs it, which is the same question
-[`test-no-progress-window-may-not-transfer-to-w1.md`](test-no-progress-window-may-not-transfer-to-w1.md)
-answered for `NO_PROGRESS` by measuring the distribution instead of the crossings.
+**Diagnosed: ordinary hosted-runner speed variance against a fixed, uninterruptible budget.** Nearly
+all of this lane is `WorkManagerLincheckTest`'s checkpoint-three tear stress arm - a fixed
+iterations-times-invocations budget that cannot stop early, so its wall clock is a function of runner
+CPU speed and nothing else. Across every successful `maven.yml` run on 2026-09-08 and 2026-09-09, on
+every branch, the job sat at roughly 5-8.5 minutes until about 01:00 UTC on 2026-09-09, then 12-20
+minutes until about 04:00 UTC - **on every branch, docs-only ones included** - then back to 7-8
+minutes on the first runs after 04:00. Codecov records the same single test between 292s and 720s on
+commits an hour apart. A change that appears on branches sharing no code, and reverses itself on a
+clock rather than on a commit, is not the code: `ubuntu-latest` ran at about half speed for a few
+hours. Reproduce rather than trusting a table here, since both go stale:
 
-**The very next run settled whether the raise was needed.** With the cap at 60, this lane PASSED at
-**20m8s** on the branch that raised it
-([job 102334638957](https://github.com/astubbs/parallel-consumer/actions/runs/34309813133/job/102334638957)) -
-eight seconds past the old cap, on a green run. Under the old 20 it would have been killed and read
-as a red on a PR that changes nothing this lane compiles, which is the exact failure the ruling below
-was made against.
-
-**Owner ruling, 2026-09-09: the cap is raised to 60 minutes, and the cost question stays open.**
-`Lincheck` is a REQUIRED merge context, so a cap sitting inside the lane's own run-time distribution
-fails unrelated PRs at random - a false red, which this repo treats as worse than no signal at all,
-and it is not a price worth paying to keep a cost measurement in a place that reports it by breaking
-merges.
-
-**The evidence is not lost by raising it**, which is the objection this ruling has to answer. The
-job-level durations above are recorded here, and Codecov keeps per-test duration per commit for
-longer than a CI log survives - so the drift stays readable without a required check going red to
-report it. Read it there rather than from job pages, which expire:
-
+    gh run list -R astubbs/parallel-consumer --workflow maven.yml --limit 60 --json databaseId,headBranch,createdAt
+    gh run view <id> -R astubbs/parallel-consumer --json jobs   # the Lincheck leg's started/completed
     bin/inflight.mjs codecov test stressMustNotRediscoverTheCheckpointThreeTear
 
-**And that command already narrows the question to one test.** `WorkManagerLincheckTest`'s stress
-arm - the one this lane's matrix comment names as "nearly all of it", because an inverted arm cannot
-stop early and always pays its full bound - was recorded between **292s and 720s** across six
-commits on 2026-09-09 alone, all passing. The upper end is most of the old 20-minute cap by itself,
-and the spread is 2.5x on a fixed bound, which is the machine-dependent stress hit rate this note
-already owns two sections up rather than a new mystery. **Why it varies that much is undiagnosed and
-stays open**; the number nobody has is what the arm costs on the runner class that actually runs it,
-which is the same prerequisite that section states.
+**Why the cap was the wrong size for that.** 20 minutes was 2.6x the 7m42s the matrix entry priced
+the lane at, which sounds generous and is not: variance of the magnitude above exceeds it, and
+`Lincheck` is a REQUIRED merge context, so the overflow lands as a red on whichever unrelated PR was
+running at the time. **Owner ruling, 2026-09-09: the cap is 60 minutes**, sized so ordinary variance
+of that size no longer fails a required check rather than sized to the lane's cost.
+
+**The budget is not the lever, and that is not a preference.** `WorkManagerLincheckTest`'s own
+comment records how its bound was priced - a deliberately starved `iterations(25)` arm run to a hit
+count, 48 runs on one machine - and re-pricing it means running that procedure again, not lowering a
+number because CI was slow. The confirming run is already in: with the cap at 60 the lane **passed at
+20m8s** on the branch that raised it
+([job 102334638957](https://github.com/astubbs/parallel-consumer/actions/runs/34309813133/job/102334638957)),
+eight seconds past the old cap, on a green run that the old cap would have killed and reported as a
+failure of a PR changing nothing this lane compiles.
+
+**What raising it costs, since nothing else says so:** `bin/lincheck-test.sh` has no internal cap, so
+this job timeout is the only backstop against a genuine hang, and the runner minutes a hang can burn
+go from 20 to 60.
 
 ## Disproven, recorded so it is not re-raised
 

--- a/docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md
+++ b/docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md
@@ -2,7 +2,7 @@
 
 <!-- inflight-type: bug -->
 <!-- inflight-impact: misdirection -->
-<!-- inflight-vetted: 2026-09-09 - REPLAYED, and the widening has landed: ChaosChurnStormIT now calls withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW), the 60s bound AbstractRevokeUnderWorkScenario already held, and NoProgressWindowIT fires the detector at that bound on a fleet that genuinely stops (three of its six tests go red under a one-term sabotage of recordFleetProgress, so the green is not vacuous). PROPOSED for the owner, and only this: whether the note is now CLOSED or kept open on the residue named in its 2026-09-09 verdict section - the demote-or-widen call was owner-gated on the misdirection impact, so the marker is not moved by the agent that ran the replays. The verdict itself is evidence, not judgement: thirteen replays of every seed in this table plus the five in bug-857-family.md, all with -Dchaos.diagnoseStallRecovery=true; one fired and DRAINED, twelve were VOID, none stayed flat. Nine firings across four seeds have now been watched past detection and nine drained -->
+<!-- inflight-vetted: 2026-09-09 - REPLAYED, and the widening has landed: ChaosChurnStormIT now calls withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW), the 60s bound AbstractRevokeUnderWorkScenario already held, and NoProgressWindowIT fires the detector at that bound on a fleet that genuinely stops - its firing assertions go red under a one-term sabotage of recordFleetProgress (stub it to return false and re-run the class), so the green is not vacuous. PROPOSED for the owner, and only this: whether the note is now CLOSED or kept open on the residue named in its 2026-09-09 verdict section - the demote-or-widen call was owner-gated on the misdirection impact, so the marker is not moved by the agent that ran the replays. The verdict itself is evidence, not judgement: thirteen replays of every seed in this table plus the five in bug-857-family.md, all with -Dchaos.diagnoseStallRecovery=true; one fired and DRAINED, twelve were VOID, none stayed flat. Nine firings across four seeds have now been watched past detection and nine drained -->
 
 Two chaos detectors have now been found asserting a timing bound that the scenario's own disturbances
 legitimately cross - `CLASS2_STALL` (demoted to an observation) and `REBALANCE_DWELL` (disarmed in
@@ -108,7 +108,7 @@ at least one stays flat.
 | `2512758007437016849` | this table | VOID |
 | `8064312734196519950` | this table | VOID |
 | `8637977624689145046` | this table | VOID |
-| `3717713223451201639` | this table | VOID |
+| `3717713223451201639` | this table | VOID on this replay; its 2026-09-09 CI firing DRAINED - the last row of the sightings table above |
 | `5650361238717170909` | this table | VOID on this replay; it DRAINED on its 2026-09-08 one |
 | `2575991864395313898` | the row above said "not recorded" - it was | VOID |
 | `3086917415748208232` | `bug-857-family.md`, ninth sighting | VOID |
@@ -152,14 +152,49 @@ window**, and a long way past the slack. That distinction chooses the fix.
 
 **So the window moves, to the 60s W4 already holds** - `ProgressProbe#CHURN_NO_PROGRESS_WINDOW`,
 named rather than repeated now that two scenarios reach the same number by two different mechanisms.
-60s is ~1.9x the measured armed peak, the ratio `REBALANCE_DWELL_BOUND` was calibrated at.
+60s is 1.9x the measured armed peak - the same METHOD `REBALANCE_DWELL_BOUND` was sized by, a
+multiple of a measured healthy peak, though at a smaller multiple than the 2.2x its own javadoc
+records.
+
+**Be exact about where the 60 comes from, because it is the caveat on "does this fix it".** The
+VALUE is inherited from W4, which chose it for a different mechanism. What was measured on W1 is
+that 60s is *enough* for it - and measured on ONE DESKTOP, over thirteen replays, one of which
+fired. **The hosted runner's own distribution is unmeasured**, and it cannot be recovered from the
+sightings: every one of them reports `for 30s (bound 30s)`, which is the bound plus detection
+latency and says nothing about how long the pause would have run. So the expected outcome is that
+this lane stops failing on `NO_PROGRESS`, not that it is proven to. If it fires again at 60s, the
+number to take is the armed pause peak from a `-Dchaos.diagnoseStallRecovery=true` replay, not
+another guess.
 
 **It is a re-calibration and not a deletion, and that is asserted rather than argued.**
-`NoProgressWindowIT` fires the detector at the wider bound on a fleet that genuinely stops; three of
-its six tests go red under a one-term sabotage of `ProgressProbe#recordFleetProgress`, so its green
-is not vacuous. A replay-and-watch-it-go-green check was deliberately NOT used as the evidence -
+`NoProgressWindowIT` fires the detector at the wider bound on a fleet that genuinely stops, and
+pins the calibrated numbers themselves so a later edit to the constant cannot pass silently. Its
+firing assertions go red under a one-term sabotage of `ProgressProbe#recordFleetProgress` - stub it
+to `return false` and re-run the class - so its green is not vacuous. A replay-and-watch-it-go-green check was deliberately NOT used as the evidence -
 the crossing is probabilistic even on a fixed seed, and a window widened to infinity would produce
 the same green. That is `RebalanceDwellToggleIT`'s argument, reused rather than rediscovered.
+
+## What the widening now tolerates - the strongest argument against it, stated
+
+An independent cross-model review of the change put it plainly, and it is right: **a genuine
+fleet-wide stall of 31 to 60 seconds, with thousands of records outstanding and no other detector
+firing, now passes this scenario.** That is not a side effect - it is the change. The 30s bound
+bought that sensitivity and paid for it with a false red several times a day on a required lane, and
+the evidence above says every crossing anyone has watched was the false kind.
+
+Two things bound the risk, and neither removes it:
+
+- **A stall does not stop at 60 seconds.** Nine firings drained; the shape a real wedge would take is
+  flat forever, which crosses any finite window. What the widening loses is the ability to catch a
+  wedge *early*, not the ability to catch one.
+- **The fleet-wide counter was never the instrument for the finer cases anyway** - one wedged member
+  or one wedged partition hides behind healthy siblings in an aggregate count, whatever the window.
+  Those have their own owners: `INSTANCE_STALL` and
+  [`test-per-shard-liveness-has-no-gate.md`](test-per-shard-liveness-has-no-gate.md).
+
+**What would retire the caveat** is the measurement this change did not make: the benign pause
+distribution on the hosted runner class, with an armed deterministic real-stall control beside it.
+Until someone takes it, 60s rests on thirteen desktop replays.
 
 ## What this does NOT close
 
@@ -174,6 +209,27 @@ the same green. That is `RebalanceDwellToggleIT`'s argument, reused rather than 
 - **The autopsy still prints `violations (0)` beside a fleet-level firing** -
   [`test-chaos-autopsy-omits-fleet-violations.md`](test-chaos-autopsy-omits-fleet-violations.md),
   still live, and reproduced again on the runs above.
+- **Nothing fast asserts that a chaos scenario WIRES the probe it means to.** `NoProgressWindowIT`
+  pins the seam and the calibrated values; delete `ChaosChurnStormIT`'s
+  `.withNoProgressWindow(...)` line and only a real chaos run would notice - and the replays above
+  say the crossing fires roughly once in thirteen, so it could hide for a long time. This is not
+  this change's doing: every fast probe test in the suite
+  (`RebalanceDwellToggleIT`, `InstanceStallProbeIT`, `DiagnosticQuietCapIT`, `ChaosConductorPlanIT`)
+  drives a seam directly and none pins a scenario's configuration call. Named here because a review
+  found it and nothing else tracks it; the cheap options are an ArchUnit-style source assertion or a
+  package-private accessor a scenario-setup test can read.
+- **The defect-class sweep's one surviving candidate, on this same scenario: `REBALANCE_DWELL` is
+  still ARMED here.** W4 and W5 both disable it because their own churn crosses it with no member
+  being a zombie; W1 is where it stays armed, and it has fired here anyway - `ChaosChurnStormIT`
+  with `rebalanceDwell=15602ms` against a 15000ms bound, seed `989468380938115993`, on a
+  documentation-only commit
+  ([run 32321963226](https://github.com/astubbs/parallel-consumer/actions/runs/32321963226/job/96285796525)),
+  and again at `15392ms` and `15482ms` in
+  [`bug-857-family.md`](bug-857-family.md). Crossings of 2.6-4.0% are this class's whole signature.
+  **It is NOT settled by this note and is not touched by this change**, because the deciding
+  experiment is a different one - measure the dwell distribution on this scenario the way the pause
+  distribution was measured above, rather than reason from the resemblance. Recorded here because
+  nothing else tracks it; naming it is not a verdict on it.
 
 **That experiment no longer rests on a single seed - every row in the table above is one**, and the
 table is where the set lives, so a sentence here does not restate it (an earlier version of this

--- a/docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md
+++ b/docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md
@@ -1,8 +1,8 @@
-# The 30s fleet-progress window may not transfer to W1 either - a possible third instance
+# The 30s fleet-progress window does not transfer to W1 either - the third instance, replayed 2026-09-09
 
 <!-- inflight-type: bug -->
 <!-- inflight-impact: misdirection -->
-<!-- inflight-vetted: 2026-09-09 - the calibration asymmetry is still unchanged in the tree (ProgressProbe's NO_PROGRESS window is still 30s and TAIL_SLACK still 500, AbstractRevokeUnderWorkScenario still calls withNoProgressWindow(Duration.ofSeconds(60)), ChaosChurnStormIT still takes the default), and the 2026-09-09 row below is new evidence. PROPOSED partly-true, for the owner: "What would settle it" and "Nobody has replayed that seed, and no control arm exists" are out of date, and this note never took delivery of the answer. The deciding experiment HAS been run with the diagnostic engaged, on two seeds that are not in this table, and both DRAINED - test-857-churn-storm-async-stalls.md's "CONFIRMED, 2026-08-28" section replayed 9086872209853284830 six times and drained six for six, and its "Sighting, 2026-09-08" section replayed 5650361238717170909 from 93487 to 101070/100000 at an outstanding count of 6513 against a TAIL_SLACK of 500, larger than every row here. That second sighting says outright that this note owns the question; the pointer was written and never followed. The 2026-09-09 row is a third drain-side observation and the first on the gate's own configuration, but it is the weak form - no diagnostic, and churn stopped 10s after the firing. Owner-gated because the impact is misdirection: the demote-or-widen call this now supports is not an agent's to make. What the note says against it still stands as written - it forbids acting on the pattern-matching argument, and these are replays, not that argument -->
+<!-- inflight-vetted: 2026-09-09 - REPLAYED, and the widening has landed: ChaosChurnStormIT now calls withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW), the 60s bound AbstractRevokeUnderWorkScenario already held, and NoProgressWindowIT fires the detector at that bound on a fleet that genuinely stops (three of its six tests go red under a one-term sabotage of recordFleetProgress, so the green is not vacuous). PROPOSED for the owner, and only this: whether the note is now CLOSED or kept open on the residue named in its 2026-09-09 verdict section - the demote-or-widen call was owner-gated on the misdirection impact, so the marker is not moved by the agent that ran the replays. The verdict itself is evidence, not judgement: thirteen replays of every seed in this table plus the five in bug-857-family.md, all with -Dchaos.diagnoseStallRecovery=true; one fired and DRAINED, twelve were VOID, none stayed flat. Nine firings across four seeds have now been watched past detection and nine drained -->
 
 Two chaos detectors have now been found asserting a timing bound that the scenario's own disturbances
 legitimately cross - `CLASS2_STALL` (demoted to an observation) and `REBALANCE_DWELL` (disarmed in
@@ -17,7 +17,7 @@ for it either:
 
 | Source | Observation | Seed |
 |---|---|---|
-| astubbs/parallel-consumer#348, in `test-chaos-autopsy-omits-fleet-violations.md` | `fleet consumed count stuck at 98804/100000 for 30s (bound 30s)` | not recorded |
+| astubbs/parallel-consumer#348, in `test-chaos-autopsy-omits-fleet-violations.md` | `fleet consumed count stuck at 98804/100000 for 30s (bound 30s)` | **`2575991864395313898`** <!-- corrected 2026-09-09: this cell read "not recorded" from the day the row was written. The seed is in the note the row cites, under `chaos seed:`, and in bug-857-family.md's 2026-08-25 entry against the same job id -->|
 | `bug-857-family.md`'s fourteenth sighting (from astubbs/parallel-consumer#347) | `NO_PROGRESS, fleet stuck at 97896/100000` - 30s against a 30s bound | **`1521825993857670757`** |
 | Torture soak 2026-08-29, cycle 51 (`bin/torture-overnight.sh`) | `fleet consumed count stuck at 97386/100000 for 30s (bound 30s)` | **`87978223167568`** |
 | Torture soak 2026-08-29, cycle 166 | `fleet consumed count stuck at 97297/100000 for 30s (bound 30s)` | **`106062481479157`** |
@@ -74,6 +74,11 @@ drained is unknown, as for every row above it.
 
 ## Why it is NOT yet called a third instance
 
+> STATUS: **SUPERSEDED 2026-09-09** by the verdict section below - the replays were run and a control
+> arm exists. The paragraph is kept verbatim because it is the standard this note set for itself and
+> the verdict has to be read against it: it forbade acting on the *pattern-matching* argument, and
+> what settled it was replays rather than that argument.
+
 Nobody has replayed that seed, and no control arm exists. The alternative reading is a genuine
 fleet-wide stall, which is exactly what this detector is for and would be the most interesting
 outcome in the whole family. **Do not demote or widen it on the argument above** - that argument is
@@ -81,10 +86,94 @@ pattern-matching, and the same reasoning applied to `CLASS2_STALL` took a replay
 
 ## What would settle it
 
+> STATUS: **SUPERSEDED 2026-09-09** - this is what was run, and the section below is what it returned.
+
 Replay `1521825993857670757` with the fleet allowed to continue past detection, and read whether
 consumption resumes. Drains -> calibration, and W1 wants the same widening W4 has. Stays flat ->
 this is the fleet-level stall the family has been hunting, and it is a much better lead than any
 `CLASS2_STALL` seed in [`bug-857-family.md`](bug-857-family.md).
+
+## ANSWERED, 2026-09-09: it DRAINS. This is the third instance, and the window is the term that moves.
+
+**Every seed in the table above, plus five more the table never carried, replayed with
+`-Dchaos.diagnoseStallRecovery=true` so the fleet ran on past detection.** The prediction was written
+before the first run: the drains reading predicted every firing drains, the stall reading predicted
+at least one stays flat.
+
+| Seed | Source | Verdict |
+|---|---|---|
+| `1521825993857670757` | this table | VOID - passed, no firing |
+| `87978223167568` | this table | **DRAINED** - fired at 97633/100000, ran on to 100742 with full key coverage |
+| `106062481479157` | this table | VOID |
+| `2512758007437016849` | this table | VOID |
+| `8064312734196519950` | this table | VOID |
+| `8637977624689145046` | this table | VOID |
+| `3717713223451201639` | this table | VOID |
+| `5650361238717170909` | this table | VOID on this replay; it DRAINED on its 2026-09-08 one |
+| `2575991864395313898` | the row above said "not recorded" - it was | VOID |
+| `3086917415748208232` | `bug-857-family.md`, ninth sighting | VOID |
+| `8603691233664838594` | `bug-857-family.md`, tenth sighting | VOID |
+| `8746139315096023802` | `bug-857-family.md`, 2026-08-26 | VOID |
+| `1630088991107806597` | `bug-857-family.md`, 2026-09-03 - *"the next experiment"* it nominates by name | VOID |
+
+**One firing, no flats, and the VOIDs are not evidence for either reading** - the void-replay rule.
+A seed that does not fire has not been asked the question. What the VOIDs do say is that these seeds
+are one-offs, which
+[`../solutions/test-flakiness/collect-more-firings-not-more-seeds-2026-09-01.md`](../solutions/test-flakiness/collect-more-firings-not-more-seeds-2026-09-01.md)
+predicted in as many words, and it is why the seed hunt this note prescribed was the weaker half of
+the instrument.
+
+**With the prior arms this line already had, nine firings have now been watched past detection and
+nine drained, on four seeds, zero flat.** The six of `9086872209853284830` and the 2026-09-08 replay
+of `5650361238717170909` are in
+[`test-857-churn-storm-async-stalls.md`](test-857-churn-storm-async-stalls.md), which **owns that
+mechanism**; the 2026-09-09 hosted-runner recovery is the last row of the table above; the ninth is
+`87978223167568` here. That answers what its `## ANSWERED, 2026-08-28` section asked for outright -
+*"a second firing, ideally on a different seed, is what would put it beyond argument."*
+
+## Which term the drains crossed - and it is not the one the sightings pointed at
+
+This note read the firings as sitting "just past the slack". They do not: they sit **just past the
+window**, and a long way past the slack. That distinction chooses the fix.
+
+- **The window is crossed by seconds.** The violation line can only ever report the bound plus the
+  probe's detection latency, so it discriminates nothing - the arithmetic
+  [`../solutions/best-practices/a-timing-bound-used-as-a-correctness-gate-manufactures-its-own-evidence.md`](../solutions/best-practices/a-timing-bound-used-as-a-correctness-gate-manufactures-its-own-evidence.md)
+  sets out. So the fleet's own pause length was measured instead, off the `[diagnose]` consumed
+  series and **restricted to the region where the detector is armed** (outside `TAIL_SLACK`), which
+  makes it readable on runs that PASSED - where nothing else records it. Across the thirteen replays
+  the armed peak reached **32.1s**, with three further runs at 28.2-30.1s that did not fire. The 30s
+  bound sits inside the ordinary distribution of this scenario's own churn, and three passing runs
+  missed it by under two seconds.
+- **The slack would have to be crossed by an order of magnitude.** The firings sit 1196-6513 records
+  short against a `TAIL_SLACK` of 500. A slack wide enough to excuse them is several percent of the
+  backlog, and would blind the detector to the "stall with THOUSANDS remaining" its own constant's
+  javadoc names as the defect signature. Raising it was the wrong lever, and this is why.
+
+**So the window moves, to the 60s W4 already holds** - `ProgressProbe#CHURN_NO_PROGRESS_WINDOW`,
+named rather than repeated now that two scenarios reach the same number by two different mechanisms.
+60s is ~1.9x the measured armed peak, the ratio `REBALANCE_DWELL_BOUND` was calibrated at.
+
+**It is a re-calibration and not a deletion, and that is asserted rather than argued.**
+`NoProgressWindowIT` fires the detector at the wider bound on a fleet that genuinely stops; three of
+its six tests go red under a one-term sabotage of `ProgressProbe#recordFleetProgress`, so its green
+is not vacuous. A replay-and-watch-it-go-green check was deliberately NOT used as the evidence -
+the crossing is probabilistic even on a fixed seed, and a window widened to infinity would produce
+the same green. That is `RebalanceDwellToggleIT`'s argument, reused rather than rediscovered.
+
+## What this does NOT close
+
+- **Whether this detector MISSES real failures** is untouched, and a wider window can only make it
+  more pressing. It is [`../testing.md`](../testing.md)'s "Experiment runners" row for
+  `bin/exp-audit-stall-detector-silence.sh`, open and reopened 2026-08-31.
+- **The lane can still go red on this scenario without `NO_PROGRESS`.** The 2026-09-08 replay of
+  `5650361238717170909` failed on the outer completion wait with `consumed=101070/100000` and the
+  ledger still short of full key coverage - the per-shard gap
+  [`test-per-shard-liveness-has-no-gate.md`](test-per-shard-liveness-has-no-gate.md) owns. Widening
+  the window does not touch it, so this is not "the chaos lane is fixed".
+- **The autopsy still prints `violations (0)` beside a fleet-level firing** -
+  [`test-chaos-autopsy-omits-fleet-violations.md`](test-chaos-autopsy-omits-fleet-violations.md),
+  still live, and reproduced again on the runs above.
 
 **That experiment no longer rests on a single seed - every row in the table above is one**, and the
 table is where the set lives, so a sentence here does not restate it (an earlier version of this

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/AbstractRevokeUnderWorkScenario.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/AbstractRevokeUnderWorkScenario.java
@@ -237,8 +237,10 @@ abstract class AbstractRevokeUnderWorkScenario extends ChaosScenarioBase {
                 // (30s max.poll.interval) and firing on them would mask the Class 2 measurement
                 .disableRebalanceDwellViolation()
                 // storm-phase rebalances can legitimately pause much of the fleet for up to the
-                // eviction horizon (all of it, under the eager assignor); widen the watermark beyond it
-                .withNoProgressWindow(Duration.ofSeconds(60));
+                // eviction horizon (all of it, under the eager assignor); widen the watermark beyond
+                // it. The number is shared with W1, which reaches the same bound by a different
+                // mechanism - ProgressProbe#CHURN_NO_PROGRESS_WINDOW carries both.
+                .withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW);
 
         ChaosConductor conductor = conductorFor(fleet, pcConfig, HEAVY_EVERY, heavySleep(), MAX_FLEET)
                 .seed(seed.getValue())

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosChurnStormIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosChurnStormIT.java
@@ -59,14 +59,24 @@ import java.util.concurrent.atomic.AtomicLong;
  *   {@code [diagnose]} series rather than off the violation line (which can only ever say "the bound
  *   plus detection latency"). Across thirteen replays on one desktop the armed peak reached 32.1s,
  *   with three further runs at 28.2-30.1s that did not fire: the 30s bound sat inside the ordinary
- *   distribution and three passing runs missed it by under two seconds. 60s is ~1.9x the measured
- *   peak, the same ratio {@link ProgressProbe#REBALANCE_DWELL_BOUND} was calibrated at.</li>
+ *   distribution and three passing runs missed it by under two seconds. 60s is 1.9x that peak -
+ *   the same METHOD {@link ProgressProbe#REBALANCE_DWELL_BOUND} was sized by, a multiple of a
+ *   measured healthy peak, though at a smaller multiple than its 2.2x.</li>
  * </ul>
- * <b>The widening is not a disabling</b>, and that is asserted rather than argued -
- * {@code NoProgressWindowIT} fires the detector at the wider bound on a fleet that genuinely stops.
- * What it does NOT cover is the separate question of whether this detector MISSES real failures
- * ({@code docs/testing.md}, "Experiment runners"), which a wider window can only make more pressing.
- * The seeds, the trajectories and the per-run numbers are in
+ * <b>The widening is not a disabling</b>, and that is asserted rather than argued.
+ * {@code NoProgressWindowIT} fires the detector at the wider bound on a fleet that genuinely stops,
+ * pins the calibrated numbers as values so a later edit to them cannot pass silently, drives the
+ * SAMPLER rather than only the decision it calls, and asserts that this class's
+ * {@link #configureProbe} really applies the wider bound - each of those arms verified by a one-term
+ * sabotage that reddens it and nothing else.
+ * <p>
+ * <b>What it costs, stated rather than left to be discovered</b>: a genuine fleet-wide stall of 31
+ * to 60 seconds with work outstanding now passes this scenario. A real wedge does not stop at 60s,
+ * so what is lost is early detection rather than detection - and the finer cases the fleet-wide
+ * counter never covered (one wedged member, one wedged partition) have their own owners. The
+ * separate question of whether this detector MISSES real failures ({@code docs/testing.md},
+ * "Experiment runners") is untouched and a wider window can only make it more pressing. The seeds,
+ * the trajectories and the per-run numbers are in
  * {@code docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md}.
  * <p>
  * <b>The instance-stall line - also answered, 2026-09-07, do not re-derive</b>: seed
@@ -141,6 +151,23 @@ class ChaosChurnStormIT extends ChaosScenarioBase {
                 "the finding worth reporting is a run that stays FLAT. ===");
     }
 
+    /**
+     * This scenario's probe configuration, named so it can be ASSERTED rather than only run.
+     * {@code NoProgressWindowIT} calls it, so deleting the widening below turns a fast broker-free
+     * test red instead of quietly changing what a five-minute chaos run gates on - a run whose own
+     * replay data says the crossing fires roughly once in thirteen, so a regression here would
+     * otherwise hide for a long time.
+     * <p>
+     * This scenario's own churn crosses the 30s default while the fleet is merely slow: the eager
+     * assignor revokes the whole assignment every few seconds, so each 45s {@link #HEAVY_SLEEP} is
+     * redelivered before it ends and the fleet can sit wholly inside the heavy tail with nothing
+     * COMPLETING while every member is working. Widened on the evidence, not on the resemblance -
+     * see this class's "Calibration status" javadoc.
+     */
+    static ProgressProbe configureProbe(ProgressProbe probe) {
+        return probe.withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW);
+    }
+
     @Test
     void churnStormMeetsSlosAndBalancesLedger() throws Exception {
         // The @Timeout clock starts here, so effectiveDiagnosticQuietCap's time-remaining sum must too.
@@ -165,13 +192,7 @@ class ChaosChurnStormIT extends ChaosScenarioBase {
         AtomicLong totalStarted = fleet.getTotalStarted();
         Queue<String> allConsumed = fleet.getAllConsumed();
         Set<String> expectedKeys = fleet.getExpectedKeys();
-        ProgressProbe probe = fleet.getProbe()
-                // This scenario's own churn crosses the 30s default while the fleet is merely slow:
-                // the eager assignor revokes the whole assignment every few seconds, so each 45s
-                // HEAVY_SLEEP is redelivered before it ends and the fleet can sit wholly inside the
-                // heavy tail with nothing COMPLETING while every member is working. Widened on the
-                // evidence, not on the resemblance - see this class's "Calibration status" javadoc.
-                .withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW);
+        ProgressProbe probe = configureProbe(fleet.getProbe());
 
         ChaosConductor conductor = conductorFor(fleet, pcConfig, HEAVY_EVERY, HEAVY_SLEEP, MAX_FLEET)
                 .seed(seed.getValue())

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosChurnStormIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ChaosChurnStormIT.java
@@ -41,6 +41,34 @@ import java.util.concurrent.atomic.AtomicLong;
  * than a distinct defect. A run that drains reproduces a known result; a run that stays FLAT is the
  * finding worth reporting.
  * <p>
+ * <b>The no-progress WINDOW was widened on that verdict, 2026-09-09</b>, to
+ * {@link ProgressProbe#CHURN_NO_PROGRESS_WINDOW} - the same bound W4 already held, reached here by a
+ * different mechanism. Three things settled it, and the third is the one that chose the number:
+ * <ul>
+ *   <li><b>Nine firings have now been watched past detection and all nine drained, on four seeds</b>
+ *   - the six above, the 2026-09-08 replay of {@code 5650361238717170909} (93487 to 101070 with 6513
+ *   outstanding at the firing), the 2026-09-09 hosted-runner run of {@code 3717713223451201639}, and
+ *   a local replay of {@code 87978223167568} (97633 to 100742, full key coverage). Zero flat.</li>
+ *   <li><b>The other term could not have been the one to move.</b> The firings sit 1196-6513 records
+ *   short, against a {@link ProgressProbe#TAIL_SLACK} of 500: a slack wide enough to excuse them
+ *   would be several percent of the backlog, and would blind the detector to the "stall with
+ *   THOUSANDS remaining" that constant's own javadoc names as the defect signature. The window is
+ *   crossed by seconds; the slack would have to be crossed by an order of magnitude.</li>
+ *   <li><b>The fleet's own pause length was measured, on PASSING runs too</b> - the longest stretch
+ *   with no completion anywhere in the fleet while the detector was armed, read off the
+ *   {@code [diagnose]} series rather than off the violation line (which can only ever say "the bound
+ *   plus detection latency"). Across thirteen replays on one desktop the armed peak reached 32.1s,
+ *   with three further runs at 28.2-30.1s that did not fire: the 30s bound sat inside the ordinary
+ *   distribution and three passing runs missed it by under two seconds. 60s is ~1.9x the measured
+ *   peak, the same ratio {@link ProgressProbe#REBALANCE_DWELL_BOUND} was calibrated at.</li>
+ * </ul>
+ * <b>The widening is not a disabling</b>, and that is asserted rather than argued -
+ * {@code NoProgressWindowIT} fires the detector at the wider bound on a fleet that genuinely stops.
+ * What it does NOT cover is the separate question of whether this detector MISSES real failures
+ * ({@code docs/testing.md}, "Experiment runners"), which a wider window can only make more pressing.
+ * The seeds, the trajectories and the per-run numbers are in
+ * {@code docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md}.
+ * <p>
  * <b>The instance-stall line - also answered, 2026-09-07, do not re-derive</b>: seed
  * {@code 6077035105695} replays the shape behind every {@code INSTANCE_STALL/NO_WORK_COMPLETED}
  * firing on this scenario - one live member's returned-result count frozen while its records-out
@@ -107,8 +135,9 @@ class ChaosChurnStormIT extends ChaosScenarioBase {
     protected void logDiagnosticContext() {
         log.warn("=== BEFORE INTERPRETING THIS RUN, read this class's 'Calibration status' javadoc. " +
                 "The recovery diagnostic has engaged on this scenario before and the backlog DRAINED " +
-                "on every one of six firings, which is what demoted the asynchronous stall to a " +
-                "timing proxy. If your result is 'it drains', you have reproduced a known result - " +
+                "on every one of nine firings across four seeds, which is what demoted the " +
+                "asynchronous stall to a timing proxy and then widened this scenario's no-progress " +
+                "window to 60s. If your result is 'it drains', you have reproduced a known result - " +
                 "the finding worth reporting is a run that stays FLAT. ===");
     }
 
@@ -136,7 +165,13 @@ class ChaosChurnStormIT extends ChaosScenarioBase {
         AtomicLong totalStarted = fleet.getTotalStarted();
         Queue<String> allConsumed = fleet.getAllConsumed();
         Set<String> expectedKeys = fleet.getExpectedKeys();
-        ProgressProbe probe = fleet.getProbe();
+        ProgressProbe probe = fleet.getProbe()
+                // This scenario's own churn crosses the 30s default while the fleet is merely slow:
+                // the eager assignor revokes the whole assignment every few seconds, so each 45s
+                // HEAVY_SLEEP is redelivered before it ends and the fleet can sit wholly inside the
+                // heavy tail with nothing COMPLETING while every member is working. Widened on the
+                // evidence, not on the resemblance - see this class's "Calibration status" javadoc.
+                .withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW);
 
         ChaosConductor conductor = conductorFor(fleet, pcConfig, HEAVY_EVERY, HEAVY_SLEEP, MAX_FLEET)
                 .seed(seed.getValue())

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/NoProgressWindowIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/NoProgressWindowIT.java
@@ -7,6 +7,9 @@ package bz.stub.parallelconsumer.integrationTests.chaostests;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -40,8 +43,13 @@ import static com.google.common.truth.Truth.assertWithMessage;
 class NoProgressWindowIT {
 
     private static final long EXPECTED_TOTAL = 100_000;
-    /** Comfortably outside {@link ProgressProbe#TAIL_SLACK}: the shape every recorded firing had. */
-    private static final long THOUSANDS_OUTSTANDING = EXPECTED_TOTAL - 3_000;
+    /**
+     * Comfortably outside {@link ProgressProbe#TAIL_SLACK} - the shape every recorded firing had,
+     * and derived from the slack rather than written as a literal so that WIDENING the slack moves
+     * this with it. A hard-coded outstanding count would keep the firing tests green through a slack
+     * bump that had quietly disarmed the detector for the case they exist to cover.
+     */
+    private static final long THOUSANDS_OUTSTANDING = EXPECTED_TOTAL - (4 * ProgressProbe.TAIL_SLACK);
 
     private static ProgressProbe probe() {
         return ProgressProbe.forSeamTest("no-progress-group", "no-progress-topic", EXPECTED_TOTAL);
@@ -53,6 +61,32 @@ class NoProgressWindowIT {
 
     private static Duration under(Duration window) {
         return window.minusSeconds(1);
+    }
+
+    /**
+     * <b>The calibration itself, pinned as a value.</b> Every other test here derives its durations
+     * from these constants, so all of them stay green if a constant changes - they prove the
+     * mechanism, never the number. The number is the whole argument: 60s is ~1.9x the longest
+     * no-completion stretch measured on the churn storm while the detector was armed (32.1s over
+     * thirteen replays, {@code docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md}),
+     * the same ratio {@link ProgressProbe#REBALANCE_DWELL_BOUND} was calibrated at.
+     * <p>
+     * <b>Going red here is not a failure, it is the request</b>: re-measure the pause distribution
+     * with {@code -Dchaos.diagnoseStallRecovery=true} and record what it says, then move this line.
+     * A gate quietly made less sensitive is the failure this whole test class exists to prevent, and
+     * a symbolic assertion cannot tell a re-calibration from a bump to make CI stop complaining.
+     */
+    @Test
+    void theCalibratedValuesAreWhatWasMeasured() {
+        assertWithMessage("the widened window is a measured value, not a convenience - see this "
+                + "method's javadoc before changing it")
+                .that(ProgressProbe.CHURN_NO_PROGRESS_WINDOW).isEqualTo(Duration.ofSeconds(60));
+        assertWithMessage("the default window every other scenario still holds")
+                .that(ProgressProbe.NO_PROGRESS_WINDOW).isEqualTo(Duration.ofSeconds(30));
+        assertWithMessage("the OTHER term - the recorded firings sat 1196-6513 records short, so a "
+                + "slack wide enough to excuse them would blind the detector to the stall with "
+                + "thousands remaining it exists to catch")
+                .that(ProgressProbe.TAIL_SLACK).isEqualTo(500);
     }
 
     @Test
@@ -111,6 +145,68 @@ class NoProgressWindowIT {
 
         assertThat(probe.getViolations().get(0))
                 .contains("bound " + ProgressProbe.CHURN_NO_PROGRESS_WINDOW.getSeconds() + "s");
+    }
+
+    /**
+     * The boundary itself, which every other case here steps a whole second clear of. The guard is
+     * strictly-greater-than, so a stall of exactly the window does NOT fire - deliberate, and worth
+     * pinning because the sampler compares a wall-clock difference where equality is reachable.
+     */
+    /**
+     * <b>The sampler actually consults the decision, and re-arms after it fires.</b> Every other case
+     * here calls {@link ProgressProbe#recordFleetProgress} directly, so deleting the sampler's call
+     * to it would leave them all green while the running detector reported nothing - the hole an
+     * independent cross-model review and this repo's own testing review found at the same time on
+     * astubbs/parallel-consumer#499. Driven through a stubbed clock, so it costs no wall time.
+     */
+    @Test
+    void theSamplerReachesTheDecisionAndReArmsAfterFiring() {
+        Instant t0 = Instant.parse("2026-09-09T00:00:00Z");
+        AtomicReference<Instant> now = new AtomicReference<>(t0);
+        AtomicLong consumed = new AtomicLong(THOUSANDS_OUTSTANDING);
+        ProgressProbe probe = ProgressProbe.forSeamTest("sampler-group", "sampler-topic", EXPECTED_TOTAL,
+                consumed::get).withClock(now::get);
+
+        probe.sampleProgress();                                   // first sample: records the count
+        now.set(t0.plus(under(ProgressProbe.NO_PROGRESS_WINDOW))); // still inside the window
+        probe.sampleProgress();
+        assertWithMessage("inside the window the sampler must stay silent")
+                .that(probe.getViolations()).isEmpty();
+
+        now.set(t0.plus(over(ProgressProbe.NO_PROGRESS_WINDOW)));  // now past it, count unchanged
+        probe.sampleProgress();
+        assertWithMessage("if the sampler ever stops calling recordFleetProgress, every other test "
+                + "in this class still passes and the running detector reports nothing")
+                .that(probe.getViolations()).hasSize(1);
+
+        now.set(t0.plus(over(ProgressProbe.NO_PROGRESS_WINDOW)).plusSeconds(1));
+        probe.sampleProgress();
+        assertWithMessage("re-armed: a genuine stall reports once per window, not once per sample")
+                .that(probe.getViolations()).hasSize(1);
+    }
+
+    /**
+     * <b>The churn storm wires the bound it means to.</b> Asserting the constant on a probe this test
+     * configured itself proves nothing about the scenario - the second half of the same gap. This
+     * calls the scenario's own configuration helper, so deleting the widening from
+     * {@code ChaosChurnStormIT} turns this red in milliseconds rather than silently changing what a
+     * five-minute chaos run gates on.
+     */
+    @Test
+    void theChurnStormConfiguresItsProbeWithTheWidenedWindow() {
+        ProgressProbe probe = ChaosChurnStormIT.configureProbe(probe());
+
+        assertThat(probe.noProgressWindow()).isEqualTo(ProgressProbe.CHURN_NO_PROGRESS_WINDOW);
+    }
+
+    @Test
+    void aStallOfExactlyTheWindowDoesNotFire() {
+        ProgressProbe probe = probe();
+
+        boolean violated = probe.recordFleetProgress(THOUSANDS_OUTSTANDING, ProgressProbe.NO_PROGRESS_WINDOW);
+
+        assertThat(violated).isFalse();
+        assertThat(probe.getViolations()).isEmpty();
     }
 
     @Test

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/NoProgressWindowIT.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/NoProgressWindowIT.java
@@ -1,0 +1,142 @@
+package bz.stub.parallelconsumer.integrationTests.chaostests;
+
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+/**
+ * The contract behind {@link ProgressProbe#withNoProgressWindow(Duration)}, and the RED CONTROL that
+ * a widened window is not a disabled one.
+ * <p>
+ * <b>Why this needed a test rather than a replay.</b> {@code ChaosChurnStormIT} widened its window
+ * from {@link ProgressProbe#NO_PROGRESS_WINDOW} to {@link ProgressProbe#CHURN_NO_PROGRESS_WINDOW}
+ * because its own churn crosses the narrower one while the fleet is merely slow - the seeds, the
+ * drain trajectories and the arithmetic are in
+ * {@code docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md}. The obvious way to check
+ * a widening is to replay a firing seed and watch it go green, and that check is WORTHLESS here for
+ * the reason {@link RebalanceDwellToggleIT} states about the dwell bound: the crossing is
+ * probabilistic even on a fixed seed, so a green run may simply never have reached the condition. A
+ * green there is an absence, the weakest evidence this repo recognises - and a window widened to
+ * infinity would produce exactly the same green.
+ * <p>
+ * So the two halves are asserted directly. The half that matters is
+ * {@link #theWidenedWindowStillFiresOnAFleetThatGenuinelyStops()}: a fleet that really does stop
+ * still fails the run at the wider bound. Without it, "we widened the window" and "we deleted the
+ * detector" are indistinguishable from the outside, which is the failure the whole
+ * {@code docs/solutions/best-practices/a-timing-bound-used-as-a-correctness-gate-manufactures-its-own-evidence.md}
+ * write-up is about.
+ * <p>
+ * Untagged deliberately, so it gates every default integration build - the
+ * {@link RebalanceDwellToggleIT} / {@link ProgressProbeLedgerIT} pattern, broker-free and with no
+ * wall clock spent waiting on a bound.
+ */
+class NoProgressWindowIT {
+
+    private static final long EXPECTED_TOTAL = 100_000;
+    /** Comfortably outside {@link ProgressProbe#TAIL_SLACK}: the shape every recorded firing had. */
+    private static final long THOUSANDS_OUTSTANDING = EXPECTED_TOTAL - 3_000;
+
+    private static ProgressProbe probe() {
+        return ProgressProbe.forSeamTest("no-progress-group", "no-progress-topic", EXPECTED_TOTAL);
+    }
+
+    private static Duration over(Duration window) {
+        return window.plusSeconds(1);
+    }
+
+    private static Duration under(Duration window) {
+        return window.minusSeconds(1);
+    }
+
+    @Test
+    void armedIsTheControl_theDefaultWindowFiresOnAFlatFleet() {
+        ProgressProbe probe = probe();
+
+        boolean violated = probe.recordFleetProgress(THOUSANDS_OUTSTANDING, over(ProgressProbe.NO_PROGRESS_WINDOW));
+
+        assertWithMessage("without this arm the widened cases below prove nothing - a detector that "
+                + "never fires either way would pass them")
+                .that(violated).isTrue();
+        assertThat(probe.getViolations()).hasSize(1);
+        assertThat(probe.getViolations().get(0)).contains("NO_PROGRESS: fleet consumed count stuck");
+    }
+
+    /**
+     * <b>The red control for the widening.</b> A fleet that genuinely stops still fails the run at
+     * the wider bound, so {@code CHURN_NO_PROGRESS_WINDOW} is a re-calibration and not a deletion.
+     */
+    @Test
+    void theWidenedWindowStillFiresOnAFleetThatGenuinelyStops() {
+        ProgressProbe probe = probe().withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW);
+
+        boolean violated = probe.recordFleetProgress(THOUSANDS_OUTSTANDING, over(ProgressProbe.CHURN_NO_PROGRESS_WINDOW));
+
+        assertWithMessage("a widened window that could not fire would be a disabled one, and nothing "
+                + "would go red to say so")
+                .that(violated).isTrue();
+        assertThat(probe.getViolations()).hasSize(1);
+    }
+
+    /**
+     * The calibration change itself: the crossings W1's own churn produces - measured at the 30s
+     * bound, never at 60s - no longer gate.
+     */
+    @Test
+    void theWidenedWindowIgnoresACrossingOfTheDefaultOne() {
+        ProgressProbe probe = probe().withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW);
+
+        boolean violated = probe.recordFleetProgress(THOUSANDS_OUTSTANDING, over(ProgressProbe.NO_PROGRESS_WINDOW));
+
+        assertThat(violated).isFalse();
+        assertWithMessage("this is the whole point of the widening").that(probe.getViolations()).isEmpty();
+    }
+
+    /**
+     * The violation text must name the window that was actually configured. A scenario's log is the
+     * only place a reader learns which bound this run held itself to, and every recorded sighting in
+     * the ledgers was read off that line.
+     */
+    @Test
+    void theViolationNamesTheConfiguredWindowNotTheDefault() {
+        ProgressProbe probe = probe().withNoProgressWindow(ProgressProbe.CHURN_NO_PROGRESS_WINDOW);
+
+        probe.recordFleetProgress(THOUSANDS_OUTSTANDING, over(ProgressProbe.CHURN_NO_PROGRESS_WINDOW));
+
+        assertThat(probe.getViolations().get(0))
+                .contains("bound " + ProgressProbe.CHURN_NO_PROGRESS_WINDOW.getSeconds() + "s");
+    }
+
+    @Test
+    void aStallShorterThanTheWindowNeverFires() {
+        ProgressProbe probe = probe();
+
+        boolean violated = probe.recordFleetProgress(THOUSANDS_OUTSTANDING, under(ProgressProbe.NO_PROGRESS_WINDOW));
+
+        assertThat(violated).isFalse();
+        assertThat(probe.getViolations()).isEmpty();
+    }
+
+    /**
+     * The OTHER term in the guard, pinned so a future re-calibration reaches for the window rather
+     * than for this one. Inside the tail slack the detector is silent however long the stall - which
+     * is why raising {@code TAIL_SLACK} to cover the recorded firings would have blinded it to
+     * exactly the "stall with THOUSANDS remaining" its own javadoc names as the defect signature.
+     */
+    @Test
+    void insideTheTailSlackNothingFiresHoweverLongTheStall() {
+        ProgressProbe probe = probe();
+        long insideTheSlack = EXPECTED_TOTAL - ProgressProbe.TAIL_SLACK;
+
+        boolean violated = probe.recordFleetProgress(insideTheSlack, Duration.ofMinutes(10));
+
+        assertThat(violated).isFalse();
+        assertThat(probe.getViolations()).isEmpty();
+    }
+}

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
@@ -281,6 +281,15 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
 
     private long lastCount = -1;
     private Instant lastAdvance = Instant.now();
+    /**
+     * The sampler's clock, so {@code NoProgressWindowIT} can drive {@link #sampleProgress} without
+     * spending wall time. Production reads {@link Instant#now()} and nothing else changes: the field
+     * exists because the ONLY thing that can catch the sampler ceasing to consult
+     * {@link #recordFleetProgress} is a test that runs the sampler, and every other test here drives
+     * the decision method directly - a gap two independent reviews of astubbs/parallel-consumer#499
+     * found at the same time.
+     */
+    private volatile Supplier<Instant> clock = Instant::now;
     private Instant rebalanceDwellStart = null;
     /**
      * The group state the dwell sampler last read, handed to {@link UncommittedCompletionDetector} so
@@ -398,7 +407,16 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
      * consumed count look like the tail and the detector silent for reasons the test never intended.
      */
     static ProgressProbe forSeamTest(String groupId, String topic, long expectedTotal) {
-        return new ProgressProbe(null, groupId, topic, () -> 0L, expectedTotal);
+        return forSeamTest(groupId, topic, expectedTotal, () -> 0L);
+    }
+
+    /**
+     * As above, with a live consumed-count supplier - for a test that drives {@link #sampleProgress}
+     * itself rather than {@link #recordFleetProgress}, which is the only way to catch the sampler
+     * ceasing to consult the decision at all.
+     */
+    static ProgressProbe forSeamTest(String groupId, String topic, long expectedTotal, LongSupplier totalConsumed) {
+        return new ProgressProbe(null, groupId, topic, totalConsumed, expectedTotal);
     }
 
     /** Observer mode never gates - violations are autopsy material only (ambient flight recorder). */
@@ -497,16 +515,36 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
         }
     }
 
-    private void sampleProgress() {
+    /**
+     * Package-private, not private, so a test can run the sampler itself - see {@link #clock}. Called
+     * only from {@link #sampleLoop} in production.
+     */
+    void sampleProgress() {
         long now = totalConsumed.getAsLong();
         if (now != lastCount) {
             lastCount = now;
-            lastAdvance = Instant.now();
+            lastAdvance = clock.get();
             return;
         }
-        if (recordFleetProgress(now, Duration.between(lastAdvance, Instant.now()))) {
-            lastAdvance = Instant.now(); // re-arm so a genuine stall reports once per window, not per sample
+        if (recordFleetProgress(now, Duration.between(lastAdvance, clock.get()))) {
+            lastAdvance = clock.get(); // re-arm so a genuine stall reports once per window, not per sample
         }
+    }
+
+    /** Test seam for {@link #clock} - see that field for why it exists. */
+    ProgressProbe withClock(Supplier<Instant> testClock) {
+        this.clock = testClock;
+        this.lastAdvance = testClock.get();
+        return this;
+    }
+
+    /**
+     * The window this probe is actually configured with. Exists so a test can assert that a SCENARIO
+     * wired the bound it meant to, rather than re-applying the constant to a probe of its own and
+     * asserting about that - the second half of the same gap {@link #clock} names.
+     */
+    Duration noProgressWindow() {
+        return noProgressWindow;
     }
 
     /**

--- a/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
+++ b/parallel-consumer-core/src/test-integration/java/bz/stub/parallelconsumer/integrationTests/chaostests/ProgressProbe.java
@@ -79,6 +79,23 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
 
     /** Fleet-wide consumption must advance at least this often while work remains. */
     public static final Duration NO_PROGRESS_WINDOW = Duration.ofSeconds(30);
+    /**
+     * The widened watermark for scenarios whose OWN churn legitimately pauses the whole fleet for
+     * longer than {@link #NO_PROGRESS_WINDOW} - see {@link #withNoProgressWindow(Duration)}. Named
+     * rather than repeated, because two scenarios now reach for the same number for two different
+     * mechanisms and a future re-calibration must move both or neither:
+     * <ul>
+     *   <li>W4 ({@code AbstractRevokeUnderWorkScenario}): a storm-phase rebalance can pause much of
+     *   the fleet for up to the eviction horizon, all of it under the eager assignor.</li>
+     *   <li>W1 ({@code ChaosChurnStormIT}): the 45s heavy tail is redelivered by every eager
+     *   revoke, so the fleet can sit wholly inside {@code HEAVY_SLEEP} with nothing completing while
+     *   every member is working - the firings and their drain trajectories are in
+     *   {@code docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md}.</li>
+     * </ul>
+     * <b>It is a re-calibration, not a disabling</b>, and that is asserted rather than argued:
+     * {@code NoProgressWindowIT} fires the detector at this bound on a fleet that genuinely stops.
+     */
+    public static final Duration CHURN_NO_PROGRESS_WINDOW = Duration.ofSeconds(60);
     /** Max continuous group-rebalancing dwell. Empirically calibrated (2026-07-30, seed 424242, same
      * schedule on both arms): healthy peak 6.7s (drainer participates, rebalance completes mid-drain) vs
      * defect peak 20.1s (protocol-absent drainer blocks the join until its LeaveGroup - the whole freeze
@@ -372,7 +389,16 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
      * @param topic   only appears in violation text; no topic is read
      */
     static ProgressProbe forSeamTest(String groupId, String topic) {
-        return new ProgressProbe(null, groupId, topic, () -> 0L, 0);
+        return forSeamTest(groupId, topic, 0);
+    }
+
+    /**
+     * As {@link #forSeamTest(String, String)}, for a seam whose decision depends on the backlog size
+     * - {@link #recordFleetProgress}'s {@link #TAIL_SLACK} term reads it, so a zero total makes every
+     * consumed count look like the tail and the detector silent for reasons the test never intended.
+     */
+    static ProgressProbe forSeamTest(String groupId, String topic, long expectedTotal) {
+        return new ProgressProbe(null, groupId, topic, () -> 0L, expectedTotal);
     }
 
     /** Observer mode never gates - violations are autopsy material only (ambient flight recorder). */
@@ -478,13 +504,34 @@ public class ProgressProbe implements ChaosConductor.ChaosObserver {
             lastAdvance = Instant.now();
             return;
         }
-        boolean workRemains = now < expectedTotal - TAIL_SLACK;
-        Duration stalled = Duration.between(lastAdvance, Instant.now());
-        if (workRemains && stalled.compareTo(noProgressWindow) > 0) {
-            violate("NO_PROGRESS: fleet consumed count stuck at " + now + "/" + expectedTotal
-                    + " for " + stalled.getSeconds() + "s (bound " + noProgressWindow.getSeconds() + "s)");
+        if (recordFleetProgress(now, Duration.between(lastAdvance, Instant.now()))) {
             lastAdvance = Instant.now(); // re-arm so a genuine stall reports once per window, not per sample
         }
+    }
+
+    /**
+     * The NO_PROGRESS decision, split from its sampler so {@code NoProgressWindowIT} can drive it
+     * with no broker and no wall clock - the {@link #recordRebalanceDwell} seam again, for the same
+     * reason and under the same thread rule: this touches only the volatile window and the
+     * synchronized violations list, never the sampler-confined clock fields, which is why the CALLER
+     * re-arms rather than this method. Keep it that way or those tests become a data race.
+     * <p>
+     * Both terms are guards, and which one a re-calibration should move is not interchangeable.
+     * {@link #TAIL_SLACK} excuses the tail; the window excuses the pause. Widening the slack far
+     * enough to cover a churn scenario's firings would blind the detector to the "stall with
+     * THOUSANDS remaining" its own javadoc names as the defect signature, so the window is the term
+     * that moves - see {@link #CHURN_NO_PROGRESS_WINDOW}.
+     *
+     * @return whether a violation fired, i.e. whether the caller should re-arm the progress clock
+     */
+    boolean recordFleetProgress(long consumed, Duration stalled) {
+        boolean workRemains = consumed < expectedTotal - TAIL_SLACK;
+        if (!workRemains || stalled.compareTo(noProgressWindow) <= 0) {
+            return false;
+        }
+        violate("NO_PROGRESS: fleet consumed count stuck at " + consumed + "/" + expectedTotal
+                + " for " + stalled.getSeconds() + "s (bound " + noProgressWindow.getSeconds() + "s)");
+        return true;
     }
 
     /**


### PR DESCRIPTION
Serves astubbs/parallel-consumer#119 (confluentinc#857).

## Description

The churn-storm chaos scenario, `ChaosChurnStormIT`, asserted a 30s fleet-wide `NO_PROGRESS` window
while the revoke-under-work scenario, `AbstractRevokeUnderWorkScenario`, had already widened to 60s. This is the third chaos detector
found asserting an elapsed-time bound the scenario's own disturbances legitimately cross, after
`CLASS2_STALL` (demoted to an observation) and `REBALANCE_DWELL` (disarmed in the key-order
scenario). The lane it fails
is required, and it has been failing docs-only PRs on it several times a day.

`docs/inflight/test-no-progress-window-may-not-transfer-to-w1.md` set the bar itself: replay a
sighting seed with `-Dchaos.diagnoseStallRecovery=true` so the fleet continues past detection, and
read whether consumption resumes. Drains means calibration; flat means a fleet-wide stall, and the
best lead in the family.

**It drains.** Thirteen replays on one desktop - every seed in that note's table plus five more
recorded in `bug-857-family.md` that the table never carried, including the one the register
nominates by name as its next experiment. One fired and drained (`87978223167568`, 97633 to 100742
with full key coverage); twelve were VOID, which is evidence for neither reading; none stayed flat.
With the arms this line already had - six drains of `9086872209853284830`, the 2026-09-08 drain of
`5650361238717170909`, the 2026-09-09 hosted-runner recovery of `3717713223451201639` - nine firings
have now been watched past detection and nine drained, on four seeds.

**Which term moves, and the note had it wrong.** It read the firings as sitting "just past the
slack". They sit just past the *window* and a long way past the slack: 1196-6513 records short
against a `TAIL_SLACK` of 500, so a slack wide enough to excuse them is several percent of the
backlog and would blind the detector to the "stall with THOUSANDS remaining" its own javadoc names
as the defect signature.

The window is crossed by seconds, and the violation line cannot say by how many - it can only ever
report the bound plus detection latency. So the fleet's own pause length was measured instead, off
the `[diagnose]` consumed series and **restricted to the region where the detector is armed**, which
makes it readable on runs that PASSED, where nothing else records it. Across the thirteen replays the
armed peak reached **32.1s**, with three further runs at 28.2-30.1s that did not fire: the 30s bound
sits inside the ordinary distribution of this scenario's churn, and three passing runs missed it by
under two seconds. 60s is ~1.9x that peak - the ratio `REBALANCE_DWELL_BOUND` was calibrated at, and
the number the revoke-under-work scenario (W4) already holds, so it is named once as
`ProgressProbe#CHURN_NO_PROGRESS_WINDOW` with both mechanisms on it.

**Where the 60 came from, stated plainly.** The VALUE is inherited from the revoke-under-work
scenario, which set it for a different mechanism. What was measured on the churn storm is that 60s
is *enough* for it: the armed pause distribution above, peaking at 32.1s over thirteen replays on
one desktop. The hosted runner's own distribution was not measured, and it cannot be recovered from
the sightings - every one of them reports the 30s bound, which is the bound plus detection latency
and says nothing about how long the pause would have run. So this is calibrated against a measured
peak, but a locally measured one.

**It is a re-calibration, not a deletion, and that is asserted rather than argued.**
`NoProgressWindowIT` fires the detector at the wider bound on a fleet that genuinely stops, pins the
calibrated numbers as values so a later edit to a constant cannot pass silently, drives the SAMPLER
rather than only the decision it calls, and asserts that `ChaosChurnStormIT` really applies the wider
bound. Each arm was verified by a one-term sabotage that reddens it and nothing else. A
replay-and-watch-it-go-green check was deliberately **not** used as the evidence: the crossing is
probabilistic even on a fixed seed, and a window widened to infinity would produce the same green.
That is `RebalanceDwellToggleIT`'s argument, reused.

The last three of those arms came from the review passes, and each closed a real hole - the
calibrated number was unpinned (a bump to `Duration.ofHours(1)` left every test green), the sampler's
call to the decision was untested (delete it and the class still passed while the running detector
reported nothing), and nothing tied the scenario's wiring to the constant.

### What the widening costs, stated rather than left to be discovered

A genuine fleet-wide stall of **31 to 60 seconds**, with work outstanding and no other detector
firing, now passes this scenario. That is the change, not a side effect. Two things bound it and
neither removes it: a real wedge does not stop at 60s, so what is lost is early detection rather than
detection; and the fleet-wide counter never covered the finer cases anyway - one wedged member or one
wedged partition hides behind healthy siblings at any window, and both have their own owners. What
would retire the caveat is the measurement this change did not make: the benign pause distribution on
the hosted runner class with an armed real-stall control beside it.

### What this does not close, stated in the note

- Whether this detector **misses** real failures - `docs/testing.md`'s
  `bin/exp-audit-stall-detector-silence.sh` row, open and reopened 2026-08-31. A wider window can
  only make it more pressing.
- The **other** way this scenario goes red: the outer completion wait with the key ledger short, the
  per-shard liveness gap `test-per-shard-liveness-has-no-gate.md` owns.
- The autopsy still printing `violations (0)` beside a fleet-level firing.

### Owner-gated

Both notes carry `inflight-impact: misdirection`, so the verdict is recorded as evidence and the
**state marker is PROPOSED, not applied** - whether the note is now closed or kept open on the
residue above is the owner's call. The widening itself has landed, because the replays are what the
note asked for.

## Checklist

- [x] Docs updated - the three notes this touches: the window note takes delivery of its own
      experiment, `test-857-churn-storm-async-stalls.md`'s ANSWERED section records that its stated
      bar was met, and `bug-857-family.md`'s shape line says the verdict was acted on
- [x] User-facing feature documentation data added under `docs/features/` - N/A - a test-calibration
      change, no product behaviour changes
- [x] Tests added/updated - `NoProgressWindowIT`, six tests, with a sabotage arm run to show its
      green is not vacuous
- [x] `docs/inflight/` working note started at the PR's first commit - N/A - this PR exists to settle
      an existing note, `test-no-progress-window-may-not-transfer-to-w1.md`, and that note carries
      the working record; a second note would state the same thing twice
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - both, against the final diff. `ce-simplify`
      returned **no findings** from all three reviewers (reuse, quality, efficiency); its efficiency
      pass separately confirmed no other job or workflow bound depends on the Lincheck timeout, and
      that the lane has no internal cap, so the raise widens the hang ceiling - now said in the
      workflow comment. `ce-code-review` ran correctness, testing and project-standards locally plus
      an **independent cross-model adversarial pass** (Codex, gpt-5.6-luna at xhigh, disclosed
      egress of this branch's diff). Six findings, all applied: the three unpinned/untested holes in
      the red control described above, the `REBALANCE_DWELL_BOUND` ratio misstatement, the wrong
      codecov subcommand, and a drifting test count `docs/inflight/AGENTS.md` forbids. The peer's P2
      - "a real 45-second stall now passes" - is not a defect to fix but the change's cost, and is
      now written into the note, the class javadoc and this body

### The defect-class sweep

The class is *a chaos detector asserting an elapsed-time bound the scenario's own disturbances
legitimately cross*. **One candidate survives, on this same scenario, and this PR does not touch
it:** `REBALANCE_DWELL` is still ARMED on `ChaosChurnStormIT` - the revoke-under-work and key-order
scenarios both disable it because their own churn crosses it - and it has fired here,
`rebalanceDwell=15602ms` against a 15000ms bound on a documentation-only commit (seed
`989468380938115993`), plus `15392ms` and `15482ms` in `bug-857-family.md`. Crossings of 2.6-4.0% are
this class's signature, but the deciding experiment is its own measurement, not this one's argument,
so it is recorded in the note rather than acted on.

Checked and dismissed, with the reason: `DRAIN_OVERDUE` (elapsed-time and gating, but no firing
recorded anywhere - `bin/inflight.mjs prior-art DRAIN_OVERDUE` across every ref returns one note
mentioning the name and no sighting); `INSTANCE_STALL` (no longer a bare elapsed-time bound - it now
requires a member with a worker free); `UNCOMMITTED_COMPLETIONS` (a consecutive-sample debounce plus
an offset difference, and its own javadoc says that is what makes it not a calibrated bound);
`PROBE_DEGRADED` (a failure count); `MultiInstanceRebalanceTest`'s reuse of the same 30s window
(cooperative assignor, no heavy-tail dwell, so nothing pauses the whole fleet); `ChaosKeyOrderIT`'s
use of it (3s tail, and no `NO_PROGRESS` firing on record for it); `ChaosConductor`'s
`DRAINER_JOIN_BUDGET` (records, never violates); and `DiagnosticQuietCap` (a watch cap in a
diagnostic mode, asserts nothing).

### Also in this PR, on the owner's ruling: the Lincheck timeout, 20 -> 60 minutes

`Lincheck` is a required merge context. Its job hit the 20-minute cap on this branch at 22m13s on a
diff the lane does not compile, and the successful runs around it on other branches were 14m49s,
12m55s and 19m58s - the last clearing the cap by two seconds. So the cap was failing unrelated PRs
at random.

**The cause is diagnosed, not papered over.** Nearly all of that lane is
`WorkManagerLincheckTest`'s checkpoint-three tear stress arm, a fixed
iterations-times-invocations budget that cannot stop early, so its wall clock is a function of runner
CPU speed alone. On 2026-09-09 the job ran 5-8.5 min until ~01:00 UTC, 12-20 min until ~04:00 **on
every branch, docs-only ones included**, then 7-8 min again; codecov records that one test between
292s and 720s on commits an hour apart. A shift that appears on branches sharing no code and reverses
itself on a clock rather than a commit is ordinary `ubuntu-latest` variance. 20 minutes was 2.6x the
lane's priced 7m42s, which that variance exceeds; 60 is sized so it no longer does. Re-pricing the
test's budget is the other lever and it is closed - that class's own comment records the
starve-and-count procedure its bound came from.

**The confirming run arrived immediately**: with the cap at 60 the lane passed at **20m8s**
([job 102334638957](https://github.com/astubbs/parallel-consumer/actions/runs/34309813133/job/102334638957)),
eight seconds past the old cap, on a green run the old cap would have killed. What it costs is named
too: `bin/lincheck-test.sh` has no internal cap, so the runner minutes a genuine hang can burn go
from 20 to 60. Durations, reproduce commands and the open question live in
`docs/inflight/test-lincheck-lane-open-items.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xoi3HYae8pjsEatuNFKieD
