### PR TITLE
feat(observability) astubbs#215: extract the state-reading substrate the dashboard and MCP both project

### DIFF
--- a/parallel-consumer-observability/pom.xml
+++ b/parallel-consumer-observability/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2026 Antony Stubbs and contributors
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>bz.stub.parallelconsumer</groupId>
+        <artifactId>parallel-consumer-parent</artifactId>
+        <version>0.6.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>parallel-consumer-observability</artifactId>
+    <name>Kafka Parallel Consumer Observability</name>
+    <description>
+        Experimental, opt-in: reads a running Parallel Consumer instance's state into an immutable value,
+        safely and cheaply, and makes each new reading visible to whoever is watching - in process, on the
+        JVM's own threads. Nothing here opens a socket or writes anywhere. It is what an observation
+        surface reads: the web dashboard, the MCP tools, or an application's own monitoring.
+    </description>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <dependencies>
+        <!--
+            The only dependency this module declares. Micrometer arrives transitively from core, which already
+            declares it at compile scope, so this module puts nothing on a consumer's classpath that core did
+            not already put there. That is the property which lets the dashboard and the MCP server both build
+            on this without either inheriting the other's dependencies, and it is worth keeping: a dependency
+            added here is a dependency added to every surface above it.
+
+            The test libraries - JUnit, AssertJ, Mockito, Logback - are declared in the parent's own
+            dependencies block and inherited by every module, so they are deliberately absent here.
+        -->
+        <dependency>
+            <groupId>bz.stub.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--
+            Core's test-jar, for the shared ArchUnit rules only. Every module with test sources has to point
+            ArchUnit at its own packages or the rules silently do not run there, which is what
+            EveryModuleWiresUpArchUnitTest enforces - and the rules themselves live once, in core's tests.
+        -->
+        <dependency>
+            <groupId>bz.stub.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-core</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/DirectStateSource.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/DirectStateSource.java
@@ -1,0 +1,69 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Reads state straight off the live Parallel Consumer instance, for the things a meter cannot carry.
+ * <p>
+ * <strong>Deliberately minimal in this phase.</strong> The seam exists because the registry is a lossy projection -
+ * it cannot hold the full incomplete-offset set, per-shard detail, or a state transition that happens between
+ * scrapes - and those reads are what makes an in-process reader able to show what an external tool cannot. But
+ * everything phase 1 draws is already published as a meter, and the richer reads need read-only accessors that do
+ * not exist on core's classes yet. So this reads only what is already public, already cheap, and already safe:
+ * identity and the closed/failed flag.
+ * <p>
+ * <strong>Called on the control thread only</strong>, from {@link ReadingPublisher}'s loop-end callback. That is
+ * also the constraint that governs what may ever be added here. Specifically forbidden, each for a recorded reason:
+ * <ul>
+ *     <li>{@code RetryQueue.size()} - reads a plain {@code HashMap} without the lock every other method on that
+ *     class takes, so it is a genuine data race rather than a theoretical one.</li>
+ *     <li>Iterating a {@code RetryQueue} - its iterator holds the read lock until closed, so a caller that forgets
+ *     to close it deadlocks the control loop permanently.</li>
+ *     <li>Anything reaching {@code KafkaConsumer}, including {@code ConsumerManager.assignment()} and
+ *     {@code paused()}, which pass straight through to it. {@code KafkaConsumer} is single-threaded and belongs to
+ *     the poll thread.</li>
+ *     <li>Anything using {@code parallelStream()}, such as {@code PartitionState.getAllIncompleteOffsets()} - it
+ *     runs on the common ForkJoinPool, so it takes the control loop's latency out of the control loop's hands.</li>
+ * </ul>
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+public class DirectStateSource {
+
+    private final AbstractParallelEoSStreamProcessor<?, ?> pc;
+
+    /**
+     * @param pc the live instance, or null for a registry-only sampler (which is how the reading model is unit
+     *           tested, and how a caller with a registry but no handle on the processor can still get a page)
+     */
+    public DirectStateSource(AbstractParallelEoSStreamProcessor<?, ?> pc) {
+        this.pc = pc;
+    }
+
+    /**
+     * Whether a live instance was supplied. False means every field this source contributes is absent, and the page
+     * should say "not available" rather than draw a default.
+     */
+    public boolean isAvailable() {
+        return pc != null;
+    }
+
+    /**
+     * Adds this source's fields to a lifecycle builder already carrying the meter-derived ones.
+     *
+     * @return the same builder, for chaining
+     */
+    public LifecycleReading.LifecycleReadingBuilder contributeTo(LifecycleReading.LifecycleReadingBuilder builder) {
+        if (pc == null) {
+            return builder;
+        }
+        return builder
+                .closedOrFailed(pc.isClosedOrFailed())
+                .instanceId(pc.getMyId().orElse(null));
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/EncodingReading.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/EncodingReading.java
@@ -1,0 +1,110 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.Builder;
+import lombok.Value;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Health of PC's offset-encoding: how long encoding takes, which codecs are winning, and how close the encoded
+ * payload is to the broker's offset-metadata size limit.
+ * <p>
+ * The payload figures are the ones that matter operationally - running out of metadata space is how PC loses its
+ * record of which offsets are incomplete, so a rising {@link #getMetadataSpaceUsedMax()} is a warning worth showing
+ * before it becomes an incident.
+ * <p>
+ * <strong>Absent is not zero.</strong> Boxed fields are {@code null} when the meter was not present; the usage map
+ * is empty rather than null, and a codec that has never been used is simply absent from it.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+@Value
+public class EncodingReading {
+
+    /**
+     * Number of encoding operations timed by {@code pc.offsets.encoding.time}.
+     */
+    Long encodingCount;
+
+    /**
+     * Total time spent encoding, in milliseconds, from {@code pc.offsets.encoding.time}.
+     */
+    Double encodingTotalTimeMillis;
+
+    /**
+     * Longest single encoding observed in the timer's decaying window, in milliseconds.
+     */
+    Double encodingMaxTimeMillis;
+
+    /**
+     * Use count per codec, from the {@code pc.offsets.encoding.usage} counter family.
+     * <p>
+     * Keyed by the value of the counter's {@code encoding} tag (e.g. {@code BitSetV2Compressed}, {@code RunLength}).
+     * Note the tag key really is {@code encoding} - {@code PCMetricsDef} documents it as {@code codec}, but that
+     * metadata is only used for generating the metrics reference, and the emitting call site in
+     * {@code OffsetMapCodecManager} tags it {@code encoding}. Unmodifiable, insertion-ordered, never null.
+     */
+    Map<String, Double> usageByEncoding;
+
+    /**
+     * Sample count for {@code pc.metadata.space.used}.
+     */
+    Long metadataSpaceUsedCount;
+
+    /**
+     * Mean ratio of encoded payload size to available offset-metadata space, from {@code pc.metadata.space.used}.
+     */
+    Double metadataSpaceUsedMean;
+
+    /**
+     * Worst observed ratio of payload size to available space. The number that predicts an encoding failure.
+     */
+    Double metadataSpaceUsedMax;
+
+    /**
+     * Sample count for {@code pc.payload.ratio.used}.
+     */
+    Long payloadRatioUsedCount;
+
+    /**
+     * Mean ratio of payload size to number of offsets encoded, from {@code pc.payload.ratio.used}.
+     */
+    Double payloadRatioUsedMean;
+
+    /**
+     * Worst observed ratio of payload size to number of offsets encoded.
+     */
+    Double payloadRatioUsedMax;
+
+    @Builder(toBuilder = true)
+    EncodingReading(Long encodingCount,
+                     Double encodingTotalTimeMillis,
+                     Double encodingMaxTimeMillis,
+                     Map<String, Double> usageByEncoding,
+                     Long metadataSpaceUsedCount,
+                     Double metadataSpaceUsedMean,
+                     Double metadataSpaceUsedMax,
+                     Long payloadRatioUsedCount,
+                     Double payloadRatioUsedMean,
+                     Double payloadRatioUsedMax) {
+        this.encodingCount = encodingCount;
+        this.encodingTotalTimeMillis = encodingTotalTimeMillis;
+        this.encodingMaxTimeMillis = encodingMaxTimeMillis;
+        this.usageByEncoding = usageByEncoding == null
+                ? Collections.<String, Double>emptyMap()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(usageByEncoding));
+        this.metadataSpaceUsedCount = metadataSpaceUsedCount;
+        this.metadataSpaceUsedMean = metadataSpaceUsedMean;
+        this.metadataSpaceUsedMax = metadataSpaceUsedMax;
+        this.payloadRatioUsedCount = payloadRatioUsedCount;
+        this.payloadRatioUsedMean = payloadRatioUsedMean;
+        this.payloadRatioUsedMax = payloadRatioUsedMax;
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/LifecycleReading.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/LifecycleReading.java
@@ -1,0 +1,76 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.Builder;
+import lombok.Value;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Run state of the controller and of the broker poller, plus the small amount of identity read directly off the PC
+ * instance.
+ * <p>
+ * The two states arrive as numbers ({@code pc.status} and {@code pc.poller.status} carry
+ * {@code bz.stub.parallelconsumer.internal.State#getValue()}), and are mapped back to the enum name here so the
+ * page never has to know the numeric mapping. Both the name and the raw number are carried: the number is what a
+ * step-function chart plots, the name is what a human reads. If the number does not correspond to any known state -
+ * which happens if core adds a state this module has not been rebuilt against - the name is left absent rather than
+ * guessed, and the number still renders.
+ * <p>
+ * <strong>Absent is not zero.</strong> Every field is boxed; {@code null} means unknown, not "off". In particular
+ * {@code null} state is meaningfully different from {@code UNUSED}.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+@Value
+public class LifecycleReading {
+
+    /**
+     * Controller run state name, e.g. {@code RUNNING}. From {@code pc.status}.
+     */
+    String state;
+
+    /**
+     * Raw numeric value behind {@link #getState()}, as published by the meter.
+     */
+    Integer stateValue;
+
+    /**
+     * Broker poller state name. From {@code pc.poller.status}.
+     */
+    String pollerState;
+
+    /**
+     * Raw numeric value behind {@link #getPollerState()}.
+     */
+    Integer pollerStateValue;
+
+    /**
+     * From {@code AbstractParallelEoSStreamProcessor#isClosedOrFailed()}, read directly on the control thread.
+     * {@code null} when no PC instance was supplied (a registry-only sampler).
+     */
+    Boolean closedOrFailed;
+
+    /**
+     * The instance's optional ID, from {@code AbstractParallelEoSStreamProcessor#getMyId()}. {@code null} when unset
+     * or when no PC instance was supplied.
+     */
+    String instanceId;
+
+    @Builder(toBuilder = true)
+    LifecycleReading(String state,
+                      Integer stateValue,
+                      String pollerState,
+                      Integer pollerStateValue,
+                      Boolean closedOrFailed,
+                      String instanceId) {
+        this.state = state;
+        this.stateValue = stateValue;
+        this.pollerState = pollerState;
+        this.pollerStateValue = pollerStateValue;
+        this.closedOrFailed = closedOrFailed;
+        this.instanceId = instanceId;
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/MeterIndex.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/MeterIndex.java
@@ -1,0 +1,134 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.metrics.PCMetricsDef;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.Search;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Parallel Consumer's own meters, pulled out of a {@link MeterRegistry} in ONE pass and keyed by name.
+ * <p>
+ * <strong>Why this exists.</strong> {@link Search} looks inviting - {@code Search.in(registry).name(x).gauge()} reads
+ * like a map lookup - but it is a linear scan of a fresh {@code ArrayList} copy of the <em>entire</em> registry, every
+ * single time: {@code Search.meters()/.gauges()/.counters()/.gauge()/.timer()/.summary()} all funnel through
+ * {@link MeterRegistry#getMeters()}, which copies the whole meter map before anything is filtered. A reading needs
+ * roughly two dozen of those lookups, and the registry it is handed is commonly the host application's shared one,
+ * carrying JVM, HTTP, connection-pool and Kafka-client meters. That made the cost of one sample proportional to the
+ * host application's whole metric surface, two dozen times over - on the control thread, which
+ * {@link MeterSource} exists to keep cheap.
+ * <p>
+ * One pass, over {@link MeterRegistry#forEachMeter} rather than {@code getMeters()} so not even a single copy of the
+ * registry is allocated, and every subsequent lookup is a hash lookup over PC's own handful of names.
+ * <p>
+ * <strong>Built per sample, never cached.</strong> Meters come and go at runtime - a rebalance adds and removes a
+ * whole partition family - so an index that outlived a sample would go stale, and staleness here reads as "that
+ * partition vanished". A per-sample index cannot: it is built at the top of {@link StateSampler#sample()} and
+ * discarded with the reading. Within a sample it is also a small bonus, in that every value read comes from one
+ * consistent view of which meters existed.
+ * <p>
+ * Only PC's own meters are retained - lookups are keyed by {@link PCMetricsDef}, so it is not possible to ask this
+ * index for a name it deliberately dropped.
+ * <p>
+ * Note this indexes meters, not readings. A {@link io.micrometer.core.instrument.Gauge} held here is still evaluated
+ * on the thread that calls {@code value()}, which is why {@link MeterSource}'s control-thread rule is unchanged.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+public final class MeterIndex {
+
+    private static final Set<String> PC_METER_NAMES = pcMeterNames();
+
+    /** Shared by every empty case - a null registry, and a registry with none of PC's meters in it. */
+    private static final MeterIndex EMPTY = new MeterIndex(Collections.<String, List<Meter>>emptyMap());
+
+    private final Map<String, List<Meter>> byName;
+
+    private MeterIndex(Map<String, List<Meter>> byName) {
+        this.byName = byName;
+    }
+
+    /**
+     * Indexes {@code registry}'s Parallel Consumer meters. A null registry - the reader was wired up without one -
+     * yields an index in which every meter is absent, which is the honest answer rather than a special case every
+     * caller has to remember.
+     */
+    static MeterIndex of(MeterRegistry registry) {
+        if (registry == null) {
+            return EMPTY;
+        }
+        Map<String, List<Meter>> byName = new HashMap<>();
+        registry.forEachMeter(meter -> {
+            String name = meter.getId().getName();
+            if (PC_METER_NAMES.contains(name)) {
+                // a family such as pc.partition.highest.seen.offset has one meter per assigned partition
+                byName.computeIfAbsent(name, key -> new ArrayList<>(2)).add(meter);
+            }
+        });
+        return byName.isEmpty() ? EMPTY : new MeterIndex(byName);
+    }
+
+    /**
+     * Whether any of Parallel Consumer's own meters were found. Distinguishes "PC has not bound its meters yet, or no
+     * registry was supplied" from "PC is genuinely idle", which the page must not conflate.
+     */
+    boolean hasPcMeters() {
+        return !byName.isEmpty();
+    }
+
+    /**
+     * Every meter of {@code def}'s family that is a {@code type} - the whole per-partition family, or empty when the
+     * meter is not registered. Mirrors {@code Search.gauges()}/{@code Search.counters()}, which likewise match on the
+     * concrete meter type as well as the name.
+     */
+    <M extends Meter> List<M> all(PCMetricsDef def, Class<M> type) {
+        List<Meter> meters = byName.get(def.getName());
+        if (meters == null) {
+            return Collections.emptyList();
+        }
+        List<M> matched = new ArrayList<>(meters.size());
+        for (Meter meter : meters) {
+            if (type.isInstance(meter)) {
+                matched.add(type.cast(meter));
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * The single meter registered under {@code def}, or null when it is absent. Null means absent and must stay
+     * distinguishable from a reading of zero all the way to the page.
+     */
+    <M extends Meter> M first(PCMetricsDef def, Class<M> type) {
+        List<Meter> meters = byName.get(def.getName());
+        if (meters == null) {
+            return null;
+        }
+        for (Meter meter : meters) {
+            if (type.isInstance(meter)) {
+                return type.cast(meter);
+            }
+        }
+        return null;
+    }
+
+    private static Set<String> pcMeterNames() {
+        Set<String> names = new HashSet<>();
+        for (PCMetricsDef def : PCMetricsDef.values()) {
+            names.add(def.getName());
+        }
+        return names;
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/MeterSource.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/MeterSource.java
@@ -1,0 +1,305 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.internal.State;
+import bz.stub.parallelconsumer.metrics.PCMetricsDef;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+/**
+ * Reads Parallel Consumer's published meters out of a {@link MeterRegistry} and shapes them into the reading value
+ * types.
+ * <p>
+ * <strong>Every method here must be called on the control thread.</strong> Reading a {@link Gauge} <em>evaluates</em>
+ * it, on the calling thread - that is the mechanism behind confluentinc/parallel-consumer#618, where a Prometheus
+ * scrape thread evaluated a PC gauge and got {@code ConcurrentModificationException: KafkaConsumer is not safe for
+ * multi-threaded access}. {@link ReadingPublisher} is what guarantees the calling thread is the right one.
+ * <p>
+ * <strong>One pass over the registry per sample.</strong> Every sampling method takes the {@link MeterIndex} rather
+ * than reaching for the registry itself, and {@link StateSampler#sample()} builds exactly one of those per pass. That
+ * is deliberate and is the reason there is no no-argument overload to fall back to: this runs on the loop that can
+ * turn over thousands of times a second, and a per-lookup registry scan is precisely the cost this module exists not
+ * to impose. See {@link MeterIndex} for what a {@code Search} call actually costs.
+ * <p>
+ * Meter names are taken from {@link PCMetricsDef} rather than written out as string literals here, so a rename in
+ * core breaks this module's compilation instead of silently turning every value absent.
+ * <p>
+ * <strong>Absent, NaN and zero are three different things.</strong> A meter that is not in the registry yields
+ * {@code null}. A gauge whose value is {@code NaN} - which is what Micrometer reports once the object a gauge weakly
+ * references has been collected - also yields {@code null}, because it is a missing reading rather than a measured
+ * one. Only a real reading of zero yields zero.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+public class MeterSource {
+
+    private static final String TOPIC_TAG = "topic";
+
+    private static final String PARTITION_TAG = "partition";
+
+    /**
+     * The tag {@code pc.offsets.encoding.usage} counters actually carry. Note this differs from the tag key
+     * {@link PCMetricsDef} documents for that meter ({@code codec}) - that metadata feeds the generated metrics
+     * reference only, while {@code OffsetMapCodecManager} tags the live counter {@code encoding}. The live tag is
+     * what has to be read.
+     */
+    private static final String ENCODING_TAG = "encoding";
+
+    private static final Map<Integer, String> STATE_NAMES_BY_VALUE = stateNamesByValue();
+
+    private final MeterRegistry registry;
+
+    public MeterSource(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    /**
+     * Indexes the registry once, for one sample's worth of reads. Every other method here takes the result.
+     */
+    public MeterIndex index() {
+        return MeterIndex.of(registry);
+    }
+
+    /**
+     * Whether any of Parallel Consumer's own meters are present. Distinguishes "PC has not bound its meters yet, or
+     * no registry was supplied" from "PC is genuinely idle", which the page must not conflate.
+     */
+    public boolean isPopulated(MeterIndex index) {
+        return index.hasPcMeters();
+    }
+
+    /**
+     * One row per topic-partition, built by grouping every {@code topic}/{@code partition}-tagged meter family into
+     * the row for its partition. Ordered by topic then partition so the page's table keeps a stable row order.
+     */
+    public List<PartitionReading> samplePartitions(MeterIndex index) {
+        Map<TopicPartition, PartitionReading.PartitionReadingBuilder> rows = new HashMap<>();
+
+        gaugePerPartition(index, rows, PCMetricsDef.PARTITION_HIGHEST_SEEN_OFFSET,
+                PartitionReading.PartitionReadingBuilder::highestSeenOffset);
+        gaugePerPartition(index, rows, PCMetricsDef.PARTITION_HIGHEST_COMPLETED_OFFSET,
+                PartitionReading.PartitionReadingBuilder::highestCompletedOffset);
+        gaugePerPartition(index, rows, PCMetricsDef.PARTITION_HIGHEST_SEQUENTIAL_SUCCEEDED_OFFSET,
+                PartitionReading.PartitionReadingBuilder::highestSequentialSucceededOffset);
+        gaugePerPartition(index, rows, PCMetricsDef.PARTITION_LAST_COMMITTED_OFFSET,
+                PartitionReading.PartitionReadingBuilder::lastCommittedOffset);
+        gaugePerPartition(index, rows, PCMetricsDef.PARTITION_INCOMPLETE_OFFSETS,
+                PartitionReading.PartitionReadingBuilder::incompleteOffsets);
+        gaugePerPartition(index, rows, PCMetricsDef.PARTITION_ASSIGNMENT_EPOCH,
+                PartitionReading.PartitionReadingBuilder::assignmentEpoch);
+
+        counterPerPartition(index, rows, PCMetricsDef.PROCESSED_RECORDS,
+                PartitionReading.PartitionReadingBuilder::processedRecords);
+        counterPerPartition(index, rows, PCMetricsDef.FAILED_RECORDS,
+                PartitionReading.PartitionReadingBuilder::failedRecords);
+        counterPerPartition(index, rows, PCMetricsDef.SLOW_RECORDS,
+                PartitionReading.PartitionReadingBuilder::slowRecords);
+
+        List<TopicPartition> keys = new ArrayList<>(rows.keySet());
+        keys.sort(Comparator.comparing(TopicPartition::topic).thenComparingInt(TopicPartition::partition));
+
+        List<PartitionReading> result = new ArrayList<>(keys.size());
+        for (TopicPartition key : keys) {
+            result.add(rows.get(key).build());
+        }
+        return result;
+    }
+
+    /**
+     * Instance-wide work state from the aggregate gauges.
+     */
+    public WorkReading sampleWork(MeterIndex index) {
+        return WorkReading.builder()
+                .inflightRecords(gaugeAsLong(index, PCMetricsDef.INFLIGHT_RECORDS))
+                .waitingRecords(gaugeAsLong(index, PCMetricsDef.WAITING_RECORDS))
+                .shards(gaugeAsLong(index, PCMetricsDef.NUMBER_OF_SHARDS))
+                .shardsSize(gaugeAsLong(index, PCMetricsDef.SHARDS_SIZE))
+                .incompleteOffsetsTotal(gaugeAsLong(index, PCMetricsDef.INCOMPLETE_OFFSETS_TOTAL))
+                .pausedPartitions(gaugeAsLong(index, PCMetricsDef.NUM_PAUSED_PARTITIONS))
+                .numberOfPartitions(gaugeAsLong(index, PCMetricsDef.NUMBER_OF_PARTITIONS))
+                .dynamicLoadFactor(gaugeValue(index, PCMetricsDef.DYNAMIC_EXTRA_LOAD_FACTOR))
+                .build();
+    }
+
+    /**
+     * Controller and poller run state, mapped from the numeric gauges back to {@link State} names.
+     * <p>
+     * Returns a builder rather than a finished value because {@link DirectStateSource} contributes the remaining
+     * fields - the composition happens once, in {@link StateSampler}.
+     */
+    public LifecycleReading.LifecycleReadingBuilder sampleLifecycle(MeterIndex index) {
+        Integer status = gaugeAsInteger(index, PCMetricsDef.PC_STATUS);
+        Integer pollerStatus = gaugeAsInteger(index, PCMetricsDef.PC_POLLER_STATUS);
+        return LifecycleReading.builder()
+                .stateValue(status)
+                .state(stateName(status))
+                .pollerStateValue(pollerStatus)
+                .pollerState(stateName(pollerStatus));
+    }
+
+    /**
+     * Offset-encoding timings, codec usage and payload-size ratios.
+     */
+    public EncodingReading sampleEncoding(MeterIndex index) {
+        EncodingReading.EncodingReadingBuilder builder = EncodingReading.builder();
+
+        Timer encodingTimer = index.first(PCMetricsDef.OFFSETS_ENCODING_TIME, Timer.class);
+        if (encodingTimer != null) {
+            builder.encodingCount(encodingTimer.count())
+                    .encodingTotalTimeMillis(sane(encodingTimer.totalTime(TimeUnit.MILLISECONDS)))
+                    .encodingMaxTimeMillis(sane(encodingTimer.max(TimeUnit.MILLISECONDS)));
+        }
+
+        builder.usageByEncoding(sampleEncodingUsage(index));
+
+        DistributionSummary metadataSpace = index.first(PCMetricsDef.METADATA_SPACE_USED, DistributionSummary.class);
+        if (metadataSpace != null) {
+            builder.metadataSpaceUsedCount(metadataSpace.count())
+                    .metadataSpaceUsedMean(sane(metadataSpace.mean()))
+                    .metadataSpaceUsedMax(sane(metadataSpace.max()));
+        }
+
+        DistributionSummary payloadRatio = index.first(PCMetricsDef.PAYLOAD_RATIO_USED, DistributionSummary.class);
+        if (payloadRatio != null) {
+            builder.payloadRatioUsedCount(payloadRatio.count())
+                    .payloadRatioUsedMean(sane(payloadRatio.mean()))
+                    .payloadRatioUsedMax(sane(payloadRatio.max()));
+        }
+
+        return builder.build();
+    }
+
+    private Map<String, Double> sampleEncodingUsage(MeterIndex index) {
+        Map<String, Double> usage = new LinkedHashMap<>();
+        List<Counter> ordered = index.all(PCMetricsDef.OFFSETS_ENCODING_USAGE, Counter.class);
+        // deterministic order, so the page's legend does not reshuffle between ticks
+        ordered.sort(Comparator.comparing(c -> String.valueOf(c.getId().getTag(ENCODING_TAG))));
+        for (Counter counter : ordered) {
+            String encoding = counter.getId().getTag(ENCODING_TAG);
+            if (encoding == null) {
+                continue;
+            }
+            Double count = sane(counter.count());
+            if (count != null) {
+                usage.put(encoding, count);
+            }
+        }
+        return usage;
+    }
+
+    private void gaugePerPartition(MeterIndex index,
+                                   Map<TopicPartition, PartitionReading.PartitionReadingBuilder> rows,
+                                   PCMetricsDef def,
+                                   BiConsumer<PartitionReading.PartitionReadingBuilder, Long> setter) {
+        for (Gauge gauge : index.all(def, Gauge.class)) {
+            PartitionReading.PartitionReadingBuilder row = rowFor(rows, gauge);
+            if (row == null) {
+                continue;
+            }
+            Double value = sane(gauge.value());
+            if (value != null) {
+                setter.accept(row, (long) (double) value);
+            }
+        }
+    }
+
+    private void counterPerPartition(MeterIndex index,
+                                     Map<TopicPartition, PartitionReading.PartitionReadingBuilder> rows,
+                                     PCMetricsDef def,
+                                     BiConsumer<PartitionReading.PartitionReadingBuilder, Double> setter) {
+        for (Counter counter : index.all(def, Counter.class)) {
+            PartitionReading.PartitionReadingBuilder row = rowFor(rows, counter);
+            if (row == null) {
+                continue;
+            }
+            Double value = sane(counter.count());
+            if (value != null) {
+                setter.accept(row, value);
+            }
+        }
+    }
+
+    /**
+     * The row a partition-tagged meter belongs to, created on first sight. Returns null - meaning "skip this meter" -
+     * for a meter that is missing either tag or whose partition tag is not a number, rather than inventing a row
+     * keyed on a guess.
+     */
+    private PartitionReading.PartitionReadingBuilder rowFor(
+            Map<TopicPartition, PartitionReading.PartitionReadingBuilder> rows, Meter meter) {
+        String topic = meter.getId().getTag(TOPIC_TAG);
+        String partition = meter.getId().getTag(PARTITION_TAG);
+        if (topic == null || partition == null) {
+            return null;
+        }
+        int partitionNumber;
+        try {
+            partitionNumber = Integer.parseInt(partition.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        TopicPartition key = new TopicPartition(topic, partitionNumber);
+        PartitionReading.PartitionReadingBuilder existing = rows.get(key);
+        if (existing == null) {
+            existing = PartitionReading.builder().topic(topic).partition(partitionNumber);
+            rows.put(key, existing);
+        }
+        return existing;
+    }
+
+    private Double gaugeValue(MeterIndex index, PCMetricsDef def) {
+        Gauge gauge = index.first(def, Gauge.class);
+        return gauge == null ? null : sane(gauge.value());
+    }
+
+    private Long gaugeAsLong(MeterIndex index, PCMetricsDef def) {
+        Double value = gaugeValue(index, def);
+        return value == null ? null : (long) (double) value;
+    }
+
+    private Integer gaugeAsInteger(MeterIndex index, PCMetricsDef def) {
+        Double value = gaugeValue(index, def);
+        return value == null ? null : (int) (double) value;
+    }
+
+    /**
+     * NaN and the infinities are missing readings, not measurements - collapse them to absent so nothing downstream
+     * has to decide what a NaN offset means.
+     */
+    private static Double sane(double value) {
+        return (Double.isNaN(value) || Double.isInfinite(value)) ? null : value;
+    }
+
+    /**
+     * Name for a {@link State#getValue()}, or null if the number matches no known state - which is what happens when
+     * core gains a state this module has not been rebuilt against. Absent beats a wrong label.
+     */
+    static String stateName(Integer value) {
+        return value == null ? null : STATE_NAMES_BY_VALUE.get(value);
+    }
+
+    private static Map<Integer, String> stateNamesByValue() {
+        Map<Integer, String> names = new HashMap<>();
+        for (State state : State.values()) {
+            names.put(state.getValue(), state.name());
+        }
+        return names;
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/PartitionReading.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/PartitionReading.java
@@ -1,0 +1,161 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.Builder;
+import lombok.Value;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * One row of per-topic-partition state, as it was at the instant the enclosing {@link PcReading} was captured.
+ * <p>
+ * <strong>Absent is not zero.</strong> Every quantity here is a boxed type and {@code null} means "the meter that
+ * supplies this was not present in the registry". A partition that has processed no records reports {@code 0}; a
+ * partition whose counter has never been created reports {@code null}. The page draws those differently - see
+ * {@link PcReading} for the rationale.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+@Value
+public class PartitionReading {
+
+    /**
+     * Topic name, from the {@code topic} meter tag. Never null.
+     */
+    String topic;
+
+    /**
+     * Partition number, from the {@code partition} meter tag.
+     */
+    int partition;
+
+    /**
+     * {@code pc.partition.highest.seen.offset} - the furthest offset PC has taken delivery of.
+     */
+    Long highestSeenOffset;
+
+    /**
+     * {@code pc.partition.highest.completed.offset} - the highest offset that has succeeded, which may sit above a
+     * gap of incomplete offsets below it. This is the marker that makes PC's "running ahead of the commit" visible.
+     */
+    Long highestCompletedOffset;
+
+    /**
+     * {@code pc.partition.highest.sequential.succeeded.offset} - the highest offset below which nothing is
+     * incomplete, i.e. the highest offset that would be safe to commit.
+     */
+    Long highestSequentialSucceededOffset;
+
+    /**
+     * {@code pc.partition.latest.committed.offset} - what has actually been committed to the broker.
+     * <p>
+     * <strong>This is the NEXT offset to consume, not the last one done.</strong> Kafka's commit is exclusive, and
+     * {@code PartitionState.getOffsetToCommit()} publishes {@code highestSequentialSucceeded + 1}, so on a partition
+     * that is completely caught up this reads one <em>above</em> every other marker here. Carried on the wire exactly
+     * as the gauge reports it - it is the number the broker holds and the offset a restart resumes from - and
+     * converted to its inclusive form only where it is compared against the other three. See
+     * {@link #isOffsetOrderingConsistent()}.
+     */
+    Long lastCommittedOffset;
+
+    /**
+     * {@code pc.partition.incomplete.offsets} - count of offsets seen but not yet succeeded.
+     */
+    Long incompleteOffsets;
+
+    /**
+     * {@code pc.partition.assignment.epoch} - increments each time this partition is re-assigned to this instance.
+     */
+    Long assignmentEpoch;
+
+    /**
+     * {@code pc.processed.records} counter for this partition. Micrometer counters are doubles; kept as a double so
+     * a very long-running counter is not silently truncated.
+     */
+    Double processedRecords;
+
+    /**
+     * {@code pc.failed.records} counter for this partition.
+     */
+    Double failedRecords;
+
+    /**
+     * {@code pc.slow.records} counter for this partition - records that waited longer than the configured threshold.
+     */
+    Double slowRecords;
+
+    @Builder(toBuilder = true)
+    PartitionReading(String topic,
+                      int partition,
+                      Long highestSeenOffset,
+                      Long highestCompletedOffset,
+                      Long highestSequentialSucceededOffset,
+                      Long lastCommittedOffset,
+                      Long incompleteOffsets,
+                      Long assignmentEpoch,
+                      Double processedRecords,
+                      Double failedRecords,
+                      Double slowRecords) {
+        this.topic = topic;
+        this.partition = partition;
+        this.highestSeenOffset = highestSeenOffset;
+        this.highestCompletedOffset = highestCompletedOffset;
+        this.highestSequentialSucceededOffset = highestSequentialSucceededOffset;
+        this.lastCommittedOffset = lastCommittedOffset;
+        this.incompleteOffsets = incompleteOffsets;
+        this.assignmentEpoch = assignmentEpoch;
+        this.processedRecords = processedRecords;
+        this.failedRecords = failedRecords;
+        this.slowRecords = slowRecords;
+    }
+
+    /**
+     * Stable identity for this row, e.g. {@code my-topic-3}. Used as the key a later unit's table and ribbon render
+     * against, so a partition keeps its row across readings.
+     */
+    public String getKey() {
+        return topic + "-" + partition;
+    }
+
+    /**
+     * Whether the four offset markers are in the only order they can legally be in:
+     * committed &lt;= sequential-succeeded &lt;= completed &lt;= seen.
+     * <p>
+     * This is the invariant the offset ribbon is drawn from - if it can be violated the graphic is meaningless, so
+     * it is asserted rather than assumed. Markers that are absent are skipped rather than treated as zero: a missing
+     * meter must not be able to report a false violation.
+     * <p>
+     * The committed marker is normalised to {@link #committedInclusive()} first. The other three are inclusive
+     * positions - the highest offset that is seen, succeeded, sequentially succeeded - while the committed gauge is
+     * exclusive, so comparing them raw reports every <em>caught-up</em> partition as violating the invariant, which is
+     * the one partition state that is unambiguously healthy.
+     */
+    public boolean isOffsetOrderingConsistent() {
+        Long committed = committedInclusive();
+        return notAbove(committed, highestSequentialSucceededOffset)
+                && notAbove(highestSequentialSucceededOffset, highestCompletedOffset)
+                && notAbove(highestCompletedOffset, highestSeenOffset)
+                // also check the pairs that skip an absent middle marker, so one missing meter does not hide a
+                // genuine inversion between the markers either side of it
+                && notAbove(committed, highestCompletedOffset)
+                && notAbove(committed, highestSeenOffset)
+                && notAbove(highestSequentialSucceededOffset, highestSeenOffset);
+    }
+
+    /**
+     * {@link #lastCommittedOffset} as an inclusive position - the highest offset actually committed - so it is
+     * comparable with the other three markers. Null in, null out: an absent meter stays absent.
+     */
+    private Long committedInclusive() {
+        return lastCommittedOffset == null ? null : lastCommittedOffset - 1;
+    }
+
+    private static boolean notAbove(Long lower, Long upper) {
+        if (lower == null || upper == null) {
+            return true;
+        }
+        return lower <= upper;
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/PcReading.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/PcReading.java
@@ -1,0 +1,116 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.Builder;
+import lombok.Value;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Everything a reader needs about a Parallel Consumer instance, as it was at one instant. The web dashboard and the
+ * MCP tools are two such readers; an application wiring this to its own monitoring is a third.
+ * <p>
+ * <strong>Deeply immutable, and holds no reference to any live PC object.</strong> That is the whole point: this
+ * value is built on the control thread by {@link StateSampler}, published through
+ * {@link ReadingPublisher}, and then read by arbitrary other threads. Nothing reachable from here can be mutated
+ * afterwards, and nothing reachable from here can drag a reader onto a {@code KafkaConsumer}, a {@code RetryQueue}
+ * or a Micrometer gauge supplier. See {@code ReadingPublisher}'s class javadoc for the recorded incident that
+ * makes this non-negotiable.
+ * <p>
+ * <strong>Absent is not zero.</strong> Every optional quantity in this tree is a boxed type whose {@code null} means
+ * "no meter supplied this", never "the value is zero". A reader that renders zero for a missing meter is asserting
+ * something it does not know; absence is carried as absence so it does not have to.
+ * <p>
+ * <strong>Confidence.</strong> {@link #getSampleSequence()} and {@link #isRegistryPopulated()} exist so a
+ * just-started reader can degrade honestly. A first sample taken microseconds after start, from a registry that
+ * has not had its meters bound yet, is a legitimate reading of "nothing known yet" - and it must be distinguishable
+ * from a confident reading of an idle consumer.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+@Value
+public class PcReading {
+
+    /**
+     * When this reading was captured, in epoch milliseconds. Staleness display and every rate derived between two
+     * readings depend on this - a rate must be divided by measured elapsed time, never by a nominal interval.
+     */
+    long captureEpochMillis;
+
+    /**
+     * 1-based count of samples the publisher has taken, this one included. {@code 1} means the page is looking at the
+     * very first reading and has no history behind it.
+     */
+    long sampleSequence;
+
+    /**
+     * Whether the meter registry contained any of Parallel Consumer's own meters when this was captured. False means
+     * the absences below are "not published yet", not "measured as nothing".
+     */
+    boolean registryPopulated;
+
+    /**
+     * Controller and poller run state. Never null; all-absent if nothing could be read.
+     */
+    LifecycleReading lifecycle;
+
+    /**
+     * Instance-wide work state. Never null; all-absent if nothing could be read.
+     */
+    WorkReading work;
+
+    /**
+     * Offset-encoding health. Never null; all-absent if nothing could be read.
+     */
+    EncodingReading encoding;
+
+    /**
+     * One row per topic-partition, ordered by topic then partition number so the page's table does not reshuffle
+     * between ticks. Unmodifiable, never null, possibly empty.
+     */
+    List<PartitionReading> partitions;
+
+    @Builder(toBuilder = true)
+    PcReading(long captureEpochMillis,
+               long sampleSequence,
+               boolean registryPopulated,
+               LifecycleReading lifecycle,
+               WorkReading work,
+               EncodingReading encoding,
+               List<PartitionReading> partitions) {
+        this.captureEpochMillis = captureEpochMillis;
+        this.sampleSequence = sampleSequence;
+        this.registryPopulated = registryPopulated;
+        // never null: a page that has to null-check every branch of this tree grows a null-check bug instead of an
+        // absence-rendering rule. An all-absent sub-reading says the same thing and says it uniformly.
+        this.lifecycle = lifecycle == null ? LifecycleReading.builder().build() : lifecycle;
+        this.work = work == null ? WorkReading.builder().build() : work;
+        this.encoding = encoding == null ? EncodingReading.builder().build() : encoding;
+        this.partitions = partitions == null
+                ? Collections.<PartitionReading>emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(partitions));
+    }
+
+    /**
+     * Whether this reading carries nothing to draw - no PC meters were registered and no partition rows were found.
+     * This is the honest "nothing known yet" state, and the page says so rather than rendering a confident zero.
+     */
+    public boolean isEmpty() {
+        return !registryPopulated && partitions.isEmpty();
+    }
+
+    /**
+     * How old this reading is, in milliseconds, relative to the supplied wall-clock instant. Negative results are
+     * clamped to zero so a clock that steps backwards cannot render a reading from the future.
+     */
+    public long ageMillis(long nowEpochMillis) {
+        long age = nowEpochMillis - captureEpochMillis;
+        return age < 0 ? 0 : age;
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/ReadingPublisher.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/ReadingPublisher.java
@@ -1,0 +1,383 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Samples Parallel Consumer's state on the control thread and publishes the result for other threads to read.
+ * <p>
+ * <strong>Why the sampling has to happen here.</strong> Micrometer evaluates a gauge on whichever thread reads it.
+ * confluentinc/parallel-consumer#618 records a Prometheus scrape thread evaluating a PC gauge and getting
+ * {@code ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access}. So this class
+ * registers a {@link Runnable} through
+ * {@link AbstractParallelEoSStreamProcessor#addLoopEndCallBack(Runnable) addLoopEndCallBack}, which is already
+ * public and already runs on the control loop, and every gauge evaluation therefore happens where it already legally
+ * happens. HTTP handlers never sample; they only read {@link #getCurrent()}.
+ * <p>
+ * <strong>Why current and previous are kept.</strong> Rate charts and the pipeline animation both need a delta.
+ * Computing it once here beats every reader recomputing it, and both readings are published through a
+ * <em>single</em> volatile reference to an immutable pair - two separate volatile fields would let a reader see a
+ * current from one tick beside a previous from another, and every rate derived from that pair would be wrong.
+ * <p>
+ * That is also why {@link #getReadings()} exists, and why a reader that needs <em>both</em> must use it:
+ * {@link #getCurrent()} and {@link #getPrevious()} are two separate volatile reads, so a publish landing between them
+ * hands back a mismatched pair. That is not hypothetical - it is what the concurrency test in
+ * {@code ReadingPublisherTest} caught on the first run, and the reason the pair is an exposed value type rather than
+ * two independent getters.
+ * <p>
+ * <strong>Why publication is announced rather than polled for.</strong> A reader that wants every sample used to
+ * have no choice but to re-read {@link #getCurrent()} on a timer of its own, which is a poll: it arrives late by up
+ * to its own period, it runs when nothing has been published, and its period becomes an accidental floor on how
+ * fresh anything downstream can be. {@link #addListener(ReadingListener)} removes the timer - a sample is announced
+ * at the instant it is published.
+ * <p>
+ * <strong>The listener contract is deliberately austere, and it is a hard constraint rather than advice.</strong>
+ * Listeners run on the control thread, inside the loop-end callback, so whatever a listener does is latency added to
+ * every single control loop iteration. A listener must therefore do nothing but hand off: set a flag, offer to a
+ * queue, wake another thread. It must not serialise anything, must not touch a socket, must not block on a lock, and
+ * must not wait on another thread. It is also handed no reading - only the fact that one exists - precisely so that
+ * the tempting shortcut of reading the value on this thread and carrying it somewhere is not the path of least
+ * resistance; a listener reads {@link #getReadings()} later, from wherever it does its real work.
+ * <p>
+ * <strong>Fault isolation.</strong> A bug in a subscriber must not be able to stop a consumer. {@link #sampleOnce()}
+ * catches {@link Throwable} from both sampling and notification, leaves the previously published pair in place, and
+ * logs at WARN with repeat suppression - the control loop runs continuously, so an unsuppressed log line here would
+ * be a log flood, which is its own outage. A listener that throws is isolated from the control loop and from the
+ * other listeners.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+@Slf4j
+public class ReadingPublisher {
+
+    /**
+     * At most one warning per this interval for a repeating failure. Long enough that a persistent fault cannot
+     * flood the log from a loop that runs thousands of times a minute, short enough that an operator watching a live
+     * log still sees it recur.
+     */
+    private static final long FAILURE_LOG_INTERVAL_MS = TimeUnit.MINUTES.toMillis(5);
+
+    /**
+     * A failure with a <em>different</em> signature is worth surfacing sooner than the repeat interval - but not
+     * unconditionally, because two faults alternating would otherwise defeat suppression entirely and flood the log
+     * exactly as a single unsuppressed one would.
+     */
+    private static final long NEW_FAULT_LOG_FLOOR_MS = TimeUnit.SECONDS.toMillis(10);
+
+    private final StateSampler sampler;
+
+    /**
+     * The single publication point. Immutable pair, volatile reference: a reader either sees the whole previous pair
+     * or the whole new one, never a mixture and never a half-built reading.
+     */
+    private volatile Readings readings = new Readings(null, null);
+
+    /**
+     * Copy-on-write because the control thread iterates this on every single loop iteration while registration
+     * happens a handful of times in a process's life: iteration must be allocation-free and lock-free, and paying
+     * for that with an array copy per registration is the right way round.
+     */
+    private final List<ReadingListener> listeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Sampling failures, kept separately from notification failures because they mean different things: a sampling
+     * failure means the page is showing a stale reading, a notification failure means a subscriber is broken while
+     * the reading itself is fine.
+     */
+    private final FailureLog samplingFailures = new FailureLog(
+            "Reading sampling failed and was suppressed - the previously published reading is left in "
+                    + "place and the consumer is unaffected.");
+
+    private final FailureLog notificationFailures = new FailureLog(
+            "A reading listener threw and was suppressed - the reading was still published, the other "
+                    + "listeners still ran, and the consumer is unaffected.");
+
+    /**
+     * Set by {@link #stopSampling()}; checked at the top of {@link #sampleOnce()}.
+     * <p>
+     * <strong>This is the only way sampling can be stopped, because core has no {@code removeLoopEndCallBack}.</strong>
+     * A registered callback lives as long as the {@link AbstractParallelEoSStreamProcessor} does, so without this flag
+     * a closed subscriber would keep walking every meter in the registry and allocating a reading on the user's
+     * control loop, forever - and every start/stop cycle would add another one. Making the callback a cheap
+     * volatile-read-and-return is the most this module can do from outside core; adding
+     * {@code removeLoopEndCallBack} there is the durable fix and would let the callback be deregistered outright.
+     * <p>
+     * Volatile because {@link #stopSampling()} is called from whichever thread closes the server and the flag is read
+     * on the control thread.
+     */
+    private volatile boolean samplingStopped;
+
+    public ReadingPublisher(StateSampler sampler) {
+        this.sampler = sampler;
+    }
+
+    /**
+     * The usual construction: sample {@code registry} for the meters and {@code pc} for identity, and register the
+     * loop-end callback immediately so the first reading appears on the next control loop iteration.
+     */
+    public static ReadingPublisher createAndRegister(AbstractParallelEoSStreamProcessor<?, ?> pc,
+                                                      MeterRegistry registry) {
+        ReadingPublisher publisher = new ReadingPublisher(new StateSampler(pc, registry));
+        publisher.registerWith(pc);
+        return publisher;
+    }
+
+    /**
+     * Registers sampling as a control-loop end callback. This is the only supported way to drive sampling in
+     * production - see the class javadoc.
+     */
+    public void registerWith(AbstractParallelEoSStreamProcessor<?, ?> pc) {
+        pc.addLoopEndCallBack(this::sampleOnce);
+    }
+
+    /**
+     * Takes one sample and publishes it, rotating the previous current into previous.
+     * <p>
+     * This is the callback body. It never throws: a failure leaves the published pair untouched, so the page keeps
+     * showing the last good reading (visibly ageing, because {@link PcReading#getCaptureEpochMillis()} does not
+     * move) instead of going blank.
+     */
+    public void sampleOnce() {
+        if (samplingStopped) {
+            // the callback cannot be deregistered from here, so this is where it becomes free - see samplingStopped
+            return;
+        }
+        PcReading fresh;
+        try {
+            fresh = sampler.sample();
+        } catch (Throwable t) {
+            samplingFailures.record(t);
+            return;
+        }
+        // read-then-write of a field only ever written from the control thread, so no CAS is needed; the volatile
+        // write is what makes the new pair visible to readers
+        this.readings = new Readings(fresh, this.readings.getCurrent());
+        // AFTER the publish, never before: a listener that reacts by reading getReadings() must find the sample it
+        // was told about, not the one before it
+        notifyListeners();
+    }
+
+    /**
+     * Stops sampling permanently. Idempotent, and safe to call from any thread.
+     * <p>
+     * After this returns, the loop-end callback registered by {@link #registerWith} does a volatile read and returns.
+     * The last published pair is left in place, so a reader that still holds this publisher sees the final reading
+     * ageing rather than a null.
+     * <p>
+     * There is no {@code startSampling()} counterpart on purpose: this is a shutdown, and a publisher that could be
+     * resumed would need to answer what happens to the gap in the middle. Construct a new one.
+     */
+    public void stopSampling() {
+        samplingStopped = true;
+    }
+
+    /**
+     * Whether {@link #stopSampling()} has been called. Exists so a shutdown can be asserted to have actually taken
+     * effect - the alternative is counting samples and waiting, which proves nothing about a slow control loop.
+     */
+    public boolean isSamplingStopped() {
+        return samplingStopped;
+    }
+
+    /**
+     * Registers a listener to be told, on the control thread, that a new reading has been published. Read the
+     * class javadoc before writing one - the constraints on what it may do are not stylistic.
+     * <p>
+     * Registering the same listener twice registers it twice; this is a list, not a set, because a caller that
+     * genuinely wants two independent subscriptions from one object should be able to have them, and silently
+     * dropping a registration is a worse failure than an obvious duplicate.
+     */
+    public void addListener(ReadingListener listener) {
+        if (listener != null) {
+            listeners.add(listener);
+        }
+    }
+
+    /**
+     * Deregisters a listener, if it is registered. A subscriber that is shutting down must call this: the publisher
+     * outlives any one subscriber, so a listener left behind is a leak that keeps calling into a closed object on
+     * every control loop iteration.
+     */
+    public void removeListener(ReadingListener listener) {
+        listeners.remove(listener);
+    }
+
+    /**
+     * How many listeners are registered. Exists so a shutdown path can be asserted to have actually deregistered,
+     * which is the only way a leak of this kind is visible from outside.
+     */
+    public int getListenerCount() {
+        return listeners.size();
+    }
+
+    private void notifyListeners() {
+        for (ReadingListener listener : listeners) {
+            try {
+                listener.onReadingPublished();
+            } catch (Throwable t) {
+                // one broken listener must not cost the others their notification, and none of them may cost the
+                // control loop anything at all
+                notificationFailures.record(t);
+            }
+        }
+    }
+
+    /**
+     * The current and previous readings as one consistent pair, read from the volatile exactly once.
+     * <p>
+     * <strong>Any reader that needs both must use this</strong> rather than calling {@link #getCurrent()} and
+     * {@link #getPrevious()} in turn - those are two separate volatile reads, and a publish landing between them
+     * returns a current and a previous from different ticks, which silently corrupts every rate derived from them.
+     * Never null; its fields are null until enough samples have been taken.
+     */
+    public Readings getReadings() {
+        return readings;
+    }
+
+    /**
+     * The most recently captured reading, or null if none has been taken yet. For a reader that needs the previous
+     * one as well, use {@link #getReadings()}.
+     */
+    public PcReading getCurrent() {
+        return readings.getCurrent();
+    }
+
+    /**
+     * The reading captured immediately before {@link #getCurrent()}, or null until at least two have been taken. For
+     * a reader that needs both, use {@link #getReadings()} - see its javadoc for why.
+     */
+    public PcReading getPrevious() {
+        return readings.getPrevious();
+    }
+
+    /**
+     * How many sampling attempts have failed since construction. Zero is the expected value; anything else means the
+     * page is showing a stale reading and something in the sampler needs looking at.
+     */
+    public long getSampleFailureCount() {
+        return samplingFailures.getCount();
+    }
+
+    /**
+     * How many listener notifications have thrown since construction. Zero is the expected value; anything else
+     * means a subscriber is broken while the published reading itself is fine.
+     */
+    public long getListenerFailureCount() {
+        return notificationFailures.getCount();
+    }
+
+    /**
+     * What a listener is told when a reading is published. Not a {@link Runnable} so that the constraints below have
+     * somewhere to live where an implementer will read them.
+     * <p>
+     * <strong>Runs on the control thread.</strong> Whatever this method does is added to the latency of every
+     * control loop iteration, on a loop that runs thousands of times a minute. So it must hand off and return: set a
+     * flag, offer to a non-blocking queue, wake an event loop. It must not serialise, must not do I/O, must not
+     * block, and must not wait on another thread.
+     * <p>
+     * It is handed no reading on purpose. Read {@link #getReadings()} from the thread that does the real work -
+     * see the class javadoc for why carrying a value off this thread is the shortcut worth designing out.
+     * <p>
+     * Experimental: this module is opt-in and its API may change without notice.
+     */
+    @InterfaceStability.Unstable
+    public interface ReadingListener {
+
+        void onReadingPublished();
+    }
+
+    /**
+     * Repeat-suppressed WARN logging for a fault that recurs on every control loop iteration, with a count of what
+     * it swallowed.
+     * <p>
+     * One class used by both failure paths rather than two copies of the bookkeeping: the suppression rules are the
+     * interesting part and they are identical, so a second copy would be a second place for them to drift.
+     * <p>
+     * Not thread-safe, and does not need to be: every field is touched only from the control thread, except the
+     * count, which is volatile because a health endpoint reads it from anywhere.
+     */
+    private static final class FailureLog {
+
+        private final String what;
+
+        private volatile long count;
+
+        private String lastSignature;
+
+        private long lastLoggedAtEpochMillis;
+
+        private long suppressedSinceLastLog;
+
+        private FailureLog(String what) {
+            this.what = what;
+        }
+
+        long getCount() {
+            return count;
+        }
+
+        void record(Throwable t) {
+            count++;
+            String signature = t.getClass().getName() + ": " + t.getMessage();
+            long now = System.currentTimeMillis();
+            boolean isNewFault = !signature.equals(lastSignature);
+            long sinceLastLog = now - lastLoggedAtEpochMillis;
+            if ((isNewFault && sinceLastLog >= NEW_FAULT_LOG_FLOOR_MS) || sinceLastLog >= FAILURE_LOG_INTERVAL_MS) {
+                log.warn("{} {} identical failure(s) were not logged since the last message; {} failure(s) in "
+                        + "total.", what, suppressedSinceLastLog, count, t);
+                lastSignature = signature;
+                lastLoggedAtEpochMillis = now;
+                suppressedSinceLastLog = 0;
+            } else {
+                suppressedSinceLastLog++;
+            }
+        }
+    }
+
+    /**
+     * The current/previous pair, published as one immutable object so the two can never be seen out of step.
+     * <p>
+     * {@link #getPrevious()} is always exactly one sample behind {@link #getCurrent()}, or null when only one sample
+     * has been taken - which is the property that makes a delta computed from this pair meaningful.
+     * <p>
+     * Experimental: this module is opt-in and its API may change without notice.
+     */
+    @InterfaceStability.Unstable
+    @Value
+    public static class Readings {
+        PcReading current;
+
+        PcReading previous;
+
+        /**
+         * Whether both ends of the pair are present, i.e. whether a delta can be computed at all. A page with only
+         * one sample shows the state but no rate, rather than a rate derived from a single point.
+         */
+        public boolean hasDelta() {
+            return current != null && previous != null;
+        }
+
+        /**
+         * Measured elapsed time between the two captures, in milliseconds, or null if there is no delta. A rate must
+         * be divided by this, never by a nominal poll interval - dividing by the nominal interval is exactly how a
+         * well-known dashboard's realtime graph came to read roughly double.
+         */
+        public Long elapsedMillis() {
+            if (!hasDelta()) {
+                return null;
+            }
+            return current.getCaptureEpochMillis() - previous.getCaptureEpochMillis();
+        }
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/StateSampler.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/StateSampler.java
@@ -1,0 +1,82 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.Getter;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Composes the two state sources into one {@link PcReading}, so nothing downstream has to care which source a value
+ * came from.
+ * <p>
+ * <strong>Control thread only.</strong> {@link #sample()} evaluates Micrometer gauges, and gauge evaluation runs the
+ * gauge's supplier on the calling thread - see {@link MeterSource} for the incident that makes this a rule rather
+ * than a preference. {@link ReadingPublisher} is what enforces it; calling {@code sample()} from anywhere else
+ * defeats the entire design.
+ * <p>
+ * Not final, and {@link #sample()} is overridable, so a test can substitute a sampler that fails and prove the
+ * publisher isolates it.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+public class StateSampler {
+
+    @Getter
+    private final MeterSource meterSource;
+
+    @Getter
+    private final DirectStateSource directStateSource;
+
+    /**
+     * Samples taken so far. Only ever incremented on the control thread; volatile so a reader that wants the count
+     * without a reading in hand sees a current value.
+     */
+    private volatile long sampleCount;
+
+    public StateSampler(MeterSource meterSource, DirectStateSource directStateSource) {
+        this.meterSource = meterSource;
+        this.directStateSource = directStateSource;
+    }
+
+    /**
+     * Convenience for the usual composition: read the meters from {@code registry}, read identity and the
+     * closed/failed flag from {@code pc}. Either may be null.
+     */
+    public StateSampler(AbstractParallelEoSStreamProcessor<?, ?> pc, MeterRegistry registry) {
+        this(new MeterSource(registry), new DirectStateSource(pc));
+    }
+
+    /**
+     * Builds one immutable reading of everything the page needs.
+     * <p>
+     * Must be called on the control thread. The result holds no reference back to any live PC object, so it is safe
+     * to hand to any number of other threads.
+     */
+    public PcReading sample() {
+        long sequence = ++sampleCount;
+        // ONE pass over the registry for the whole sample. See MeterIndex for what the per-lookup alternative costs.
+        MeterIndex meters = meterSource.index();
+        LifecycleReading lifecycle = directStateSource.contributeTo(meterSource.sampleLifecycle(meters)).build();
+        return PcReading.builder()
+                .captureEpochMillis(System.currentTimeMillis())
+                .sampleSequence(sequence)
+                .registryPopulated(meterSource.isPopulated(meters))
+                .lifecycle(lifecycle)
+                .work(meterSource.sampleWork(meters))
+                .encoding(meterSource.sampleEncoding(meters))
+                .partitions(meterSource.samplePartitions(meters))
+                .build();
+    }
+
+    /**
+     * How many samples this sampler has taken. Feeds {@link PcReading#getSampleSequence()}, which is how a
+     * just-started reader knows it has no history behind it.
+     */
+    public long getSampleCount() {
+        return sampleCount;
+    }
+}

--- a/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/WorkReading.java
+++ b/parallel-consumer-observability/src/main/java/bz/stub/parallelconsumer/observability/WorkReading.java
@@ -1,0 +1,81 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import lombok.Builder;
+import lombok.Value;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+/**
+ * Instance-wide work state - what PC is holding, running and waiting on right now.
+ * <p>
+ * <strong>Absent is not zero.</strong> Every field is boxed and {@code null} means the meter was not present. See
+ * {@link PcReading} for why that distinction is kept all the way to the page.
+ * <p>
+ * Experimental: this module is opt-in and its API may change without notice.
+ */
+@InterfaceStability.Unstable
+@Value
+public class WorkReading {
+
+    /**
+     * {@code pc.inflight.records} - records currently being processed or waiting for a retry.
+     */
+    Long inflightRecords;
+
+    /**
+     * {@code pc.waiting.records} - records downloaded and waiting to be selected for processing.
+     */
+    Long waitingRecords;
+
+    /**
+     * {@code pc.shards} - number of shards (the ordering-key buckets work is queued into).
+     */
+    Long shards;
+
+    /**
+     * {@code pc.shards.size} - records queued across all shards.
+     */
+    Long shardsSize;
+
+    /**
+     * {@code pc.incomplete.offsets.total} - incomplete offsets across every assigned partition.
+     */
+    Long incompleteOffsetsTotal;
+
+    /**
+     * {@code pc.partitions.paused} - partitions the broker poller has paused for back-pressure.
+     */
+    Long pausedPartitions;
+
+    /**
+     * {@code pc.partitions.number} - partitions currently assigned.
+     */
+    Long numberOfPartitions;
+
+    /**
+     * {@code pc.dynamic.load.factor} - the multiple of max concurrency PC is currently buffering to. A ratio rather
+     * than a count, so it stays a double.
+     */
+    Double dynamicLoadFactor;
+
+    @Builder(toBuilder = true)
+    WorkReading(Long inflightRecords,
+                 Long waitingRecords,
+                 Long shards,
+                 Long shardsSize,
+                 Long incompleteOffsetsTotal,
+                 Long pausedPartitions,
+                 Long numberOfPartitions,
+                 Double dynamicLoadFactor) {
+        this.inflightRecords = inflightRecords;
+        this.waitingRecords = waitingRecords;
+        this.shards = shards;
+        this.shardsSize = shardsSize;
+        this.incompleteOffsetsTotal = incompleteOffsetsTotal;
+        this.pausedPartitions = pausedPartitions;
+        this.numberOfPartitions = numberOfPartitions;
+        this.dynamicLoadFactor = dynamicLoadFactor;
+    }
+}

--- a/parallel-consumer-observability/src/test/java/bz/stub/parallelconsumer/observability/MeterRegistrySamplerTest.java
+++ b/parallel-consumer-observability/src/test/java/bz/stub/parallelconsumer/observability/MeterRegistrySamplerTest.java
@@ -1,0 +1,406 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
+import bz.stub.parallelconsumer.internal.State;
+import bz.stub.parallelconsumer.metrics.PCMetricsDef;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Proves the reading a {@link StateSampler} builds actually matches the meters in the registry - including the two
+ * things a reader gets wrong by default: treating an absent meter as zero, and asserting a confident reading from
+ * a registry that has not been populated yet.
+ */
+class MeterRegistrySamplerTest {
+
+    private static StateSampler samplerOver(MeterRegistry registry) {
+        return new StateSampler(new MeterSource(registry), new DirectStateSource(null));
+    }
+
+    /**
+     * The names this module reads are core's, not this module's. If core renames one, this module silently reports
+     * every value from that family as absent - which looks exactly like an idle consumer. Pin them.
+     */
+    @Test
+    void meterNamesMatchCoreDefinitions() {
+        assertThat(PCMetricsDef.PARTITION_HIGHEST_SEEN_OFFSET.getName()).isEqualTo(PcMeterFixture.PARTITION_HIGHEST_SEEN);
+        assertThat(PCMetricsDef.PARTITION_HIGHEST_COMPLETED_OFFSET.getName()).isEqualTo(PcMeterFixture.PARTITION_HIGHEST_COMPLETED);
+        assertThat(PCMetricsDef.PARTITION_HIGHEST_SEQUENTIAL_SUCCEEDED_OFFSET.getName()).isEqualTo(PcMeterFixture.PARTITION_HIGHEST_SEQUENTIAL_SUCCEEDED);
+        assertThat(PCMetricsDef.PARTITION_LAST_COMMITTED_OFFSET.getName()).isEqualTo(PcMeterFixture.PARTITION_LATEST_COMMITTED);
+        assertThat(PCMetricsDef.PARTITION_INCOMPLETE_OFFSETS.getName()).isEqualTo(PcMeterFixture.PARTITION_INCOMPLETE_OFFSETS);
+        assertThat(PCMetricsDef.PARTITION_ASSIGNMENT_EPOCH.getName()).isEqualTo(PcMeterFixture.PARTITION_ASSIGNMENT_EPOCH);
+        assertThat(PCMetricsDef.PROCESSED_RECORDS.getName()).isEqualTo(PcMeterFixture.PROCESSED_RECORDS);
+        assertThat(PCMetricsDef.FAILED_RECORDS.getName()).isEqualTo(PcMeterFixture.FAILED_RECORDS);
+        assertThat(PCMetricsDef.SLOW_RECORDS.getName()).isEqualTo(PcMeterFixture.SLOW_RECORDS);
+        assertThat(PCMetricsDef.INFLIGHT_RECORDS.getName()).isEqualTo(PcMeterFixture.INFLIGHT_RECORDS);
+        assertThat(PCMetricsDef.WAITING_RECORDS.getName()).isEqualTo(PcMeterFixture.WAITING_RECORDS);
+        assertThat(PCMetricsDef.NUMBER_OF_SHARDS.getName()).isEqualTo(PcMeterFixture.SHARDS);
+        assertThat(PCMetricsDef.SHARDS_SIZE.getName()).isEqualTo(PcMeterFixture.SHARDS_SIZE);
+        assertThat(PCMetricsDef.INCOMPLETE_OFFSETS_TOTAL.getName()).isEqualTo(PcMeterFixture.INCOMPLETE_OFFSETS_TOTAL);
+        assertThat(PCMetricsDef.DYNAMIC_EXTRA_LOAD_FACTOR.getName()).isEqualTo(PcMeterFixture.DYNAMIC_LOAD_FACTOR);
+        assertThat(PCMetricsDef.NUM_PAUSED_PARTITIONS.getName()).isEqualTo(PcMeterFixture.PARTITIONS_PAUSED);
+        assertThat(PCMetricsDef.NUMBER_OF_PARTITIONS.getName()).isEqualTo(PcMeterFixture.PARTITIONS_NUMBER);
+        assertThat(PCMetricsDef.PC_STATUS.getName()).isEqualTo(PcMeterFixture.STATUS);
+        assertThat(PCMetricsDef.PC_POLLER_STATUS.getName()).isEqualTo(PcMeterFixture.POLLER_STATUS);
+        assertThat(PCMetricsDef.OFFSETS_ENCODING_TIME.getName()).isEqualTo(PcMeterFixture.ENCODING_TIME);
+        assertThat(PCMetricsDef.OFFSETS_ENCODING_USAGE.getName()).isEqualTo(PcMeterFixture.ENCODING_USAGE);
+        assertThat(PCMetricsDef.METADATA_SPACE_USED.getName()).isEqualTo(PcMeterFixture.METADATA_SPACE_USED);
+        assertThat(PCMetricsDef.PAYLOAD_RATIO_USED.getName()).isEqualTo(PcMeterFixture.PAYLOAD_RATIO_USED);
+    }
+
+    @Test
+    void populatedRegistryProducesOneRowPerTopicPartition() {
+        PcReading reading = samplerOver(PcMeterFixture.fullyPopulated().getRegistry()).sample();
+
+        assertThat(reading.isRegistryPopulated()).isTrue();
+        assertThat(reading.isEmpty()).isFalse();
+        assertThat(reading.getSampleSequence()).isEqualTo(1);
+        assertThat(reading.getCaptureEpochMillis()).isGreaterThan(0);
+
+        // ordered by topic then partition, so the page's table does not reshuffle between ticks
+        assertThat(reading.getPartitions()).extracting(PartitionReading::getKey)
+                .containsExactly("orders-0", "orders-1", "payments-7");
+
+        PartitionReading orders0 = reading.getPartitions().get(0);
+        assertThat(orders0.getTopic()).isEqualTo("orders");
+        assertThat(orders0.getPartition()).isEqualTo(0);
+        // the gauge carries the next offset to consume, so a commit that has taken offset 100 reads 101
+        assertThat(orders0.getLastCommittedOffset()).isEqualTo(101L);
+        assertThat(orders0.getHighestSequentialSucceededOffset()).isEqualTo(100L);
+        assertThat(orders0.getHighestCompletedOffset()).isEqualTo(140L);
+        assertThat(orders0.getHighestSeenOffset()).isEqualTo(150L);
+        assertThat(orders0.getIncompleteOffsets()).isEqualTo(12L);
+        assertThat(orders0.getAssignmentEpoch()).isEqualTo(3L);
+        assertThat(orders0.getProcessedRecords()).isEqualTo(100d);
+        assertThat(orders0.getFailedRecords()).isEqualTo(2d);
+        assertThat(orders0.getSlowRecords()).isEqualTo(1d);
+    }
+
+    /**
+     * The invariant the offset ribbon is drawn from. If it can be violated the graphic is meaningless, so it is
+     * asserted here rather than assumed downstream.
+     * <p>
+     * The committed marker is compared as {@code committed - 1}, because the gauge is exclusive and the other three
+     * are not. Comparing it raw is what made this invariant read as violated on every caught-up partition.
+     */
+    @Test
+    void offsetMarkersAreNonDecreasing() {
+        PcReading reading = samplerOver(PcMeterFixture.fullyPopulated().getRegistry()).sample();
+
+        assertThat(reading.getPartitions()).isNotEmpty();
+        for (PartitionReading row : reading.getPartitions()) {
+            assertThat(row.isOffsetOrderingConsistent())
+                    .as("offset markers must be non-decreasing for %s", row.getKey())
+                    .isTrue();
+            assertThat(row.getLastCommittedOffset() - 1)
+                    .as("highest committed offset <= sequential-succeeded for %s", row.getKey())
+                    .isLessThanOrEqualTo(row.getHighestSequentialSucceededOffset());
+            assertThat(row.getHighestSequentialSucceededOffset())
+                    .as("sequential-succeeded <= completed for %s", row.getKey())
+                    .isLessThanOrEqualTo(row.getHighestCompletedOffset());
+            assertThat(row.getHighestCompletedOffset())
+                    .as("completed <= seen for %s", row.getKey())
+                    .isLessThanOrEqualTo(row.getHighestSeenOffset());
+        }
+    }
+
+    /**
+     * The other half of the detector: a partition whose commit has caught up is the shape a real instance spends most
+     * of its life in, and the committed gauge then sits one <em>above</em> every other marker. Compared raw it looks
+     * like an inversion, which would un-hide the "markers sampled out of order" badge permanently and make the page's
+     * whole caught-up path unreachable.
+     */
+    @Test
+    void aCommitThatHasCaughtUpIsConsistentRatherThanInverted() {
+        PcMeterFixture fixture = new PcMeterFixture()
+                // everything through 900 done and committed, so the gauge reads 901
+                .partitionOffsets("orders", 0, 901, 900, 900, 900, 0, 3);
+
+        PcReading reading = samplerOver(fixture.getRegistry()).sample();
+
+        PartitionReading row = reading.getPartitions().get(0);
+        assertThat(row.getLastCommittedOffset())
+                .as("the wire keeps the raw gauge value - it is the offset a restart resumes from")
+                .isEqualTo(901L);
+        assertThat(row.isOffsetOrderingConsistent()).isTrue();
+    }
+
+    /**
+     * One past caught up is still a genuine inversion and must still be reported: the normalisation subtracts exactly
+     * one, it does not grant the committed marker a free pass.
+     */
+    @Test
+    void aCommittedOffsetTwoAboveTheSequentialMarkerIsStillInconsistent() {
+        PcMeterFixture fixture = new PcMeterFixture()
+                .partitionOffsets("orders", 0, 902, 900, 900, 900, 0, 3);
+
+        PcReading reading = samplerOver(fixture.getRegistry()).sample();
+
+        assertThat(reading.getPartitions().get(0).isOffsetOrderingConsistent()).isFalse();
+    }
+
+    /**
+     * The detector for the assertion above: an inverted registry must be reported as inconsistent, otherwise
+     * {@link #offsetMarkersAreNonDecreasing()} is asserting nothing.
+     */
+    @Test
+    void invertedOffsetMarkersAreReportedAsInconsistent() {
+        PcMeterFixture fixture = new PcMeterFixture()
+                // committed above seen - impossible in a healthy instance
+                .partitionOffsets("orders", 0, 900, 100, 140, 150, 12, 3);
+
+        PcReading reading = samplerOver(fixture.getRegistry()).sample();
+
+        assertThat(reading.getPartitions()).hasSize(1);
+        assertThat(reading.getPartitions().get(0).isOffsetOrderingConsistent()).isFalse();
+    }
+
+    @Test
+    void absentMeterYieldsAbsentValueNotZero() {
+        // only the "seen" gauge and the processed counter exist for this partition
+        PcMeterFixture fixture = new PcMeterFixture()
+                .gauge(PcMeterFixture.PARTITION_HIGHEST_SEEN, "orders", 0, 150)
+                .counter(PcMeterFixture.PROCESSED_RECORDS, "orders", 0, 7);
+
+        PcReading reading = samplerOver(fixture.getRegistry()).sample();
+
+        PartitionReading row = reading.getPartitions().get(0);
+        assertThat(row.getHighestSeenOffset()).isEqualTo(150L);
+        assertThat(row.getProcessedRecords()).isEqualTo(7d);
+        // absent, NOT zero - zero would claim nothing has been committed, which is a different statement
+        assertThat(row.getLastCommittedOffset()).isNull();
+        assertThat(row.getHighestCompletedOffset()).isNull();
+        assertThat(row.getHighestSequentialSucceededOffset()).isNull();
+        assertThat(row.getIncompleteOffsets()).isNull();
+        assertThat(row.getAssignmentEpoch()).isNull();
+        assertThat(row.getFailedRecords()).isNull();
+        assertThat(row.getSlowRecords()).isNull();
+
+        assertThat(reading.getWork().getInflightRecords()).isNull();
+        assertThat(reading.getWork().getDynamicLoadFactor()).isNull();
+        assertThat(reading.getLifecycle().getState()).isNull();
+        assertThat(reading.getLifecycle().getStateValue()).isNull();
+        assertThat(reading.getEncoding().getEncodingCount()).isNull();
+        assertThat(reading.getEncoding().getUsageByEncoding()).isEmpty();
+    }
+
+    /**
+     * A real measurement of zero must survive as zero - otherwise the absence rule above has quietly swallowed a
+     * legitimate reading.
+     */
+    @Test
+    void measuredZeroSurvivesAsZero() {
+        PcReading reading = samplerOver(PcMeterFixture.fullyPopulated().getRegistry()).sample();
+
+        PartitionReading payments = reading.getPartitions().get(2);
+        assertThat(payments.getKey()).isEqualTo("payments-7");
+        assertThat(payments.getIncompleteOffsets()).isEqualTo(0L);
+        assertThat(payments.getProcessedRecords()).isEqualTo(0d);
+    }
+
+    /**
+     * NaN is what Micrometer reports once a weakly-referenced gauge target has been collected. It is a missing
+     * reading, so it must be absent rather than rendered as a NaN offset.
+     */
+    @Test
+    void nanGaugeIsAbsentRatherThanNaN() {
+        PcMeterFixture fixture = new PcMeterFixture().nanGauge(PcMeterFixture.INFLIGHT_RECORDS);
+
+        PcReading reading = samplerOver(fixture.getRegistry()).sample();
+
+        assertThat(reading.isRegistryPopulated()).isTrue();
+        assertThat(reading.getWork().getInflightRecords()).isNull();
+    }
+
+    @Test
+    void emptyRegistryProducesAnEmptyButValidReading() {
+        PcReading reading = samplerOver(new SimpleMeterRegistry()).sample();
+
+        assertThat(reading.isRegistryPopulated()).isFalse();
+        assertThat(reading.isEmpty()).isTrue();
+        assertThat(reading.getPartitions()).isEmpty();
+        // valid, not null - the page renders absence, it does not null-check every branch
+        assertThat(reading.getWork()).isNotNull();
+        assertThat(reading.getLifecycle()).isNotNull();
+        assertThat(reading.getEncoding()).isNotNull();
+        assertThat(reading.getEncoding().getUsageByEncoding()).isEmpty();
+        assertThat(reading.getCaptureEpochMillis()).isGreaterThan(0);
+        assertThat(reading.getSampleSequence()).isEqualTo(1);
+    }
+
+    /**
+     * A registry holding only unrelated application meters is still "not populated" as far as PC is concerned.
+     */
+    @Test
+    void registryWithOnlyForeignMetersIsNotConsideredPopulated() {
+        PcMeterFixture fixture = new PcMeterFixture().gauge("my.app.queue.depth", 42);
+
+        PcReading reading = samplerOver(fixture.getRegistry()).sample();
+
+        assertThat(reading.isRegistryPopulated()).isFalse();
+        assertThat(reading.isEmpty()).isTrue();
+    }
+
+    @Test
+    void aggregateWorkStateIsRead() {
+        PcReading reading = samplerOver(PcMeterFixture.fullyPopulated().getRegistry()).sample();
+
+        WorkReading work = reading.getWork();
+        assertThat(work.getInflightRecords()).isEqualTo(9L);
+        assertThat(work.getWaitingRecords()).isEqualTo(31L);
+        assertThat(work.getShards()).isEqualTo(4L);
+        assertThat(work.getShardsSize()).isEqualTo(40L);
+        assertThat(work.getIncompleteOffsetsTotal()).isEqualTo(16L);
+        assertThat(work.getPausedPartitions()).isEqualTo(1L);
+        assertThat(work.getNumberOfPartitions()).isEqualTo(3L);
+        assertThat(work.getDynamicLoadFactor()).isEqualTo(2.5d);
+    }
+
+    @Test
+    void numericStateGaugesAreMappedBackToStateNames() {
+        PcMeterFixture fixture = new PcMeterFixture()
+                .lifecycle(State.RUNNING.getValue(), State.DRAINING.getValue());
+
+        LifecycleReading lifecycle = samplerOver(fixture.getRegistry()).sample().getLifecycle();
+
+        assertThat(lifecycle.getStateValue()).isEqualTo(State.RUNNING.getValue());
+        assertThat(lifecycle.getState()).isEqualTo("RUNNING");
+        assertThat(lifecycle.getPollerStateValue()).isEqualTo(State.DRAINING.getValue());
+        assertThat(lifecycle.getPollerState()).isEqualTo("DRAINING");
+    }
+
+    /**
+     * A number no {@link State} maps to means core has a state this module was not built against. The number still
+     * renders; the name is left absent rather than guessed.
+     */
+    @Test
+    void unknownStateNumberLeavesTheNameAbsentButKeepsTheNumber() {
+        PcMeterFixture fixture = new PcMeterFixture().gauge(PcMeterFixture.STATUS, 99);
+
+        LifecycleReading lifecycle = samplerOver(fixture.getRegistry()).sample().getLifecycle();
+
+        assertThat(lifecycle.getStateValue()).isEqualTo(99);
+        assertThat(lifecycle.getState()).isNull();
+    }
+
+    @Test
+    void encodingHealthIsRead() {
+        EncodingReading encoding = samplerOver(PcMeterFixture.fullyPopulated().getRegistry()).sample().getEncoding();
+
+        assertThat(encoding.getEncodingCount()).isEqualTo(2L);
+        assertThat(encoding.getEncodingTotalTimeMillis()).isEqualTo(10d);
+        assertThat(encoding.getEncodingMaxTimeMillis()).isEqualTo(7d);
+        // the live counter is tagged "encoding", although PCMetricsDef documents the tag as "codec"
+        assertThat(encoding.getUsageByEncoding())
+                .containsEntry("RunLength", 4d)
+                .containsEntry("BitSetV2Compressed", 2d);
+        assertThat(encoding.getMetadataSpaceUsedCount()).isEqualTo(2L);
+        assertThat(encoding.getMetadataSpaceUsedMean()).isEqualTo(0.5d);
+        assertThat(encoding.getMetadataSpaceUsedMax()).isEqualTo(0.75d);
+        assertThat(encoding.getPayloadRatioUsedCount()).isEqualTo(1L);
+        assertThat(encoding.getPayloadRatioUsedMax()).isEqualTo(0.5d);
+    }
+
+    /**
+     * A partition-tagged meter missing either tag cannot be attributed to a row, so it is skipped rather than
+     * creating a row keyed on a guess.
+     */
+    @Test
+    void partitionMeterMissingItsTagsIsSkippedRatherThanCreatingABogusRow() {
+        PcMeterFixture fixture = new PcMeterFixture()
+                .gauge(PcMeterFixture.PARTITION_HIGHEST_SEEN, 150)
+                .gauge(PcMeterFixture.PARTITION_HIGHEST_SEEN, "orders", 0, 150);
+
+        PcReading reading = samplerOver(fixture.getRegistry()).sample();
+
+        assertThat(reading.getPartitions()).extracting(PartitionReading::getKey).containsExactly("orders-0");
+    }
+
+    @Test
+    void directStateSourceContributesIdentityAndClosedFlagWhenAPcInstanceIsSupplied() {
+        AbstractParallelEoSStreamProcessor<?, ?> pc = mock(AbstractParallelEoSStreamProcessor.class);
+        when(pc.isClosedOrFailed()).thenReturn(true);
+        when(pc.getMyId()).thenReturn(Optional.of("pc-7"));
+
+        StateSampler sampler = new StateSampler(new MeterSource(PcMeterFixture.fullyPopulated().getRegistry()),
+                new DirectStateSource(pc));
+        LifecycleReading lifecycle = sampler.sample().getLifecycle();
+
+        assertThat(lifecycle.getClosedOrFailed()).isTrue();
+        assertThat(lifecycle.getInstanceId()).isEqualTo("pc-7");
+        // and the meter-derived fields are still there
+        assertThat(lifecycle.getState()).isEqualTo("RUNNING");
+    }
+
+    @Test
+    void withoutAPcInstanceTheDirectFieldsAreAbsentRatherThanDefaulted() {
+        DirectStateSource source = new DirectStateSource(null);
+        assertThat(source.isAvailable()).isFalse();
+
+        LifecycleReading lifecycle = samplerOver(PcMeterFixture.fullyPopulated().getRegistry()).sample().getLifecycle();
+
+        assertThat(lifecycle.getClosedOrFailed()).isNull();
+        assertThat(lifecycle.getInstanceId()).isNull();
+    }
+
+    @Test
+    void aNullRegistryIsToleratedAndReportsEverythingAbsent() {
+        PcReading reading = samplerOver(null).sample();
+
+        assertThat(reading.isRegistryPopulated()).isFalse();
+        assertThat(reading.isEmpty()).isTrue();
+        assertThat(reading.getWork().getInflightRecords()).isNull();
+        assertThat(reading.getEncoding().getUsageByEncoding()).isEmpty();
+    }
+
+    @Test
+    void sampleSequenceCountsSamplesTaken() {
+        StateSampler sampler = samplerOver(PcMeterFixture.fullyPopulated().getRegistry());
+
+        assertThat(sampler.sample().getSampleSequence()).isEqualTo(1);
+        assertThat(sampler.sample().getSampleSequence()).isEqualTo(2);
+        assertThat(sampler.getSampleCount()).isEqualTo(2);
+    }
+
+    /**
+     * Deep immutability is the property that makes the reading safe to hand to any thread - so the collections in it
+     * must actually reject mutation rather than merely be documented as immutable.
+     */
+    @Test
+    void readingCollectionsRejectMutation() {
+        PcReading reading = samplerOver(PcMeterFixture.fullyPopulated().getRegistry()).sample();
+
+        assertThat(reading.getPartitions()).isNotEmpty();
+        try {
+            reading.getPartitions().clear();
+            org.junit.jupiter.api.Assertions.fail("partition list must be unmodifiable");
+        } catch (UnsupportedOperationException expected) {
+            // the point of the test
+        }
+        try {
+            reading.getEncoding().getUsageByEncoding().clear();
+            org.junit.jupiter.api.Assertions.fail("encoding usage map must be unmodifiable");
+        } catch (UnsupportedOperationException expected) {
+            // the point of the test
+        }
+    }
+
+    @Test
+    void ageIsMeasuredAgainstTheCaptureTimestampAndNeverNegative() {
+        PcReading reading = samplerOver(new SimpleMeterRegistry()).sample();
+
+        assertThat(reading.ageMillis(reading.getCaptureEpochMillis() + 1_500)).isEqualTo(1_500);
+        // a clock that steps backwards must not produce a reading from the future
+        assertThat(reading.ageMillis(reading.getCaptureEpochMillis() - 1_000)).isEqualTo(0);
+    }
+}

--- a/parallel-consumer-observability/src/test/java/bz/stub/parallelconsumer/observability/PcMeterFixture.java
+++ b/parallel-consumer-observability/src/test/java/bz/stub/parallelconsumer/observability/PcMeterFixture.java
@@ -1,0 +1,208 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/**
+ * Builds a {@link SimpleMeterRegistry} shaped like the one a running Parallel Consumer publishes into, without
+ * needing a broker or a live instance.
+ * <p>
+ * Meter names here are deliberately written out as <strong>string literals</strong> rather than taken from
+ * {@code PCMetricsDef}. Production code reads the names from that enum, so a fixture that did the same could never
+ * detect a wrong name - both sides would simply move together. Literals here make these tests an actual check on the
+ * wire names, and {@code MeterRegistrySamplerTest#meterNamesMatchCoreDefinitions} pins the two together explicitly.
+ * <p>
+ * Public rather than package-private so the surfaces above this module - the web dashboard, and the MCP tools
+ * planned for 6.1 - can build the same realistic registry in their own tests, instead of each growing a copy that
+ * drifts from this one.
+ */
+public class PcMeterFixture {
+
+    public static final String PARTITION_HIGHEST_SEEN = "pc.partition.highest.seen.offset";
+
+    public static final String PARTITION_HIGHEST_COMPLETED = "pc.partition.highest.completed.offset";
+
+    public static final String PARTITION_HIGHEST_SEQUENTIAL_SUCCEEDED = "pc.partition.highest.sequential.succeeded.offset";
+
+    public static final String PARTITION_LATEST_COMMITTED = "pc.partition.latest.committed.offset";
+
+    public static final String PARTITION_INCOMPLETE_OFFSETS = "pc.partition.incomplete.offsets";
+
+    public static final String PARTITION_ASSIGNMENT_EPOCH = "pc.partition.assignment.epoch";
+
+    public static final String PROCESSED_RECORDS = "pc.processed.records";
+
+    public static final String FAILED_RECORDS = "pc.failed.records";
+
+    public static final String SLOW_RECORDS = "pc.slow.records";
+
+    public static final String INFLIGHT_RECORDS = "pc.inflight.records";
+
+    public static final String WAITING_RECORDS = "pc.waiting.records";
+
+    public static final String SHARDS = "pc.shards";
+
+    public static final String SHARDS_SIZE = "pc.shards.size";
+
+    public static final String INCOMPLETE_OFFSETS_TOTAL = "pc.incomplete.offsets.total";
+
+    public static final String DYNAMIC_LOAD_FACTOR = "pc.dynamic.load.factor";
+
+    public static final String PARTITIONS_PAUSED = "pc.partitions.paused";
+
+    public static final String PARTITIONS_NUMBER = "pc.partitions.number";
+
+    public static final String STATUS = "pc.status";
+
+    public static final String POLLER_STATUS = "pc.poller.status";
+
+    public static final String ENCODING_TIME = "pc.offsets.encoding.time";
+
+    public static final String ENCODING_USAGE = "pc.offsets.encoding.usage";
+
+    public static final String METADATA_SPACE_USED = "pc.metadata.space.used";
+
+    public static final String PAYLOAD_RATIO_USED = "pc.payload.ratio.used";
+
+    private final MeterRegistry registry = new SimpleMeterRegistry();
+
+    public MeterRegistry getRegistry() {
+        return registry;
+    }
+
+    /**
+     * Registers the six offset gauges for one partition, in an order that satisfies the ribbon invariant.
+     * <p>
+     * {@code committed} is the value the {@code pc.partition.latest.committed.offset} gauge carries, which is the
+     * <strong>next offset to consume</strong> - {@code PartitionState.getOffsetToCommit()} publishes
+     * {@code highestSequentialSucceeded + 1}. So a caught-up partition has {@code committed == sequentialSucceeded + 1},
+     * and a fixture that passes {@code committed == sequentialSucceeded} is describing a state no running instance
+     * produces.
+     */
+    PcMeterFixture partitionOffsets(String topic,
+                                    int partition,
+                                    long committed,
+                                    long sequentialSucceeded,
+                                    long completed,
+                                    long seen,
+                                    long incomplete,
+                                    long epoch) {
+        gauge(PARTITION_LATEST_COMMITTED, topic, partition, committed);
+        gauge(PARTITION_HIGHEST_SEQUENTIAL_SUCCEEDED, topic, partition, sequentialSucceeded);
+        gauge(PARTITION_HIGHEST_COMPLETED, topic, partition, completed);
+        gauge(PARTITION_HIGHEST_SEEN, topic, partition, seen);
+        gauge(PARTITION_INCOMPLETE_OFFSETS, topic, partition, incomplete);
+        gauge(PARTITION_ASSIGNMENT_EPOCH, topic, partition, epoch);
+        return this;
+    }
+
+    PcMeterFixture partitionCounters(String topic, int partition, double processed, double failed, double slow) {
+        counter(PROCESSED_RECORDS, topic, partition, processed);
+        counter(FAILED_RECORDS, topic, partition, failed);
+        counter(SLOW_RECORDS, topic, partition, slow);
+        return this;
+    }
+
+    PcMeterFixture aggregates(long inflight,
+                              long waiting,
+                              long shards,
+                              long shardsSize,
+                              long incompleteTotal,
+                              double loadFactor,
+                              long paused,
+                              long partitions) {
+        gauge(INFLIGHT_RECORDS, inflight);
+        gauge(WAITING_RECORDS, waiting);
+        gauge(SHARDS, shards);
+        gauge(SHARDS_SIZE, shardsSize);
+        gauge(INCOMPLETE_OFFSETS_TOTAL, incompleteTotal);
+        gauge(DYNAMIC_LOAD_FACTOR, loadFactor);
+        gauge(PARTITIONS_PAUSED, paused);
+        gauge(PARTITIONS_NUMBER, partitions);
+        return this;
+    }
+
+    PcMeterFixture lifecycle(int statusValue, int pollerStatusValue) {
+        gauge(STATUS, statusValue);
+        gauge(POLLER_STATUS, pollerStatusValue);
+        return this;
+    }
+
+    PcMeterFixture encoding() {
+        io.micrometer.core.instrument.Timer.builder(ENCODING_TIME).register(registry)
+                .record(Duration.ofMillis(7));
+        io.micrometer.core.instrument.Timer.builder(ENCODING_TIME).register(registry)
+                .record(Duration.ofMillis(3));
+        Counter.builder(ENCODING_USAGE).tag("encoding", "RunLength").register(registry).increment(4);
+        Counter.builder(ENCODING_USAGE).tag("encoding", "BitSetV2Compressed").register(registry).increment(2);
+        DistributionSummary.builder(METADATA_SPACE_USED).register(registry).record(0.25);
+        DistributionSummary.builder(METADATA_SPACE_USED).register(registry).record(0.75);
+        DistributionSummary.builder(PAYLOAD_RATIO_USED).register(registry).record(0.5);
+        return this;
+    }
+
+    /**
+     * A gauge whose supplier returns NaN - which is what Micrometer reports once a weakly-referenced gauge target has
+     * been collected. A missing reading, not a measurement of zero.
+     */
+    PcMeterFixture nanGauge(String name) {
+        Gauge.builder(name, (Supplier<Number>) () -> Double.NaN).register(registry);
+        return this;
+    }
+
+    PcMeterFixture gauge(String name, double value) {
+        Gauge.builder(name, (Supplier<Number>) () -> value).register(registry);
+        return this;
+    }
+
+    PcMeterFixture gauge(String name, String topic, int partition, double value) {
+        Gauge.builder(name, (Supplier<Number>) () -> value)
+                .tags(topicPartitionTags(topic, partition))
+                .register(registry);
+        return this;
+    }
+
+    PcMeterFixture counter(String name, String topic, int partition, double amount) {
+        Counter.builder(name).tags(topicPartitionTags(topic, partition)).register(registry).increment(amount);
+        return this;
+    }
+
+    private static Tags topicPartitionTags(String topic, int partition) {
+        return Tags.of("topic", topic, "partition", String.valueOf(partition));
+    }
+
+    /**
+     * The registry a fully-populated PC would look like: two partitions on one topic, one on another, plus every
+     * aggregate, lifecycle and encoding meter.
+     * <p>
+     * The three partitions deliberately cover the three commit positions a real instance produces: a commit level with
+     * the sequential marker while work runs ahead of it (orders-0), a commit lagging behind processing that has
+     * already succeeded (orders-1), and a partition completely caught up (payments-7). Every committed value is one
+     * above the highest offset it represents - see {@link #partitionOffsets}.
+     */
+    public static PcMeterFixture fullyPopulated() {
+        return new PcMeterFixture()
+                // committed up to 100, succeeded out of order as far as 140, seen to 150
+                .partitionOffsets("orders", 0, 101, 100, 140, 150, 12, 3)
+                .partitionCounters("orders", 0, 100, 2, 1)
+                // the last commit recorded offset 49, so 50..55 are done and waiting for the next commit
+                .partitionOffsets("orders", 1, 50, 55, 55, 60, 4, 3)
+                .partitionCounters("orders", 1, 55, 0, 0)
+                // completely caught up: everything through 900 done and committed, nothing outstanding
+                .partitionOffsets("payments", 7, 901, 900, 900, 900, 0, 1)
+                .partitionCounters("payments", 7, 0, 0, 0)
+                .aggregates(9, 31, 4, 40, 16, 2.5d, 1, 3)
+                .lifecycle(1, 1)
+                .encoding();
+    }
+}

--- a/parallel-consumer-observability/src/test/java/bz/stub/parallelconsumer/observability/ReadingPublisherTest.java
+++ b/parallel-consumer-observability/src/test/java/bz/stub/parallelconsumer/observability/ReadingPublisherTest.java
@@ -1,0 +1,440 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import bz.stub.parallelconsumer.internal.AbstractParallelEoSStreamProcessor;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Proves the two properties the publisher exists for: a subscriber fault cannot reach the control loop, and a reader
+ * on any other thread always sees a whole, consistent pair of readings.
+ */
+class ReadingPublisherTest {
+
+    /**
+     * A sampler that can be told to fail, so the publisher's fault isolation can be exercised without needing a
+     * broken registry.
+     */
+    private static class ControllableSampler extends StateSampler {
+
+        private final AtomicBoolean shouldThrow = new AtomicBoolean(false);
+
+        /**
+         * Unique per instance, so a test inspecting the shared class logger can tell its own failures from those of
+         * another test running concurrently - surefire runs this module's tests in parallel.
+         */
+        private final String faultMessage;
+
+        ControllableSampler(String faultMessage) {
+            super(new MeterSource(PcMeterFixture.fullyPopulated().getRegistry()), new DirectStateSource(null));
+            this.faultMessage = faultMessage;
+        }
+
+        @Override
+        public PcReading sample() {
+            if (shouldThrow.get()) {
+                throw new IllegalStateException(faultMessage);
+            }
+            return super.sample();
+        }
+    }
+
+    private static ReadingPublisher publisherOverFullyPopulatedRegistry() {
+        return new ReadingPublisher(new StateSampler(
+                new MeterSource(PcMeterFixture.fullyPopulated().getRegistry()), new DirectStateSource(null)));
+    }
+
+    @Test
+    void beforeTheFirstSampleBothReadingsAreAbsent() {
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+
+        assertThat(publisher.getCurrent()).isNull();
+        assertThat(publisher.getPrevious()).isNull();
+        assertThat(publisher.getSampleFailureCount()).isZero();
+    }
+
+    @Test
+    void twoSuccessivePublishesMakeCurrentAndPreviousReadable() {
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+
+        publisher.sampleOnce();
+        PcReading first = publisher.getCurrent();
+        assertThat(first).isNotNull();
+        assertThat(publisher.getPrevious()).isNull();
+
+        publisher.sampleOnce();
+        PcReading second = publisher.getCurrent();
+
+        assertThat(second).isNotSameAs(first);
+        // previous is exactly the prior current, not a re-sample
+        assertThat(publisher.getPrevious()).isSameAs(first);
+        assertThat(second.getSampleSequence()).isEqualTo(first.getSampleSequence() + 1);
+
+        publisher.sampleOnce();
+        assertThat(publisher.getPrevious()).isSameAs(second);
+    }
+
+    /**
+     * The pair accessor is what a reader needing both ends must use, and it must always be internally consistent -
+     * previous exactly one sample behind current, with a measured elapsed time between them.
+     */
+    @Test
+    void thePairIsAlwaysOneSampleApartAndCarriesMeasuredElapsedTime() throws Exception {
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+
+        assertThat(publisher.getReadings().hasDelta()).isFalse();
+        assertThat(publisher.getReadings().elapsedMillis()).isNull();
+
+        publisher.sampleOnce();
+        assertThat(publisher.getReadings().hasDelta()).isFalse();
+
+        Thread.sleep(5);
+        publisher.sampleOnce();
+
+        ReadingPublisher.Readings pair = publisher.getReadings();
+        assertThat(pair.hasDelta()).isTrue();
+        assertThat(pair.getCurrent().getSampleSequence() - pair.getPrevious().getSampleSequence()).isEqualTo(1);
+        assertThat(pair.elapsedMillis()).isNotNull().isGreaterThanOrEqualTo(1L);
+    }
+
+    /**
+     * A subscriber bug must not be able to stop a consumer. The callback swallows the fault, the last good reading
+     * stays on the page, and the failure is counted.
+     */
+    @Test
+    void aThrowingSamplerLeavesThePreviousReadingIntactAndDoesNotPropagate() {
+        ControllableSampler sampler = new ControllableSampler("fault-isolation-test");
+        ReadingPublisher publisher = new ReadingPublisher(sampler);
+
+        publisher.sampleOnce();
+        publisher.sampleOnce();
+        PcReading goodCurrent = publisher.getCurrent();
+        PcReading goodPrevious = publisher.getPrevious();
+        assertThat(goodCurrent).isNotNull();
+        assertThat(goodPrevious).isNotNull();
+
+        sampler.shouldThrow.set(true);
+        for (int i = 0; i < 50; i++) {
+            // must not throw - this is the control loop callback
+            publisher.sampleOnce();
+        }
+
+        assertThat(publisher.getCurrent()).isSameAs(goodCurrent);
+        assertThat(publisher.getPrevious()).isSameAs(goodPrevious);
+        assertThat(publisher.getSampleFailureCount()).isEqualTo(50);
+
+        // and it recovers once the fault clears
+        sampler.shouldThrow.set(false);
+        publisher.sampleOnce();
+        assertThat(publisher.getCurrent()).isNotSameAs(goodCurrent);
+        assertThat(publisher.getPrevious()).isSameAs(goodCurrent);
+    }
+
+    /**
+     * The control loop runs continuously, so an unsuppressed WARN per failed sample is itself an outage. One line,
+     * then silence until the fault changes or the interval elapses.
+     */
+    @Test
+    void repeatedIdenticalFailuresAreLoggedOnceNotOncePerLoopIteration() {
+        Logger publisherLogger = (Logger) LoggerFactory.getLogger(ReadingPublisher.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        publisherLogger.addAppender(appender);
+        try {
+            String faultMessage = "log-suppression-test-fault";
+            ControllableSampler sampler = new ControllableSampler(faultMessage);
+            ReadingPublisher publisher = new ReadingPublisher(sampler);
+            sampler.shouldThrow.set(true);
+
+            for (int i = 0; i < 500; i++) {
+                publisher.sampleOnce();
+            }
+
+            assertThat(publisher.getSampleFailureCount()).isEqualTo(500);
+            // surefire runs this module's tests in parallel and the appender is on the shared class logger, so
+            // count only the events carrying THIS test's fault
+            List<ILoggingEvent> mine = new ArrayList<>();
+            for (ILoggingEvent event : new ArrayList<>(appender.list)) {
+                if (event.getThrowableProxy() != null
+                        && faultMessage.equals(event.getThrowableProxy().getMessage())) {
+                    mine.add(event);
+                }
+            }
+            assertThat(mine)
+                    .as("500 identical failures must produce exactly one WARN, not 500")
+                    .hasSize(1);
+            assertThat(mine.get(0).getLevel()).isEqualTo(Level.WARN);
+            assertThat(mine.get(0).getFormattedMessage()).contains("Reading sampling failed");
+        } finally {
+            publisherLogger.detachAppender(appender);
+        }
+    }
+
+    /**
+     * An {@link Error} is still a subscriber fault as far as the control loop is concerned - catching only
+     * {@link Exception} would let one through and kill the consumer.
+     */
+    @Test
+    void anErrorFromTheSamplerIsAlsoIsolated() {
+        ReadingPublisher publisher = new ReadingPublisher(new StateSampler(
+                new MeterSource(new SimpleMeterRegistry()), new DirectStateSource(null)) {
+            @Override
+            public PcReading sample() {
+                throw new StackOverflowError("deliberate");
+            }
+        });
+
+        publisher.sampleOnce();
+
+        assertThat(publisher.getCurrent()).isNull();
+        assertThat(publisher.getSampleFailureCount()).isEqualTo(1);
+    }
+
+    /**
+     * The property the event stream is built on: a subscriber is told at publication time, not on a timer of its
+     * own, and by the time it is told the reading it was told about is already readable.
+     */
+    @Test
+    void aListenerIsToldOnPublicationAndFindsTheSampleItWasToldAbout() {
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+        List<Long> sequencesVisibleWhenTold = new ArrayList<>();
+        publisher.addListener(() -> sequencesVisibleWhenTold.add(publisher.getCurrent().getSampleSequence()));
+
+        publisher.sampleOnce();
+        publisher.sampleOnce();
+        publisher.sampleOnce();
+
+        assertThat(sequencesVisibleWhenTold)
+                .as("told once per publication, and never before the publication it is about")
+                .containsExactly(1L, 2L, 3L);
+    }
+
+    @Test
+    void aListenerThatThrowsIsIsolatedFromTheControlLoopAndFromTheOtherListeners() {
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+        AtomicBoolean survivorRan = new AtomicBoolean();
+        publisher.addListener(() -> {
+            throw new IllegalStateException("a subscriber's problem is not the consumer's problem");
+        });
+        publisher.addListener(() -> survivorRan.set(true));
+
+        publisher.sampleOnce();
+
+        assertThat(survivorRan).as("one broken listener must not cost the others their notification").isTrue();
+        assertThat(publisher.getCurrent()).as("the reading was published regardless").isNotNull();
+        assertThat(publisher.getListenerFailureCount()).isEqualTo(1);
+        assertThat(publisher.getSampleFailureCount())
+                .as("a broken subscriber is not a sampling failure - the reading itself was fine")
+                .isZero();
+    }
+
+    /**
+     * A publisher outlives the subscriber that registered with it, so a subscriber that shuts down without
+     * deregistering is not merely untidy: it keeps being called on every control loop iteration for the rest of the
+     * consumer's life.
+     */
+    @Test
+    void aRemovedListenerIsNotCalledAgain() {
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+        AtomicBoolean called = new AtomicBoolean();
+        ReadingPublisher.ReadingListener listener = () -> called.set(true);
+
+        publisher.addListener(listener);
+        assertThat(publisher.getListenerCount()).isEqualTo(1);
+        publisher.removeListener(listener);
+        assertThat(publisher.getListenerCount()).isZero();
+        publisher.sampleOnce();
+
+        assertThat(called).isFalse();
+    }
+
+    @Test
+    void registeringWiresSamplingIntoTheControlLoopEndCallback() {
+        AbstractParallelEoSStreamProcessor<?, ?> pc = mock(AbstractParallelEoSStreamProcessor.class);
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+
+        publisher.registerWith(pc);
+
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(pc).addLoopEndCallBack(captor.capture());
+
+        assertThat(publisher.getCurrent()).isNull();
+        // running the captured callback is what the control loop does
+        captor.getValue().run();
+        assertThat(publisher.getCurrent()).isNotNull();
+    }
+
+    @Test
+    void createAndRegisterBuildsASamplerAndRegistersItInOneStep() {
+        AbstractParallelEoSStreamProcessor<?, ?> pc = mock(AbstractParallelEoSStreamProcessor.class);
+
+        ReadingPublisher publisher =
+                ReadingPublisher.createAndRegister(pc, PcMeterFixture.fullyPopulated().getRegistry());
+
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(pc).addLoopEndCallBack(captor.capture());
+        captor.getValue().run();
+
+        assertThat(publisher.getCurrent()).isNotNull();
+        assertThat(publisher.getCurrent().getPartitions()).hasSize(3);
+    }
+
+    /**
+     * The callback cannot be removed - core has no {@code removeLoopEndCallBack} - so the only thing that can stop a
+     * closed subscriber from sampling forever on the user's control loop is this flag.
+     * <p>
+     * Asserted by running the CAPTURED callback, which is exactly what the control loop does with it. Without the
+     * guard, every iteration after a close would still walk the whole meter registry and allocate a reading, and
+     * every start/stop cycle would add another sampler to the loop.
+     */
+    @Test
+    void stoppingSamplingMakesTheControlLoopCallbackFree() {
+        AbstractParallelEoSStreamProcessor<?, ?> pc = mock(AbstractParallelEoSStreamProcessor.class);
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+        publisher.registerWith(pc);
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(pc).addLoopEndCallBack(captor.capture());
+        Runnable controlLoopCallback = captor.getValue();
+
+        controlLoopCallback.run();
+        controlLoopCallback.run();
+        long sequenceBeforeStopping = publisher.getCurrent().getSampleSequence();
+        assertThat(sequenceBeforeStopping).isEqualTo(2L);
+
+        publisher.stopSampling();
+        for (int i = 0; i < 20; i++) {
+            controlLoopCallback.run();
+        }
+
+        assertThat(publisher.isSamplingStopped()).isTrue();
+        assertThat(publisher.getCurrent().getSampleSequence())
+                .as("no further sample may be taken once sampling is stopped")
+                .isEqualTo(sequenceBeforeStopping);
+        assertThat(publisher.getCurrent())
+                .as("the last good reading is left in place, so a reader sees it ageing rather than a null")
+                .isNotNull();
+    }
+
+    @Test
+    void stoppingSamplingIsIdempotentAndDoesNotUnstop() {
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+
+        publisher.stopSampling();
+        publisher.stopSampling();
+        publisher.sampleOnce();
+
+        assertThat(publisher.isSamplingStopped()).isTrue();
+        assertThat(publisher.getCurrent()).isNull();
+    }
+
+    /**
+     * Readers on other threads must never see a half-built reading, and must never see a current from one tick
+     * beside a previous from another - every rate the page derives is computed from that pair, so an inconsistent
+     * pair is a wrong chart rather than a crash.
+     */
+    @Test
+    void concurrentReadersNeverObserveAPartiallyConstructedOrMismatchedReading() throws Exception {
+        ReadingPublisher publisher = publisherOverFullyPopulatedRegistry();
+        publisher.sampleOnce();
+
+        int readerCount = 6;
+        int publishCount = 5_000;
+        ExecutorService pool = Executors.newFixedThreadPool(readerCount + 1);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicBoolean publishing = new AtomicBoolean(true);
+        AtomicReference<Throwable> firstFailure = new AtomicReference<>();
+        List<java.util.concurrent.Future<?>> futures = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < readerCount; i++) {
+                futures.add(pool.submit(() -> {
+                    try {
+                        start.await();
+                        long reads = 0;
+                        while (publishing.get() || reads < 1_000) {
+                            // ONE volatile read for both - see ReadingPublisher#getReadings
+                            ReadingPublisher.Readings pair = publisher.getReadings();
+                            PcReading current = pair.getCurrent();
+                            PcReading previous = pair.getPrevious();
+                            reads++;
+                            if (current == null) {
+                                throw new AssertionError("current went back to null after the first publish");
+                            }
+                            // fully constructed: every field the sampler sets is set
+                            if (current.getPartitions().size() != 3) {
+                                throw new AssertionError("partially constructed reading: "
+                                        + current.getPartitions().size() + " partitions");
+                            }
+                            if (current.getCaptureEpochMillis() <= 0 || current.getSampleSequence() <= 0) {
+                                throw new AssertionError("partially constructed reading: no capture stamp");
+                            }
+                            for (PartitionReading row : current.getPartitions()) {
+                                if (!row.isOffsetOrderingConsistent()) {
+                                    throw new AssertionError("torn partition row: " + row.getKey());
+                                }
+                                if (row.getHighestSeenOffset() == null || row.getProcessedRecords() == null) {
+                                    throw new AssertionError("partially constructed row: " + row.getKey());
+                                }
+                            }
+                            // the pair is published atomically, so previous is always exactly one sample behind
+                            if (previous != null
+                                    && previous.getSampleSequence() != current.getSampleSequence() - 1) {
+                                throw new AssertionError("mismatched pair: current="
+                                        + current.getSampleSequence() + " previous=" + previous.getSampleSequence());
+                            }
+                        }
+                    } catch (Throwable t) {
+                        firstFailure.compareAndSet(null, t);
+                    }
+                }));
+            }
+
+            futures.add(pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < publishCount; i++) {
+                        publisher.sampleOnce();
+                    }
+                } catch (Throwable t) {
+                    firstFailure.compareAndSet(null, t);
+                } finally {
+                    publishing.set(false);
+                }
+            }));
+
+            start.countDown();
+            for (java.util.concurrent.Future<?> future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        if (firstFailure.get() != null) {
+            throw new AssertionError("concurrent reader observed an inconsistent reading", firstFailure.get());
+        }
+        assertThat(publisher.getCurrent().getSampleSequence()).isEqualTo(publishCount + 1);
+        assertThat(publisher.getSampleFailureCount()).isZero();
+    }
+}

--- a/parallel-consumer-observability/src/test/java/bz/stub/parallelconsumer/observability/TestConventionsArchTest.java
+++ b/parallel-consumer-observability/src/test/java/bz/stub/parallelconsumer/observability/TestConventionsArchTest.java
@@ -1,0 +1,21 @@
+package bz.stub.parallelconsumer.observability;
+/*-
+ * Copyright (C) 2026 Antony Stubbs and contributors
+ */
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+import bz.stub.parallelconsumer.TestConventionRules;
+
+/**
+ * Applies the shared {@link TestConventionRules} to this module's test classes - the rule logic lives once in
+ * {@link TestConventionRules} (core test-jar); this only points ArchUnit at this module's packages.
+ */
+@AnalyzeClasses(packages = "bz.stub.parallelconsumer.observability", importOptions = ImportOption.OnlyIncludeTests.class)
+class TestConventionsArchTest {
+
+    @ArchTest
+    static final ArchTests conventions = ArchTests.in(TestConventionRules.class);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <modules>
         <module>parallel-consumer-core</module>
+        <module>parallel-consumer-observability</module>
         <module>parallel-consumer-vertx</module>
         <module>parallel-consumer-reactor</module>
         <module>parallel-consumer-mutiny</module>


### PR DESCRIPTION
## Description

Extracts the state-reading layer out of the embedded dashboard (astubbs/parallel-consumer#268) into its own module, `parallel-consumer-observability`, so it is not the dashboard's private property. Three readers want the same thing: the web GUI, the MCP tools planned for 6.1 (astubbs/parallel-consumer#508), and an application wiring its own monitoring.

**Off master, stacked on nothing.** Two commits along the seam of what each half does.

**1. Read the state.** Five value types plus the sampling that produces one reading of them — a pure function of the meter registry plus a few direct reads. Two properties worth having on their own:

- **Control-thread-only by contract.** Reading a Micrometer gauge *evaluates* it, on the calling thread, which is the mechanism behind confluentinc/parallel-consumer#618 (a Prometheus scrape thread evaluating a PC gauge and getting `ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access`). The result is deeply immutable and holds no reference to any live PC object, which is what lets another thread read it afterwards.
- **One registry walk per sample.** The index is built per pass and every sampling method takes it, because this runs on a loop that turns over thousands of times a second. There is deliberately no no-argument overload to fall back to.

Meter names come from core's `PCMetricsDef` rather than string literals, so a rename in core breaks this module's compilation instead of silently turning every value absent. Absent, NaN and zero stay three different things.

**2. Make each new reading visible to watchers.** The loop-end callback, immutable publication, listener fan-out. All in process — nothing here opens a socket or crosses a wire. Three properties the sampling half doesn't need: a watcher's bug cannot stop a consumer (both sampling and notification are wrapped, with repeat-suppressed logging because the control loop would otherwise emit thousands of lines a second); a closed watcher stops costing anything; a listener that outlives its watcher is a leak, so deregistration is explicit.

**Dependencies:** core, plus core's test-jar for the shared ArchUnit rules — every module with test sources has to wire those up or they silently don't run there, which a guard in core enforced the moment this module gained tests. Micrometer arrives transitively from core, so **nothing reaches a consumer's classpath that core did not already put there**. That property is what lets the GUI and the MCP server each build on this without inheriting the other's dependencies, and it is the thing to protect.

**Naming:** the module is named for the roadmap's own concern, "seeing what the client-side queue is doing", rather than for what it reads. `-metrics` would collide with core's `metrics` package where the meters are registered, and would misdescribe the direction — this reads meters, it doesn't produce them. The types say `Reading` rather than `Snapshot` because Maven already means something else by SNAPSHOT.

**Sequencing:** astubbs/parallel-consumer#268 still carries its own copy of these classes. Changing it to depend on this module and delete its copy is deliberately left for later, per the owner.

## Checklist

- [x] Docs updated - N/A - the javadoc is the documentation here, and it travels with the classes; the module's purpose is in its pom description
- [x] User-facing feature documentation data added under `docs/features/` - N/A - experimental and opt-in; it ships no user-facing feature on its own
- [x] Tests added/updated - the three test classes came across with the code and all pass; a repo guard also required this module's own ArchUnit wiring, which is added
- [x] `docs/inflight/` working note (`pr-`/`branch-`) started at the PR's first commit - N/A - a pure extraction with no cross-branch state `gh` cannot show; the dashboard PR's own notes still own that work
- [x] Title & body reflect the final content of this PR
- [x] Ran `ce-simplify` and `ce-code-review` locally - N/A - asking for `@claude review this` on the PR instead, which is the cheaper route and the only one that can open inline threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161fFujinEiyds3HHJapDfB
