### PR TITLE
build(release) astubbs#197: the release push needs an HTTPS scm URL - the runner has no SSH key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com:astubbs/parallel-consumer.git</connection>
-        <developerConnection>scm:git:git@github.com:astubbs/parallel-consumer.git</developerConnection>
+        <connection>scm:git:https://github.com/astubbs/parallel-consumer.git</connection>
+        <developerConnection>scm:git:https://github.com/astubbs/parallel-consumer.git</developerConnection>
         <url>https://github.com/astubbs/parallel-consumer.git</url>
         <tag>HEAD</tag>
     </scm>
@@ -952,6 +952,13 @@
                          bypasses the master ruleset's pull_request requirement. release.yml then checks
                          out the exact tag vX and deploys it. The tag is the single source of truth -
                          nothing scans history.
+
+                         The push goes to <scm><developerConnection>, so that URL must be HTTPS: the
+                         runner authenticates with the PAT actions/checkout stored as an http
+                         extraheader for github.com, and it holds no SSH key. The first real 0.6.0.0
+                         dispatch failed at exactly this point with "git@github.com: Permission denied
+                         (publickey)", after every guard and the whole build had passed - a dry run
+                         never pushes, so it cannot catch this.
 
                          preparationGoals=clean install (not the "poms only" validate we first tried):
                          the modules cross-depend on parallel-consumer-core's test-jar


### PR DESCRIPTION
## Description

The first real 0.6.0.0 release dispatch (actions run 34548906750) passed every guard, extracted the notes and built the whole reactor, then failed at `release:prepare`'s push:

```
git@github.com: Permission denied (publickey).
```

`maven-release-plugin` pushes to the pom's `<developerConnection>`, which was an SSH URL. The runner authenticates only through the HTTPS extraheader `actions/checkout` stores for `RELEASE_PAT`, and holds no SSH key, so the ruleset bypass was never even reached. Nothing landed on the remote: no tag, no commits, master is still `0.6.0.0-SNAPSHOT`.

This PR switches both scm URLs in the root pom to HTTPS. `<connection>` was also malformed (`git://github.com:owner/repo`, a colon where the path starts), which nothing had exercised. The pom comment on the release plugin now records that the push URL must be HTTPS and what the failure looked like, because a dry run never pushes and so cannot rehearse this step.

Tracker: astubbs/parallel-consumer#197.

## Checklist

- [x] Docs updated - the pom comment on the release plugin; `docs/releasing.md` describes the PAT and bypass, both still true
- [x] User-facing feature documentation data added under `docs/features/` - N/A - release plumbing
- [x] Tests added/updated - N/A - the only test is the next real dispatch; a dry run cannot exercise the push
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - one commit, two URLs; nothing here that `gh` cannot show
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - config only; `bin/check-all.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
