### PR TITLE
ci(lincheck): size the job timeout for a slow hosted VM, not a typical one

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -184,14 +184,25 @@ jobs:
           # layer along. If the probe stops firing, the lane is broken and must go red until it is fixed;
           # docs/solutions/best-practices/a-stress-probe-is-an-instrument-you-built-not-a-test.md owns why.
           #
-          # 7m42s measured on ubuntu-latest (about 2m50s locally), nearly all of it
-          # WorkManagerLincheckTest, whose inverted arm cannot stop early and always pays its full
-          # bound. bin/lincheck-test.sh's header owns the five flags that each fail silently on their
-          # own.
+          # 7m42s measured on ubuntu-latest (about 2m50s locally) when this entry was written, nearly
+          # all of it WorkManagerLincheckTest, whose inverted arm cannot stop early and always pays
+          # its full bound. bin/lincheck-test.sh's header owns the five flags that each fail silently
+          # on their own.
+          #
+          # THE TIMEOUT IS SIZED FOR A SLOW VM, NOT A TYPICAL ONE. The inverted arm is pure CPU, so
+          # its cost scales with whatever hosted VM the job draws: on 2026-09-09 the same class took
+          # 292s on one VM and 707s on another for the same commit, with every other job on that
+          # commit at its normal duration, and two jobs that day finished at 19m against the 20m cap
+          # that used to be here. The class has also grown since calibration - about five minutes on
+          # a good VM now, from two - because the state classes it drives gained work. 30 fits a slow
+          # VM with the build in front of it. The right fix is recalibrating the inverted arm's
+          # iteration bound against the current tree, per
+          # docs/plans/2026-08-25-001-test-lincheck-poc-plan.md; this is the ceiling that keeps a slow
+          # VM from reading as a failure until that is done.
           - suite: lincheck
             name: "Lincheck"
             cmd: "bin/lincheck-test.sh"
-            timeout: 20
+            timeout: 30
             scenarios: ""
             shard: ""
 


### PR DESCRIPTION
Serves astubbs/parallel-consumer#197: keeps a slow hosted VM from reading as a red on the release path. Closes nothing.

## Description

The Lincheck job's timeout goes from 20 to 30 minutes. One line in the `test` matrix, plus the comment that says why.

**What was measured.** On 2026-09-09, on the same code, the Lincheck job finished in 6 minutes on some hosted VMs and 19 on others, and one run on astubbs/parallel-consumer#498 hit the 20-minute cap. The whole difference is `WorkManagerLincheckTest`: 292s on one VM, 707s on another, same commit. Every other job on the slow commit (unit tests, static analysis, the chaos shard) took its normal time, and each job draws its own VM, so this is VM speed variance landing on the one class that is pure CPU and cannot stop early. Its inverted arm always pays its full bound.

**Why now.** The class has grown from about two minutes at calibration to about five on a good VM, because the state classes it drives gained work since 2026-08-26. Five minutes times a slow-VM factor of about 2.4, plus the build, no longer fits in 20. Two runs finished at 19 today; the next slow VM is a red on a PR that did nothing wrong.

**What this is not.** A ceiling, not a fix. The fix is recalibrating the inverted arm's iteration bound against the current tree, per `docs/plans/2026-08-25-001-test-lincheck-poc-plan.md`, which is post-v6 work. The matrix comment records the measurements and names that follow-up.

## Checklist

- [x] Docs updated - the matrix comment beside the entry carries the reasoning; no topic doc states the Lincheck timeout
- [x] User-facing feature documentation data added under `docs/features/` - N/A - CI only
- [x] Tests added/updated - N/A - a workflow timeout
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - one line and its comment; the recalibration follow-up is named in the comment and the commit body rather than opened as a note before anyone starts it
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - a one-line workflow change; `bin/check-all.sh` clean, and asked for `@claude review this` on the PR instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XS64Xttx4vF5datYh7fmk
