### PR TITLE
docs(changelog) astubbs#197: the 0.6.0.0 preamble is two short bullet lists, not two walls of text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,20 @@ A high level summary of noteworthy changes in each version.
 
 ## 0.6.0.0
 
-First release of the community fork of [confluentinc/parallel-consumer](https://github.com/confluentinc/parallel-consumer), which is no longer maintained, published to Maven Central as `bz.stub.parallelconsumer`. For most users, upgrading from upstream 0.5.x is the pom and the imports: the Maven groupId and the Java package every import names both change. It is not source-compatible beyond that - the Breaking section below is short and worth reading once. Most of it narrows the internal controller's subclass surface, but a commit that exhausts its budget now throws a PC exception type rather than Kafka's, the JStream result stream now blocks until close, an internal exception is renamed, and `RecordContext` equality is now identity. The committed offset format is unchanged, so an existing consumer group upgrades in place without resetting or migrating offsets. Upstream's last release on Maven Central is 0.5.3.2; its `0.5.3.3` section below was tagged but never published, and everything merged upstream after it - the Mutiny module, the commit-failure log detail, the metrics fix - reaches users here for the first time.
+First release of the community fork of [confluentinc/parallel-consumer](https://github.com/confluentinc/parallel-consumer), which is no longer maintained. Published to Maven Central as `bz.stub.parallelconsumer`.
 
-**This is a stability release, and that is the point.** The change set since 0.5.3.3 is the largest this codebase has shipped in one version, and almost all of it is fixes: the commit-path deadlock behind the long-standing "consumption stops after a rebalance" reports, a family of torn reads that lost records silently in every 0.5.x line, the metrics leak, offset accuracy on assignment, an asynchronous commit recorded before the broker answered, and the test lanes that now guard each of them. For the users this library serves, that is the release that matters. The capabilities are queued behind it, and the What comes next section lists them by how far each has got. The bar applied was: every known critical defect resolved, each with a named regression guard that passes. Two known critical defects sit outside that bar, both in the transactional producer mode only, and are named under Known limitations below alongside what the test suite still cannot see. Every fix below was reproduced deterministically and shown to fail before the fix and pass after it; the write-up behind each is in the linked PR.
+- **Upgrading from upstream 0.5.x** means changing the Maven groupId and the package your imports name. The Breaking section below is short; read it once.
+- **Committed offsets are unchanged.** An existing consumer group upgrades in place, with no reset and no migration.
+- **Everything upstream merged after its last published release ships here for the first time.** Upstream's last release on Maven Central is 0.5.3.2; its `0.5.3.3` section below was tagged but never published.
+
+**This is a stability release, and that is the point.** The change set is the largest this codebase has shipped in one version, and almost all of it is fixes:
+
+- the commit-path deadlock behind the long-standing "consumption stops after a rebalance" reports
+- a family of torn reads that silently lost records in every 0.5.x line
+- the metrics leak, offset accuracy on assignment, and an asynchronous commit recorded before the broker answered
+- the test lanes that now guard each of them
+
+The bar was every known critical defect resolved, each with a named regression guard that passes. Every fix was reproduced deterministically and shown to fail before and pass after; the write-up behind each is in its linked PR. Two known critical defects sit outside that bar, both in the transactional producer mode only, and are named under Known limitations. New capabilities are queued behind this release; What comes next lists them by how far each has got.
 
 ### Breaking
 


### PR DESCRIPTION
## Description

The 0.6.0.0 section of `CHANGELOG.md` opened with two paragraphs of a dozen sentences each before its first heading. The release dry run (actions run 34428431557) put that body on a page for the first time, and the owner's read was that the opening is a wall of text. This PR turns the preamble into two short bullet lists.

What a reader needs up front is four facts: what to change to upgrade, that committed offsets carry over, that upstream's post-0.5.3.2 merges ship here for the first time, and why the release is almost all fixes. Each is now one bullet. The old preamble's sentence-long summary of the Breaking section's contents is dropped, because the Breaking section is one heading down and says it.

This is the one kind of changelog edit a PR may make: reshaping text already there, adding no entry. The two phrases `bin/rename-packages.sh`'s prose guard requires are in the Breaking section and are untouched. The section's structure below the preamble is unchanged, and every paragraph and bullet stays on one line, which the release page's renderer needs (astubbs/parallel-consumer#475).

changelog-ref: N/A - reshapes the existing 0.6.0.0 preamble; adds no entry

## Checklist

- [x] Docs updated - or `N/A`
- [x] User-facing feature documentation data added under `docs/features/` - N/A - release-note prose only
- [x] Tests added/updated - N/A - docs only
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - one commit reshaping one preamble; nothing here that `gh` cannot show
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - docs only; `bin/check-all.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XS64Xttx4vF5datYh7fmk
